### PR TITLE
feat(skills): classify pre-work git operations as automatic prerequisites

### DIFF
--- a/guidelines/000-critical-rules.md
+++ b/guidelines/000-critical-rules.md
@@ -81,6 +81,10 @@ When `WORKTREE_REQUIRED` is NOT set (direct-branch mode):
 - 🚫 FORBIDDEN: Starting work without creating a feature branch first; operating in main working directory on `main` or `dev`; creating/editing files on `main` or `dev`
 - ✅ REQUIRED: See `git-workflow` skill `--task pre-work` for mandatory feature branch creation and environment verification
 
+### Automatic Prerequisite Operations (Pre-Work Git Operations)
+
+**Pre-work git operations classified as automatic prerequisites in `git-workflow --task pre-work` §Step 2.7 do NOT require separate developer confirmation when authorization has been verified.** These operations (submodule sync, branch creation, initial push, `git fetch`, etc.) are deterministic, mechanical steps that are either Tier 1 mandates or pipeline prerequisites. Soliciting developer confirmation for these operations violates `000-critical-rules.md` §"Pushing Agent Intelligence Decisions to the User" — whether to sync a submodule or create a branch is NOT a decision requiring user input when the pipeline scope covers that stage.
+
 ## Critical Violation: Relative File Paths in Worktree Context
 
 **⚠️ Using relative paths with `read`/`edit`/`write`/`glob`/`grep` tools when `worktree.path` is set is a CRITICAL GUIDELINE VIOLATION.**

--- a/skills/git-workflow/tasks/pre-work.md
+++ b/skills/git-workflow/tasks/pre-work.md
@@ -150,6 +150,42 @@ fi
 2. **Submodule currency check:** If any submodule is not on `dev` branch, sync it: `git submodule foreach "git checkout dev && git pull"`
 3. **Fresh clone handling:** After `git clone`, the dev parking protocol must be run: `git checkout dev && git pull && git submodule init && git submodule foreach "git checkout dev && git pull"`
 
+### Step 2.7: Automatic Prerequisite Operations
+
+**⚠️ When authorization has been verified (approval-gate `verify-authorization` passed), the following git operations are AUTOMATIC prerequisites that MUST be performed WITHOUT soliciting developer confirmation.**
+
+These operations are deterministic, mechanical steps that are either Tier 1 mandates (required by guidelines) or pipeline prerequisites (necessary for the authorized scope). They require NO judgment from the agent or the developer.
+
+| Operation | Step | Classification | Condition |
+|-----------|------|----------------|-----------|
+| `git fetch origin` | Step 1.5/2 | Pipeline prerequisite | Remote exists |
+| `git checkout dev && git pull origin dev` | Step 2 | Tier 1 mandate prerequisite | Always when remote exists |
+| `git submodule init` + `git submodule foreach "git checkout dev && git pull"` | Step 2.5 | Tier 1 mandate prerequisite | `.gitmodules` exists |
+| `git add .opencode` (submodule bump) | Step 3.5 | Tier 1 mandate prerequisite | Submodule SHA changed |
+| `git checkout -b feature/N-xyz` or `git switch -c feature/N-xyz` | Step 3 | Tier 1 mandate — required by `000-critical-rules.md` §Skipping Git Pre-Check | Always |
+| `git push -u origin feature/N-xyz` | Post-Step 5 | Pipeline prerequisite for `for_pr` scope | Remote exists, `halt_at >= pr_created` |
+
+**Automatic classification conditions (ALL must be true):**
+
+1. Authorization has been verified — `approval-gate --task verify-authorization` passed
+2. The operation is a Tier 1 mandate or a deterministic prerequisite for authorized work
+3. The operation requires no judgment — it is a deterministic, mechanical step
+4. The scope covers the pipeline stage containing the operation (`for_pr`, `for_implementation`, `for_code_review`)
+
+**🚫 FORBIDDEN: Soliciting developer confirmation for automatic prerequisites:**
+
+- "Should I sync the submodule?" → FORBIDDEN — submodule sync is automatic
+- "May I create the feature branch?" → FORBIDDEN — branch creation is a Tier 1 mandate
+- "Ready to proceed with git push?" → FORBIDDEN — initial push is a pipeline prerequisite
+- "Proceed with pre-work?" → FORBIDDEN — pre-work is mandatory after authorization
+- Any confirmation request for operations in the table above → FORBIDDEN
+
+**✅ REQUIRED: Proceed autonomously through all pre-work steps once authorization is verified.**
+
+The agent MUST NOT ask for confirmation, permission, or readiness before performing any operation listed in the table above. These are mechanical prerequisites that the agent MUST execute as part of the approved workflow.
+
+**See also:** `000-critical-rules.md` §"Pushing Agent Intelligence Decisions to the User" — whether to sync a submodule, create a branch, or push is NOT a decision requiring user input when authorization covers the pipeline stage.
+
 ### Step 3: Create Feature Branch (Mode-Dependent)
 
 #### Direct-Branch Mode (DEFAULT — when WORKTREE_REQUIRED is NOT set)

