### PR TITLE
feat(#44,#47,#48,#49,#77): P1 enforcement specs — provenance, formalization, null-baseline fix

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Michael Conrad
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/guidelines/000-critical-rules.md
+++ b/guidelines/000-critical-rules.md
@@ -830,7 +830,7 @@ Git remote and configuration mutations can silently redirect pushes, disable sec
 ### Enforcement Mechanisms (session-enforcement.ts)
 
 1. **Config Mutation Watchdog**: Captures baseline of `.git/config` and `git config --local --list` at session start; diffs after each assistant turn; injects `<GIT_CONFIG_MUTATION>` block if security-relevant keys changed.
-2. **`--no-verify` Detection**: Scans assistant message content for `--no-verify` in bash commands; injects `<NO_VERIFY_BLOCKED>` block if repo has remotes. Post-hoc commit audit checks git log for commits lacking session-enforcement signature.
+2. **`--no-verify` Detection**: Scans assistant message content for `--no-verify` in bash commands; injects `<NO_VERIFY_BLOCKED>` block if repo has remotes. **Null-baseline fallback**: When `gitConfigBaseline` is null (baseline capture failed at session start), performs an inline `git remote -v` check at detection time. If the inline check also fails, treats the repo as local-only (no remotes) and permits `--no-verify`. This ensures the local-only exemption works even when the baseline is unavailable. Post-hoc commit audit checks git log for commits lacking session-enforcement signature.
 3. **Baseline Snapshot**: `GitConfigBaseline` interface with `{ configHash, localConfigHash, remotes[], remoteCount, capturedAt }`; SHA-256 hash comparison with full diff on mismatch.
 
 **AUTHORITY: Issue #72**

--- a/guidelines/080-code-standards.md
+++ b/guidelines/080-code-standards.md
@@ -261,6 +261,64 @@ AI co-authored attribution:
 4. Helps identify AI-generated content for review
 5. **Respects copyright** - only claims co-authorship on genuinely original AI work
 
+## Provenance Headers
+
+### Provenance Distinct from Byline
+
+- **Byline** = *who* created it (identity attribution) — specified in §AI Co-Authored Attribution
+- **Provenance** = *how* it was created (origin category) — new concept
+
+### Provenance Categories
+
+| Category | Meaning | Header Value |
+|----------|---------|--------------|
+| AI-generated | Entirely written by AI agent | `Provenance: AI-generated` |
+| AI-assisted | Human wrote, AI assisted | `Provenance: AI-assisted` |
+| Human-written | Entirely human-authored | `Provenance: Human-written` |
+| Derived | Adapted from another source | `Provenance: Derived from <source>` |
+
+### Header Format by File Type
+
+#### Python Files (.py)
+
+```python
+# SPDX-FileCopyrightText: <year> <dev.name>
+# SPDX-License-Identifier: MIT
+# Provenance: AI-generated
+"""
+Module description.
+
+Co-authored with AI: <AgentName> (<ModelId>)
+"""
+```
+
+#### SKILL.md Files (YAML frontmatter)
+
+```yaml
+---
+name: skill-name
+license: MIT
+provenance: AI-generated
+---
+```
+
+#### Markdown Files (guidelines, docs)
+
+```markdown
+<!-- SPDX-FileCopyrightText: <year> <dev.name> -->
+<!-- SPDX-License-Identifier: MIT -->
+<!-- Provenance: AI-generated -->
+```
+
+### Provenance + Byline Rules
+
+| Provenance | AI Byline Required? |
+|------------|-------------------|
+| AI-generated | MUST include |
+| AI-assisted | SHOULD include if AI contributions substantive |
+| Human-written | MUST NOT include |
+| Derived | MUST NOT include AI byline; MUST attribute source |
+
 ## Enforcement Test Mandate for Guideline and Skill Changes
 
 Guideline files (`.opencode/guidelines/*.md`) and skill files (`.opencode/skills/*/SKILL.md`, `.opencode/skills/*/tasks/*.md`) are enforcement-critical documents that control AI agent behavior. Changes to these files MUST be accompanied by corresponding enforcement test updates.

--- a/plugins/session-enforcement.ts
+++ b/plugins/session-enforcement.ts
@@ -1484,7 +1484,24 @@ export default async function sessionEnforcementPlugin(input: PluginInput): Prom
       }
 
       // --- Per-turn: --no-verify detection ---
