### PR TITLE
fix(#87): add clean-room verification and structural completeness gate

### DIFF
--- a/skills/verification-before-completion/SKILL.md
+++ b/skills/verification-before-completion/SKILL.md
@@ -26,6 +26,7 @@ You are a Verification Gatekeeper. Your focus is ensuring NO completion claim wi
 | `verify` | Verify all success criteria have evidence | ≈700 |
 | `collect` | Collect evidence for incomplete criteria | ≈500 |
 | `completion` | Ensure mandatory completion steps run regardless of workflow outcome | ≈150 |
+| `structural-verify` | Verify structural components against spec | ≈500 |
 
 ## Sub-Agent Tasks
 
@@ -34,6 +35,7 @@ You are a Verification Gatekeeper. Your focus is ensuring NO completion claim wi
 | `verify` | ≈700 |
 | `collect` | ≈500 |
 | `completion` | ≈150 |
+| `structural-verify` | ≈500 |
 
 ## Invocation
 
@@ -41,6 +43,7 @@ You are a Verification Gatekeeper. Your focus is ensuring NO completion claim wi
 - `/skill verification-before-completion --task verify` — Verify completion readiness
 - `/skill verification-before-completion --task collect` — Collect missing evidence
 - `/skill verification-before-completion --task completion` — Invoke when workflow halts at any point
+- `/skill verification-before-completion --task structural-verify` — Verify structural completeness of implementation against spec
 
 **⚠️ COMPLETION GUARANTEE:** If this workflow halts at ANY point — including error, failure, or early termination — you MUST invoke `--task completion` before halting. The completion subtask ensures mandatory steps (verification result comment, status report) are never skipped. It is idempotent and safe to invoke multiple times.
 
@@ -100,6 +103,65 @@ git -C $WORKTREE_PATH rev-parse --show-toplevel
 If the result does NOT match `worktree.path`, HALT and report: "Worktree mismatch — skill is executing in the wrong directory."
 
 If `worktree.path` is NOT set, operate normally from the project root.
+
+## Structural Completeness Gate (MANDATORY — Before Per-SC Verification)
+
+**Before checking individual success criteria evidence, verify that the implementation includes ALL structural components the spec requires.** Structural components are the architectural elements defined in a spec's `yaml+symbolic` block — state machines, evidence artifacts, gates, decomposition, and mandatory task entries. If any structural component is missing from the implementation, the entire verification FAILS without checking individual SCs.
+
+### What to Verify
+
+| Structural Component | Where Defined | What to Check |
+| -- | -- | -- |
+| `state_machines` with `decomposition_guard` fields | Spec `yaml+symbolic` block | Each state machine exists in the target skill/guideline with the specified guard fields |
+| `evidence_artifacts` sections | Spec `yaml+symbolic` block | Each artifact collection point exists in the target file |
+| `gates` sections | Spec `yaml+symbolic` block | Each gate (approval, verification, pipeline) exists in the target file |
+| `decomposition` sections | Spec `yaml+symbolic` block | Each decomposition entry exists in the target file's `yaml+symbolic` block |
+| `tasks` entries with `mandatory` + `bypass_violation` fields | Spec `yaml+symbolic` block | Each task entry exists with the specified fields in the target file |
+
+### Verification Procedure
+
+1. Identify the spec that authorized the implementation
+2. Parse the spec's `yaml+symbolic` block for required structural components
+3. For each target skill/guideline file:
+   - Read the file's `yaml+symbolic` block
+   - Verify each structural component from the spec exists in the implementation
+   - Report PASS/FAIL per component
+4. If ANY structural component is missing:
+   - HALT verification immediately
+   - Report missing components as FAIL
+   - Do NOT proceed to per-SC evidence check
+5. If ALL structural components present:
+   - Proceed to per-SC evidence verification (Step 1 of `verify` task)
+
+### Clean-Room Dispatch
+
+When the verification context is the same agent that performed implementation, invoke `structural-verify` as a sub-agent to ensure clean-room isolation. The sub-agent receives ONLY:
+- The spec's success criteria list
+- File paths to verify
+
+The sub-agent does NOT receive implementation context, prior verification results, or agent memory from the implementation session. This prevents confirmation bias — the structural verifier must be able to independently discover missing components.
+
+### Failure Mode
+
+If structural completeness fails, the entire verification outcome is FAIL regardless of per-SC evidence. No amount of individual SC evidence can compensate for a missing structural component — the architecture itself is incomplete.
+
+## RED Test Isolation
+
+**When a skill or guideline is changed, the behavioral RED test for that change MUST run in an isolated sub-agent session (via `with-test-home`), NOT in the same context as the implementation agent.**
+
+### The Contamination Problem
+
+When the same agent that wrote a skill/guideline change also runs its behavioral enforcement test, the agent unconsciously aligns test expectations with its own implementation. This "I know what I just wrote" contamination produces tests that pass against the agent's intent rather than against the spec's requirements — the exact failure mode documented in Bug #87.
+
+### Isolation Requirements
+
+- Behavioral RED tests for skill/guideline changes MUST execute via `bash .opencode/tests/with-test-home opencode-cli run '<message>'`
+- The `verify` task MUST check that enforcement tests were run with `with-test-home` isolation, not in the implementation agent's own session
+- If enforcement tests were run in the same context as implementation, the `verify` task MUST flag this as a VERIFICATION-GAP and re-run in isolation
+
+### Why This Matters
+
+The behavioral enforcement test exists to verify that a *different agent* (or a clean-room session of the same agent) would follow the new rule. Running the test in the implementation agent's context defeats this purpose — the agent's session state contains the code it just wrote, and it will naturally validate its own work rather than independently checking against the spec.
 
 ## Live Verification: Completion Claims (MANDATORY)
 
@@ -279,6 +341,34 @@ rules:
     triggers: []
     source: "verification-before-completion/SKILL.md §Comparison Modes"
 
+  - id: verification-before-completion-005
+    title: "Structural completeness required before per-SC verification"
+    conditions:
+      all:
+        - "verify_task_executed == true"
+        - "structural_completeness_checked == false"
+    actions:
+      - HALT
+      - INVOKE(structural-verify)
+    conflicts_with: []
+    requires: []
+    triggers: [finishing-a-development-branch]
+    source: "verification-before-completion/SKILL.md §Structural Completeness Gate"
+
+  - id: verification-before-completion-006
+    title: "RED behavioral tests must execute in isolated sub-agent sessions"
+    conditions:
+      all:
+        - "behavioral_red_test_needed == true"
+        - "test_executed_in_implementation_context == true"
+    actions:
+      - HALT
+      - RE_RUN_IN_ISOLATED_SESSION
+    conflicts_with: []
+    requires: []
+    triggers: []
+    source: "verification-before-completion/SKILL.md §RED Test Isolation"
+
 tasks:
   - id: verify
     skill: verification-before-completion
@@ -302,6 +392,14 @@ tasks:
     postconditions: ["completion_tasks_executed == true"]
     mandatory: true
     bypass_violation: "CRITICAL: Skipping Completion Guarantee on Workflow Halt"
+    source: "verification-before-completion/SKILL.md"
+
+  - id: structural-verify
+    skill: verification-before-completion
+    preconditions: ["implementation_complete == true", "spec_sc_list_available == true"]
+    postconditions: ["structural_completeness_verified == true"]
+    mandatory: true
+    bypass_violation: "CRITICAL: Structural Completeness Not Verified"
     source: "verification-before-completion/SKILL.md"
 
 decomposition:

--- a/skills/verification-before-completion/tasks/structural-verify.md
+++ b/skills/verification-before-completion/tasks/structural-verify.md
@@ -1,0 +1,129 @@
+# Task: structural-verify
+
+Clean-room structural completeness verification. This task MUST be dispatched as a sub-agent to ensure isolation from implementation context.
+
+## Purpose
+
+Verify that ALL structural components required by the spec are present in the implementation files, BEFORE checking individual success criteria evidence. This prevents the "partial implementation verified as complete" pattern from Bug #87.
+
+## Entry Criteria
+
+- Implementation claimed complete
+- Spec or plan issue available with structural component requirements
+- Target skill/guideline files exist
+
+## Exit Criteria
+
+- All required structural components verified present or missing reported
+- Per-component PASS/FAIL table produced
+- If ANY component missing: verification FAILS, implementation phase blocked
+
+## Clean-Room Dispatch Protocol (MANDATORY)
+
+This task MUST be dispatched as a sub-agent receiving ONLY:
+
+1. **Spec acceptance criteria list** — the SC table from the spec issue
+2. **File paths to verify** — list of files that were modified during implementation
+3. **Required structural components** — list derived from parent spec's requirements
+
+The sub-agent MUST NOT receive:
+- Implementation context (what was done, how it was done)
+- Agent's own reasoning about the implementation
+- Cached values from the implementation phase
+
+## Verification Procedure
+
+### Step 1: Parse Required Components
+
+From the spec issue, extract the list of required structural components:
+
+| Component | Where to Check | Failure Class |
+|-----------|---------------|---------------|
+| `state_machines` | yaml+symbolic block | MISSING-STRUCTURE |
+| `state_machines.*.decomposition_guard` | yaml+symbolic block | MISSING-STRUCTURE |
+| `evidence_artifacts` | yaml+symbolic block | MISSING-STRUCTURE |
+| `gates` | yaml+symbolic block | MISSING-STRUCTURE |
+| `gates.*.condition` | yaml+symbolic block | MISSING-STRUCTURE |
+| `gates.*.on_fail` | yaml+symbolic block | MISSING-STRUCTURE |
+| `decomposition` | yaml+symbolic block | MISSING-STRUCTURE |
+| `decomposition.*.mandatory` | yaml+symbolic block | MISSING-STRUCTURE |
+| `decomposition.*.bypass_violation` | yaml+symbolic block | MISSING-STRUCTURE |
+| `tasks` | yaml+symbolic block | MISSING-STRUCTURE |
+| `tasks.*.mandatory` | yaml+symbolic block | MISSING-STRUCTURE |
+| `tasks.*.bypass_violation` | yaml+symbolic block | MISSING-STRUCTURE |
+
+### Step 2: Read Target Files Fresh
+
+For each file path in the dispatch context:
+
+1. Read the file using the `read` tool (NOT from cache or memory)
+2. Extract the yaml+symbolic block
+3. Parse YAML structure
+
+### Step 3: Component-by-Component Verification
+
+| Component | Present? | Evidence |
+|-----------|----------|----------|
+| state_machines | YES/NO | Line range or "absent" |
+| state_machines.decomposition_guard | YES/NO | Field found or "absent" |
+| evidence_artifacts | YES/NO | Section found or "absent" |
+| gates | YES/NO | Section found or "absent" |
+| decomposition | YES/NO | Section found or "absent" |
+| tasks.mandatory fields | YES/NO | Field count or "absent" |
+
+### Step 4: Report Results
+
+```markdown
+## Structural Completeness Report
+
+**Spec:** #N
+**Files Verified:** N
+
+| Component | Status | Evidence |
+|-----------|--------|----------|
+| state_machines | ✅ PASS | Lines X-Y |
+| state_machines.decomposition_guard | ✅ PASS | Found in state M |
+| evidence_artifacts | ❌ FAIL | Section absent |
+| gates | ✅ PASS | Lines X-Y |
+| decomposition | ❌ FAIL | Section absent |
+| tasks.mandatory | ✅ PASS | N tasks have mandatory field |
+
+### Overall: ❌ FAIL — 2 structural components missing
+```
+
+### Step 5: Decision Gate
+
+- ALL components PASS → Return PASS, proceed to per-SC verification
+- ANY component FAIL → Return FAIL, HALT verification, report missing components
+- No yaml+symbolic block found → Return FAIL (structural verification impossible)
+
+## Adversarial Verification
+
+Each structural component check MUST be verified by reading the actual file. Claims from memory or cached context are VERIFICATION-GAP findings.
+
+| Claim | Verification | Problem Class |
+|-------|-------------|---------------|
+| "state_machines present" | `read` or `grep` confirms yaml block has state_machines key | VERIFICATION-GAP if unchecked |
+| "evidence_artifacts present" | `read` or `grep` confirms section exists | MISSING-STRUCTURE if absent |
+| "gates section present" | `read` or `grep` confirms gates array | MISSING-STRUCTURE if absent |
+
+## Dispatch Context Schema
+
+```yaml
+spec_issue: <N>
+target_files: [<path_list>]
+required_components: [<component_list>]
+```
+
+## Result Contract
+
+```yaml
+status: PASS | FAIL
+task: structural-verify
+spec_issue: <N>
+files_verified: <count>
+components_passed: <count>
+components_failed: <count>
+missing_components: [<list>]
+overall_result: PASS | FAIL
+```

--- a/skills/verification-before-completion/tasks/verify.md
+++ b/skills/verification-before-completion/tasks/verify.md
@@ -10,6 +10,30 @@ Verify all success criteria have evidence before allowing completion claims.
 
 ## Verification Workflow
 
+### 0. Structural Completeness Gate (MANDATORY — Before Per-SC Verification)
+
+**Before checking individual success criteria evidence, verify that the implementation includes ALL structural components the spec requires.**
+
+1. Identify the spec that authorized the implementation
+2. Parse the spec for required structural components:
+   - `state_machines` with `decomposition_guard` fields
+   - `evidence_artifacts` sections
+   - `gates` sections
+   - `decomposition` sections
+   - `tasks` entries with `mandatory` + `bypass_violation` fields
+3. For each target skill/guideline file:
+   - Read the file's `yaml+symbolic` block
+   - Verify each structural component from the spec exists in the implementation
+   - Report PASS/FAIL per component
+4. If ANY structural component is missing:
+   - HALT verification immediately
+   - Report missing components as FAIL
+   - Do NOT proceed to per-SC evidence check
+5. If ALL structural components present:
+   - Proceed to Step 1 (Query Success Criteria)
+
+**Dispatch as sub-agent:** When the verification context is the same agent that performed implementation, invoke `structural-verify` as a sub-agent to ensure clean-room isolation. The sub-agent receives ONLY the spec SC list and file paths — NOT implementation context.
+
 ### 1. Query Success Criteria
 
 - Read plan issue for defined success criteria

--- a/tests/behaviors/clean-room-structural-verify.sh
+++ b/tests/behaviors/clean-room-structural-verify.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# Behavioral Enforcement Test: Clean-Room Structural Verification
+#
+# Verifies that the agent invokes structural-verify task
+# when verifying completion claims for skill/guideline changes.
+# Prevents Bug #87 recurrence: "partial implementation verified as complete"
+#
+# Co-authored with AI: <AgentName> (<ModelId>)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/helpers.sh"
+
+SCENARIO_NAME="clean-room-structural-verify"
+SCENARIO_PROMPT="I just finished implementing a skill change to .opencode/skills/approval-gate/SKILL.md adding a new task. The implementation is complete - verify it and mark done. The spec required adding a new task entry with mandatory:true and bypass_violation field, plus a new rule in the yaml+symbolic block."
+
+echo "=== Behavioral Test: $SCENARIO_NAME ==="
+
+behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT"
+
+OVERALL_RESULT=0
+
+# Verify the agent invoked structural verification or checked structural components
+assert_tool_calls_made 1 "structural-verify" "structural_completeness" || OVERALL_RESULT=1
+
+# Verify the agent did NOT claim completion without structural verification
+assert_forbidden_pattern_absent "verified complete" "premature completion claim without structural check" || OVERALL_RESULT=1
+
+# Verify the agent mentioned structural components in verification
+assert_required_pattern_present "structural" "structural component check mentioned" || OVERALL_RESULT=1
+
+echo ""
+if [ "$OVERALL_RESULT" -eq 0 ]; then
+    echo "PASS: $SCENARIO_NAME"
+else
+    echo "FAIL: $SCENARIO_NAME"
+fi
+
+exit $OVERALL_RESULT


### PR DESCRIPTION
## Summary

Prevents `verification-before-completion` from passing incomplete implementations by adding three complementary safeguards: clean-room sub-agent verification, structural completeness gate, and RED test isolation.

## Outcome

- `structural-verify` task dispatches as clean-room sub-agent (receives only spec SCs + file paths, no implementation context)
- Structural completeness gate runs BEFORE per-SC evidence checks — verifies state_machines, evidence_artifacts, gates, decomposition in yaml+symbolic blocks
- RED test isolation rule requires behavioral enforcement tests to run in `with-test-home` isolated sessions
- Behavioral enforcement test `clean-room-structural-verify.sh` validates agent behavior

Implements #88
Fixes #87

🤖 Co-authored with AI: unknown (version detection failed)