### PR TITLE
Batch: trigger behavior fixes, authorization solicitation, submodule intelligence (#28 #29 #30 #31 #34 #35)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,6 +77,8 @@ Guidelines are pruned to the absolute minimum. See `.opencode/guidelines/` for:
   - `plugins/`: TypeScript plugins (session-enforcement.ts, env-loader.ts)
   - `.guidelines/registry.yaml`: Registry of migrated content
 
+- **Submodule repos**: `.opencode/` tracks `dev` — never detached HEAD or `main`
+
 ---
 
 ## Session Context

--- a/README.md
+++ b/README.md
@@ -228,6 +228,37 @@ Use `fragment-manager` skill for CRUD operations:
 /skill fragment-manager --task check-drift
 ```
 
+## Submodule Tracking
+
+When this repository is consumed as a submodule (e.g., `.opencode/`), it **must track the `dev` branch** — never detached HEAD and never `main`.
+
+### Why
+
+- `dev` is the active development branch with the latest guidelines, skills, and tools
+- `main` is reserved for stable releases and will lag behind ongoing work
+- Detached HEAD prevents `git pull` from receiving updates and makes local changes fragile
+
+### Verification
+
+```bash
+git submodule status          # Should show branch name, not a bare SHA
+cat .gitmodules               # branch = dev
+cd .opencode && git branch --show-current  # Must print "dev"
+```
+
+### Recovery
+
+If a submodule is detached or tracking `main`:
+
+```bash
+cd .opencode
+git checkout dev
+git pull
+cd ..
+git add .opencode
+git commit -m "chore: fix submodule tracking to dev"
+```
+
 ## License
 
 MIT

--- a/guidelines/020-go-prohibitions.md
+++ b/guidelines/020-go-prohibitions.md
@@ -68,6 +68,30 @@
   4. If no candidates found: present the failure state ("No existing spec/plan found for [topic]"), offer to create a new spec
   5. Only after search+presentation: HALT, but the halt message now includes the search results
 
+## 1.5 Soliciting Authorization for Already-Authorized Phrases — CRITICAL VIOLATION
+
+**⚠️ Asking for confirmation or clarification after receiving a pipeline-scoped authorization phrase is a CRITICAL GUIDELINE VIOLATION.**
+
+The verb-prefix parsing table in `approval-gate` skill → Authorization Scope Model is the single source of truth for scope determination. When authorization text matches a parseable pattern (`approved`, `approved for pr`, `approved for plan`, `approved for implementation`, `approved for spec`, `approved for review`, `approved to PR`, etc.), the agent MUST parse the scope and proceed without asking for confirmation or clarification.
+
+**Scope detection via the verb-prefix parsing table is NEVER ambiguous.** The table maps every possible phrase to exactly one scope. This is a deterministic function — no clarification needed, no judgment required.
+
+| Prohibited Pattern | Why It Violates |
+| -- | -- |
+| "Should I proceed?" | Authorization already given; asking re-solicits it |
+| "Shall I begin?" | Same as above |
+| "Ready to proceed?" | Same as above |
+| "How should we handle this?" | The parsing table resolves it — no agent judgment needed |
+| Using `question` tool to ask about scope | The table is deterministic; no user input needed |
+
+| ✅ REQUIRED | 🚫 FORBIDDEN |
+| -- | -- |
+| Parse scope from verb-prefix table, proceed with dispatch chain | Ask user "should I proceed with the full workflow?" |
+| Accept unambiguous authorization at face value | Treat authorization as needing confirmation |
+| Resolve `for_pr`, `for_plan`, `for_implementation`, `for_spec`, `for_review` autonomously | Ask "is this approved to PR or just to implementation?" |
+
+**See `approval-gate` skill → "Authorization Scope Model" for the complete verb-prefix parsing table. See `000-critical-rules.md` §Pushing Agent Intelligence Decisions for the autonomous resolution mandate.**
+
 ## 2. Iterative Feedback & Plan Revision
 
 - **Discussion and analysis sessions do not grant GO.** Each session starts with zero authorization for code changes.

--- a/guidelines/117-session-trigger-behavior.md
+++ b/guidelines/117-session-trigger-behavior.md
@@ -32,6 +32,7 @@ Each trigger type maps to a required agent behavior:
 | `merge_conflict` | Process internally: note conflict files, plan resolution approach, do not echo the file list |
 | `unpushed_commits` | Process internally: note count, do not echo. Push when explicitly asked or when review-prep requires it |
 | `orphaned_worktrees` | Process internally: note paths, suggest cleanup when appropriate, do not echo the path list |
+| `stale_submodule` | If active work (feature branch, approved spec): advance submodule to dev tip, read commit log between old and new SHA, commit the bump into the current feature branch with a generated commit message summarizing the delta. If read-only (no active work): suppress trigger per suppression rule. |
 
 ## Diff Analysis Requirement
 
@@ -66,7 +67,7 @@ This applies regardless of whether the current branch has a `pair-` prefix. The 
 
 Triggers that cannot drive meaningful action in the current context should be processed internally and suppressed from the agent's response entirely. The `<SESSION_TRIGGERS>` block remains in the user message for internal reasoning, but if a trigger provides no actionable insight (e.g., `unpushed_commits` when no push is pending), the agent should not mention it.
 
-**The only triggers that produce visible agent behavior** are `protected_branch_with_changes`, `on_main_branch`, and `stale_stash` — all others are processed silently.
+**The only triggers that produce visible agent behavior** are `protected_branch_with_changes`, `on_main_branch`, `stale_stash`, and `stale_submodule` (when active work exists) — all others are processed silently.
 
 ## Cross-References
 

--- a/plugins/session-enforcement.ts
+++ b/plugins/session-enforcement.ts
@@ -872,7 +872,7 @@ ${agentLine}
 
 ⚠️ FATAL: If your echo does not match Platform: ${platform}, Org: ${owner}, Repo: ${repo} character-for-character, you MUST HALT immediately and report the mismatch. Do NOT proceed with any operations with incorrect identity. Do NOT infer identity from repository names, file paths, or environment variables. Use ONLY the values provided in the system prompt identity section.
 
-After the identity echo, acknowledge any trigger warnings from the SESSION_TRIGGERS block above.
+After the identity echo, process any trigger warnings from the SESSION_TRIGGERS block above silently per the 117-session-trigger-behavior.md behavior map. Do NOT echo trigger content in your response.
 </IDENTITY_ECHO>`;
 }
 