--- a/tests/behaviors/automatic-prerequisite-operations.sh
+++ b/tests/behaviors/automatic-prerequisite-operations.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+# Behavioral Enforcement Test: Automatic Prerequisite Operations
+#
+# Verifies that the agent does NOT solicit developer confirmation for
+# mechanical git operations during pre-work when authorization has been
+# verified. These operations are classified as automatic prerequisites
+# that proceed autonomously.
+#
+# See: .opencode/skills/git-workflow/tasks/pre-work.md §Automatic Prerequisite Operations
+# See: #82 — Agent Fails to Perform Automatic Git Management
+#
+# Co-authored with AI: <AgentName> (<ModelId>)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/helpers.sh"
+
+SCENARIO_NAME="automatic-prerequisite-operations"
+
+OVERALL_RESULT=0
+
+echo "=== Behavioral Test: $SCENARIO_NAME ==="
+
+# Test 1: Agent does not solicit confirmation for pre-work git operations
+# when processing an authorized implementation request.
+# The agent should perform submodule sync, branch creation, and initial push
+# autonomously without asking "Should I...?", "May I...?", or "Ready to proceed?"
+test_no_solicitation_for_prereqs() {
+    local test_label="no-solicitation-for-prereqs"
+    local message="#82 approved for pr — process this authorization and begin pre-work"
+
+    echo "--- Test: No solicitation for automatic prerequisite git operations ---"
+
+    behavior_run "${SCENARIO_NAME}-${test_label}" "$message"
+
+    # Forbidden patterns: agent asking for confirmation on mechanical operations
+    assert_forbidden_pattern_absent "[Ss]hould I (sync|run|perform|execute|create|push)" "Should I [mechanical operation]" || OVERALL_RESULT=1
+    assert_forbidden_pattern_absent "[Mm]ay I (sync|run|perform|execute|create|push)" "May I [mechanical operation]" || OVERALL_RESULT=1
+    assert_forbidden_pattern_absent "[Rr]eady to (sync|create|push|proceed)" "Ready to [mechanical operation]" || OVERALL_RESULT=1
+    assert_forbidden_pattern_absent "[Pp]roceed with (submodule|branch|pre-work)" "Proceed with [mechanical operation]" || OVERALL_RESULT=1
+    assert_forbidden_pattern_absent "awaiting.*(confirmation|approval).*git" "awaiting confirmation for git" || OVERALL_RESULT=1
+    # General solicitation patterns already tested in no-authorization-solicitation-pipeline-scope
+}
+
+test_no_solicitation_for_prereqs
+
+echo ""
+if [ "$OVERALL_RESULT" -eq 0 ]; then
+    echo "PASS: $SCENARIO_NAME"
+else
+    echo "FAIL: $SCENARIO_NAME"
+fi
+
+exit $OVERALL_RESULT


### PR DESCRIPTION
## Summary

Classifies pre-work git operations (submodule sync, branch creation, initial push, git fetch) as automatic prerequisites that proceed without developer solicitation when authorization has been verified, fixing the agent's tendency to ask for confirmation on mechanical steps.

## Outcome

Agents will no longer solicit developer confirmation for Tier 1 mandate prerequisites (branch creation, submodule sync) or pipeline prerequisites (initial push, git fetch) during pre-work, resolving the behavior described in #82.

Fixes #82

🤖 Co-authored with AI: OpenCode (ollama-cloud/glm-5.1) ✅ completed