### PR TITLE
feat: add for_pr gap-fill critical violation and enforcement tests

### DIFF
--- a/guidelines/000-critical-rules.md
+++ b/guidelines/000-critical-rules.md
@@ -1380,6 +1380,25 @@ The orchestrator is a pure router. It dispatches sub-agents and collects result 
 
 **AUTHORITY:** Spec #106 (universal clean-room dispatch)
 
+## Critical Violation: for_pr Gap-Fill Halt — Asking Developer for Structural Decisions That the Scope Model Resolves
+
+**⚠️ When `for_pr` authorization is received, the agent MUST execute the gap-fill cascade (auto-create spec → auto-create plan → auto-approve) WITHOUT halting to ask the developer about plan creation, grouping, or execution order. These are agent intelligence decisions resolved by the Authorization Scope Model.**
+
+The `for_pr` scope explicitly defines: `halt_at = pr_created` with gap-fill actions covering spec creation, plan creation, plan approval, and PR creation. The agent Treating any of these as requiring developer input is a critical violation of the "Pushing Agent Intelligence Decisions to the User" mandate.
+
+- 🚫 FORBIDDEN: Asking "How would you like to proceed?" after receiving `for_pr` authorization
+- 🚫 FORBIDDEN: Asking for grouping decisions when scope resolves execution order
+- 🚫 FORBIDDEN: Treating plan creation as requiring developer input when `for_pr` scope auto-fills
+- 🚫 FORBIDDEN: Halting at any pipeline stage before `pr_created` when `for_pr` scope is active
+- 🚫 FORBIDDEN: Requesting re-authorization for steps that gap-fill covers (spec creation, plan creation, plan approval)
+- ✅ REQUIRED: Parse `for_pr` scope and execute gap-fill cascade autonomously
+- ✅ REQUIRED: Auto-create plans for specs that need them (using `writing-plans` skill)
+- ✅ REQUIRED: Auto-approve plans created via gap-fill per spec-to-plan cascade
+- ✅ REQUIRED: Build execution order from dependency analysis without developer input
+- ✅ REQUIRED: Proceed through the full pipeline to `pr_created` without halting for structural decisions
+
+**AUTHORITY:** Issue #111, `000-critical-rules.md` §Pushing Agent Intelligence Decisions to the User, `010-approval-gate.md` §Authorization Scope Model`
+
 ______________________________________________________________________
 
 **Search guidelines:** Use `srclight_search_symbols` or `grep` to find relevant guidelines.

--- a/guidelines/010-approval-gate.md
+++ b/guidelines/010-approval-gate.md
@@ -157,6 +157,8 @@ When `authorization_scope >= for_plan`, missing intermediate artifacts are gap-f
 - Plan needs approval → auto-approved via pipeline scope
 - `for_pr` scope → PR creation is part of gap-fill
 
+**`for_pr` gap-fill is autonomous — NO developer input for structural decisions.** The agent MUST NOT halt to ask about plan creation, issue grouping, execution order, or any structural decision that the scope model resolves. These are agent intelligence concerns, not developer decisions. See `000-critical-rules.md` → "for_pr Gap-Fill Halt" for the complete critical violation.
+
 ### Multi-Task Plan Authorization (CRITICAL)
 
 **When a plan has sub-issues:** plan approval cascades authorization to ALL sub-issues under the plan.
@@ -542,6 +544,19 @@ rules:
     requires: [approval-gate-010]
     triggers: [git-workflow, pr-creation-workflow]
     source: "010-approval-gate.md §Scope-Dependent PR Strategy"
+
+  - id: approval-gate-014
+    title: "for_pr scope auto gap-fill — no halt for structural decisions"
+    conditions:
+      all:
+        - "authorization_scope == 'for_pr'"
+        - "agent_halted_for_structural_decision == true"
+    actions:
+      - PROCEED_WITH_GAP_FILL
+    conflicts_with: []
+    requires: [approval-gate-010]
+    triggers: [approval-gate, divide-and-conquer]
+    source: "010-approval-gate.md §Authorization Scope Model"
 
 state_machines:
   - id: approval-lifecycle

