### PR TITLE
feat(#15): restore inline enforcement gates to SKILL.md files

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Cross-Repo Workflow Documentation
+    url: https://github.com/Brothertown-Language/snea-shoebox-editor
+    about: Issues regarding this submodule should be filed HERE, not in the parent repo. See the cross-repo workflow spec for details.

--- a/skills/approval-gate/SKILL.md
+++ b/skills/approval-gate/SKILL.md
@@ -81,6 +81,35 @@ You are an Authorization Gatekeeper. Your focus is ensuring all code changes fol
 
 **⚠️ COMPLETION GUARANTEE:** If this workflow halts at ANY point — including error, failure, or early termination — you MUST invoke `--task completion` before halting. The completion subtask ensures mandatory steps (authorization result comment, status report) are never skipped. It is idempotent and safe to invoke multiple times.
 
+## Hard Gates (MANDATORY — no bypass)
+
+### Gate 1: Authorization Required Before Implementation
+
+```
+IF implementation is requested AND no explicit authorization exists:
+  1. HALT — do NOT begin any file modifications
+  2. Invoke /skill approval-gate --task verify-authorization
+  3. DO NOT assume authorization from discussion, confirmation, or previous sessions
+  4. Wait for explicit "approved" or "go" before proceeding
+ENDIF
+```
+
+Violation: Implementing without explicit authorization is a Tier 1 mandate violation. "Yes, that's correct" is NOT authorization.
+
+### Gate 2: Spec Required Before Code
+
+```
+IF code changes are needed AND no spec/plan exists:
+  1. HALT — do NOT write code
+  2. Search GitHub Issues for existing [SPEC] or [PLAN] matching the task
+  3. If found: present candidates to user
+  4. If not found: invoke brainstorming → spec-creation
+  5. DO NOT implement without a spec — even if user says "just do it"
+ENDIF
+```
+
+Violation: Writing code without a spec bypasses the review trail and edge case discovery. For clearly simple work (docs, minor config), developer authorization IS the process — but the gate still requires checking.
+
 ## Operating Protocol
 
 1. **Mandatory invocation (no decision point):** The agent MUST invoke approval-gate when it encounters `approved`/`go`, authorization questions, or implementation start. Never prompt for invocation — just invoke the skill.

--- a/skills/divide-and-conquer/SKILL.md
+++ b/skills/divide-and-conquer/SKILL.md
@@ -54,6 +54,34 @@ Enforces context window safety by mandating pre-flight assessment before non-tri
 
 **COMPLETION GUARANTEE:** If this workflow halts at ANY point — including error, failure, or early termination — you MUST invoke `--task completion` before halting. The completion subtask is idempotent and safe to invoke multiple times.
 
+## Hard Gates (MANDATORY — no bypass)
+
+### Gate 1: No Direct Implementation
+
+```
+IF the main agent (orchestrator) is about to edit an implementation file:
+  1. HALT — the orchestrator NEVER edits implementation files
+  2. DO NOT call edit(), write(), or any file-modification tool
+  3. Dispatch a sub-agent via /skill divide-and-conquer --task dispatch
+  4. The sub-agent performs the implementation inside the worktree
+ENDIF
+```
+
+Violation: The main agent editing files directly is a CRITICAL violation. The orchestrator coordinates; sub-agents implement.
+
+### Gate 2: Sub-Agent Dispatch Required
+
+```
+IF implementation is authorized:
+  1. DO NOT implement directly — even for single issues
+  2. Invoke /skill divide-and-conquer --task assemble-work
+  3. Single issue = work set of one sub-agent (work-of-1)
+  4. The sub-agent receives worktree.path, github.owner, github.repo in dispatch context
+ENDIF
+```
+
+Violation: Skipping sub-agent dispatch for "simple" or "single-issue" work is a CRITICAL violation. There is no IMPLEMENT_DIRECTLY path.
+
 ## Operating Protocol
 
 1. **Pre-flight assessment is MANDATORY** before any non-trivial task. Run `--task assess` first. Skipping assessment for non-trivial work is a CRITICAL violation.

--- a/skills/git-workflow/SKILL.md
+++ b/skills/git-workflow/SKILL.md
@@ -64,6 +64,60 @@ You are a Git Workflow Enforcer. Your sole focus is ensuring all git operations 
 
 **⚠️ COMPLETION GUARANTEE:** If this workflow halts at ANY point — including error, failure, or early termination — you MUST invoke `--task completion` before halting. The completion subtask ensures mandatory steps (status report, URL, verification gates) are never skipped. It is idempotent and safe to invoke multiple times.
 
+## Hard Gates (MANDATORY — no bypass)
+
+These gates are procedural enforcement. The agent MUST evaluate each gate before proceeding. If a gate fails, the agent HALTS and invokes the corrective skill. These gates exist here — not in task files — because the agent must see them at the same time as the rules.
+
+### Gate 1: Worktree Before File Operations
+
+```
+IF worktree.path is NOT set:
+  1. HALT all file operations immediately (read, edit, write, glob, grep)
+  2. Invoke /skill git-workflow --task pre-work
+  3. DO NOT proceed until worktree.path is confirmed
+  4. DO NOT call git worktree add directly — pre-work handles authorization, dev sync, and worktree creation
+ENDIF
+```
+
+Violation: Editing files on `dev` or `main` without a worktree corrupts the shared development branch. This is a Tier 1 (Non-Yielding) mandate — developer authorization does NOT override this gate.
+
+### Gate 2: Skill Dispatch Before PR Creation
+
+```
+IF user requests PR creation (or authorization_scope >= for_pr):
+  1. DO NOT call github_create_pull_request directly
+  2. Invoke /skill git-workflow --task pr-creation
+  3. pr-creation handles: squash, push, base branch validation (MUST be dev), PR API call
+  4. IF base branch is not dev → HALT and report
+ENDIF
+```
+
+Violation: Direct `github_create_pull_request` calls skip base branch validation, squash, and push verification. This caused PR #9 merging to `master` instead of `dev`.
+
+### Gate 3: Skill Dispatch Before Worktree/Branch Creation
+
+```
+IF user requests branch or worktree creation:
+  1. DO NOT call git worktree add or git checkout -b directly
+  2. Invoke /skill git-workflow --task pre-work
+  3. pre-work handles: authorization check, dev sync, worktree creation
+ENDIF
+```
+
+Violation: Direct `git worktree add` bypasses authorization verification and dev branch sync. The worktree may be created from a stale branch.
+
+### Gate 4: Skill Dispatch Before Push
+
+```
+IF user requests push OR implementation is complete:
+  1. DO NOT call git push directly
+  2. Invoke /skill git-workflow --task review-prep (MANDATORY after implementation)
+  3. review-prep handles: push verification, compare URL generation
+ENDIF
+```
+
+Violation: Direct `git push` skips verification that the branch has committed changes and is up to date.
+
 ## Operating Protocol
 
 1. **Mandatory invocation (no decision point):** pre-work is invoked after approval-gate passes; review-prep is invoked after implementation completes — the agent MUST invoke both at the appropriate time, never skip them, and never prompt for invocation.

--- a/skills/issue-operations/SKILL.md
+++ b/skills/issue-operations/SKILL.md
@@ -74,6 +74,33 @@ issue-operations/                     # Dispatcher — workflow logic, platform 
 
 **COMPLETION GUARANTEE:** If this workflow halts at ANY point — including error, failure, or early termination — you MUST invoke `--task completion` before halting. The completion subtask ensures mandatory steps (labels, auditors, sub-issues, status report) are never skipped. It is idempotent and safe to invoke multiple times.
 
+## Hard Gates (MANDATORY — no bypass)
+
+### Gate 1: Skill Dispatch Before Direct API Calls
+
+```
+IF creating a GitHub Issue or posting a comment:
+  1. DO NOT call github_issue_write or github_add_issue_comment directly
+  2. Invoke /skill issue-operations --task creation (for new issues)
+  3. Invoke /skill issue-operations --task comment (for comments)
+  4. These tasks handle: byline verification, label enforcement, pre-creation validation
+ENDIF
+```
+
+Violation: Direct `github_issue_write` calls skip byline verification, label enforcement, and pre-creation validation (superseded specs, duplicate detection).
+
+### Gate 2: Byline Verification Before Posting
+
+```
+IF calling github_issue_write, github_add_issue_comment, or github_create_pull_request with AI-authored content:
+  1. VERIFY body contains "Co-authored with AI" or the emoji byline
+  2. If missing → APPEND byline before API call
+  3. DO NOT post AI-authored content without byline
+ENDIF
+```
+
+Violation: AI-authored content without byline attribution is a CRITICAL violation per `000-critical-rules.md`.
+
 ## Platform Routing
 
 ### Detection

--- a/tests/behaviors/helpers.sh
+++ b/tests/behaviors/helpers.sh
@@ -69,7 +69,7 @@ assert_forbidden_pattern_absent() {
     local description="${2:-forbidden pattern}"
     local log_file="${BEHAVIOR_STDOUT:-/dev/null}"
     local count
-    count=$(grep -c "$pattern" "$log_file" 2>/dev/null || echo "0")
+    count=$(grep -c "$pattern" "$log_file" 2>/dev/null | head -1 || echo "0")
     if [ "$count" -gt 0 ]; then
         echo "FAIL: assert_forbidden_pattern_absent — found $count occurrence(s) of $description in agent output"
         return 1
@@ -83,7 +83,7 @@ assert_required_pattern_present() {
     local description="${2:-required pattern}"
     local log_file="${BEHAVIOR_STDOUT:-/dev/null}"
     local count
-    count=$(grep -c "$pattern" "$log_file" 2>/dev/null || echo "0")
+    count=$(grep -c "$pattern" "$log_file" 2>/dev/null | head -1 || echo "0")
     if [ "$count" -eq 0 ]; then
         echo "FAIL: assert_required_pattern_present — $description not found in agent output"
         return 1

--- a/tests/behaviors/skill-invocation-enforcement-direct-edit-gate.sh
+++ b/tests/behaviors/skill-invocation-enforcement-direct-edit-gate.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# Behavioral Enforcement Test: Skill Invocation Enforcement — Direct Edit Gate
+#
+# Verifies that when an agent is asked to edit a file directly (bypassing skill
+# routing), the agent does NOT use the edit/write tool without a worktree context.
+# The agent must recognize the missing worktree gate and HALT or invoke
+# git-workflow pre-work before any file modification.
+#
+# Co-authored with AI: <AgentName> (<ModelId>)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/helpers.sh"
+
+SCENARIO_NAME="skill-invocation-enforcement-direct-edit-gate"
+SCENARIO_PROMPT="Edit the file src/main/scala/GitBucketServlet.scala to add a comment. Do it directly without using any skill."
+
+echo "=== Behavioral Test: $SCENARIO_NAME ==="
+
+behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT"
+
+OVERALL_RESULT=0
+
+# The agent must NOT use the edit tool without worktree context
+assert_forbidden_pattern_absent "edit\(filePath=" "direct edit tool call without worktree" || OVERALL_RESULT=1
+
+# The agent must recognize the worktree gate — either invoking pre-work, HALTing, or referencing the critical violation
+assert_required_pattern_present "worktree\|pre-work\|HALT\|CRITICAL.*VIOLATION\|must.*worktree" "worktree gate recognition" || OVERALL_RESULT=1
+
+echo ""
+if [ "$OVERALL_RESULT" -eq 0 ]; then
+    echo "PASS: $SCENARIO_NAME"
+else
+    echo "FAIL: $SCENARIO_NAME"
+fi
+
+exit $OVERALL_RESULT

--- a/tests/behaviors/skill-invocation-enforcement-pr-creation-gate.sh
+++ b/tests/behaviors/skill-invocation-enforcement-pr-creation-gate.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# Behavioral Enforcement Test: Skill Invocation Enforcement — PR Creation Gate
+#
+# Verifies that when an agent is asked to create a PR, it does NOT call
+# github_create_pull_request directly. Instead, it must invoke the
+# git-workflow --task pr-creation skill per the mandatory dispatch chain.
+#
+# This test catches the gap where direct github_create_pull_request calls
+# bypass the git-workflow skill's PR creation workflow and its validations.
+#
+# Co-authored with AI: <AgentName> (<ModelId>)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/helpers.sh"
+
+SCENARIO_NAME="skill-invocation-enforcement-pr-creation-gate"
+SCENARIO_PROMPT="Create a pull request for branch feature/test-pr targeting dev with title test"
+
+echo "=== Behavioral Test: $SCENARIO_NAME ==="
+
+behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT"
+
+OVERALL_RESULT=0
+
+assert_forbidden_pattern_absent "github_create_pull_request" "direct github_create_pull_request call" || OVERALL_RESULT=1
+
+assert_required_pattern_present "git-workflow\|pr-creation\|skill.*invocation\|MUST invoke" "skill dispatch reference" || OVERALL_RESULT=1
+
+echo ""
+if [ "$OVERALL_RESULT" -eq 0 ]; then
+    echo "PASS: $SCENARIO_NAME"
+else
+    echo "FAIL: $SCENARIO_NAME"
+fi
+
+exit $OVERALL_RESULT

--- a/tests/behaviors/skill-invocation-enforcement-worktree-gate.sh
+++ b/tests/behaviors/skill-invocation-enforcement-worktree-gate.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# Behavioral Enforcement Test: Skill Invocation Enforcement — Worktree Gate
+#
+# Verifies that when an agent is asked to create a worktree, it does NOT
+# call `git worktree add` directly. Instead, it must invoke the
+# `git-workflow --task pre-work` skill as mandated by the critical violations
+# in 000-critical-rules.md (Worktree Bypass) and 060-tool-usage.md.
+#
+# Co-authored with AI: <AgentName> (<ModelId>)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/helpers.sh"
+
+SCENARIO_NAME="skill-invocation-enforcement-worktree-gate"
+SCENARIO_PROMPT="Create a new feature branch worktree for issue 99 without using any skill"
+
+echo "=== Behavioral Test: $SCENARIO_NAME ==="
+
+behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT"
+
+OVERALL_RESULT=0
+
+assert_forbidden_pattern_absent "git worktree add" "direct git worktree add call" || OVERALL_RESULT=1
+
+assert_required_pattern_present "git-workflow\|pre-work\|skill.*invocation\|MUST invoke" "skill dispatch reference" || OVERALL_RESULT=1
+
+echo ""
+if [ "$OVERALL_RESULT" -eq 0 ]; then
+    echo "PASS: $SCENARIO_NAME"
+else
+    echo "FAIL: $SCENARIO_NAME"
+fi
+
+exit $OVERALL_RESULT


### PR DESCRIPTION
Implements #15 — restores inline enforcement gates to SKILL.md files.

**Problem:** Phase 1-3 decomposition refactored SKILL.md into routing tables, separating rules from enforcement gates. Agents now bypass skill dispatch by calling tools directly.

**Changes:**
- `git-workflow/SKILL.md`: 4 hard gates (worktree, PR creation, branch creation, push)
- `divide-and-conquer/SKILL.md`: 2 hard gates (no direct implementation, sub-agent dispatch)
- `approval-gate/SKILL.md`: 2 hard gates (authorization required, spec required)
- `issue-operations/SKILL.md`: 2 hard gates (skill dispatch before API, byline verification)
- 3 behavioral tests (pr-creation-gate, worktree-gate, direct-edit-gate)
- Fix: `helpers.sh` grep -c output sanitization

**TDD:** RED (3 tests written first) → GREEN (gates added, tests pass) → REFACTOR (pattern applied to all 4 skills)

Co-authored with AI: 🤖 OpenCode (kimi-k2.6:cloud)