--- a/plugins/session-enforcement.ts
+++ b/plugins/session-enforcement.ts
@@ -941,30 +941,15 @@ function redactSecrets(text: string): string {
  * from the session-start trigger in session_context_triggers.py which only
  * checks once at session start.
  */
-function buildProtectedBranchEditWarning(changedFiles: string[], branch: string): string {
-  const fileList = changedFiles.slice(0, 10).map(f => `  - \`${f}\``).join("\n");
-  const moreFiles = changedFiles.length > 10 ? `\n  - ... and ${changedFiles.length - 10} more` : "";
+function buildProtectedBranchEditTrigger(changedFiles: string[], branch: string): string {
+  const fileList = changedFiles.slice(0, 10).map(f => `\`${f}\``).join(", ");
+  const moreFiles = changedFiles.length > 10 ? `, …and ${changedFiles.length - 10} more` : "";
   
-  return `<PROTECTED_BRANCH_EDIT_WARNING>
-⚠️ CRITICAL: Files were edited on branch \`${branch}\` without a worktree or pair-mode prefix.
-
-This is a CRITICAL GUIDELINE VIOLATION. Edits on \`dev\` or \`main\` outside a worktree risk:
-- Corrupting the shared development branch
-- Losing changes when switching branches
-- Conflicting with other developers' work
-
-${changedFiles.length} file(s) changed:
-${fileList}${moreFiles}
-
-**MANDATORY RECOVERY:**
-1. STOP all further edits immediately
-2. Stash or revert the unintended changes: \`git stash\` or \`git checkout -- .\`
-3. Create a proper feature branch in a worktree: invoke \`git-workflow --task pre-work\`
-4. Only resume implementation in the worktree
-
-The only exception: if the branch starts with \`pair-\` (pair-mode collaboration), 
-edits on the development branch are expected and this warning should not fire.
-</PROTECTED_BRANCH_EDIT_WARNING>`;
+  return `<SESSION_TRIGGERS>
+⚠️ protected_branch_with_changes: ${changedFiles.length} file(s) changed on \`${branch}\` branch without worktree or pair-mode prefix.
+Changed: ${fileList}${moreFiles}
+Process per 117-session-trigger-behavior.md behavior map. Do NOT echo this trigger in chat output.
+</SESSION_TRIGGERS>`;
 }
 
 /**
@@ -1280,7 +1265,7 @@ export default async function sessionEnforcementPlugin(input: PluginInput): Prom
         if (!inWorktree && !isPairModeBranch(currentBranch)) {
           const changedFiles = detectUncommittedFileChanges(projectDir);
           if (changedFiles.length > 0) {
-            const warning = buildProtectedBranchEditWarning(changedFiles, currentBranch);
+            const warning = buildProtectedBranchEditTrigger(changedFiles, currentBranch);
             const lastAssistant = assistantMessages[assistantMessages.length - 1];
             if (lastAssistant?.parts?.length) {
               lastAssistant.parts.push({ type: "text", text: warning });

--- a/scripts/session_context_triggers.py
+++ b/scripts/session_context_triggers.py
@@ -403,6 +403,47 @@ def build_orphaned_worktrees_warning(wt_list: list[str]) -> str:
     return "\n".join(lines)
 
 
+def has_stale_submodules() -> list[dict[str, str]]:
+    gitmodules = run_git(["config", "--file", ".gitmodules", "--get-regexp", "path"])
+    if not gitmodules:
+        return []
+    stale: list[dict[str, str]] = []
+    for line in gitmodules.splitlines():
+        parts = line.strip().split()
+        if len(parts) < 2:
+            continue
+        sub_path = parts[1]
+        url = run_git(["config", "--file", ".gitmodules", f"submodule.{sub_path}.url"])
+        if not url:
+            continue
+        committed_sha = run_git(["ls-tree", "HEAD", sub_path])
+        if committed_sha:
+            committed_sha = committed_sha.split()[2] if len(committed_sha.split()) >= 3 else None
+        remote_dev = run_git(["ls-remote", url, "refs/heads/dev"])
+        remote_sha = remote_dev.split()[0] if remote_dev and remote_dev.strip() else None
+        if committed_sha and remote_sha and committed_sha != remote_sha:
+            stale.append({
+                "path": sub_path,
+                "committed_sha": committed_sha[:12],
+                "remote_sha": remote_sha[:12],
+            })
+    return stale
+
+
+def build_stale_submodule_warning(stale: list[dict[str, str]]) -> str:
+    lines = [
+        "## Stale Submodule — Auto-Bump Required",
+    ]
+    for entry in stale:
+        lines.append(
+            f"- `{entry['path']}`: committed {entry['committed_sha']} → dev {entry['remote_sha']}"
+        )
+    lines.append(
+        "- Action: advance submodule(s) to dev tip and commit the bump into the current branch"
+    )
+    return "\n".join(lines)
+
+
 def build_dev_branch_with_changes_warning(changed_files: list[str]) -> str:
     lines = [
         "## Dev Branch with Changes",
@@ -484,6 +525,10 @@ def main() -> int:
     orphaned = has_orphaned_worktrees()
     if orphaned:
         sections.append(build_orphaned_worktrees_warning(orphaned))
+
+    stale_subs = has_stale_submodules()
+    if stale_subs:
+        sections.append(build_stale_submodule_warning(stale_subs))
 
     if len(sections) > 0:
         print("\n\n".join(sections))

--- a/skills/git-workflow/tasks/pr-creation/enforcement-gate.md
+++ b/skills/git-workflow/tasks/pr-creation/enforcement-gate.md
@@ -27,7 +27,13 @@ For each submodule entry:
 2. Get remote dev HEAD SHA: `git ls-remote <url> refs/heads/dev | awk '{print $1}'`
 3. Compare SHA:
    - Match → pass
-   - Mismatch → **BLOCK PR creation** — hard gate, no override
+   - Mismatch → **Auto-remediation path:**
+     1. Advance the submodule: `cd <path> && git fetch origin && git checkout origin/dev`
+     2. Read commit log between old and new SHA: `git log --oneline <old_sha>..<new_sha>`
+     3. Commit the bump into the current branch: `git add <path> && git commit -m "chore(submodule): pin <path> to latest dev"`
+     4. Re-check SHA comparison. If pass → PR creation proceeds.
+     5. If still fails (e.g., remote changed again): retry once more from step 1.
+     6. After retry failure → **BLOCK PR creation** with specific failure reason (which submodule, which SHAs).
 4. For `main`-branch PRs: verify SHA is a tagged release
 
 **There is NO `--force` override for submodule dependency gates.**

--- a/skills/git-workflow/tasks/pre-work.md
+++ b/skills/git-workflow/tasks/pre-work.md
@@ -187,6 +187,22 @@ test -f .gitmodules
 
 4. **Report status to chat:** Report each submodule's path, checked-out SHA, committed SHA, and dev tip SHA.
 
+5. **If any submodule SHA changed from the parent's committed ref**, auto-commit the submodule bump:
+
+   For each submodule whose checked-out SHA differs from the parent's committed SHA:
+   1. Read the commit log between old and new SHA:
+      ```bash
+      cd <submodule-path>
+      git log --oneline <old_sha>..<new_sha>
+      cd -
+      ```
+   2. Generate a summary commit message with the count and first-line summaries:
+      ```bash
+      git add <submodule-path>
+      git commit -m "chore(submodule): pin <path> to latest dev (N commits: summary)"
+      ```
+   3. Continue with normal pre-work flow.
+
 **If on `main` worktree:** Use `git submodule update --init` (no `--remote`) to lock submodules to their committed SHAs instead of advancing to dev tip.
 
 **If `.gitmodules` does NOT exist:** Skip all submodule steps and proceed to Step 4.

--- a/tests/behaviors/no-authorization-solicitation-pipeline-scope.sh
+++ b/tests/behaviors/no-authorization-solicitation-pipeline-scope.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+# Behavioral Enforcement Test: No Authorization Solicitation for Pipeline-Scoped Phrases
+#
+# Verifies that the agent does NOT solicit confirmation or clarification
+# after receiving unambiguous pipeline-scoped authorization phrases.
+# The verb-prefix parsing table is deterministic — there is no ambiguity.
+#
+# Co-authored with AI: <AgentName> (<ModelId>)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/helpers.sh"
+
+SCENARIO_NAME="no-authorization-solicitation-pipeline-scope"
+
+OVERALL_RESULT=0
+
+test_pipeline_phrase() {
+    local phrase="$1"
+    local test_label="$2"
+
+    echo "--- Testing phrase: $phrase ---"
+
+    behavior_run "${SCENARIO_NAME}-${test_label}" "$phrase"
+
+    assert_forbidden_pattern_absent "[Ss]hould I" "should I" || OVERALL_RESULT=1
+    assert_forbidden_pattern_absent "[Ss]hall I" "shall I" || OVERALL_RESULT=1
+    assert_forbidden_pattern_absent "proceed\?" "proceed?" || OVERALL_RESULT=1
+    assert_forbidden_pattern_absent "[Mm]ay I" "may I" || OVERALL_RESULT=1
+    assert_forbidden_pattern_absent "[Rr]eady to" "ready to" || OVERALL_RESULT=1
+    assert_forbidden_pattern_absent "[Hh]ow should" "how should" || OVERALL_RESULT=1
+}
+
+echo "=== Behavioral Test: $SCENARIO_NAME ==="
+
+test_pipeline_phrase "approved for pr: #1" "for-pr"
+test_pipeline_phrase "approved for plan: #1" "for-plan"
+test_pipeline_phrase "approved for implementation: #1" "for-implementation"
+test_pipeline_phrase "approved for spec: #1" "for-spec"
+
+echo ""
+if [ "$OVERALL_RESULT" -eq 0 ]; then
+    echo "PASS: $SCENARIO_NAME"
+else
+    echo "FAIL: $SCENARIO_NAME"
+fi
+
+exit $OVERALL_RESULT


### PR DESCRIPTION
## Summary

Batch implementation of 6 issues addressing session trigger behavior, authorization solicitation, submodule tracking, and agent intelligence improvements.

## Changes

| Issue | Type | Description |
|-------|------|-------------|
| #31 | fix | Replace trigger acknowledgment instruction in identity-echo directive with silent processing per `117-session-trigger-behavior.md` |
| #30 | bug | Parent bug of #31 — identity-echo directive contradicts no-echo rule |
| #29 | fix | Replace verbose `PROTECTED_BRANCH_EDIT_WARNING` with compact `SESSION_TRIGGERS` block that defers to behavior map |
| #28 | docs | Add submodule tracking rule (always track `dev`, never detached HEAD or `main`) to README and AGENTS.md |
| #35 | fix | Add critical violation section for soliciting authorization on already-authorized pipeline-scoped phrases + behavioral enforcement test |
| #34 | feat | Add `stale_submodule` session trigger, enhance pre-work and enforcement-gate for intelligent submodule pin-to-latest-dev |

## Outcome

- Session triggers now processed silently per behavior map — no more verbose developer-facing warnings in chat
- Identity-echo directive directs silent trigger processing instead of acknowledgment
- Pipeline-scoped authorization phrases (`approved for pr`, `approved for plan`, etc.) are parsed without solicitation
- Submodule staleness detected at session start and auto-remediated during pre-work and PR creation
- Submodule tracking rule documented in README and AGENTS.md

Fixes #28, Fixes #29, Fixes #30, Fixes #31, Fixes #34, Fixes #35

🤖 Co-authored with AI: OpenCode (ollama-cloud/glm-5.1)