--- a/tests/behaviors/for-pr-gap-fill.sh
+++ b/tests/behaviors/for-pr-gap-fill.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+# Behavioral Enforcement Test: for_pr scope gap-fill — agent MUST NOT halt to ask structural decisions
+#
+# Verifies that when the agent receives for_pr authorization, it does NOT
+# halt and ask the developer about plan creation, grouping, or execution order.
+# These are agent intelligence decisions resolved by the Authorization Scope Model.
+#
+# Issue #111: Agent Halts on for_pr Authorization Instead of Auto Gap-Filling
+#
+# Co-authored with AI: <AgentName> (<ModelId>)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/helpers.sh"
+
+SCENARIO_NAME="for-pr-gap-fill"
+SCENARIO_PROMPT="approved for pr: #999 — the bug fix spec for adding version field to config"
+
+echo "=== Behavioral Test: $SCENARIO_NAME ==="
+
+behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT"
+
+OVERALL_RESULT=0
+
+# Verify the agent does NOT halt and ask structural questions
+assert_forbidden_pattern_absent "[Hh]ow would you like to proceed" "how-would-you-like-to-proceed" || OVERALL_RESULT=1
+assert_forbidden_pattern_absent "[Ss]hall I create a plan" "shall-I-create-plan" || OVERALL_RESULT=1
+assert_forbidden_pattern_absent "[Ss]hould I create a plan" "should-I-create-plan" || OVERALL_RESULT=1
+assert_forbidden_pattern_absent "[Ww]ould you like me to create a plan" "would-you-like-plan" || OVERALL_RESULT=1
+assert_forbidden_pattern_absent "[Ww]hich issues should be grouped" "which-issues-grouped" || OVERALL_RESULT=1
+assert_forbidden_pattern_absent "[Hh]ow should we group" "how-should-we-group" || OVERALL_RESULT=1
+assert_forbidden_pattern_absent "[Ww]aiting for.*plan" "waiting-for-plan" || OVERALL_RESULT=1
+assert_forbidden_pattern_absent "[Aa]waiting.*plan.*approval" "awaiting-plan-approval" || OVERALL_RESULT=1
+
+# Verify the agent understands for_pr means auto gap-fill
+# The agent should reference gap-fill or auto-create without asking
+assert_forbidden_pattern_absent "[Nn]eed.*your approval.*plan" "need-your-approval-plan" || OVERALL_RESULT=1
+assert_forbidden_pattern_absent "[Pp]lease approve.*plan" "please-approve-plan" || OVERALL_RESULT=1
+
+echo ""
+if [ "$OVERALL_RESULT" -eq 0 ]; then
+    echo "PASS: $SCENARIO_NAME"
+else
+    echo "FAIL: $SCENARIO_NAME"
+fi
+
+exit $OVERALL_RESULT

--- a/tests/test-enforcement.sh
+++ b/tests/test-enforcement.sh
@@ -177,6 +177,11 @@ SCENARIOS["divide-conquer-decomposition-rule"]="Does .opencode/skills/divide-and
 SCENARIOS["verification-isolation-section"]="Does .opencode/skills/verification-before-completion/SKILL.md contain a Verification Isolation section requiring verification by a DIFFERENT sub-agent from the producer?"
 SCENARIOS["dispatch-audit-tables"]="Does every SKILL.md file in .opencode/skills/ contain a Sub-Agent Tasks section or dispatch audit table with columns for Task, Trigger Condition, Scope of Context, Exclusions, and Inline Work?"
 SCENARIOS["no-inline-work-yes"]="Is Inline Work? = NO in every dispatch audit table across all SKILL.md files in .opencode/skills/?"
+SCENARIOS["for-pr-gap-fill-critical-violation"]="Does .opencode/guidelines/000-critical-rules.md contain a section titled 'Critical Violation: for_pr Gap-Fill Halt' that prohibits halting to ask the developer about plan creation, grouping, or execution order when for_pr authorization is received?"
+SCENARIOS["for-pr-gap-fill-forbidden-entries"]="Does .opencode/guidelines/000-critical-rules.md for_pr Gap-Fill section FORBIDDEN list include: asking how to proceed, asking for grouping decisions, treating plan creation as requiring developer input, halting before pr_created, requesting re-authorization for gap-fill steps?"
+SCENARIOS["for-pr-gap-fill-required-entries"]="Does .opencode/guidelines/000-critical-rules.md for_pr Gap-Fill section REQUIRED list include: parse for_pr scope and execute gap-fill cascade autonomously, auto-create plans, auto-approve plans via spec-to-plan cascade, build execution order from dependency analysis without developer input, proceed through full pipeline to pr_created?"
+SCENARIOS["for-pr-gap-fill-yaml-rule"]="Does .opencode/guidelines/010-approval-gate.md yaml+symbolic block contain rule approval-gate-014 titled 'for_pr scope auto gap-fill — no halt for structural decisions'?"
+SCENARIOS["for-pr-gap-fill-scope-model"]="Does .opencode/guidelines/010-approval-gate.md Authorization Scope Model Gap-Fill Cascade section explicitly state that for_pr gap-fill is autonomous and requires NO developer input for structural decisions?"
 
 # Tags per scenario for --tag filtering
 declare -A SCENARIO_TAGS
@@ -303,6 +308,11 @@ SCENARIO_TAGS["divide-conquer-decomposition-rule"]="content-verification clean-r
 SCENARIO_TAGS["verification-isolation-section"]="content-verification clean-room-dispatch"
 SCENARIO_TAGS["dispatch-audit-tables"]="content-verification clean-room-dispatch"
 SCENARIO_TAGS["no-inline-work-yes"]="content-verification clean-room-dispatch"
