### PR TITLE
Direct-branch primary workflow — make worktrees opt-in

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@ package-lock.json
 bun.lock
 tmp/
 .node/
+.worktrees/
 .gitignore

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,0 +1,28 @@
+<component name="InspectionProjectProfileManager">
+  <profile version="1.0">
+    <option name="myName" value="Project Default" />
+    <inspection_tool class="DuplicatedCode" enabled="true" level="WEAK WARNING" enabled_by_default="true">
+      <Languages>
+        <language minSize="107" name="Python" />
+      </Languages>
+    </inspection_tool>
+    <inspection_tool class="PyCompatibilityInspection" enabled="true" level="WARNING" enabled_by_default="true">
+      <option name="ourVersions">
+        <value>
+          <list size="2">
+            <item index="0" class="java.lang.String" itemvalue="3.11" />
+            <item index="1" class="java.lang.String" itemvalue="3.12" />
+          </list>
+        </value>
+      </option>
+    </inspection_tool>
+    <inspection_tool class="PyMissingTypeHintsInspection" enabled="true" level="WEAK WARNING" enabled_by_default="true" />
+    <inspection_tool class="PyPep8Inspection" enabled="true" level="WEAK WARNING" enabled_by_default="true">
+      <option name="ignoredErrors">
+        <list>
+          <option value="E712" />
+        </list>
+      </option>
+    </inspection_tool>
+  </profile>
+</component>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/.opencode" vcs="Git" />
+  </component>
+</project>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="AutoImportSettings">
+    <option name="autoReloadType" value="SELECTIVE" />
+  </component>
+  <component name="ChangeListManager">
+    <list default="true" id="6d547896-8b81-49ff-a3c1-95606af82da5" name="Changes" comment="">
+      <change beforePath="$PROJECT_DIR$/.opencode" beforeDir="false" afterPath="$PROJECT_DIR$/.opencode" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/.opencode/.issues/.counter" beforeDir="false" afterPath="$PROJECT_DIR$/.opencode/.issues/.counter" afterDir="false" />
+    </list>
+    <option name="SHOW_DIALOG" value="false" />
+    <option name="HIGHLIGHT_CONFLICTS" value="true" />
+    <option name="HIGHLIGHT_NON_ACTIVE_CHANGELIST" value="false" />
+    <option name="LAST_RESOLUTION" value="IGNORE" />
+  </component>
+  <component name="EmbeddingIndexingInfo">
+    <option name="fileBasedEmbeddingIndicesEnabled" value="true" />
+  </component>
+  <component name="Git.Settings">
+    <option name="RECENT_GIT_ROOT_PATH" value="$PROJECT_DIR$/.opencode" />
+  </component>
+  <component name="McpProjectServerCommands">
+    <commands />
+    <urls />
+  </component>
+  <component name="ProjectColorInfo">{
+  &quot;associatedIndex&quot;: 6,
+  &quot;fromUser&quot;: false
+}</component>
+  <component name="ProjectId" id="3Cr2KzNPhvolmWXjJ17pH27bTUr" />
+  <component name="ProjectViewState">
+    <option name="hideEmptyMiddlePackages" value="true" />
+    <option name="showLibraryContents" value="true" />
+    <option name="showMembers" value="true" />
+  </component>
+  <component name="PropertiesComponent">{
+  &quot;keyToString&quot;: {
+    &quot;ModuleVcsDetector.initialDetectionPerformed&quot;: &quot;true&quot;,
+    &quot;RunOnceActivity.MCP Project settings loaded&quot;: &quot;true&quot;,
+    &quot;RunOnceActivity.ShowReadmeOnStart&quot;: &quot;true&quot;,
+    &quot;RunOnceActivity.typescript.service.memoryLimit.init&quot;: &quot;true&quot;,
+    &quot;ai.playground.ignore.import.keys.banner.in.settings&quot;: &quot;true&quot;,
+    &quot;last_opened_file_path&quot;: &quot;/home/muksihs/git/opencode-config&quot;,
+    &quot;node.js.detected.package.eslint&quot;: &quot;true&quot;,
+    &quot;node.js.selected.package.eslint&quot;: &quot;(autodetect)&quot;,
+    &quot;nodejs_package_manager_path&quot;: &quot;npm&quot;,
+    &quot;settings.editor.selected.configurable&quot;: &quot;terminal&quot;,
+    &quot;vue.rearranger.settings.migration&quot;: &quot;true&quot;
+  }
+}</component>
+  <component name="RecapSpentCounter">
+    <option name="endsOfQuotaMs" value="1777399219695" />
+    <option name="spentUsd" value="0.027497552" />
+  </component>
+  <component name="RecapUselessUpdatesCounter">
+    <option name="suspendCountdown" value="2" />
+  </component>
+  <component name="SharedIndexes">
+    <attachedChunks>
+      <set>
+        <option value="bundled-js-predefined-d6986cc7102b-9b0f141eb926-JavaScript-PY-253.32098.74" />
+        <option value="bundled-python-sdk-1cd77e80b48f-6d6dccd035ac-com.jetbrains.pycharm.pro.sharedIndexes.bundled-PY-253.32098.74" />
+      </set>
+    </attachedChunks>
+  </component>
+  <component name="TaskManager">
+    <task active="true" id="Default" summary="Default task">
+      <changelist id="6d547896-8b81-49ff-a3c1-95606af82da5" name="Changes" comment="" />
+      <created>1757223119033</created>
+      <option name="number" value="Default" />
+      <option name="presentableId" value="Default" />
+      <updated>1757223119033</updated>
+      <workItem from="1777129310604" duration="1173000" />
+      <workItem from="1777130492295" duration="5361000" />
+      <workItem from="1777136759629" duration="2132000" />
+      <workItem from="1777140593338" duration="840000" />
+      <workItem from="1777142722037" duration="409000" />
+    </task>
+    <servers />
+  </component>
+  <component name="TerminalProjectNonSharedOptionsProvider">
+    <option name="startingDirectory" value="$USER_HOME$/Documents/Brothertown-Language" />
+  </component>
+  <component name="TypeScriptGeneratedFilesManager">
+    <option name="version" value="3" />
+  </component>
+</project>

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,6 +100,25 @@ Credential status values: `verified` (token exists + API ping succeeds), `presen
 
 ---
 
+## Direct-Branch Primary Workflow
+
+**Direct-branch is the PRIMARY and DEFAULT workflow.** Agent creates feature branch directly in main repo using `git checkout -b` or `git switch -c`. Worktrees are **opt-in**, created only when `WORKTREE_REQUIRED` flag is set or developer explicitly requests them.
+
+| Mode | When | Path Behavior |
+|------|------|---------------|
+| **Direct-branch (default)** | `WORKTREE_REQUIRED` NOT set | Relative paths work directly; `worktree.path` NOT set |
+| **Worktree (opt-in)** | `WORKTREE_REQUIRED` set or developer request | All paths prefixed with `worktree.path` |
+
+**Branch and submodule state model:** See `git-workflow` skill → Branch and Submodule State Model for the complete workflow including proactive repo state verification, mid-feature submodule currency, rebase-always hygiene, and post-merge integration.
+
+**Submodule discipline:**
+- Dev parking: `git checkout dev && git pull && git submodule init && git submodule foreach "git checkout dev && git pull"`
+- Mid-feature: Sync submodules to upstream `dev` periodically
+- Release: Lock submodule SHAs to current checkout state (NOT a fresh pull)
+- Hotfix: No submodule state changes; use pinned SHAs from `main`
+
+---
+
 ## Pair Mode
 
 When the current branch starts with `pair-`, the agent operates in **dev-pair mode**: working directly in the main project directory alongside the developer, using WIP-commit switching instead of worktrees.
@@ -108,8 +127,8 @@ When the current branch starts with `pair-`, the agent operates in **dev-pair mo
 |---|---|---|
 | `pair-feature/123-xyz` | Dev-pair | Main project dir |
 | `pair-spec/456-abc` | Dev-pair | Main project dir |
-| `feature/789-xyz` | Autonomous | `.worktrees/` |
-| `spec/789-abc` | Autonomous | `.worktrees/` |
+| `feature/789-xyz` | Autonomous | Main project dir (direct-branch) or `.worktrees/` (opt-in) |
+| `spec/789-abc` | Autonomous | Main project dir (direct-branch) or `.worktrees/` (opt-in) |
 
 Pair mode tasks: `pair-pre-work`, `pair-commit`, `pair-pr-creation`, `pair-cleanup`, `pair-mode-resume`. See `git-workflow` skill for full task documentation.
 


### PR DESCRIPTION
## Summary

Reverses the default workflow from mandatory worktrees to direct-branch in the main repo, making worktrees an opt-in mechanism activated by the `WORKTREE_REQUIRED` flag. This aligns enforcement with actual practice — most development happens on feature branches in the main checkout, and the worktree mandate was creating friction without proportional safety benefit.

## Outcome

Agents default to creating feature branches via `git checkout -b` in the main repo; worktrees are only created when `WORKTREE_REQUIRED` is set or the developer explicitly requests isolation. All related guidelines, skills, tasks, enforcement tests, and AGENTS.md updated to reflect the two-mode model.

Fixes #63

🤖 Co-authored with AI: OpenCode (ollama-cloud/glm-5.1)