-      const hasRemotes = gitConfigBaseline ? gitConfigBaseline.remoteCount > 0 : true;
+      let hasRemotes: boolean;
+      if (gitConfigBaseline) {
+        hasRemotes = gitConfigBaseline.remoteCount > 0;
+      } else {
+        // Baseline capture failed — check remotes inline
+        try {
+          const remoteCheck = execSync("git remote -v", {
+            cwd: projectDir,
+            encoding: "utf8",
+            input: "",
+            timeout: 5000,
+            stdio: ["pipe", "pipe", "pipe"],
+          }).trim();
+          hasRemotes = remoteCheck.length > 0;
+        } catch {
+          hasRemotes = false; // No remotes = local-only → permit --no-verify
+        }
+      }
       for (const msg of assistantMessages) {
         if (!msg.parts?.length) continue;
         for (const part of msg.parts) {

--- a/skills/approval-gate/SKILL.md
+++ b/skills/approval-gate/SKILL.md
@@ -3,6 +3,7 @@ name: approval-gate
 description: Use when user says "approved", "go", or any implementation instruction, or when authorization needs verification. Triggers on: approval, authorized, implement, start work, go ahead, needs-approval label, authorization set, multiple issues approved, interdependency analysis.
 type: discipline-enforcing
 license: MIT
+provenance: AI-generated
 compatibility: opencode
 ---
 

--- a/skills/brainstorming/SKILL.md
+++ b/skills/brainstorming/SKILL.md
@@ -3,6 +3,7 @@ name: brainstorming
 description: Use when creating a spec, planning a feature, or exploring requirements before implementation. Triggers on: spec, plan, feature, brainstorm, explore, requirements, ideate, think through, what should.
 type: technique
 license: MIT
+provenance: AI-generated
 compatibility: opencode
 ---
 

--- a/skills/changelog-generator/SKILL.md
+++ b/skills/changelog-generator/SKILL.md
@@ -3,6 +3,7 @@ name: changelog-generator
 description: Use when creating release notes, documenting changes between versions, or preparing a changelog. Triggers on: changelog, release notes, what changed, version history, commit summary, release.
 type: technique
 license: MIT
+provenance: AI-generated
 compatibility: opencode
 ---
 

--- a/skills/code-size-enforcement/SKILL.md
+++ b/skills/code-size-enforcement/SKILL.md
@@ -3,6 +3,7 @@ name: code-size-enforcement
 description: Use when writing or modifying code and function length, file size, or cell size may exceed limits. Triggers on: long function, big file, too many lines, size limit, code size, function length, cell size.
 type: discipline-enforcing
 license: MIT
+provenance: AI-generated
 compatibility: opencode
 ---
 

--- a/skills/coherence-auditor/SKILL.md
+++ b/skills/coherence-auditor/SKILL.md
@@ -3,6 +3,7 @@ name: coherence-auditor
 description: Use when guidelines or skills are updated, to check consistency between rules and behavior. Triggers on: coherence, consistency, audit guidelines, skill extraction, drift detection, guideline update, skill update.
 type: discipline-enforcing
 license: MIT
+provenance: AI-generated
 compatibility: opencode
 ---
 

--- a/skills/coherence-auditor/SKILL.md
+++ b/skills/coherence-auditor/SKILL.md
@@ -155,3 +155,139 @@ GitHub Issue #316: Guidelines Audit: Extract Complex Workflows to Skills
 | After guideline update | maintenance |
 | After skill creation | maintenance |
 | Before major release | maintenance |
+
+```yaml+symbolic
+schema_version: "2.0"
+last_updated: "2026-04-26T00:00:00Z"
+rules:
+  - id: coherence-auditor-001
+    title: "Extraction scan requires valid guidelines directory"
+    conditions:
+      all:
+        - "guidelines_available == true"
+    actions:
+      - PROCEED
+    conflicts_with: []
+    requires: []
+    triggers: [skill-creator]
+    source: "coherence-auditor/SKILL.md"
+
+  - id: coherence-auditor-002
+    title: "Maintenance drift detection requires baseline"
+    conditions:
+      all:
+        - "guidelines_changed == true"
+        - "baseline_available == true"
+    actions:
+      - INVOKE(maintenance-detect)
+    conflicts_with: []
+    requires: []
+    triggers: []
+    source: "coherence-auditor/SKILL.md"
+
+tasks:
+  - id: extract-scan
+    skill: coherence-auditor
+    preconditions: ["guidelines_available == true"]
+    postconditions: ["extraction_complete == true"]
+    mandatory: true
+    bypass_violation: "CRITICAL: Skipping extraction scan"
+    source: "coherence-auditor/SKILL.md"
+
+  - id: extract-analyze
+    skill: coherence-auditor
+    preconditions: ["extraction_complete == true"]
+    postconditions: ["analysis_complete == true"]
+    mandatory: true
+    bypass_violation: "CRITICAL: Skipping extraction analysis"
+    source: "coherence-auditor/SKILL.md"
+
+  - id: maintenance-detect
+    skill: coherence-auditor
+    preconditions: ["guidelines_changed == true"]
+    postconditions: ["drift_detected == true OR no_drift == true"]
+    mandatory: true
+    bypass_violation: "CRITICAL: Skipping drift detection"
+    source: "coherence-auditor/SKILL.md"
+
+  - id: maintenance-verify
+    skill: coherence-auditor
+    preconditions: ["drift_detected == true"]
+    postconditions: ["drift_verified == true"]
+    mandatory: true
+    bypass_violation: "CRITICAL: Skipping drift verification"
+    source: "coherence-auditor/SKILL.md"
+
+  - id: create-report
+    skill: coherence-auditor
+    preconditions: ["any_state"]
+    postconditions: ["report_produced == true"]
+    mandatory: true
+    bypass_violation: "CRITICAL: Skipping report generation"
+    source: "coherence-auditor/SKILL.md"
+
+decomposition:
+  - type: skill-task
+    skill: spec-auditor
+    task: ground-truth
+    mandatory: true
+    bypass_violation: "CRITICAL: Skipping Ground-Truth Verification"
+    purpose: "Adversarial verification of drift findings against actual skill content"
+
+  - type: skill-task
+    skill: skill-creator
+    task: validate-skill
+    mandatory: true
+    bypass_violation: "WARNING: Skipping skill card validation"
+    purpose: "Validate candidate skills meet structural requirements"
+
+gates:
+  - id: guidelines-available
+    condition: "guidelines_available == true"
+    on_fail: "HALT"
+    critical_violation: true
+
+  - id: drift-genuine
+    condition: "drift_verified == true"
+    on_fail: "RECLASSIFY_AS_FALSE_POSITIVE"
+    critical_violation: false
+
+evidence_artifacts:
+  - name: drift_findings_table
+    type: structured_table
+    verification: "Each drift finding has pattern, location, severity, recommendation"
+
+  - name: cross_reference_verification
+    type: tool_call_artifact
+    verification: "Each cross-reference verified against actual skill content"
+
+state_machines:
+  - id: coherence-audit-session
+    states: [idle, scanning, analyzing, detecting, verifying, reporting, complete]
+    start_state: idle
+    transitions:
+      - from: idle
+        to: scanning
+        guard: "mode_selected == true"
+        action: INVOKE(extract-scan OR maintenance-detect)
+      - from: scanning
+        to: analyzing
+        guard: "scan_complete == true"
+        action: INVOKE(extract-analyze)
+      - from: analyzing
+        to: detecting
+        guard: "analysis_complete == true AND mode == 'maintenance'"
+        action: INVOKE(maintenance-detect)
+      - from: detecting
+        to: verifying
+        guard: "drift_detected == true"
+        action: INVOKE(maintenance-verify)
+      - from: verifying
+        to: reporting
+        guard: "verification_complete == true"
+        action: INVOKE(create-report)
+      - from: reporting
+        to: complete
+        guard: "report_produced == true"
+        action: PROCEED
+```

--- a/skills/concern-separation-auditor/SKILL.md
+++ b/skills/concern-separation-auditor/SKILL.md
@@ -3,6 +3,7 @@ name: concern-separation-auditor
 description: Use when auditing a spec for phase structure quality or concern separation. Triggers on: concern separation, phase structure, spec audit, mixed concerns.
 type: discipline-enforcing
 license: MIT
+provenance: AI-generated
 compatibility: opencode
 ---
 

--- a/skills/concern-separation-auditor/SKILL.md
+++ b/skills/concern-separation-auditor/SKILL.md
@@ -171,3 +171,108 @@ Co-authored with AI: <AgentName> (<ModelId>)
 Results are used as **evidence** (not verdict) — they supplement prose-only analysis with formal activation graph showing cross-concern dependencies.
 
 **Graceful degradation:** If the engine is unavailable or produces no results, fall back to prose-only analysis. Do NOT block the audit if the engine fails.
+
+```yaml+symbolic
+schema_version: "2.0"
+last_updated: "2026-04-26T00:00:00Z"
+rules:
+  - id: concern-separation-001
+    title: "Concern analysis must verify against actual code"
+    conditions:
+      all:
+        - "boundary_claim_made == true"
+        - "code_verification_performed == false"
+    actions:
+      - HALT
+      - VERIFY_AGAINST_CODE
+    conflicts_with: []
+    requires: []
+    triggers: []
+    source: "concern-separation-auditor/SKILL.md §Live Verification"
+
+tasks:
+  - id: audit-phases
+    skill: concern-separation-auditor
+    preconditions: ["plan_available == true"]
+    postconditions: ["phase_audit_complete == true"]
+    mandatory: true
+    bypass_violation: "CRITICAL: Skipping Phase Audit"
+    source: "concern-separation-auditor/SKILL.md"
+
+  - id: check-independence
+    skill: concern-separation-auditor
+    preconditions: ["phases_identified == true"]
+    postconditions: ["independence_checked == true"]
+    mandatory: true
+    bypass_violation: "CRITICAL: Skipping Independence Check"
+    source: "concern-separation-auditor/SKILL.md"
+
+  - id: concern-coverage
+    skill: concern-separation-auditor
+    preconditions: ["independence_checked == true"]
+    postconditions: ["coverage_checked == true"]
+    mandatory: true
+    bypass_violation: "CRITICAL: Skipping Concern Coverage Check"
+    source: "concern-separation-auditor/SKILL.md"
+
+decomposition:
+  - type: skill-task
+    skill: spec-auditor
+    task: ground-truth
+    mandatory: true
+    bypass_violation: "CRITICAL: Skipping Ground-Truth Verification"
+    purpose: "Adversarial verification of boundary claims against actual code"
+
+  - type: skill-task
+    skill: programming-principles
+    task: audit
+    mandatory: false
+    bypass_violation: "WARNING: Skipping Engineering Principle Audit"
+    purpose: "Check SoC and Blast Radius principle definitions"
+
+gates:
+  - id: code-verification-mandatory
+    condition: "boundary_claim_verified_against_code == true"
+    on_fail: "HALT AND VERIFY"
+    critical_violation: true
+
+  - id: independence-verified
+    condition: "independence_check_performed == true"
+    on_fail: "PERFORM_INDEPENDENCE_CHECK"
+    critical_violation: false
+
+evidence_artifacts:
+  - name: phase_structure_analysis
+    type: structured_table
+    verification: "Each phase has concern, deployment independence, risk profile, blast radius"
+
+  - name: boundary_verification
+    type: tool_call_artifact
+    verification: "Each boundary claim verified via srclight against actual code"
+
+  - name: coverage_findings
+    type: structured_table
+    verification: "Each sub-issue checked for scope match against plan phase"
+
+state_machines:
+  - id: concern-audit
+    states: [idle, analyzing, checking_independence, checking_coverage, complete]
+    start_state: idle
+    transitions:
+      - from: idle
+        to: analyzing
+        guard: "plan_available == true"
+        action: INVOKE(audit-phases)
+      - from: analyzing
+        to: checking_independence
+        guard: "phases_identified == true"
+        action: INVOKE(check-independence)
+      - from: checking_independence
+        to: checking_coverage
+        guard: "independence_checked == true"
+        action: INVOKE(concern-coverage)
+      - from: checking_coverage
+        to: complete
+        guard: "coverage_checked == true"
+        action: PROCEED
+```

--- a/skills/correspondence/SKILL.md
+++ b/skills/correspondence/SKILL.md
@@ -3,6 +3,7 @@ name: correspondence
 description: Use when drafting stakeholder emails, status updates, or external communications. Triggers on: email, correspondence, stakeholder email, status update, communication, draft email, reply, notification.
 type: discipline-enforcing
 license: MIT
+provenance: AI-generated
 compatibility: opencode
 ---
 

--- a/skills/divide-and-conquer/SKILL.md
+++ b/skills/divide-and-conquer/SKILL.md
@@ -3,6 +3,7 @@ name: divide-and-conquer
 description: Use when implementing an approved spec, orchestrating sub-agents, or when a task risks context window overflow. Triggers on: implement, build, orchestrate, context overflow, decompose, dispatch subagent, work execution.
 type: discipline-enforcing
 license: MIT
+provenance: AI-generated
 compatibility: opencode
 ---
 

--- a/skills/engineering-approach/SKILL.md
+++ b/skills/engineering-approach/SKILL.md
@@ -3,6 +3,7 @@ name: engineering-approach
 description: Use when implementing a spec, or when design, verification, and scope discipline are needed. Triggers on: implement, build, develop, engineering checklist, design before code, verify before complete.
 type: discipline-enforcing
 license: MIT
+provenance: AI-generated
 compatibility: opencode
 ---
 

--- a/skills/executing-plans/SKILL.md
+++ b/skills/executing-plans/SKILL.md
@@ -3,6 +3,7 @@ name: executing-plans
 description: Use when executing an approved plan step-by-step or moving through implementation gates sequentially. Triggers on: execute plan, next step, continue implementation, plan approved, start implementation.
 type: technique
 license: MIT
+provenance: AI-generated
 compatibility: opencode
 ---
 

--- a/skills/finishing-a-development-branch/SKILL.md
+++ b/skills/finishing-a-development-branch/SKILL.md
@@ -3,6 +3,7 @@ name: finishing-a-development-branch
 description: Use when implementation is complete and branch needs final checks before PR. Triggers on: done, finished, ready for PR, implementation complete, branch ready, push changes, final check.
 type: technique
 license: MIT
+provenance: AI-generated
 compatibility: opencode
 ---
 

--- a/skills/fragment-manager/SKILL.md
+++ b/skills/fragment-manager/SKILL.md
@@ -3,6 +3,7 @@ name: fragment-manager
 description: Use when managing duplicate content blocks (fragments) across guidelines or skills. Triggers on: fragment, duplicate content, sync content, content block, shared content, master copy, synchronize.
 type: technique
 license: MIT
+provenance: AI-generated
 compatibility: opencode
 ---
 

--- a/skills/git-workflow/SKILL.md
+++ b/skills/git-workflow/SKILL.md
@@ -3,6 +3,7 @@ name: git-workflow
 description: Use when creating a branch, committing changes, pushing work, or creating a PR. Also use when git rebase/merge produces conflicts — invoke conflict-resolution skill for classification. Also use when user says "check pr" or "check prs" to trigger PR state verification and cleanup if merged. Also use when user says "release PR", "promote to main", or "dev to main" — invokes release-promotion task for dev → main promotion. Triggers on: branch, commit, push, PR, pull request, pre-work, review-prep, feature branch, dev branch, squash, conflict, merge conflict, rebase conflict, check pr, check prs, check pull request, check pull requests, release PR, release pr, promote to main, dev to main, release promotion.
 type: discipline-enforcing
 license: MIT
+provenance: AI-generated
 compatibility: opencode
 ---
 

--- a/skills/guideline-auditor/SKILL.md
+++ b/skills/guideline-auditor/SKILL.md
@@ -3,6 +3,7 @@ name: guideline-auditor
 description: Use when checking guideline files for ambiguity, conflicts, or LLM compliance issues. Triggers on: audit guidelines, guideline quality, guideline conflict, ambiguous rule, LLM compliance.
 type: discipline-enforcing
 license: MIT
+provenance: AI-generated
 compatibility: opencode
 ---
 

--- a/skills/issue-operations/SKILL.md
+++ b/skills/issue-operations/SKILL.md
@@ -3,6 +3,7 @@ name: issue-operations
 description: Use when creating, commenting on, or closing GitHub Issues. Routes to GitHub MCP or GitBucket API based on github.platform. Triggers on: create issue, new issue, spec creation, submit issue, issue, bug report, comment, progress update, issue comment, PR comment, post to GitHub, byline, status indicator, sub-issue, phase issue, multi-task, create sub issue, link issue, task breakdown, subtask, parent issue, close issue, verify merge.
 type: technique
 license: MIT
+provenance: AI-generated
 compatibility: opencode
 ---
 

--- a/skills/issue-operations/platforms/gitbucket-api/SKILL.md
+++ b/skills/issue-operations/platforms/gitbucket-api/SKILL.md
@@ -3,6 +3,7 @@ name: gitbucket-api
 description: GitBucket platform sub-skill for issue-operations. Provides capability manifest and Python client for GitBucket API operations.
 type: reference
 license: MIT
+provenance: AI-generated
 compatibility: opencode
 ---
 

--- a/skills/issue-operations/platforms/github-mcp/SKILL.md
+++ b/skills/issue-operations/platforms/github-mcp/SKILL.md
@@ -3,6 +3,7 @@ name: github-mcp
 description: GitHub MCP platform sub-skill for issue-operations. Provides capability manifest and thin wrappers around github_* MCP tools.
 type: reference
 license: MIT
+provenance: AI-generated
 compatibility: opencode
 ---
 

--- a/skills/issue-operations/platforms/local/SKILL.md
+++ b/skills/issue-operations/platforms/local/SKILL.md
@@ -3,6 +3,7 @@ name: local
 description: Local .issues/ directory platform for issue tracking. Used when github.platform is local or unset. Routes all issue operations to .issues/ directory with YAML frontmatter and markdown files.
 type: technique
 license: MIT
+provenance: AI-generated
 compatibility: opencode
 ---
 

--- a/skills/issue-review/SKILL.md
+++ b/skills/issue-review/SKILL.md
@@ -3,6 +3,7 @@ name: issue-review
 description: Use when reviewing a GitHub issue for comments, audits, or Q/A. Triggers on: review issue, review spec, check issue, issue review, audit issue.
 type: orchestrator
 license: MIT
+provenance: AI-generated
 compatibility: opencode
 ---
 

--- a/skills/mcp-tool-usage/SKILL.md
+++ b/skills/mcp-tool-usage/SKILL.md
@@ -3,6 +3,7 @@ name: mcp-tool-usage
 description: Use when selecting tools for file operations, code search, or any task that could use multiple tool options. Triggers on: which tool, tool priority, MCP, PyCharm, JetBrains, read file, write file, search code, tool selection.
 type: reference
 license: MIT
+provenance: AI-generated
 compatibility: opencode
 ---
 

--- a/skills/multimodal-dispatch/SKILL.md
+++ b/skills/multimodal-dispatch/SKILL.md
@@ -3,6 +3,7 @@ name: multimodal-dispatch
 description: Use when routing AI agent tasks to appropriate models based on content modality, probing Ollama model capabilities, or dispatching sub-agents with modality-aware model selection. Triggers on: multimodal dispatch, modality routing, capability probe, model selection, sub-agent dispatch, content modality, vision task, audio task.
 type: routing
 license: Apache-2.0
+provenance: AI-generated
 compatibility: opencode
 ---
 

--- a/skills/notebook-operations/SKILL.md
+++ b/skills/notebook-operations/SKILL.md
@@ -3,6 +3,7 @@ name: notebook-operations
 description: Use when working with .ipynb Jupyter notebook files for reading, writing, or executing cells. Triggers on: notebook, ipynb, Jupyter, cell, execute cell, kernel, zero tolerance, forbidden operations.
 type: discipline-enforcing
 license: MIT
+provenance: AI-generated
 compatibility: opencode
 ---
 

--- a/skills/plan-fidelity-auditor/SKILL.md
+++ b/skills/plan-fidelity-auditor/SKILL.md
@@ -194,3 +194,138 @@ Action: [auto-fix|conditional|flag-for-review]
 - Related guidelines: `065-verification-honesty.md` (metadata verification extension)
 
 Co-authored with AI: <AgentName> (<ModelId>)
+
+```yaml+symbolic
+schema_version: "2.0"
+last_updated: "2026-04-26T00:00:00Z"
+rules:
+  - id: plan-fidelity-001
+    title: "Clean-room input must not contain existing plan details"
+    conditions:
+      all:
+        - "clean_room_input_leaks_plan == true"
+    actions:
+      - REGENERATE_INPUT
+    conflicts_with: []
+    requires: []
+    triggers: []
+    source: "plan-fidelity-auditor/SKILL.md §Clean-Room Input Isolation"
+
+  - id: plan-fidelity-002
+    title: "Significant gaps must recommend brainstorming"
+    conditions:
+      all:
+        - "gap_severity == 'HIGH'"
+        - "gap_type == 'fundamental_misunderstanding'"
+    actions:
+      - RECOMMEND_BRAINSTORMING
+    conflicts_with: []
+    requires: []
+    triggers: [brainstorming]
+    source: "plan-fidelity-auditor/SKILL.md"
+
+tasks:
+  - id: audit
+    skill: plan-fidelity-auditor
+    preconditions: ["spec_and_plan_available == true"]
+    postconditions: ["fidelity_audit_complete == true"]
+    mandatory: true
+    bypass_violation: "CRITICAL: Skipping Plan Fidelity Audit"
+    source: "plan-fidelity-auditor/SKILL.md"
+
+  - id: compare
+    skill: plan-fidelity-auditor
+    preconditions: ["clean_room_generated == true"]
+    postconditions: ["comparison_complete == true"]
+    mandatory: true
+    bypass_violation: "CRITICAL: Skipping Clean-Room Comparison"
+    source: "plan-fidelity-auditor/SKILL.md"
+
+  - id: report
+    skill: plan-fidelity-auditor
+    preconditions: ["comparison_complete == true"]
+    postconditions: ["report_produced == true"]
+    mandatory: true
+    bypass_violation: "CRITICAL: Skipping Fidelity Report"
+    source: "plan-fidelity-auditor/SKILL.md"
+
+  - id: sub-issue-fidelity
+    skill: plan-fidelity-auditor
+    preconditions: ["plan_has_sub_issues == true"]
+    postconditions: ["sub_issue_fidelity_checked == true"]
+    mandatory: true
+    bypass_violation: "CRITICAL: Skipping Sub-Issue Fidelity Check"
+    source: "plan-fidelity-auditor/SKILL.md"
+
+decomposition:
+  - type: skill-task
+    skill: spec-auditor
+    task: ground-truth
+    mandatory: true
+    bypass_violation: "CRITICAL: Skipping Ground-Truth Verification"
+    purpose: "Adversarial verification of code references and metadata claims"
+
+  - type: skill-task
+    skill: writing-plans
+    task: clean-room
+    mandatory: true
+    bypass_violation: "CRITICAL: Skipping Clean-Room Generation"
+    purpose: "Generate clean-room plan from spec for comparison"
+
+  - type: skill-task
+    skill: brainstorming
+    task: explore
+    mandatory: false
+    bypass_violation: "WARNING: Skipping brainstorming recommendation for significant gaps"
+    purpose: "Deeper exploration recommended for fundamental gaps"
+
+gates:
+  - id: clean-room-isolation
+    condition: "clean_room_input_excludes_plan == true"
+    on_fail: "REGENERATE"
+    critical_violation: true
+
+  - id: semantic-matching-before-report
+    condition: "semantic_matching_performed == true"
+    on_fail: "PERFORM_MATCHING"
+    critical_violation: false
+
+evidence_artifacts:
+  - name: clean_room_input
+    type: file
+    verification: "./tmp/clean-room-input-N.md exists and excludes plan details"
+
+  - name: comparison_findings
+    type: structured_table
+    verification: "Each finding has level (phase/step/content), description, recommendation"
+
+  - name: sub_issue_alignment
+    type: structured_table
+    verification: "Each sub-issue checked against plan phase content"
+
+state_machines:
+  - id: fidelity-audit
+    states: [idle, extracting, generating, comparing, reporting, complete]
+    start_state: idle
+    transitions:
+      - from: idle
+        to: extracting
+        guard: "spec_available == true"
+        action: EXTRACT_PROBLEM_STATEMENT
+      - from: extracting
+        to: generating
+        guard: "input_isolated == true"
+        action: INVOKE(writing-plans/clean-room)
+      - from: generating
+        to: comparing
+        guard: "clean_room_generated == true"
+        action: INVOKE(compare)
+      - from: comparing
+        to: reporting
+        guard: "comparison_complete == true"
+        action: INVOKE(report)
+      - from: reporting
+        to: complete
+        guard: "report_produced == true"
+        action: PROCEED
+```

--- a/skills/plan-fidelity-auditor/SKILL.md
+++ b/skills/plan-fidelity-auditor/SKILL.md
@@ -3,6 +3,7 @@ name: plan-fidelity-auditor
 description: Use when auditing a plan for fidelity against a spec. Triggers on: plan fidelity, plan audit, spec vs plan, discrepancy, clean-room plan.
 type: discipline-enforcing
 license: MIT
+provenance: AI-generated
 compatibility: opencode
 ---
 

--- a/skills/pr-creation-workflow/SKILL.md
+++ b/skills/pr-creation-workflow/SKILL.md
@@ -3,6 +3,7 @@ name: pr-creation-workflow
 description: Use when asking about when to create a PR or whether PR creation is authorized. Triggers on: create PR, make PR, pull request, PR timing, when to PR, PR authorized. This skill covers feature branch PRs targeting dev only. Release PRs (dev → main promotion) are handled by git-workflow --task release-promotion. Do NOT invoke this skill for release promotion requests.
 type: technique
 license: MIT
+provenance: AI-generated
 compatibility: opencode
 ---
 

--- a/skills/programming-principles/SKILL.md
+++ b/skills/programming-principles/SKILL.md
@@ -3,6 +3,7 @@ name: programming-principles
 description: Use when designing functions, classes, or modules; writing or reviewing implementation code; making architecture decisions; or evaluating tradeoffs between competing approaches. Triggers on: design, implement, refactor, architecture, tradeoff, principle, KISS, DRY, SRP, coupling, cohesion, YAGNI.
 type: pattern
 license: MIT
+provenance: AI-generated
 compatibility: opencode
 ---
 

--- a/skills/receiving-code-review/SKILL.md
+++ b/skills/receiving-code-review/SKILL.md
@@ -3,6 +3,7 @@ name: receiving-code-review
 description: Use when receiving code review feedback on a PR, or when addressing review comments. Triggers on: code review, PR feedback, review comment, address feedback, fix review, respond to review.
 type: technique
 license: MIT
+provenance: AI-generated
 compatibility: opencode
 ---
 

--- a/skills/requesting-code-review/SKILL.md
+++ b/skills/requesting-code-review/SKILL.md
@@ -3,6 +3,7 @@ name: requesting-code-review
 description: Use when preparing a PR for code review, or when reviewer context and documentation are needed. Triggers on: request review, code review, review request, ready for review, review preparation.
 type: technique
 license: MIT
+provenance: AI-generated
 compatibility: opencode
 ---
 

--- a/skills/research/SKILL.md
+++ b/skills/research/SKILL.md
@@ -3,6 +3,7 @@ name: research
 description: Use when discovering information using appropriate modalities, producing findings with source attribution and explicit gap reporting. Triggers on: research, discover, investigate, find information, multimodal research, information discovery.
 type: research
 license: Apache-2.0
+provenance: AI-generated
 compatibility: opencode
 ---
 

--- a/skills/skill-creator/SKILL.md
+++ b/skills/skill-creator/SKILL.md
@@ -2,6 +2,7 @@
 name: skill-creator
 description: Use when creating a new skill, updating an existing skill, or validating skill cards. Triggers on: new skill, update skill, create skill, skill template, skill structure, SKILL.md, validate skill cards, review skills, skill card review.
 license: Apache-2.0
+provenance: AI-generated
 compatibility: opencode
 type: technique
 ---

--- a/skills/skill-creator/scripts/init_skill.py
+++ b/skills/skill-creator/scripts/init_skill.py
@@ -21,6 +21,8 @@ from pathlib import Path
 SKILL_TEMPLATE = """---
 name: {skill_name}
 description: [TODO: Complete and informative explanation of what the skill does and when to use it. Include WHEN to use this skill - specific scenarios, file types, or tasks that trigger it.]
+license: MIT
+provenance: AI-generated
 ---
 
 # {skill_title}

--- a/skills/skill-creator/scripts/validate_skill_cards.py
+++ b/skills/skill-creator/scripts/validate_skill_cards.py
@@ -10,6 +10,7 @@ Validates SKILL.md files per spec #1124:
   REQ-1: Frontmatter validation (name, description, type, license, compatibility)
   REQ-2: Placeholder enforcement (no hardcoded identity values)
   REQ-3: Worktree Mode section requirement for skills with bash/git/file ops
+  REQ-4: Provenance field validation
 
 Usage:
     uv run .opencode/skills/skill-creator/scripts/validate_skill_cards.py           # validate
@@ -25,6 +26,7 @@ from pathlib import Path
 from typing import NamedTuple
 
 VALID_TYPES = {"discipline-enforcing", "technique", "pattern", "reference", "orchestrator"}
+VALID_PROVENANCE = {"AI-generated", "AI-assisted", "Human-written", "Derived"}
 HARDCODED_AGENT_NAMES = re.compile(r"\bOpenCode\b|\bClaude\b|\bCopilot\b|\bGemini\b|\bGPT-4\b")
 HARDCODED_MODEL_IDS = re.compile(
     r"\bollama-cloud/[a-z0-9._-]+\b"
@@ -180,6 +182,24 @@ def validate_req3(name: str, body: str, file_path: str) -> list[Violation]:
     return violations
 
 
+def validate_req4(name: str, fields: dict[str, str], file_path: str) -> list[Violation]:
+    violations: list[Violation] = []
+    if "provenance" not in fields:
+        violations.append(Violation("REQ-4", name, "provenance", "Missing 'provenance' field", file_path=file_path))
+    elif fields["provenance"] not in VALID_PROVENANCE:
+        violations.append(
+            Violation(
+                "REQ-4",
+                name,
+                "provenance",
+                f"provenance must be one of: {', '.join(sorted(VALID_PROVENANCE))}",
+                fields["provenance"],
+                file_path=file_path,
+            )
+        )
+    return violations
+
+
 def validate_card(card_path: Path, root: Path) -> list[Violation]:
     name = skill_name_from_path(card_path.relative_to(root))
     rel_path = str(card_path.relative_to(root))
@@ -195,6 +215,7 @@ def validate_card(card_path: Path, root: Path) -> list[Violation]:
     violations.extend(validate_req1(name, fields, fm_text, rel_path))
     violations.extend(validate_req2(name, content, rel_path))
     violations.extend(validate_req3(name, body, rel_path))
+    violations.extend(validate_req4(name, fields, rel_path))
     return violations
 
 

--- a/skills/spec-auditor/SKILL.md
+++ b/skills/spec-auditor/SKILL.md
@@ -3,6 +3,7 @@ name: spec-auditor
 description: Use when auditing a spec for quality, structure, or completeness. Triggers on: audit spec, review spec, spec quality, validate spec, check spec, audit issue, revisit spec, audit plan, audit runbook, audit SOP, audit checklist, audit document, content-aware audit.
 type: discipline-enforcing
 license: MIT
+provenance: AI-generated
 compatibility: opencode
 ---
 

--- a/skills/spec-auditor/SKILL.md
+++ b/skills/spec-auditor/SKILL.md
@@ -688,3 +688,301 @@ sys.modules["symstates"] = mod
 exec(compile(source, str(impl_dir / "sym-states"), "exec"), mod.__dict__)
 anomalies = mod.validate_state_machines(state_machines, rules)
 ```
+
+```yaml+symbolic
+schema_version: "2.0"
+last_updated: "2026-04-26T00:00:00Z"
+rules:
+  - id: spec-auditor-001
+    title: "Spec audit is mandatory for all new specs"
+    conditions:
+      all:
+        - "spec_created == true"
+        - "audit_invoked == false"
+    actions:
+      - HALT
+    conflicts_with: []
+    requires: []
+    triggers: [spec-creation, issue-operations]
+    source: "spec-auditor/SKILL.md §Mandatory Invocation"
+
+  - id: spec-auditor-002
+    title: "Auto-fix findings applied directly without authorization"
+    conditions:
+      all:
+        - "finding_classification == 'auto-fix'"
+        - "fix_targets_github_issue_body == true"
+        - "fix_is_non_substantive == true"
+    actions:
+      - APPLY_FIX
+      - REPORT_IN_EXECUTIVE_SUMMARY
+    conflicts_with: [approval-gate-001]
+    requires: []
+    triggers: []
+    source: "spec-auditor/SKILL.md §Auto-Fix Model"
+
+  - id: spec-auditor-003
+    title: "Conditional findings require authorization before application"
+    conditions:
+      all:
+        - "finding_classification == 'conditional'"
+    actions:
+      - SAFETY_CHECK
+      - APPLY_IF_SAFE
+      - ESCALATE_IF_UNSAFE
+    conflicts_with: []
+    requires: []
+    triggers: []
+    source: "spec-auditor/SKILL.md §Auto-Fix Model"
+
+  - id: spec-auditor-004
+    title: "Flag-for-review findings are never applied"
+    conditions:
+      all:
+        - "finding_classification == 'flag-for-review'"
+    actions:
+      - REPORT_IN_EXECUTIVE_SUMMARY_ONLY
+      - DO_NOT_APPLY
+    conflicts_with: []
+    requires: []
+    triggers: []
+    source: "spec-auditor/SKILL.md §Auto-Fix Model"
+
+  - id: spec-auditor-005
+    title: "Body preservation gate prevents issue body erasure"
+    conditions:
+      all:
+        - "new_body_length < 0.8 * original_body_length"
+    actions:
+      - HALT
+      - REPORT_ERASURE_RISK
+    conflicts_with: []
+    requires: []
+    triggers: []
+    source: "spec-auditor/SKILL.md §Body-Preservation Safeguard"
+
+  - id: spec-auditor-006
+    title: "Ground-truth verification is mandatory for all audits"
+    conditions:
+      all:
+        - "audit_requested == true"
+    actions:
+      - INVOKE(ground-truth)
+    conflicts_with: []
+    requires: []
+    triggers: []
+    source: "spec-auditor/SKILL.md §ground-truth task"
+
+  - id: spec-auditor-007
+    title: "Executive summary posted to chat after every audit"
+    conditions:
+      all:
+        - "audit_session_complete == true"
+    actions:
+      - POST_EXECUTIVE_SUMMARY_TO_CHAT
+    conflicts_with: []
+    requires: []
+    triggers: []
+    source: "spec-auditor/SKILL.md §Chat Executive Summary"
+
+tasks:
+  - id: fresh-start
+    skill: spec-auditor
+    preconditions: ["spec_issue_exists == true"]
+    postconditions: ["self_containment_checked == true"]
+    mandatory: true
+    bypass_violation: "CRITICAL: Skipping fresh-start checks"
+    source: "spec-auditor/SKILL.md"
+
+  - id: structure
+    skill: spec-auditor
+    preconditions: ["fresh_start_complete == true"]
+    postconditions: ["structural_audit_complete == true"]
+    mandatory: true
+    bypass_violation: "CRITICAL: Skipping structure audit"
+    source: "spec-auditor/SKILL.md"
+
+  - id: content-quality
+    skill: spec-auditor
+    preconditions: ["structural_audit_complete == true"]
+    postconditions: ["content_audit_complete == true"]
+    mandatory: false
+    bypass_violation: "WARNING: Skipping content quality audit"
+    source: "spec-auditor/SKILL.md"
+
+  - id: traceability
+    skill: spec-auditor
+    preconditions: ["structural_audit_complete == true"]
+    postconditions: ["trace_audit_complete == true"]
+    mandatory: false
+    bypass_violation: "WARNING: Skipping traceability audit"
+    source: "spec-auditor/SKILL.md"
+
+  - id: operational
+    skill: spec-auditor
+    preconditions: ["structural_audit_complete == true"]
+    postconditions: ["operational_audit_complete == true"]
+    mandatory: false
+    bypass_violation: "WARNING: Skipping operational audit"
+    source: "spec-auditor/SKILL.md"
+
+  - id: fidelity
+    skill: spec-auditor
+    preconditions: ["document_type == 'spec'"]
+    postconditions: ["fidelity_audit_complete == true"]
+    mandatory: true
+    bypass_violation: "CRITICAL: Skipping fidelity audit for spec documents"
+    source: "spec-auditor/SKILL.md"
+
+  - id: concerns
+    skill: spec-auditor
+    preconditions: ["structural_audit_complete == true"]
+    postconditions: ["concern_audit_complete == true"]
+    mandatory: false
+    bypass_violation: "WARNING: Skipping concern separation audit"
+    source: "spec-auditor/SKILL.md"
+
+  - id: ground-truth
+    skill: spec-auditor
+    preconditions: ["spec_content_available == true"]
+    postconditions: ["ground_truth_established == true"]
+    mandatory: true
+    bypass_violation: "CRITICAL: Skipping Ground-Truth Verification"
+    source: "spec-auditor/SKILL.md"
+
+  - id: sc-precision
+    skill: spec-auditor
+    preconditions: ["document_type == 'spec'"]
+    postconditions: ["sc_precision_audit_complete == true"]
+    mandatory: true
+    bypass_violation: "CRITICAL: Skipping SC precision audit for spec documents"
+    source: "spec-auditor/SKILL.md"
+
+  - id: completion
+    skill: spec-auditor
+    preconditions: ["any_state"]
+    postconditions: ["completion_tasks_executed == true"]
+    mandatory: true
+    bypass_violation: "CRITICAL: Skipping Completion Guarantee on Workflow Halt"
+    source: "spec-auditor/SKILL.md"
+
+decomposition:
+  - type: skill-task
+    skill: spec-auditor
+    task: ground-truth
+    mandatory: true
+    bypass_violation: "CRITICAL: Skipping Ground-Truth Verification"
+    purpose: "Adversarial verification of metadata claims against direct evidence"
+
+  - type: skill-task
+    skill: plan-fidelity-auditor
+    task: compare
+    mandatory: true
+    bypass_violation: "CRITICAL: Skipping Plan Fidelity Comparison"
+    purpose: "Clean-room plan comparison for fidelity subtask"
+
+  - type: skill-task
+    skill: concern-separation-auditor
+    task: audit-phases
+    mandatory: true
+    bypass_violation: "CRITICAL: Skipping Concern Separation Audit"
+    purpose: "Phase independence and concern boundary verification"
+
+  - type: skill-task
+    skill: verification-enforcement
+    task: verify
+    mandatory: true
+    bypass_violation: "CRITICAL: Skipping Verification-Enforcement During Content Generation"
+    purpose: "Verify all claims in audit findings before generating reports"
+
+  - type: skill-task
+    skill: programming-principles
+    task: audit
+    mandatory: true
+    bypass_violation: "WARNING: Skipping Engineering Principle Audit"
+    purpose: "Check for principle violations without documented tradeoffs"
+
+gates:
+  - id: auto-fix-eligible
+    condition: "finding_classification == 'auto-fix' AND fix_targets_issue_body == true AND fix_is_non_substantive == true"
+    on_fail: "RECLASSIFY"
+    critical_violation: false
+
+  - id: conditional-safety-check
+    condition: "finding_classification == 'conditional' AND safety_check_passed == true"
+    on_fail: "ESCALATE_TO_FLAG_FOR_REVIEW"
+    critical_violation: false
+
+  - id: body-preservation
+    condition: "new_body_length >= 0.8 * original_body_length"
+    on_fail: "HALT"
+    critical_violation: true
+
+  - id: ground-truth-mandatory
+    condition: "ground_truth_invoked == true"
+    on_fail: "HALT"
+    critical_violation: true
+
+evidence_artifacts:
+  - name: audit_findings_table
+    type: structured_table
+    verification: "Each finding has Subtask, Problem Class, Location, Classification, Fix Action, Severity"
+
+  - name: auto_fix_verification
+    type: re-read_confirmation
+    verification: "Re-read of issue body confirms all auto-fixes applied"
+
+  - name: body_length_check
+    type: comparison
+    verification: "len(new_body) >= 0.8 * len(original_body)"
+
+  - name: ground_truth_evidence
+    type: tool_call_artifact
+    verification: "Each metadata claim verified via tool call against actual state"
+
+  - name: executive_summary_posted
+    type: chat_output
+    verification: "Executive summary present in chat with all required fields"
+
+state_machines:
+  - id: audit-session
+    states: [idle, type_detected, baseline_running, conditional_running, findings_classified, auto_fixes_applied, conditional_applied, report_generated, complete]
+    start_state: idle
+    transitions:
+      - from: idle
+        to: type_detected
+        guard: "source_input_valid == true"
+        action: DETECT_DOCUMENT_TYPE
+      - from: type_detected
+        to: baseline_running
+        guard: "document_type_determined == true"
+        action: RUN_BASELINE_SUBTASKS
+      - from: baseline_running
+        to: conditional_running
+        guard: "baseline_complete == true"
+        action: RUN_CONDITIONAL_SUBTASKS
+      - from: conditional_running
+        to: findings_classified
+        guard: "all_subtasks_complete == true"
+        action: CLASSIFY_FINDINGS
+      - from: findings_classified
+        to: auto_fixes_applied
+        guard: "auto_fix_findings_exist == true"
+        action: APPLY_AUTO_FIXES
+      - from: findings_classified
+        to: conditional_applied
+        guard: "conditional_findings_exist == true AND auto_fixes_applied == true"
+        action: APPLY_CONDITIONAL_FIXES
+      - from: auto_fixes_applied
+        to: report_generated
+        guard: "all_fixes_verified == true"
+        action: GENERATE_EXECUTIVE_SUMMARY
+      - from: conditional_applied
+        to: report_generated
+        guard: "all_fixes_verified == true"
+        action: GENERATE_EXECUTIVE_SUMMARY
+      - from: report_generated
+        to: complete
+        guard: "executive_summary_posted == true"
+        action: PROCEED
+```

--- a/skills/spec-creation/SKILL.md
+++ b/skills/spec-creation/SKILL.md
@@ -3,6 +3,7 @@ name: spec-creation
 description: Use when creating a spec or writing a specification. Triggers on: create spec, write spec, spec creation, spec writing, structure spec, specification.
 type: technique
 license: MIT
+provenance: AI-generated
 compatibility: opencode
 ---
 

--- a/skills/sre-runbook/SKILL.md
+++ b/skills/sre-runbook/SKILL.md
@@ -3,6 +3,7 @@ name: sre-runbook
 description: Use when generating operational runbooks for infrastructure incidents or procedures. Triggers on: runbook, SRE, on-call, incident, outage, escalation, playbook, procedure, operation, diagnose, troubleshoot, debug
 type: discipline-enforcing
 license: MIT
+provenance: AI-generated
 compatibility: opencode
 ---
 

--- a/skills/sync-guidelines/SKILL.md
+++ b/skills/sync-guidelines/SKILL.md
@@ -3,6 +3,7 @@ name: sync-guidelines
 description: Use when synchronizing guidelines, skills, or tools between repositories. Triggers on: sync guidelines, cross-repo sync, guideline update, skill update, multi-repo, consistency between repos.
 type: technique
 license: MIT
+provenance: AI-generated
 compatibility: opencode
 ---
 

--- a/skills/systematic-debugging/SKILL.md
+++ b/skills/systematic-debugging/SKILL.md
@@ -3,6 +3,7 @@ name: systematic-debugging
 description: Use when encountering a bug, error, or unexpected behavior, or before making code changes to fix an issue. Triggers on: bug, error, fix, debug, diagnose, crash, failure, unexpected behavior, vibe debugging.
 type: discipline-enforcing
 license: MIT
+provenance: AI-generated
 compatibility: opencode
 ---
 

--- a/skills/test-driven-development/SKILL.md
+++ b/skills/test-driven-development/SKILL.md
@@ -3,6 +3,7 @@ name: test-driven-development
 description: Use when writing tests before implementation, or when adopting a test-first development approach. Triggers on: TDD, test first, red green refactor, write test, test-driven, unit test, regression.
 type: discipline-enforcing
 license: MIT
+provenance: AI-generated
 compatibility: opencode
 ---
 

--- a/skills/ui-design/SKILL.md
+++ b/skills/ui-design/SKILL.md
@@ -3,6 +3,7 @@ name: ui-design
 description: Use when designing UI wireframes, mockups, interaction specs, or visual artifacts. Triggers on: ui design, wireframe, mockup, interaction spec, visual layout, UI mock, screenshot capture, sidebar navigation, page layout.
 type: technique
 license: MIT
+provenance: AI-generated
 compatibility: opencode
 ---
 

--- a/skills/ui-engineer/SKILL.md
+++ b/skills/ui-engineer/SKILL.md
@@ -3,6 +3,7 @@ name: ui-engineer
 description: Use when implementing UI from design artifacts, producing framework-specific code. Triggers on: implement UI, UI implementation, UI code, frontend code, Streamlit component, framework implementation, build page, create view.
 type: technique
 license: MIT
+provenance: AI-generated
 compatibility: opencode
 ---
 

--- a/skills/using-git-worktrees/SKILL.md
+++ b/skills/using-git-worktrees/SKILL.md
@@ -3,6 +3,7 @@ name: using-git-worktrees
 description: Use when creating a feature branch or worktree for implementation. Always invoke before git-workflow pre-work. Triggers on: branch, worktree, feature branch, create worktree, pre-work, worktree.path.
 type: discipline-enforcing
 license: MIT
+provenance: AI-generated
 ---
 
 # Skill: using-git-worktrees

--- a/skills/verification-before-completion/SKILL.md
+++ b/skills/verification-before-completion/SKILL.md
@@ -3,6 +3,7 @@ name: verification-before-completion
 description: Use when claiming a task is complete, marking a step done, or closing an issue. Triggers on: task complete, done, finished, step complete, mark done, verify completion, success criteria.
 type: discipline-enforcing
 license: MIT
+provenance: AI-generated
 compatibility: opencode
 ---
 

--- a/skills/verification-enforcement/SKILL.md
+++ b/skills/verification-enforcement/SKILL.md
@@ -3,6 +3,7 @@ name: verification-enforcement
 description: Use when generating content that makes factual claims — specs, plans, runbooks, docs, or correspondence — to enforce live-source verification before generation. Triggers on: verify before generation, content generation, evidence collection, unverified claims, verification gate, prose structure check.
 type: discipline-enforcing
 license: Apache-2.0
+provenance: AI-generated
 compatibility: opencode
 ---
 

--- a/skills/verification-enforcement/SKILL.md
+++ b/skills/verification-enforcement/SKILL.md
@@ -149,4 +149,186 @@ When `worktree.path` is set:
 - ALL `read`/`write`/`edit`/`glob`/`grep` tool calls MUST prefix `filePath`/`path` with `worktree.path/`
 - Sub-agent dispatch prompts MUST include `worktree.path: <value>`
 
-Co-authored with AI: <AgentName> (<ModelId>)
+ Co-authored with AI: <AgentName> (<ModelId>)
+
+```yaml+symbolic
+schema_version: "2.0"
+last_updated: "2026-04-26T00:00:00Z"
+rules:
+  - id: verification-enforcement-001
+    title: "Content generation requires verification gate"
+    conditions:
+      all:
+        - "content_generation_requested == true"
+        - "verification_invoked == false"
+    actions:
+      - HALT
+    conflicts_with: []
+    requires: []
+    triggers: []
+    source: "verification-enforcement/SKILL.md §Operating Protocol"
+
+  - id: verification-enforcement-002
+    title: "Reporting unverified information as verified is a critical violation"
+    conditions:
+      all:
+        - "claim_made == true"
+        - "verification_tool_call_made == false"
+    actions:
+      - HALT
+      - MARK_UNVERIFIED
+    conflicts_with: []
+    requires: []
+    triggers: []
+    source: "065-verification-honesty.md"
+
+  - id: verification-enforcement-003
+    title: "Revisit pass required after generation"
+    conditions:
+      all:
+        - "content_generated == true"
+        - "revisit_invoked == false"
+    actions:
+      - HALT
+    conflicts_with: []
+    requires: [verification-enforcement-001]
+    triggers: []
+    source: "verification-enforcement/SKILL.md §Operating Protocol"
+
+  - id: verification-enforcement-004
+    title: "Sub-agent output without evidence artifacts is rejected"
+    conditions:
+      all:
+        - "sub_agent_returned == true"
+        - "evidence_artifacts_present == false"
+    actions:
+      - REJECT
+      - RE_DISPATCH
+    conflicts_with: []
+    requires: [verification-enforcement-001]
+    triggers: [divide-and-conquer]
+    source: "verification-enforcement/SKILL.md §Enforcement Rules"
+
+tasks:
+  - id: verify
+    skill: verification-enforcement
+    preconditions: ["content_generation_requested == true"]
+    postconditions: ["all_claims_verified == true || unverified_markers_present == true"]
+    mandatory: true
+    bypass_violation: "CRITICAL: Skipping Verification-Enforcement During Content Generation"
+    source: "verification-enforcement/SKILL.md §verify task"
+
+  - id: revisit
+    skill: verification-enforcement
+    preconditions: ["content_generated == true"]
+    postconditions: ["revisit_complete == true"]
+    mandatory: true
+    bypass_violation: "CRITICAL: Skipping verification-enforcement revisit"
+    source: "verification-enforcement/SKILL.md §revisit task"
+
+  - id: enforce
+    skill: verification-enforcement
+    preconditions: ["orchestration_context == true"]
+    postconditions: ["enforcement_gate_passed == true"]
+    mandatory: true
+    bypass_violation: "CRITICAL: Sub-agent output lacks evidence artifacts"
+    source: "verification-enforcement/SKILL.md §enforce task"
+
+  - id: completion
+    skill: verification-enforcement
+    preconditions: ["any_state"]
+    postconditions: ["completion_tasks_executed == true"]
+    mandatory: true
+    bypass_violation: "CRITICAL: Skipping Completion Guarantee on Workflow Halt"
+    source: "verification-enforcement/SKILL.md §completion task"
+
+decomposition:
+  - type: skill-task
+    skill: spec-creation
+    task: write
+    mandatory: true
+    bypass_violation: "CRITICAL: Skipping Verification-Enforcement During Content Generation"
+
+  - type: skill-task
+    skill: writing-plans
+    task: create
+    mandatory: true
+    bypass_violation: "CRITICAL: Skipping Verification-Enforcement During Content Generation"
+
+  - type: skill-task
+    skill: sre-runbook
+    task: generate
+    mandatory: true
+    bypass_violation: "CRITICAL: Skipping Verification-Enforcement During Content Generation"
+
+  - type: skill-task
+    skill: skill-creator
+    task: create-skill
+    mandatory: true
+    bypass_violation: "CRITICAL: Skipping Verification-Enforcement During Content Generation"
+
+  - type: skill-task
+    skill: correspondence
+    task: draft
+    mandatory: true
+    bypass_violation: "CRITICAL: Skipping Verification-Enforcement During Content Generation"
+
+gates:
+  - id: content-generation-verification
+    condition: "verification_invoked == true"
+    on_fail: "HALT"
+    critical_violation: true
+
+  - id: audience-separation
+    condition: "content_audience == 'stakeholder' AND internal_artifacts_absent == true"
+    on_fail: "REPHRASE OR REMOVE"
+    critical_violation: false
+
+  - id: evidence-artifacts-present
+    condition: "sub_agent_evidence_artifacts_present == true"
+    on_fail: "REJECT AND RE-DISPATCH"
+    critical_violation: true
+
+evidence_artifacts:
+  - name: section_evidence_table
+    type: structured_table
+    verification: "Each content section has evidence entries with Claim, Domain, Source, Verified fields"
+
+  - name: unverified_markers_resolved
+    type: scan_result
+    verification: "No ⚠️ UNVERIFIED markers remain after revisit pass"
+
+  - name: audience_classification
+    type: metadata
+    verification: "Content audience tier (stakeholder/operator) is recorded before generation"
+
+state_machines:
+  - id: verification-lifecycle
+    states: [idle, verifying, generating, revisiting, complete, escalated]
+    start_state: idle
+    transitions:
+      - from: idle
+        to: verifying
+        guard: "content_generation_requested == true"
+        action: INVOKE(verify)
+      - from: verifying
+        to: generating
+        guard: "verification_complete == true"
+        action: PROCEED
+      - from: generating
+        to: revisiting
+        guard: "content_generated == true"
+        action: INVOKE(revisit)
+      - from: revisiting
+        to: complete
+        guard: "all_unverified_resolved == true"
+        action: PROCEED
+      - from: revisiting
+        to: escalated
+        guard: "unverifiable_claims_remain == true"
+        action: ESCALATE_TO_DEVELOPER
+      - from: escalated
+        to: complete
+        guard: "developer_accepted == true"
+        action: PROCEED
+```

--- a/skills/verification/SKILL.md
+++ b/skills/verification/SKILL.md
@@ -3,6 +3,7 @@ name: verification
 description: Use when verifying claims against evidence using appropriate modalities. Produces PASS/FAIL/UNVERIFIED per claim with evidence artifacts. Triggers on: verify claim, claim verification, evidence verification, verify against source, multimodal verification.
 type: verification
 license: Apache-2.0
+provenance: AI-generated
 compatibility: opencode
 ---
 

--- a/skills/writing-plans/SKILL.md
+++ b/skills/writing-plans/SKILL.md
@@ -3,6 +3,7 @@ name: writing-plans
 description: Use when creating an implementation plan from an approved spec. Triggers on: write plan, create plan, implementation plan, plan spec, approved plan, plan creation.
 type: technique
 license: MIT
+provenance: AI-generated
 compatibility: opencode
 ---
 

--- a/tests/behaviors/git-no-verify-local-allowed.sh
+++ b/tests/behaviors/git-no-verify-local-allowed.sh
@@ -67,6 +67,19 @@ else
     OVERALL_RESULT=1
 fi
 
+# Verify 5: Null-baseline fallback — inline remote check exists
+if grep -q "git remote -v" "$FULL_PATH" && ! grep -q "captureGitConfigBaseline" <(grep -n "git remote -v" "$FULL_PATH" | head -1); then
+    echo "PASS: $SCENARIO_NAME — inline remote check fallback present for null baseline"
+else
+    # Alternate check: just verify git remote -v exists in the --no-verify section
+    if grep -A5 -B5 "hasRemotes" "$FULL_PATH" | grep -q "git remote -v"; then
+        echo "PASS: $SCENARIO_NAME — inline remote check fallback present for null baseline"
+    else
+        echo "FAIL: $SCENARIO_NAME — inline remote check fallback for null baseline missing"
+        OVERALL_RESULT=1
+    fi
+fi
+
 echo ""
 if [ "$OVERALL_RESULT" -eq 0 ]; then
     echo "PASS: $SCENARIO_NAME"


### PR DESCRIPTION
## Summary

Implements 5 approved P1 enforcement specs: copyright/provenance header system, formalization of 5 skill cards to yaml+symbolic v2.0 (spec-auditor, verification-enforcement, coherence-auditor, plan-fidelity-auditor, concern-separation-auditor), and a bug fix for null-baseline fallback in session-enforcement.ts.

## Outcome

- **#77**: Fix null-baseline fallback in `session-enforcement.ts:1487` — inline `git remote -v` check when baseline is null instead of defaulting to `hasRemotes=true`; guideline and behavioral test updated
- **#48**: Formalize `verification-enforcement/SKILL.md` to v2.0 — 4 rules, 4 task contracts, 5 decomposition mandates, 3 gates, verification lifecycle state machine
- **#47**: Formalize `spec-auditor/SKILL.md` to v2.0 — 7 rules, 10 task contracts, 5 decomposition mandates, 4 gates (including body preservation), audit session state machine
- **#49**: Formalize audit triad (coherence-auditor, plan-fidelity-auditor, concern-separation-auditor) to v2.0 — cross-skill entailment with spec-auditor formalized
- **#44**: Copyright/provenance header system — MIT LICENSE, provenance field in validate_skill_cards.py, init_skill.py template, 080-code-standards.md section, provenance: AI-generated added to 39 SKILL.md files

Fixes #44
Fixes #47
Fixes #48
Fixes #49
Fixes #77

🤖 Co-authored with AI: OpenCode (ollama-cloud/glm-5.1)