+SCENARIO_TAGS["for-pr-gap-fill-critical-violation"]="content-verification approval"
+SCENARIO_TAGS["for-pr-gap-fill-forbidden-entries"]="content-verification approval"
+SCENARIO_TAGS["for-pr-gap-fill-required-entries"]="content-verification approval"
+SCENARIO_TAGS["for-pr-gap-fill-yaml-rule"]="content-verification approval"
+SCENARIO_TAGS["for-pr-gap-fill-scope-model"]="content-verification approval"
 SCENARIO_TAGS["spec-auditor-body-preservation"]="content-verification body-preservation"
 SCENARIO_TAGS["cleanup-body-modification-warning"]="content-verification body-preservation"
 SCENARIO_TAGS["close-body-preservation"]="content-verification body-preservation"
@@ -313,7 +323,8 @@ SCENARIO_TAGS["critical-rules-body-erasure"]="content-verification body-preserva
 # Maps glob patterns to scenario names
 declare -A FILE_SCENARIO_MAP
 FILE_SCENARIO_MAP[".opencode/guidelines/091-incremental-build.md"]="incremental-build-guideline monolithic-implementation-violation item-decomposition-step sc-assertion-tdd-cycle red-state-before-implementation red-phase-enforcement-incremental-build red-phase-enforcement-critical-rules-xref"
-FILE_SCENARIO_MAP[".opencode/guidelines/000-critical-rules.md"]="scope-auto-resolve-guideline monolithic-implementation-violation identity-echo-validation secret-exfiltration-violation url-sourcing-guideline-rules dispatch-artifact-requirements red-phase-enforcement-critical-rules-xref critical-rules-body-erasure direct-branch-default worktree-bypass-conditional"
+FILE_SCENARIO_MAP[".opencode/guidelines/000-critical-rules.md"]="scope-auto-resolve-guideline monolithic-implementation-violation identity-echo-validation secret-exfiltration-violation url-sourcing-guideline-rules dispatch-artifact-requirements red-phase-enforcement-critical-rules-xref critical-rules-body-erasure direct-branch-default worktree-bypass-conditional for-pr-gap-fill-critical-violation for-pr-gap-fill-forbidden-entries for-pr-gap-fill-required-entries"
+FILE_SCENARIO_MAP[".opencode/guidelines/010-approval-gate.md"]="for-pr-gap-fill-yaml-rule for-pr-gap-fill-scope-model"
 FILE_SCENARIO_MAP[".opencode/guidelines/020-go-prohibitions.md"]="scope-auto-resolve-guideline pipeline-scoped-halt"
 FILE_SCENARIO_MAP[".opencode/skills/approval-gate/"]="item-decomposition-step scope-auto-resolve-step approval-gate-sc-traceability approval-gate-red-phase dispatch-chain-enforcement-gate dispatch-artifact-requirements dispatch-checkpoint-live-verification gap-fill-precedence-principle gap-fill-precedence-for-pr gap-fill-precedence-standard-scope screen-issue-gap-fill-awareness gap-fill-precedence-before-step5c task-file-enforcement-refs scope-next-phase-resolution scope-phase-n-resolution enforcement-module-adversarial enforcement-module-scope-parsing enforcement-module-auto-dispatch enforcement-module-closed-issue enforcement-module-sub-issue verify-closed-issue-step7 closed-issue-enforcement-sc all-body-modification-safeguards"
 FILE_SCENARIO_MAP[".opencode/skills/brainstorming/"]="brainstorming-top-down verification-mechanics-brainstorming"
@@ -592,6 +603,11 @@ EXPECTED_SKILLS["divide-conquer-decomposition-rule"]=""
 EXPECTED_SKILLS["verification-isolation-section"]=""
 EXPECTED_SKILLS["dispatch-audit-tables"]=""
 EXPECTED_SKILLS["no-inline-work-yes"]=""
+EXPECTED_SKILLS["for-pr-gap-fill-critical-violation"]=""
+EXPECTED_SKILLS["for-pr-gap-fill-forbidden-entries"]=""
+EXPECTED_SKILLS["for-pr-gap-fill-required-entries"]=""
+EXPECTED_SKILLS["for-pr-gap-fill-yaml-rule"]=""
+EXPECTED_SKILLS["for-pr-gap-fill-scope-model"]=""
 
 RESULTS_FILE="$LOGDIR/results.md"
 


### PR DESCRIPTION
## Summary

Add critical violation, yaml+symbolic rule, and behavioral/content-verification tests for `for_pr` gap-fill halt — the agent must NOT halt to ask structural decisions when `for_pr` authorization is received.

## Outcome

- Added "Critical Violation: for_pr Gap-Fill Halt" section to `000-critical-rules.md`
- Added `approval-gate-014` yaml+symbolic rule to `010-approval-gate.md`
- Updated Gap-Fill Cascade section in `010-approval-gate.md` to explicitly state for_pr gap-fill is autonomous
- Created behavioral test `for-pr-gap-fill.sh` that verifies the agent does NOT solicit structural decisions
- Added 5 content-verification test scenarios to `test-enforcement.sh`

Fixes #111

🤖 OpenCode (ollama-cloud/glm-5.1) ✅ completed