### PR TITLE
fix(#73): prose-first architecture for identity_source routing

### DIFF
--- a/guidelines/060-tool-usage.md
+++ b/guidelines/060-tool-usage.md
@@ -179,11 +179,11 @@ Invoke skills when their trigger keywords match the current task. Each skill def
 
 The `github.identity_source` value (emitted by session-init) determines the agent's relationship to git remotes and GitHub API routing.
 
-| `github.identity_source` | Parent repo remotes | Agent behavior |
-|---|---|---|
-| `root` | 1+ | Standard workflow; owner/repo from parent remote |
-| `submodule` | 0 | Local-only parent; owner/repo from submodule for API routing only; do NOT add remotes to parent |
-| `none` | 0 | Full local-only; no GitHub API calls possible |
+| `identity_source` | Routing Description |
+|---|---|
+| `root` | Standard workflow — parent repo has a remote, owner/repo from parent remote. All git operations work normally through the parent repo. |
+| `submodule` | Submodule-local mode — parent repo has ZERO remotes by design. All remote git operations (fetch, pull, push, remote branch management) must run from inside the submodule directory, not the project root. The submodule path is the only path to the remote repository. Do NOT add remotes to the parent repo. Do NOT push from the parent repo. |
+| `none` | Full local-only mode — no remote exists anywhere. All remote git operations (fetch, pull, push) will fail. No GitHub or GitBucket API calls are possible. Do NOT add remotes. |
 
 **When `identity_source == "submodule"`:**
 

--- a/plugins/session-enforcement.ts
+++ b/plugins/session-enforcement.ts
@@ -1360,14 +1360,12 @@ export default async function sessionEnforcementPlugin(input: PluginInput): Prom
               });
             }
           } else if (isSubmoduleMode) {
-            // Submodule mode: parent repo has zero remotes, owner/repo from submodule for API routing only.
-            // Emit a LOCAL_MODE block telling agent the parent is local-only.
-            const parentRemotes = extractValue(cachedIdentityOutput, "github.parent_remotes") || "0";
+            const parentRemoteCount = gitConfigBaseline?.remoteCount ?? 0;
             const lastUser = userMessages[userMessages.length - 1];
             if (lastUser?.parts?.length) {
               lastUser.parts.push({
                 type: "text",
-                text: `<LOCAL_MODE>\n⚠️ Operating in submodule-local mode — parent repo has ${parentRemotes} remote(s).\n\n- github.identity_source: submodule\n- github.parent_remotes: ${parentRemotes}\n- Parent repo has ZERO remotes by design\n- github.owner and github.repo are from the submodule remote for API routing ONLY\n\n**MANDATORY RESTRICTIONS:**\n- Do NOT add remotes to the parent repo (git remote add is FORBIDDEN)\n- Do NOT push from the parent repo (git push without specifying remote is FORBIDDEN)\n- Do NOT assume the parent repo has any remote relationship with the submodule's GitHub repo\n- GitHub MCP and GitBucket API calls route to the submodule's repository\n- Local git operations (branch, commit, stash) on the parent repo are permitted\n\nSee 000-critical-rules.md → "Git Configuration and Destructive Command Authorization".\n</LOCAL_MODE>`
+                text: `<LOCAL_MODE>\n⚠️ Operating in submodule-local mode — parent repo has ${parentRemoteCount} remote(s).\n\n- github.identity_source: submodule\n- All remote git operations (fetch, pull, push, remote branch management) must run from inside the submodule directory — not the project root.\n- The parent repo has ZERO remotes by design.\n- github.owner and github.repo are from the submodule remote for API routing ONLY\n- GitHub MCP calls route to the submodule's repository\n- Local git operations (branch, commit, stash) on the parent repo are permitted\n- Do NOT push from the parent repo — there is no remote to push to.\n- Do NOT add remotes to the parent repo.\n</LOCAL_MODE>`
               });
             }
           } else if (!knownPlatform || !knownOwner || !knownRepo) {

--- a/scripts/session_context_identity.py
+++ b/scripts/session_context_identity.py
@@ -258,7 +258,7 @@ def build_identity_section(
     platform: str,
     credential_status: str,
     identity_source: str = "root",
-    parent_remotes: int = 0,
+    submod_path: str | None = None,
 ) -> str:
     lines = [
         "## Repository Hosting Identity",
@@ -266,13 +266,24 @@ def build_identity_section(
         f"- github.repo={repo}",
         f"- github.platform={platform}",
         f"- github.identity_source={identity_source}",
-        f"- github.parent_remotes={parent_remotes}",
     ]
     cred_key = (
         f"{platform.upper()}_CREDENTIALS" if platform != "unknown" else "CREDENTIALS"
     )
     lines.append(f"- {cred_key}={credential_status}")
     lines.append("- Use these exact values for ALL GitHub MCP and GitBucket API calls")
+
+    if identity_source == "submodule":
+        remote_display = "(none)"
+        if submod_path:
+            remote_display = f"(none) [submodule: {submod_path} -> {platform}:{owner}/{repo}]"
+        else:
+            remote_display = f"(none) [submodule: {platform}:{owner}/{repo}]"
+        lines.append(f"- Remote: {remote_display}")
+    elif identity_source == "none":
+        lines.append("- Remote: (none)")
+    else:
+        lines.append(f"- Remote: {platform} remote configured")
 
     lines.append("")
     lines.append("## Target API Credentials")
@@ -290,6 +301,30 @@ def build_identity_section(
             f"- WARNING: {platform} token was rejected — "
             "check credentials in .env, secrets.toml, or environment variables"
         )
+
+    if identity_source == "submodule":
+        lines.append("")
+        lines.append("## Submodule Routing")
+        submod_display = submod_path if submod_path else "(unknown submodule path)"
+        lines.append(f"- Operating in submodule-local mode — parent repo has 0 remote(s)")
+        lines.append(f"- github.identity_source: submodule")
+        lines.append(f"- All remote git operations (fetch, pull, push, remote branch management) must run from inside the submodule directory — not the project root")
+        lines.append(f"- The submodule at \"{submod_display}\" is the only path to the remote repository")
+        lines.append(f"- Local git operations (branch, commit, stash, checkout) work on the parent repo normally")
+        lines.append(f"- Do NOT add remotes to the parent repo")
+        lines.append(f"- Do NOT push from the parent repo — there is no remote to push to")
+    elif identity_source == "none":
+        lines.append("")
+        lines.append("## Local-Only Mode")
+        lines.append("- Operating in local-only mode — no git remote configured")
+        lines.append("- github.platform: local")
+        lines.append("- github.owner: (none)")
+        lines.append("- github.repo: (none)")
+        lines.append("- github.identity_source: none")
+        lines.append("- No remote exists anywhere in this repository or its submodules")
+        lines.append("- All remote git operations (fetch, pull, push) will fail. No GitHub or GitBucket API calls are possible")
+        lines.append("- Local git operations (branch, commit, stash, checkout) work normally")
+        lines.append("- Do NOT add remotes")
 
     return "\n".join(lines)
 
@@ -325,11 +360,11 @@ def get_submodule_dirs() -> list[str]:
 
 def main() -> int:
     remote_url = get_remote_url()
-    parent_remote_url = remote_url
     identity_source = "root"
     owner: str | None = None
     repo: str | None = None
     platform: str = "local"
+    active_submod_path: str | None = None
 
     if remote_url:
         platform = detect_platform(remote_url)
@@ -360,6 +395,7 @@ def main() -> int:
                 repo = submod_repo
                 platform = submod_platform
                 identity_source = "submodule"
+                active_submod_path = submod_path
                 remote_url = submod_url
                 print(
                     f"Using submodule remote for degraded mode: {submod_path} -> {submod_url}",
@@ -385,10 +421,6 @@ def main() -> int:
         print("Not in a git repository.", file=sys.stderr)
         return 1
 
-    parent_remote_count = 0
-    if parent_remote_url:
-        parent_remote_count = 1
-
     credential_status = "unavailable"
     if platform not in ("local",) and remote_url and remote_url != "(none)":
         tier1 = probe_credentials_tier1(platform, root_dir)
@@ -401,7 +433,7 @@ def main() -> int:
             platform,
             credential_status,
             identity_source,
-            parent_remote_count,
+            active_submod_path,
         )
     )
 

--- a/scripts/session_context_identity.py
+++ b/scripts/session_context_identity.py
@@ -276,7 +276,9 @@ def build_identity_section(
     if identity_source == "submodule":
         remote_display = "(none)"
         if submod_path:
-            remote_display = f"(none) [submodule: {submod_path} -> {platform}:{owner}/{repo}]"
+            remote_display = (
+                f"(none) [submodule: {submod_path} -> {platform}:{owner}/{repo}]"
+            )
         else:
             remote_display = f"(none) [submodule: {platform}:{owner}/{repo}]"
         lines.append(f"- Remote: {remote_display}")
@@ -306,13 +308,23 @@ def build_identity_section(
         lines.append("")
         lines.append("## Submodule Routing")
         submod_display = submod_path if submod_path else "(unknown submodule path)"
-        lines.append(f"- Operating in submodule-local mode — parent repo has 0 remote(s)")
-        lines.append(f"- github.identity_source: submodule")
-        lines.append(f"- All remote git operations (fetch, pull, push, remote branch management) must run from inside the submodule directory — not the project root")
-        lines.append(f"- The submodule at \"{submod_display}\" is the only path to the remote repository")
-        lines.append(f"- Local git operations (branch, commit, stash, checkout) work on the parent repo normally")
-        lines.append(f"- Do NOT add remotes to the parent repo")
-        lines.append(f"- Do NOT push from the parent repo — there is no remote to push to")
+        lines.append(
+            "- Operating in submodule-local mode — parent repo has 0 remote(s)"
+        )
+        lines.append("- github.identity_source: submodule")
+        lines.append(
+            "- All remote git operations (fetch, pull, push, remote branch management) must run from inside the submodule directory — not the project root"
+        )
+        lines.append(
+            f'- The submodule at "{submod_display}" is the only path to the remote repository'
+        )
+        lines.append(
+            "- Local git operations (branch, commit, stash, checkout) work on the parent repo normally"
+        )
+        lines.append("- Do NOT add remotes to the parent repo")
+        lines.append(
+            "- Do NOT push from the parent repo — there is no remote to push to"
+        )
     elif identity_source == "none":
         lines.append("")
         lines.append("## Local-Only Mode")
@@ -322,8 +334,12 @@ def build_identity_section(
         lines.append("- github.repo: (none)")
         lines.append("- github.identity_source: none")
         lines.append("- No remote exists anywhere in this repository or its submodules")
-        lines.append("- All remote git operations (fetch, pull, push) will fail. No GitHub or GitBucket API calls are possible")
-        lines.append("- Local git operations (branch, commit, stash, checkout) work normally")
+        lines.append(
+            "- All remote git operations (fetch, pull, push) will fail. No GitHub or GitBucket API calls are possible"
+        )
+        lines.append(
+            "- Local git operations (branch, commit, stash, checkout) work normally"
+        )
         lines.append("- Do NOT add remotes")
 
     return "\n".join(lines)

--- a/tests/behaviors/identity-source-submodule-no-remote.sh
+++ b/tests/behaviors/identity-source-submodule-no-remote.sh
@@ -30,20 +30,18 @@ resolve_tool() {
     fi
 }
 
-# Test 1: session-init emits github.parent_remotes when identity_source is submodule
-echo "--- Test 1: session-init emits github.parent_remotes ---"
+# Test 1: session-init does NOT emit github.parent_remotes (prose-first architecture)
+echo "--- Test 1: session-init does NOT emit github.parent_remotes (prose-first) ---"
 SESSION_INIT=$(resolve_tool "tools/session-init")
 if [ -z "$SESSION_INIT" ] || [ ! -f "$SESSION_INIT" ]; then
     echo "SKIP: session-init not found"
 else
-    # This repo is a submodule context, so session-init should emit parent_remotes
     OUTPUT=$("$SESSION_INIT" 2>/dev/null) || true
     if echo "$OUTPUT" | grep -q "github.parent_remotes:"; then
-        PARENT_REMOTES=$(echo "$OUTPUT" | grep "github.parent_remotes:" | head -1 | awk '{print $2}')
-        echo "PASS: github.parent_remotes: $PARENT_REMOTES found in session-init output"
-    else
-        echo "FAIL: github.parent_remotes NOT found in session-init output"
+        echo "FAIL: github.parent_remotes found in session-init output (should be replaced with prose)"
         OVERALL_RESULT=1
+    else
+        echo "PASS: github.parent_remotes NOT found in session-init output (prose-first architecture)"
     fi
 fi
 

--- a/tools/session-init
+++ b/tools/session-init
@@ -20,7 +20,7 @@ Agents read dotted names from session-init; bash scripts read UPPER_CASE
 names from env-loader. Never couple these pipelines.
 
 Canonical session-init variable names (dotted, LLM context):
-github.owner, github.repo, github.platform, github.identity_source, github.parent_remotes, github.html_url,
+github.owner, github.repo, github.platform, github.identity_source, github.html_url,
 gitbucket.owner, gitbucket.repo, gitbucket.html_url, gitbucket.ssh_url,
 gitbucket.has_credentials, srclight.project, dev.name, dev.email,
 branch, worktree.path, worktree.fatal, AgentName, ModelId
@@ -767,6 +767,7 @@ def main() -> int:
     platform: str | None = None
     owner: str | None = None
     repo: str | None = None
+    active_submod_path: str | None = None
 
     if remote_url:
         platform, owner, repo = resolve_identity(remote_url)
@@ -798,6 +799,7 @@ def main() -> int:
                 platform = submod_platform
                 identity_source = "submodule"
                 remote_url = submod_url
+                active_submod_path = submod_path
                 print(
                     f"Using submodule remote for degraded mode: {submod_path} -> {submod_url}",
                     file=sys.stderr,
@@ -842,22 +844,11 @@ def main() -> int:
     print("# Convention: dotted prefix = tool scope, suffix = MCP/API parameter name")
     print("# Use scope.param directly as the tool parameter value.")
     print("# Example: github_issue_read(owner=github.owner, repo=github.repo)")
-    parent_remote_count = 0
-    parent_remotes_raw = run_git_command(["remote", "-v"])
-    if parent_remotes_raw:
-        parent_remote_count = len(
-            set(
-                line.split()[0]
-                for line in parent_remotes_raw.splitlines()
-                if line.strip()
-            )
-        )
 
     print(f"github.owner: {owner}")
     print(f"github.repo: {repo}")
     print(f"github.platform: {platform}")
     print(f"github.identity_source: {identity_source}")
-    print(f"github.parent_remotes: {parent_remote_count}")
     print("AgentName: ")
     print("ModelId: ")
     print(f"dev.name: {user_name}")
@@ -865,7 +856,10 @@ def main() -> int:
     print(f"branch: {current_branch}")
 
     if identity_source == "submodule":
+        submod_display = submod_path if submod_path else "(unknown)"
         print(f"Remote: (none) [submodule: {remote_url}]")
+    elif identity_source == "none":
+        print("Remote: (none)")
     else:
         print(f"Remote: {remote_url}")
 


### PR DESCRIPTION
## Summary

Replace opaque `github.parent_remotes: 0` numeric values with prose routing descriptions in LLM identity output, and decouple `session-enforcement.ts` from parsing Python script stdout for remote discovery.

## Outcome

- LLM agents receive human-readable routing descriptions ("Operating in submodule-local mode — parent repo has 0 remote(s)") instead of opaque numeric values, reducing misrouting errors
- `session-enforcement.ts` discovers git remotes directly via `git remote -v` (`GitConfigBaseline`) instead of parsing `session_context_identity.py` stdout, eliminating shared-parse coupling
- Submodule path is dynamically discovered from `.gitmodules` instead of hardcoded `.opencode/`

https://github.com/michael-conrad/opencode-config/issues/73

🤖 Co-authored with AI: OpenCode (ollama-cloud/glm-5.1) ✅ completed