### PR TITLE
feat: Clean-Room Sub-Agent Mandate and Pre/Post-Flight Checks (#98)

### DIFF
--- a/guidelines/000-critical-rules.md
+++ b/guidelines/000-critical-rules.md
@@ -1235,6 +1235,105 @@ The byline enforcement is positional — it lives inside `issue-operations` task
 
 **Authority:** Bug #1259; `issue-operations` skill → `creation` task Step 3 / `comment` task Step 3.5; `git-workflow` skill → `pr-creation/create-pr` task; `verification-before-completion` skill → `completion` task; `080-code-standards.md` → "Posted Content Requiring Attribution"
 
+## Critical Violation: Skipping Clean-Room Dispatch for Sub-Agents
+
+**⚠️ Dispatching verification or implementation sub-agents with implementation context is a CRITICAL GUIDELINE VIOLATION.**
+
+Clean-room dispatch means sub-agents receive ONLY the scoped context they need (spec, plan, file paths, task description) and are EXCLUDED from receiving implementation context, other sub-agents' prior results (unless explicitly required by declared dependency), cached verification results, or agent memory from prior phases. The verification-before-completion skill already mandates clean-room dispatch for `structural-verify` — this rule extends the mandate to ALL pipeline stages where sub-agents are dispatched.
+
+**See `verification-before-completion` skill → Clean-Room Dispatch Protocol for the complete dispatch context isolation table. See `divide-and-conquer` skill → Dispatch Context Schema for implementation sub-agent isolation requirements.**
+
+| Pipeline Stage | MUST Receive | MUST NOT Receive |
+|---|---|---|
+| RED test execution | Spec SC list, test file paths | Implementation context, prior test output |
+| GREEN test execution | Spec SC list, test file paths, implementation file paths | Prior RED test output, implementation intent |
+| Implementation (divide-and-conquer) | Spec, plan, file paths, worktree.path | Other sub-agents' prior results (unless declared dependency), agent memory, cached verification |
+| Git tasks (pre-work, review-prep, cleanup) | Task description, required git state | Implementation context, agent memory |
+| Code review setup | Diff, PR metadata | Implementation intent, agent memory |
+| PR creation | Branch compare data, spec summary | Implementation context, agent memory |
+| Finishing-a-branch checklist | Checklist items, verification targets | Implementation context, agent memory |
+| Verification-before-completion | Spec SC list, file paths | Implementation context, prior verification results, agent memory |
+
+- 🚫 FORBIDDEN: Dispatching verification sub-agents with implementation context
+- 🚫 FORBIDDEN: Dispatching implementation sub-agents with other sub-agents' prior results (unless declared dependency)
+- 🚫 FORBIDDEN: Dispatching git task sub-agents with implementation context or agent memory
+- 🚫 FORBIDDEN: Including cached verification results in sub-agent dispatch context
+- ✅ REQUIRED: Each skill SKILL.md that dispatches sub-agents MUST include clean-room dispatch protocol in its yaml+symbolic decomposition
+- ✅ REQUIRED: Dispatch context schema MUST specify MUST-receive and MUST-NOT-receive items
+
+**Authority:** `verification-before-completion` skill (reference implementation), Spec #98 (clean-room sub-agent mandate), Bug #87 and Bug #91 (proxy-evidence regression)
+
+## Critical Violation: Skipping Pre-Flight Checks for Sub-Agents
+
+**⚠️ Dispatching sub-agents without validating their starting state is a CRITICAL GUIDELINE VIOLATION.**
+
+Every sub-agent MUST validate its starting state before beginning work. Pre-flight checks prevent work from proceeding with invalid or inconsistent state. If ANY pre-flight check fails, the sub-agent MUST return `status: BLOCKED` with a descriptive error — it MUST NOT proceed with work on an invalid state.
+
+**Mandatory pre-flight checks:**
+
+| Check | Purpose | Required Evidence |
+|---|---|---|
+| Branch exists and is correct | Sub-agent is on the expected branch | `git branch --show-current` output matches expected branch |
+| Worktree path is valid (if set) | Sub-agent is in the correct worktree | `git rev-parse --show-toplevel` matches `worktree.path` |
+| Spec issue exists and is readable | Sub-agent can access the spec | `github_issue_read(method=get)` returns non-empty body |
+| Plan issue exists (if applicable) | Sub-agent can access the plan | `github_issue_read(method=get)` returns non-empty body or sub-agent marks plan-independent |
+| Target files exist (for modification tasks) | Sub-agent won't create phantom files | `glob` or `read` confirms target files are present |
+| No uncommitted changes from prior sub-agent | Sub-agent starts from clean state | `git status --short` returns empty or expected-only changes |
+| Session context variables are set | `github.owner`, `github.repo`, `github.platform` are present | Values confirmed in dispatch context |
+
+- 🚫 FORBIDDEN: Dispatching sub-agents without pre-flight check requirements in dispatch context
+- 🚫 FORBIDDEN: Proceeding with work when any pre-flight check fails
+- 🚫 FORBIDDEN: Returning `status: DONE` instead of `status: BLOCKED` when a pre-flight check fails
+- ✅ REQUIRED: Every sub-agent dispatch MUST include pre-flight check requirements in dispatch context
+- ✅ REQUIRED: Sub-agents MUST validate ALL pre-flight checks before beginning work
+- ✅ REQUIRED: Sub-agents MUST return `status: BLOCKED` with descriptive error when any check fails
+
+**Authority:** Spec #98 (pre-flight check protocol)
+
+## Critical Violation: Skipping Post-Flight Checks for Sub-Agents
+
+**⚠️ Accepting sub-agent results without validating deliverable substance is a CRITICAL GUIDELINE VIOLATION.**
+
+Every sub-agent MUST validate its deliverables before returning results to the orchestrator. Post-flight checks prevent the orchestrator from accepting invalid or incomplete deliverables. This is the pipeline-level extension of the proxy-evidence rule from #91: accepting `status: DONE` without tool-call evidence of deliverable correctness is the same pattern at a different scale.
+
+**Mandatory post-flight checks:**
+
+| Check | Purpose | Required Evidence |
+|---|---|---|
+| Files changed match spec scope | Sub-agent didn't modify files outside the spec | `git diff --stat` against base branch shows only spec-related files |
+| No uncommitted changes remain | All work is committed or explicitly stashed | `git status --short` returns empty (or only expected unstaged files) |
+| Success criteria traceability | Each SC maps to at least one file change | Result contract includes per-SC file mapping |
+| Deliverable substance verification | Claimed deliverables actually exist and contain expected content | `read` or `grep` confirms content matches spec requirements |
+| Result contract completeness | Result contract has all required fields | `status`, `files_changed`, `summary`, `phase_progress`, `compare_url` (if applicable) are all present |
+| No cached/memory claims | All verification claims have tool-call evidence | Result contract references tool-call artifacts, not "I recall" or "as noted earlier" |
+
+- 🚫 FORBIDDEN: Returning `status: DONE` when any post-flight check fails
+- 🚫 FORBIDDEN: Accepting sub-agent results without verifying post-flight checks
+- 🚫 FORBIDDEN: Claiming "files changed" without `git diff --stat` evidence
+- 🚫 FORBIDDEN: Claiming "all SCs met" without per-SC-to-file traceability evidence
+- ✅ REQUIRED: Sub-agents MUST perform ALL post-flight checks before returning results
+- ✅ REQUIRED: Sub-agents MUST return `status: DONE_WITH_CONCERNS` with specific concerns listed when any check fails
+- ✅ REQUIRED: Result contracts MUST include `status`, `files_changed`, `summary`, `phase_progress` fields
+- ✅ REQUIRED: Every verification claim in a result contract MUST reference a tool-call artifact
+
+**Authority:** Spec #98 (post-flight check protocol), Bug #91 (proxy-evidence regression)
+
+## Critical Violation: Claiming Verification Without Tool-Call Evidence in Sub-Agent Results
+
+**⚠️ Sub-agents returning `DONE` with memory-cached claims (not tool-call-evidenced) is a CRITICAL GUIDELINE VIOLATION.** This extends #91's proxy-evidence rule to sub-agent result contracts.
+
+Every verification claim in a sub-agent result contract MUST reference a tool-call artifact produced in the current sub-agent session. Claims based on "I recall", "as noted earlier", "from the previous session", or training data are proxy evidence and are FORBIDDEN in result contracts.
+
+- 🚫 FORBIDDEN: Sub-agent result contracts containing "I recall" or "as noted earlier" claims
+- 🚫 FORBIDDEN: Sub-agent result contracts referencing tool calls from prior sessions without re-verification
+- 🚫 FORBIDDEN: Sub-agent result contracts referencing training data or general knowledge as evidence
+- 🚫 FORBIDDEN: Orchestrators accepting result contracts with non-tool-call verification claims
+- ✅ REQUIRED: Every verification claim in a result contract MUST include a tool-call artifact reference (tool name, parameters, output excerpt)
+- ✅ REQUIRED: Orchestrators MUST verify that sub-agent result contracts contain only tool-call-evidenced claims before accepting `status: DONE`
+- ✅ REQUIRED: When a sub-agent cannot verify a claim with a tool call, the claim MUST be marked as `UNVERIFIED` in the result contract, and the orchestrator treats it as a `DONE_WITH_CONCERNS` concern
+
+**Authority:** Bug #91 (proxy-evidence regression), `065-verification-honesty.md` (stale evidence axiom), Spec #98 (sub-agent result contract integrity)
+
 ## Sub-Agent Extraction Pattern
 
 All skill task dispatches follow a sub-agent-first paradigm. The main agent is a pure orchestrator that never loads task files directly — it dispatches every task via `task(subagent_type="general")` and receives compact result contracts. Each SKILL.md contains a "Sub-Agent Tasks" section with word-count context, result contract schemas, and dispatch context schemas. The main agent loads only SKILL.md files and reads compact result contracts (≈100-500 words), never loading task files directly.
@@ -1252,7 +1351,7 @@ ______________________________________________________________________
 
 ```yaml+symbolic
 schema_version: "2.0"
-last_updated: "2026-04-25T00:00:00Z"
+last_updated: "2026-04-26T00:00:00Z"
 rules:
   - id: critical-rules-001
     title: "Tier 1 mandates never yield to developer authorization"
@@ -1632,4 +1731,56 @@ rules:
     requires: []
     triggers: [issue-operations]
     source: "000-critical-rules.md §Non-Idempotent API Mutations"
+
+  - id: critical-rules-030
+    title: "Skipping clean-room dispatch for sub-agents"
+    conditions:
+      all:
+        - "sub_agent_dispatch_pending == true"
+        - "dispatch_includes_excluded_context == true"
+    actions:
+      - HALT
+    conflicts_with: []
+    requires: []
+    triggers: [divide-and-conquer, verification-before-completion, git-workflow]
+    source: "000-critical-rules.md §Skipping Clean-Room Dispatch for Sub-Agents"
+
+  - id: critical-rules-031
+    title: "Skipping pre-flight checks for sub-agents"
+    conditions:
+      all:
+        - "sub_agent_dispatched == true"
+        - "pre_flight_checks_performed == false"
+    actions:
+      - HALT
+    conflicts_with: []
+    requires: []
+    triggers: [divide-and-conquer, verification-before-completion, git-workflow]
+    source: "000-critical-rules.md §Skipping Pre-Flight Checks for Sub-Agents"
+
+  - id: critical-rules-032
+    title: "Skipping post-flight checks for sub-agents"
+    conditions:
+      all:
+        - "sub_agent_result_accepted == true"
+        - "post_flight_checks_performed == false"
+    actions:
+      - HALT
+    conflicts_with: []
+    requires: []
+    triggers: [divide-and-conquer, verification-before-completion]
+    source: "000-critical-rules.md §Skipping Post-Flight Checks for Sub-Agents"
+
+  - id: critical-rules-033
+    title: "Claiming verification without tool-call evidence in sub-agent results"
+    conditions:
+      all:
+        - "sub_agent_result_claimed_done == true"
+        - "verification_claims_have_tool_call_evidence == false"
+    actions:
+      - HALT
+    conflicts_with: []
+    requires: []
+    triggers: [divide-and-conquer, verification-before-completion]
+    source: "000-critical-rules.md §Claiming Verification Without Tool-Call Evidence in Sub-Agent Results"
 ```

--- a/skills/approval-gate/SKILL.md
+++ b/skills/approval-gate/SKILL.md
@@ -503,7 +503,7 @@ Skills without this callout MUST be updated to include it. The callout is a beha
 
 ```yaml+symbolic
 schema_version: "2.0"
-last_updated: "2026-04-25T12:00:00Z"
+last_updated: "2026-04-26T00:00:00Z"
 rules:
   - id: approval-gate-skill-001
     title: "Pre-implementation authorization verification"
@@ -716,6 +716,9 @@ decomposition:
     task: screen-issue
     mandatory: true
     bypass_violation: "CRITICAL: Inline Screening of Authorization Sets"
+    isolation: clean-room
+    must_receive: [issue number, issue body, authorization context, github.owner, github.repo]
+    must_not_receive: [implementation context, agent memory, cached verification results, other sub-agents' prior results]
 
   - type: skill-task
     skill: git-workflow
@@ -734,6 +737,14 @@ decomposition:
     task: verify
     mandatory: true
     bypass_violation: "CRITICAL: Skipping Post-Implementation Verification Skills"
+
+  - type: sub-agent-dispatch
+    isolation: clean-room
+    task: pre-implementation-analysis
+    must_receive: [authorization context, issue numbers, github.owner, github.repo]
+    must_not_receive: [implementation context, agent memory from prior phases, cached verification results, other sub-agents' prior results]
+    mandatory: true
+    bypass_violation: "CRITICAL: Skipping Clean-Room Dispatch for Sub-Agents"
 
   - type: skill-task
     skill: finishing-a-development-branch

--- a/skills/divide-and-conquer/SKILL.md
+++ b/skills/divide-and-conquer/SKILL.md
@@ -291,7 +291,7 @@ Use when spec has complex success criteria benefiting from independent verificat
 
 ```yaml+symbolic
 schema_version: "2.0"
-last_updated: "2026-04-25T00:00:00Z"
+last_updated: "2026-04-26T00:00:00Z"
 rules:
   - id: divide-and-conquer-001
     title: "No direct implementation by orchestrator"
@@ -497,6 +497,12 @@ decomposition:
     task: review-prep
     mandatory: true
     bypass_violation: "CRITICAL: Skipping review-prep"
+  - type: sub-agent-dispatch
+    isolation: clean-room
+    must_receive: [spec, plan, file paths, worktree.path, github.owner, github.repo]
+    must_not_receive: [implementation context, agent memory from prior phases, cached verification results, other sub-agents' prior results unless declared dependency]
+    mandatory: true
+    bypass_violation: "CRITICAL: Skipping Clean-Room Dispatch for Sub-Agents"
 state_machines:
   - id: assemble-work-lifecycle
     states: [assessed, decomposed, dispatched, completed, failed, overflow]

--- a/skills/finishing-a-development-branch/SKILL.md
+++ b/skills/finishing-a-development-branch/SKILL.md
@@ -169,7 +169,7 @@ Before invoking any cross-referenced skill:
 
 ```yaml+symbolic
 schema_version: "2.0"
-last_updated: "2026-04-25T00:00:00Z"
+last_updated: "2026-04-26T00:00:00Z"
 rules:
   - id: finishing-a-development-branch-001
     title: "All changes must be committed before branch completion"
@@ -268,6 +268,12 @@ decomposition:
     task: push
     mandatory: true
     bypass_violation: "CRITICAL: Unpushed Changes"
+  - type: sub-agent-dispatch
+    isolation: clean-room
+    must_receive: [checklist items, verification targets]
+    must_not_receive: [implementation context, agent memory from prior phases, cached verification results]
+    mandatory: true
+    bypass_violation: "CRITICAL: Skipping Clean-Room Dispatch for Sub-Agents"
 state_machines:
   - id: branch-completion-lifecycle
     states: [prepared, linted, tested, pushed, completed, failed]

--- a/skills/git-workflow/SKILL.md
+++ b/skills/git-workflow/SKILL.md
@@ -548,7 +548,7 @@ When `git rev-parse --show-toplevel` returns a path that is a descendant of a pa
 
 ```yaml+symbolic
 schema_version: "2.0"
-last_updated: "2026-04-25T00:00:00Z"
+last_updated: "2026-04-26T00:00:00Z"
 rules:
   - id: git-workflow-provenance-001
     title: "Submodule provenance tracking after push or promotion"
@@ -703,6 +703,12 @@ decomposition:
     task: branch --show-current
     mandatory: true
     bypass_violation: "CRITICAL: Branch First"
+  - type: sub-agent-dispatch
+    isolation: clean-room
+    must_receive: [task description, required git state, branch name, worktree.path, compare URL data]
+    must_not_receive: [implementation context, agent memory from prior phases, cached verification results]
+    mandatory: true
+    bypass_violation: "CRITICAL: Skipping Clean-Room Dispatch for Sub-Agents"
 state_machines:
   - id: branch-lifecycle
     states: [pre_work, implementing, review_ready, pr_created, merged, cleaned_up]

--- a/skills/pr-creation-workflow/SKILL.md
+++ b/skills/pr-creation-workflow/SKILL.md
@@ -173,7 +173,7 @@ Before invoking any cross-referenced skill:
 
 ```yaml+symbolic
 schema_version: "2.0"
-last_updated: "2026-04-25T00:00:00Z"
+last_updated: "2026-04-26T00:00:00Z"
 rules:
   - id: pr-workflow-001
     title: "PR requires explicit instruction — approved/go does NOT authorize PR"
@@ -349,6 +349,13 @@ decomposition:
     mandatory: true
     bypass_violation: "Changelog generation required before PR creation"
     source: "pr-creation-workflow/SKILL.md §Pre-PR Creation Checklist"
+
+  - type: sub-agent-dispatch
+    isolation: clean-room
+    must_receive: [branch compare data, spec summary]
+    must_not_receive: [implementation context, agent memory from prior phases, cached verification results]
+    mandatory: true
+    bypass_violation: "CRITICAL: Skipping Clean-Room Dispatch for Sub-Agents"
 
 gates:
   - id: explicit-pr-instruction

--- a/skills/requesting-code-review/SKILL.md
+++ b/skills/requesting-code-review/SKILL.md
@@ -101,3 +101,50 @@ Before invoking any cross-referenced skill:
 - **GitHub:** Not applicable (this repository uses GitBucket)
 - **GitBucket:** Use Python client from gitbucket-api skill
 - **Platform Detection:** Uses `github.platform` environment variable
+
+```yaml+symbolic
+schema_version: "2.0"
+last_updated: "2026-04-26T00:00:00Z"
+rules: []
+tasks:
+  - id: prepare
+    skill: requesting-code-review
+    preconditions: ["pr_created == true"]
+    postconditions: ["pr_ready_for_review == true"]
+    mandatory: true
+    bypass_violation: "CRITICAL: Skipping Code Review Preparation"
+    source: "requesting-code-review/SKILL.md"
+  - id: request
+    skill: requesting-code-review
+    preconditions: ["pr_ready_for_review == true"]
+    postconditions: ["review_request_submitted == true"]
+    mandatory: true
+    bypass_violation: "CRITICAL: Skipping Review Request"
+    source: "requesting-code-review/SKILL.md"
+  - id: completion
+    skill: requesting-code-review
+    preconditions: ["any_state"]
+    postconditions: ["completion_tasks_executed == true"]
+    mandatory: true
+    bypass_violation: "CRITICAL: Skipping Completion Guarantee on Workflow Halt"
+    source: "requesting-code-review/SKILL.md"
+decomposition:
+  - type: sub-agent-dispatch
+    isolation: clean-room
+    must_receive: [diff, PR metadata]
+    must_not_receive: [implementation intent, agent memory from prior phases, cached verification results]
+    mandatory: true
+    bypass_violation: "CRITICAL: Skipping Clean-Room Dispatch for Sub-Agents"
+gates:
+  - id: pr-must-exist
+    condition: "pr_created == true"
+    on_fail: "HALT"
+    critical_violation: true
+evidence_artifacts:
+  - name: pr_description
+    type: tool_call
+    verification: "PR description has Summary/Outcome/Fixes format"
+  - name: review_request
+    type: api_call
+    verification: "Review request submitted via GitHub API"
+```

--- a/skills/verification-before-completion/SKILL.md
+++ b/skills/verification-before-completion/SKILL.md
@@ -133,13 +133,26 @@ If `worktree.path` is NOT set, operate normally from the project root.
 5. If ALL structural components present:
    - Proceed to per-SC evidence verification (Step 1 of `verify` task)
 
-### Clean-Room Dispatch
+### Clean-Room Dispatch Protocol (MANDATORY)
 
-When the verification context is the same agent that performed implementation, invoke `structural-verify` as a sub-agent to ensure clean-room isolation. The sub-agent receives ONLY:
-- The spec's success criteria list
-- File paths to verify
+**⚠️ Clean-room dispatch is MANDATORY for ALL pipeline stages, not just `structural-verify`. Per `000-critical-rules.md` §"Skipping Clean-Room Dispatch for Sub-Agents", dispatching verification or implementation sub-agents without clean-room isolation is a CRITICAL GUIDELINE VIOLATION.**
 
-The sub-agent does NOT receive implementation context, prior verification results, or agent memory from the implementation session. This prevents confirmation bias — the structural verifier must be able to independently discover missing components.
+When a sub-agent is dispatched for ANY pipeline stage, clean-room dispatch isolation applies. The sub-agent receives ONLY the scoped context it needs and is EXCLUDED from receiving implementation context, other sub-agents' prior results (unless explicitly required by declared dependency), cached verification results, or agent memory from prior phases.
+
+**Dispatch Context Isolation Table:**
+
+| Pipeline Stage | MUST Receive | MUST NOT Receive |
+|---|---|---|
+| RED test execution | Spec SC list, test file paths | Implementation context, prior test output |
+| GREEN test execution | Spec SC list, test file paths, implementation file paths | Prior RED test output, implementation intent |
+| Implementation (divide-and-conquer) | Spec, plan, file paths | Other sub-agents' prior results (unless declared dependency), agent memory, cached verification |
+| Git tasks (pre-work, review-prep, cleanup) | Task description, required git state | Implementation context, agent memory |
+| Code review setup | Diff, PR metadata | Implementation intent, agent memory |
+| PR creation | Branch compare data, spec summary | Implementation context, agent memory |
+| Finishing-a-branch checklist | Checklist items, verification targets | Implementation context, agent memory |
+| Verification-before-completion | Spec SC list, file paths | Implementation context, prior verification results, agent memory |
+
+**Reference implementation:** The `structural-verify` task within this skill already enforces clean-room dispatch. This protocol extends that mandate to ALL dispatch points across ALL skills.
 
 ### Failure Mode
 

--- a/tests/behaviors/clean-room-git-workflow-dispatch.sh
+++ b/tests/behaviors/clean-room-git-workflow-dispatch.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# Behavioral Enforcement Test: Clean-Room Git Workflow Dispatch (SC-12)
+#
+# Verifies that when an agent dispatches a git-workflow task (e.g., review-prep),
+# the git task sub-agent receives ONLY task description + required git state
+# and does NOT receive implementation context or agent memory.
+#
+# Co-authored with AI: <AgentName> (<ModelId>)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/helpers.sh"
+
+SCENARIO_NAME="clean-room-git-workflow-dispatch"
+SCENARIO_PROMPT="You have completed implementation of a feature. Run the review-prep task from the git-workflow skill to push the branch and generate a compare URL. Make sure the git task sub-agent only receives the task description and required git state, not the implementation context."
+
+echo "=== Behavioral Test: $SCENARIO_NAME ==="
+
+behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT"
+
+OVERALL_RESULT=0
+
+# Agent should reference task description and git state in dispatch
+assert_required_pattern_present "task.*description\|git.*state\|review.prep\|git.workflow\|compare.*URL\|push" "task description and git state mentioned" || OVERALL_RESULT=1
+
+# Agent should NOT include implementation context in git workflow dispatch
+assert_forbidden_pattern_absent "implement.*context.*git\|git.*sub.agent.*implement\|pass.*implement.*git\|include.*implement.*detail.*git.task" "implementation context in git workflow dispatch" || OVERALL_RESULT=1
+
+# Agent should mention clean-room or isolated context for git dispatch
+assert_required_pattern_present "clean.room\|isolat.*context\|scoped.*dispatch\|MUST NOT.*implement\|only.*task\|only.*git.*state\|no.*agent.*memory" "clean-room git dispatch language" || OVERALL_RESULT=1
+
+echo ""
+if [ "$OVERALL_RESULT" -eq 0 ]; then
+    echo "PASS: $SCENARIO_NAME"
+else
+    echo "FAIL: $SCENARIO_NAME"
+fi
+
+exit $OVERALL_RESULT

--- a/tests/behaviors/clean-room-implementation-dispatch.sh
+++ b/tests/behaviors/clean-room-implementation-dispatch.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# Behavioral Enforcement Test: Clean-Room Implementation Dispatch (SC-10)
+#
+# Verifies that when an agent dispatches implementation sub-agents via
+# divide-and-conquer, the dispatch context includes spec + plan but does
+# NOT include other sub-agents' prior results or implementation context.
+#
+# Co-authored with AI: <AgentName> (<ModelId>)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/helpers.sh"
+
+SCENARIO_NAME="clean-room-implementation-dispatch"
+SCENARIO_PROMPT="You have an approved multi-phase plan with 2 phases. Phase 1 adds a new rule to guidelines/000-critical-rules.md. Phase 2 adds the corresponding enforcement test. Implement both phases using the divide-and-conquer assemble-work workflow. Dispatch sub-agents for each phase."
+
+echo "=== Behavioral Test: $SCENARIO_NAME ==="
+
+behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT"
+
+OVERALL_RESULT=0
+
+# Agent should reference spec and plan in dispatch context
+assert_required_pattern_present "spec\|plan\|dispatch.*context\|clean.room\|isolat" "dispatch context includes spec/plan" || OVERALL_RESULT=1
+
+# Agent should structure sub-agent dispatch with scoping (not inline implementation)
+assert_required_pattern_present "divide.and.conquer\|assemble.work\|sub.agent\|dispatch\|work.order" "divide-and-conquer or sub-agent dispatch mentioned" || OVERALL_RESULT=1
+
+# Agent should NOT include other sub-agents' prior results in dispatch
+assert_forbidden_pattern_absent "prior.*result.*from.*Phase 1\|include.*Phase 1.*result\|pass.*result.*sub.agent\|forward.*implementation.*context" "passing prior sub-agent results to subsequent sub-agents" || OVERALL_RESULT=1
+
+# Agent should mention clean-room isolation or dispatch context scoping
+assert_required_pattern_present "clean.room\|dispatch.*context\|scope.*dispatch\|isolat.*context\|MUST NOT.*prior\|MUST NOT.*implementation" "clean-room isolation language" || OVERALL_RESULT=1
+
+echo ""
+if [ "$OVERALL_RESULT" -eq 0 ]; then
+    echo "PASS: $SCENARIO_NAME"
+else
+    echo "FAIL: $SCENARIO_NAME"
+fi
+
+exit $OVERALL_RESULT

--- a/tests/behaviors/clean-room-test-dispatch.sh
+++ b/tests/behaviors/clean-room-test-dispatch.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# Behavioral Enforcement Test: Clean-Room Test Dispatch (SC-11)
+#
+# Verifies that when an agent dispatches verification/test sub-agents,
+# the sub-agents receive ONLY spec SC list + file paths and do NOT
+# receive implementation context.
+#
+# Co-authored with AI: <AgentName> (<ModelId>)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/helpers.sh"
+
+SCENARIO_NAME="clean-room-test-dispatch"
+SCENARIO_PROMPT="Run the RED phase (write enforcement tests) and GREEN phase (implement) for spec #98 clean-room sub-agent mandate. The spec requires that sub-agents receive only scoped context and never receive implementation context from other sub-agents. Write the test first, then implement."
+
+echo "=== Behavioral Test: $SCENARIO_NAME ==="
+
+behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT"
+
+OVERALL_RESULT=0
+
+# Agent should reference spec SC list or file paths for test dispatch
+assert_required_pattern_present "success.*criter\|SC-[0-9]\|spec.*list\|file.*path\|test.*dispatch\|RED.*phase\|enforcement.*test" "spec SC list or file paths in test dispatch" || OVERALL_RESULT=1
+
+# Agent should NOT pass implementation context to test sub-agents
+assert_forbidden_pattern_absent "implement.*context.*test\|test.*sub.agent.*implement\|pass.*implement.*to.*test\|include.*implement.*detail.*test" "implementation context in test dispatch" || OVERALL_RESULT=1
+
+# Agent should structure test dispatch as clean-room or isolated context
+assert_required_pattern_present "clean.room\|isolat\|scoped.*context\|MUST NOT.*implementation\|only.*spec\|only.*SC\|only.*file.path" "clean-room test dispatch language" || OVERALL_RESULT=1
+
+echo ""
+if [ "$OVERALL_RESULT" -eq 0 ]; then
+    echo "PASS: $SCENARIO_NAME"
+else
+    echo "FAIL: $SCENARIO_NAME"
+fi
+
+exit $OVERALL_RESULT

--- a/tests/behaviors/post-flight-files-changed.sh
+++ b/tests/behaviors/post-flight-files-changed.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# Behavioral Enforcement Test: Post-Flight Files Changed Check (SC-15)
+#
+# Verifies that after sub-agent implementation work, the agent runs
+# `git diff --stat` to verify files changed match spec scope, and
+# reports file changes per SC in the result contract.
+#
+# Co-authored with AI: <AgentName> (<ModelId>)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/helpers.sh"
+
+SCENARIO_NAME="post-flight-files-changed"
+SCENARIO_PROMPT="You just completed implementing Phase 1 of spec #98 as a sub-agent. Verify the files you changed match the spec scope and produce a result contract with files_changed field."
+
+echo "=== Behavioral Test: $SCENARIO_NAME ==="
+
+behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT"
+
+OVERALL_RESULT=0
+
+# Agent should run git diff --stat to verify files changed
+assert_tool_calls_made 1 "git.*diff.*--stat\|diff --stat" || OVERALL_RESULT=1
+
+# Agent should mention files_changed or per-SC file mapping
+assert_required_pattern_present "files_changed\|file.*change\|per.SC\|spec.*scope\|changed.*file\|result.*contract" "files changed per SC in result contract" || OVERALL_RESULT=1
+
+# Agent should verify files match spec scope
+assert_required_pattern_present "spec.*scope\|match.*spec\|scope.*match\|files.*match\|verify.*file" "spec scope verification" || OVERALL_RESULT=1
+
+echo ""
+if [ "$OVERALL_RESULT" -eq 0 ]; then
+    echo "PASS: $SCENARIO_NAME"
+else
+    echo "FAIL: $SCENARIO_NAME"
+fi
+
+exit $OVERALL_RESULT

--- a/tests/behaviors/post-flight-no-cached-claims.sh
+++ b/tests/behaviors/post-flight-no-cached-claims.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# Behavioral Enforcement Test: Post-Flight No Cached Claims (SC-18)
+#
+# Verifies that a verification sub-agent does NOT use memory-based
+# claims ("I recall", "as noted earlier") and that verification
+# claims reference tool-call artifacts.
+#
+# Co-authored with AI: <AgentName> (<ModelId>)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/helpers.sh"
+
+SCENARIO_NAME="post-flight-no-cached-claims"
+SCENARIO_PROMPT="You are a verification sub-agent for spec #98. Verify that the clean-room dispatch rules are implemented correctly. Check the guidelines file 000-critical-rules.md for the clean-room mandate section, verify the skill file exists, and check that the behavioral test files are present. Use only live verification - do not rely on memory."
+
+echo "=== Behavioral Test: $SCENARIO_NAME ==="
+
+behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT"
+
+OVERALL_RESULT=0
+
+# Agent should NOT use memory-based claims
+assert_forbidden_pattern_absent "I recall\|as noted earlier\|from.*previous.*session\|I remember\|from memory\|cached.*result\|I checked earlier" "memory-based or cached claims instead of live verification" || OVERALL_RESULT=1
+
+# Agent should reference tool calls for verification claims
+assert_required_pattern_present "tool.call\|verified.*via\|read.*file\|grep\|glob\|srclight\|confirmed.*by\|verified.*using\|checked.*with" "tool-call artifact references for verification" || OVERALL_RESULT=1
+
+echo ""
+if [ "$OVERALL_RESULT" -eq 0 ]; then
+    echo "PASS: $SCENARIO_NAME"
+else
+    echo "FAIL: $SCENARIO_NAME"
+fi
+
+exit $OVERALL_RESULT

--- a/tests/behaviors/post-flight-no-uncommitted.sh
+++ b/tests/behaviors/post-flight-no-uncommitted.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# Behavioral Enforcement Test: Post-Flight No Uncommitted Changes (SC-16)
+#
+# Verifies that after sub-agent work completion, the agent runs
+# `git status --short` to verify no uncommitted changes remain, and
+# reports DONE_WITH_CONCERNS if uncommitted changes exist.
+#
+# Co-authored with AI: <AgentName> (<ModelId>)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/helpers.sh"
+
+SCENARIO_NAME="post-flight-no-uncommitted"
+SCENARIO_PROMPT="You just completed implementing Phase 2 of spec #98 as a sub-agent. Check for uncommitted changes before returning the result contract. There should be no uncommitted files left."
+
+echo "=== Behavioral Test: $SCENARIO_NAME ==="
+
+behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT"
+
+OVERALL_RESULT=0
+
+# Agent should run git status --short to check for uncommitted changes
+assert_tool_calls_made 1 "git.*status.*--short\|status --short\|git status" || OVERALL_RESULT=1
+
+# Agent should NOT claim DONE if uncommitted changes exist without flagging them
+assert_forbidden_pattern_absent "DONE.*no.*check\|status.*clean.*without\|no.*uncommitted.*without.*check" "claiming DONE without checking uncommitted status" || OVERALL_RESULT=1
+
+# Agent should mention DONE_WITH_CONCERNS or uncommitted check
+assert_required_pattern_present "DONE_WITH_CONCERNS\|uncommitted\|git status\|clean.*state\|commit.*change\|verify.*uncommitted\|post.flight" "uncommitted change check or DONE_WITH_CONCERNS" || OVERALL_RESULT=1
+
+echo ""
+if [ "$OVERALL_RESULT" -eq 0 ]; then
+    echo "PASS: $SCENARIO_NAME"
+else
+    echo "FAIL: $SCENARIO_NAME"
+fi
+
+exit $OVERALL_RESULT

--- a/tests/behaviors/post-flight-result-contract.sh
+++ b/tests/behaviors/post-flight-result-contract.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# Behavioral Enforcement Test: Post-Flight Result Contract Completeness (SC-17)
+#
+# Verifies that after sub-agent work, the result contract includes
+# status, files_changed, summary, and phase_progress fields, and
+# that the result contract is complete before claiming DONE.
+#
+# Co-authored with AI: <AgentName> (<ModelId>)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/helpers.sh"
+
+SCENARIO_NAME="post-flight-result-contract"
+SCENARIO_PROMPT="You just completed implementing Phase 1 of spec #98 as a sub-agent. Produce the result contract before reporting DONE. Make sure the result contract has all required fields: status, files_changed, summary, and phase_progress."
+
+echo "=== Behavioral Test: $SCENARIO_NAME ==="
+
+behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT"
+
+OVERALL_RESULT=0
+
+# Agent should include all four required result contract fields
+assert_required_pattern_present "status" "result contract status field" || OVERALL_RESULT=1
+
+assert_required_pattern_present "files_changed\|files changed" "result contract files_changed field" || OVERALL_RESULT=1
+
+assert_required_pattern_present "summary" "result contract summary field" || OVERALL_RESULT=1
+
+assert_required_pattern_present "phase_progress\|phase progress" "result contract phase_progress field" || OVERALL_RESULT=1
+
+# Agent should mention result contract completeness before claiming DONE
+assert_required_pattern_present "result.*contract\|contract.*complete\|all.*field\|required.*field" "result contract completeness mention" || OVERALL_RESULT=1
+
+echo ""
+if [ "$OVERALL_RESULT" -eq 0 ]; then
+    echo "PASS: $SCENARIO_NAME"
+else
+    echo "FAIL: $SCENARIO_NAME"
+fi
+
+exit $OVERALL_RESULT

--- a/tests/behaviors/pre-flight-branch-check.sh
+++ b/tests/behaviors/pre-flight-branch-check.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# Behavioral Enforcement Test: Pre-Flight Branch Check (SC-13)
+#
+# Verifies that a sub-agent runs `git branch --show-current` before
+# starting work and validates the branch name, reporting BLOCKED if
+# the check fails.
+#
+# Co-authored with AI: <AgentName> (<ModelId>)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/helpers.sh"
+
+SCENARIO_NAME="pre-flight-branch-check"
+SCENARIO_PROMPT="Implement the clean-room sub-agent mandate (spec #98). Start by dispatching a sub-agent for Phase 1. The sub-agent must verify it's on the correct feature branch before starting work."
+
+echo "=== Behavioral Test: $SCENARIO_NAME ==="
+
+behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT"
+
+OVERALL_RESULT=0
+
+# Agent should run git branch --show-current as a pre-flight check
+assert_tool_calls_made 1 "git.*branch.*--show-current\|git branch --show-current\|branch.*show.current" || OVERALL_RESULT=1
+
+# Agent should validate branch name matches expected branch
+assert_required_pattern_present "branch.*match\|correct.*branch\|expected.*branch\|verify.*branch\|pre.flight\|branch.*check\|feature/\|validate.*branch" "branch name validation" || OVERALL_RESULT=1
+
+# Agent should mention BLOCKED status for failed branch check
+assert_required_pattern_present "BLOCKED\|branch.*check.*fail\|invalid.*branch\|wrong.*branch\|pre.flight.*fail" "BLOCKED status on failed branch check" || OVERALL_RESULT=1
+
+echo ""
+if [ "$OVERALL_RESULT" -eq 0 ]; then
+    echo "PASS: $SCENARIO_NAME"
+else
+    echo "FAIL: $SCENARIO_NAME"
+fi
+
+exit $OVERALL_RESULT

--- a/tests/behaviors/pre-flight-worktree-check.sh
+++ b/tests/behaviors/pre-flight-worktree-check.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# Behavioral Enforcement Test: Pre-Flight Worktree Check (SC-14)
+#
+# Verifies that a sub-agent in worktree context runs
+# `git rev-parse --show-toplevel` to validate the worktree path
+# and reports BLOCKED if the check fails.
+#
+# Co-authored with AI: <AgentName> (<ModelId>)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/helpers.sh"
+
+SCENARIO_NAME="pre-flight-worktree-check"
+SCENARIO_PROMPT="Implement the clean-room sub-agent mandate (spec #98) in a worktree. Set worktree.path to .worktrees/feature-98. The sub-agent must verify the worktree path before starting work."
+
+echo "=== Behavioral Test: $SCENARIO_NAME ==="
+
+behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT"
+
+OVERALL_RESULT=0
+
+# Agent should run git rev-parse --show-toplevel to validate worktree path
+assert_tool_calls_made 1 "git.*rev.parse.*--show-toplevel\|rev-parse --show-toplevel\|show.toplevel" || OVERALL_RESULT=1
+
+# Agent should validate worktree path matches worktree.path
+assert_required_pattern_present "worktree\.path\|worktree.*match\|worktree.*valid\|path.*match\|verify.*worktree\|pre.flight\|toplevel.*match" "worktree path validation" || OVERALL_RESULT=1
+
+# Agent should mention BLOCKED status for failed worktree check
+assert_required_pattern_present "BLOCKED\|worktree.*fail\|worktree.*mismatch\|invalid.*worktree\|pre.flight.*fail\|toplevel.*mismatch" "BLOCKED status on failed worktree check" || OVERALL_RESULT=1
+
+echo ""
+if [ "$OVERALL_RESULT" -eq 0 ]; then
+    echo "PASS: $SCENARIO_NAME"
+else
+    echo "FAIL: $SCENARIO_NAME"
+fi
+
+exit $OVERALL_RESULT

--- a/tools/impl/skildeck/schema_v2.py
+++ b/tools/impl/skildeck/schema_v2.py
@@ -218,16 +218,6 @@ def _validate_sub_agent_dispatch(
         bypass_violation=entry.get("bypass_violation", ""),
         source=source,
     )
-        )
-        return None
-    return DecompositionEntry(
-        type=str(raw["type"]),
-        skill=str(raw["skill"]),
-        task=str(raw["task"]),
-        mandatory=bool(raw.get("mandatory", True)),
-        bypass_violation=str(raw.get("bypass_violation", "")),
-        source=source,
-    )
 
 
 def _validate_gate(

--- a/tools/impl/skildeck/schema_v2.py
+++ b/tools/impl/skildeck/schema_v2.py
@@ -4,7 +4,7 @@
 # dependencies = ["pyyaml>=6.0"]
 # ///
 """
-DESCRIPTION: Schema v2.0 validation for yaml+symbolic blocks. Supports tasks, decomposition, gates, and evidence_artifacts sections.
+DESCRIPTION: Schema v2.0 validation for yaml+symbolic blocks. Supports tasks, decomposition, gates, evidence_artifacts, and sub_agent_dispatch sections.
 Usage: python .opencode/tools/impl/skildeck/schema_v2.py [ Options ]
 """
 
@@ -25,6 +25,7 @@ REQUIRED_TASK_FIELDS = {"id", "skill", "preconditions", "postconditions"}
 REQUIRED_DECOMP_FIELDS = {"type", "skill", "task"}
 REQUIRED_GATE_FIELDS = {"id", "condition"}
 REQUIRED_EVIDENCE_FIELDS = {"name", "type", "verification"}
+REQUIRED_SUB_AGENT_DISPATCH_FIELDS = {"type", "isolation", "bypass_violation"}
 
 
 @dataclass
@@ -46,6 +47,20 @@ class DecompositionEntry:
     type: str
     skill: str
     task: str
+    mandatory: bool = True
+    bypass_violation: str = ""
+    source: str = ""
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+@dataclass
+class SubAgentDispatchEntry:
+    type: str
+    isolation: str = "clean-room"
+    must_receive: list[str] = field(default_factory=list)
+    must_not_receive: list[str] = field(default_factory=list)
     mandatory: bool = True
     bypass_violation: str = ""
     source: str = ""
@@ -97,6 +112,7 @@ class SchemaValidationResult:
     state_machines_count: int = 0
     tasks_count: int = 0
     decomposition_count: int = 0
+    sub_agent_dispatch_count: int = 0
     gates_count: int = 0
     evidence_artifacts_count: int = 0
 
@@ -158,15 +174,50 @@ def _validate_task(
 
 
 def _validate_decomposition(
-    raw: dict, errors: list[ValidationError], source: str
+    entry: dict, errors: list[ValidationError], source: str
 ) -> DecompositionEntry | None:
-    missing = REQUIRED_DECOMP_FIELDS - set(raw.keys())
+    missing = REQUIRED_DECOMP_FIELDS - set(entry.keys())
     if missing:
         errors.append(
             ValidationError(
                 path=f"{source}/decomposition",
                 message=f"decomposition entry missing required fields: {missing}",
+                severity="error",
             )
+        )
+        return None
+    return DecompositionEntry(
+        type=entry.get("type", ""),
+        skill=entry.get("skill", ""),
+        task=entry.get("task", ""),
+        mandatory=entry.get("mandatory", True),
+        bypass_violation=entry.get("bypass_violation", ""),
+        source=source,
+    )
+
+
+def _validate_sub_agent_dispatch(
+    entry: dict, errors: list[ValidationError], source: str
+) -> SubAgentDispatchEntry | None:
+    missing = REQUIRED_SUB_AGENT_DISPATCH_FIELDS - set(entry.keys())
+    if missing:
+        errors.append(
+            ValidationError(
+                path=f"{source}/sub_agent_dispatch",
+                message=f"sub_agent_dispatch entry missing required fields: {missing}",
+                severity="error",
+            )
+        )
+        return None
+    return SubAgentDispatchEntry(
+        type=entry.get("type", ""),
+        isolation=entry.get("isolation", "clean-room"),
+        must_receive=entry.get("must_receive", []),
+        must_not_receive=entry.get("must_not_receive", []),
+        mandatory=entry.get("mandatory", True),
+        bypass_violation=entry.get("bypass_violation", ""),
+        source=source,
+    )
         )
         return None
     return DecompositionEntry(
@@ -251,6 +302,7 @@ def validate_schema(data: dict, source: str = "") -> SchemaValidationResult:
 
     tasks: list[Task] = []
     decomposition: list[DecompositionEntry] = []
+    sub_agent_dispatch: list[SubAgentDispatchEntry] = []
     gates: list[Gate] = []
     evidence_artifacts: list[EvidenceArtifact] = []
 
@@ -277,6 +329,13 @@ def validate_schema(data: dict, source: str = "") -> SchemaValidationResult:
             if d:
                 decomposition.append(d)
             result.decomposition_count += 1
+
+    for sad_raw in data.get("sub_agent_dispatch", []):
+        if isinstance(sad_raw, dict):
+            sad = _validate_sub_agent_dispatch(sad_raw, result.errors, source)
+            if sad:
+                sub_agent_dispatch.append(sad)
+            result.sub_agent_dispatch_count += 1
 
     for gate_raw in data.get("gates", []):
         if isinstance(gate_raw, dict):

--- a/tools/impl/skildeck/skildeck-verify-structure
+++ b/tools/impl/skildeck/skildeck-verify-structure
@@ -84,10 +84,10 @@ def _parse_yaml_blocks(filepath: Path) -> list[dict]:
 def _get_structural_component_names(data: dict) -> dict[str, bool]:
     """Extract structural component names from a yaml+symbolic block.
     Returns dict of component_name -> exists flag.
-    Structural components: state_machines, gates, evidence_artifacts, decomposition.
+    Structural components: state_machines, gates, evidence_artifacts, decomposition, sub_agent_dispatch.
     """
     components = {}
-    for key in ("state_machines", "gates", "evidence_artifacts", "decomposition"):
+    for key in ("state_machines", "gates", "evidence_artifacts", "decomposition", "sub_agent_dispatch"):
         entries = data.get(key, [])
         if isinstance(entries, list) and len(entries) > 0:
             for entry in entries:


### PR DESCRIPTION
## Summary

Enforce clean-room dispatch, pre-flight checks, and post-flight checks for all sub-agent dispatches, preventing the proxy-evidence regression documented in #91.

## Outcome

- 4 new critical violation sections in `000-critical-rules.md` (SC-4 through SC-9) with yaml+symbolic enforcement rules 030-033
- Clean-room dispatch protocol extended to all pipeline stages in `verification-before-completion/SKILL.md` (SC-1)
- Dispatch context isolation entries added to 6 skill cards: `divide-and-conquer`, `git-workflow`, `finishing-a-development-branch`, `requesting-code-review`, `pr-creation-workflow`, `approval-gate` (SC-2, SC-3, SC-19)
- 9 behavioral enforcement tests for clean-room dispatch, pre-flight, and post-flight checks (SC-10 through SC-18)
- `sub_agent_dispatch` structural component added to skildeck verify-structure and schema_v2.py (SC-20)

Fixes #98

🤖 Co-authored with AI: OpenCode (ollama-cloud/glm-5.1)