### PR TITLE
feat: add Blockers section to halt output and post-tool execution output guarantee (#23 #24)

### DIFF
--- a/guidelines/000-critical-rules.md
+++ b/guidelines/000-critical-rules.md
@@ -278,7 +278,39 @@ The format applies to ALL halt points where implementation is reported complete:
 - **Completion task** reports (approval-gate completion)
 - **Any completion message** where the agent reports work done and halts
 
-**Mandatory format (with URL):**
+**Blockers section (REQUIRED when workflow is incomplete/blocked — omit when complete):**
+
+When the agent halts with incomplete work (blocked state), the output MUST include a Blockers section explaining:
+
+1. **What remains blocked** (missing authorization, missing plan, missing spec, context budget exhausted, etc.)
+2. **Why the agent stopped** (constraint violated, scope boundary reached, pipeline gate failed, etc.)
+3. **What explicit developer action is needed** to unblock (specific phrase or step)
+
+Examples:
+- "Blocked: Spec updated but lacks explicit authorization. Say 'approved #N' to proceed."
+- "Blocked: No approved plan exists for this spec. Create and approve a plan first."
+- "Blocked: Context budget insufficient for implementation. Provide authorization with scope."
+- "Blocked: Scope boundary reached — halt_at == plan_created. Provide re-authorization for implementation."
+
+Vague phrasing like "needs approval" without specifying WHICH issue and WHAT phrase is a STRUCTURE-VIOLATION (auto-fix: add specific issue number and required phrase).
+
+**Mandatory format (with URL and blockers):**
+
+```
+**Summary:**
+
+<1-2 sentences describing impact and stakeholder value.>
+
+**Outcome:** <What changed for stakeholders>
+
+**Blockers:** <Why stopped + required developer action>
+
+<Compare URL or Issue URL>
+
+🤖 <AgentName> (<ModelId>) <status-icon> <status>
+```
+
+**Mandatory format (with URL, no blockers — workflow complete):**
 
 ```
 **Summary:**
@@ -292,7 +324,21 @@ The format applies to ALL halt points where implementation is reported complete:
 🤖 <AgentName> (<ModelId>) <status-icon> <status>
 ```
 
-**Mandatory format (without URL — when no relevant URL exists):**
+**Mandatory format (without URL, with blockers):**
+
+```
+**Summary:**
+
+<1-2 sentences describing impact and stakeholder value.>
+
+**Outcome:** <What changed for stakeholders>
+
+**Blockers:** <Why stopped + required developer action>
+
+🤖 <AgentName> (<ModelId>) <status-icon> <status>
+```
+
+**Mandatory format (without URL, no blockers — workflow complete):**
 
 ```
 **Summary:**
@@ -304,8 +350,8 @@ The format applies to ALL halt points where implementation is reported complete:
 🤖 <AgentName> (<ModelId>) <status-icon> <status>
 ```
 
-- 🚫 FORBIDDEN: Producing casual one-liner summaries at halt points; omitting any required element (summary, outcome, byline); wrong ordering (URL before summary, byline before URL); reporting missing elements after the fact instead of auto-fixing before output is sent; including a URL when no relevant URL exists; label-format mismatch (e.g., "Compare URL" with `pull/N` URL or "PR URL" with `compare/dev...` URL)
-- ✅ REQUIRED: Verify chat output format before sending at every halt point; auto-fix missing or misordered elements before output is sent; summary first, outcome after summary, URL if relevant (omit if not), byline last; label and URL format MUST match context (pre-PR → "Compare URL" + `compare/dev...`; post-PR → "PR URL" + `pull/N`); each verification checkpoint MUST produce a tool-call artifact as evidence
+- 🚫 FORBIDDEN: Producing casual one-liner summaries at halt points; omitting any required element (summary, outcome, byline); wrong ordering (URL before summary, byline before URL); reporting missing elements after the fact instead of auto-fixing before output is sent; including a URL when no relevant URL exists; label-format mismatch (e.g., "Compare URL" with `pull/N` URL or "PR URL" with `compare/dev...` URL); producing halt messages without a Blockers section when workflow state is incomplete/blocked; vague blocker phrasing ("needs approval") without specifying the exact issue and required action
+- ✅ REQUIRED: Verify chat output format before sending at every halt point; auto-fix missing or misordered elements before output is sent; summary first, outcome after summary, blockers after outcome (when workflow incomplete), URL if relevant (omit if not) after blockers or outcome, byline last; Blockers section present when `workflow_state != complete`; blocker text specifies the constraint, why it fired, and the exact developer action; Blockers section omitted when workflow is fully complete (no incomplete state); label and URL format MUST match context (pre-PR → "Compare URL" + `compare/dev...`; post-PR → "PR URL" + `pull/N`); each verification checkpoint MUST produce a tool-call artifact as evidence
 
 **See `git-workflow` skill → "Chat Output Format (CRITICAL)" for complete format requirements and examples. See `approval-gate/tasks/post-implementation.md` Step 4.5, `approval-gate/tasks/completion.md`, `divide-and-conquer/tasks/assemble-work.md` Step 6, `finishing-a-development-branch/tasks/checklist.md` §Chat Output Format, and `git-workflow/tasks/review-prep.md` §Live Verification for the verification checkpoints.**
 
@@ -956,6 +1002,32 @@ After EVERY `task(subagent_type="general")` dispatch, the agent MUST produce out
 **This guarantee supplements the existing Silent Agent Termination rule by specifying the post-dispatch scenario explicitly.** The existing rule covers general halts; this adds the specific case where the agent dispatches a sub-agent, gets an empty result, and has no code path to recovery or reporting.
 
 **See `020-go-prohibitions.md` for the complete halt requirements and `finishing-a-development-branch` skill for completion guarantees.** **AUTHORITY: `020-go-prohibitions.md`** (this line is a reference only)
+
+### Post-Tool Execution Output Checkpoint
+
+After EVERY batch of tool calls (including ALL types: bash, read, write, edit, github_*, srclight_*, task, etc.), the agent MUST produce visible chat output before halting.
+
+This checkpoint applies regardless of whether:
+- Tool calls succeeded or failed
+- Sub-agents returned valid, empty, or error results
+- The agent has reached a natural workflow end-state
+- The agent believes "no further action is needed"
+
+The output MUST include at minimum:
+1. What operation/tool was invoked
+2. What the result was (success/failure/error)
+3. What state this leaves the workflow in
+4. What developer action (if any) is required to proceed
+5. AI byline (if halting)
+
+**This output must be generated BEFORE `--task completion` runs, not delegated TO it.**
+
+- 🚫 FORBIDDEN: Transitioning from tool execution directly to halt without chat output
+- 🚫 FORBIDDEN: Delegating output to `--task completion` as a substitute for normal visible output
+- 🚫 FORBIDDEN: Producing zero chat messages in a user-turn even when tool calls succeeded
+- ✅ REQUIRED: After every tool call batch, produce at minimum a one-line status of what happened
+- ✅ REQUIRED: After every sub-agent dispatch, produce Summary/Outcome output before any halt
+- ✅ REQUIRED: Context budget exhaustion produces explicit "budget exhausted" message before halt
 
 ## Critical Violation: Skipping Interdependency Analysis for Batch Approvals
 

--- a/skills/approval-gate/SKILL.md
+++ b/skills/approval-gate/SKILL.md
@@ -131,6 +131,18 @@ Before any dispatch chain step begins, the orchestrator MUST verify that it has 
 - 🚫 FORBIDDEN: Orchestrator loading task files or guideline text into its own context for inline execution
 - ✅ REQUIRED: The orchestrator dispatches sub-agents for ALL work; it only routes result contracts
 
+**Step 0.5: Post-Dispatch Output Gate (MANDATORY)**
+
+After every sub-agent dispatch completes, the main agent MUST produce visible chat output before proceeding to the next step or halting.
+
+| Dispatch Result | Next Step | Output Required? |
+|---|---|---|
+| Sub-agent DONE | Next phase | Yes — summarize completion |
+| Sub-agent BLOCKED | Halt | Yes — summarize blocker and required action |
+| Sub-agent ERROR | Inline fallback | Yes — summarize error, fallback attempt |
+| Tool call success | Continue | Yes — state what changed |
+| Tool call failure | Halt | Yes — state what failed and why |
+
 After `verify-authorization` completes successfully (all gates pass), the skill auto-dispatches based on approval context:
 
 ```

--- a/skills/approval-gate/tasks/completion.md
+++ b/skills/approval-gate/tasks/completion.md
@@ -30,6 +30,10 @@ Before adding or removing labels in completion, consult `141-planning-status-tra
 1. Authorization decision (approved/rejected/blocked)
 2. Issue number and branch (if applicable)
 3. What happens next (workflow forward, HALT, or error)
+4. **Blocker state** — what constraint caused the halt (authorization/spec/plan/budget/error/none)
+5. **Developer action required** — exact phrase or step the developer must provide to continue (empty string when no blocker)
+
+When `status == blocked`, fields 4 and 5 MUST be non-empty and specific. Vague phrasing like "needs approval" is STRUCTURE-VIOLATION — the blocker state must name the specific constraint and the developer action must specify the exact phrase or step.
 
 This is the completion guarantee: NO authorization check ends without a status message.
 
@@ -43,6 +47,8 @@ Generate executive summary in chat:
 <Authorization verification result and scope>
 
 **Outcome:** <What the result means for stakeholders>
+
+**Blockers:** <Why stopped + required developer action> (omit when workflow complete)
 
 Issue URL: <html_url from github_issue_write or github_issue_read API response — NEVER construct from template>
 
@@ -68,8 +74,10 @@ URL is ALWAYS last per `000-critical-rules.md`.
 
 - [ ] Executive summary present as **first** element (before any URL)
 - [ ] Outcome line present after summary
-- [ ] URL present IF relevant (after outcome, before byline) — required when branch pushed or issue URL exists, **omitted** when no URL exists
-- [ ] AI byline present as **LAST** element (after URL, or after outcome when no URL)
+- [ ] Blockers section present when `workflow_state != complete` (between outcome and URL, or between outcome and byline when no URL)
+- [ ] Blockers section omitted when workflow is fully complete
+- [ ] URL present IF relevant (after outcome/blockers, before byline) — required when branch pushed or issue URL exists, **omitted** when no URL exists
+- [ ] AI byline present as **LAST** element (after URL, or after outcome/blockers when no URL)
 - [ ] No URL before executive summary
 - [ ] No byline before URL/outcome
 
@@ -116,6 +124,8 @@ When the workflow halts due to a blocker (authorization denied, missing spec, va
 
 **Outcome:** <What is blocked and why>
 
+**Blockers:** <Constraint name + required developer action>
+
 🤖 <AgentName> (<ModelId>) ⛔ blocked
 ```
 
@@ -140,6 +150,17 @@ This format is verified by behavioral enforcement tests in `.opencode/tests/beha
 - **Authorization result comment posted:** Search issue comments via `github_issue_read(method=get_comments)` for the authorization result (byline pattern). If missing → MISSING-ELEMENT (auto-fix: post now).
 - **Label state matches authorization:** Check labels via `github_issue_read(method=get_labels)`. If `needs-approval` present AND authorization granted → STRUCTURE-VIOLATION (auto-fix: remove label). If `needs-approval` absent AND no authorization found → VERIFICATION-GAP (flag-for-review).
 - **Status report matches workflow outcome:** If completion claims "approved" but no authorization comment found → CONFLICTING (flag-for-review). If claims "blocked" but blocker issue is closed → VERIFICATION-GAP (flag-for-review).
+
+### Completion Task Scope Clarification
+
+The `--task completion` subtask is for cleanup-state reporting (labels, comments, verification), NOT for generating the agent's primary visible output.
+
+The agent's visible output is generated:
+1. AFTER tool execution
+2. BEFORE invoking `--task completion`
+3. By the main agent reasoning context, not delegated to completion subtask
+
+**Rule:** If the agent has produced zero chat messages in the current user-turn, invoking `--task completion` does NOT satisfy the output guarantee. Completion runs AFTER output is produced, not INSTEAD of output.
 
 ## Enforcement References
 

--- a/tests/behaviors/halt-blockers-section.sh
+++ b/tests/behaviors/halt-blockers-section.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+# Behavioral Enforcement Test: Halt messages require Blockers section when workflow incomplete
+#
+# Verifies that agent halt-point output includes a Blockers section explaining
+# why the agent stopped and what developer action is required to continue.
+#
+# Issue #23: Agent halt messages lack required Blockers section
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/helpers.sh"
+
+SCENARIO_NAME="halt-blockers-section"
+
+echo "=== Behavioral Test: $SCENARIO_NAME ==="
+
+OVERALL_RESULT=0
+
+WORKTREE_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+
+# Verify 1: 000-critical-rules.md contains Blockers section requirement
+CR_FILE="$WORKTREE_ROOT/.opencode/guidelines/000-critical-rules.md"
+if ! grep -qi "Blockers.*REQUIRED\|Blockers.*required\|Blockers.*incomplete" "$CR_FILE"; then
+    echo "FAIL: $SCENARIO_NAME — 000-critical-rules.md missing Blockers section requirement"
+    OVERALL_RESULT=1
+else
+    echo "PASS: $SCENARIO_NAME — 000-critical-rules.md has Blockers section requirement"
+fi
+
+# Verify 2: Completion task includes blocker state fields
+COMPLETION_FILE="$WORKTREE_ROOT/.opencode/skills/approval-gate/tasks/completion.md"
+if [ ! -f "$COMPLETION_FILE" ]; then
+    echo "FAIL: $SCENARIO_NAME — completion.md not found"
+    OVERALL_RESULT=1
+elif ! grep -qi "blocker.state\|Blocker state\|developer.action.required\|Developer action required" "$COMPLETION_FILE"; then
+    echo "FAIL: $SCENARIO_NAME — completion.md missing blocker state / developer action required fields"
+    OVERALL_RESULT=1
+else
+    echo "PASS: $SCENARIO_NAME — completion.md has blocker state fields"
+fi
+
+# Verify 3: Chat output format includes Blockers element
+if ! grep -qi "Blockers" "$CR_FILE"; then
+    echo "FAIL: $SCENARIO_NAME — 000-critical-rules.md chat output format missing Blockers element"
+    OVERALL_RESULT=1
+else
+    echo "PASS: $SCENARIO_NAME — 000-critical-rules.md chat output format includes Blockers"
+fi
+
+if [ $OVERALL_RESULT -eq 0 ]; then
+    echo "PASS: $SCENARIO_NAME — all checks passed"
+else
+    echo "FAIL: $SCENARIO_NAME — one or more checks failed"
+fi
+
+exit $OVERALL_RESULT

--- a/tests/behaviors/post-dispatch-output-guarantee.sh
+++ b/tests/behaviors/post-dispatch-output-guarantee.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+# Behavioral Enforcement Test: Post-Dispatch Output Guarantee
+#
+# Verifies that agent produces visible chat output after every
+# sub-agent dispatch, never transitioning directly to halt.
+#
+# Issue #24: Agent completes work but produces no chat output
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/helpers.sh"
+
+WORKTREE_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+
+SCENARIO_NAME="post-dispatch-output-guarantee"
+
+echo "=== Behavioral Test: $SCENARIO_NAME ==="
+
+OVERALL_RESULT=0
+
+CR_FILE="$WORKTREE_ROOT/.opencode/guidelines/000-critical-rules.md"
+if ! grep -q "Post-Tool Execution Output Checkpoint" "$CR_FILE"; then
+    echo "FAIL: $SCENARIO_NAME — Post-Tool Execution Output Checkpoint missing from 000-critical-rules.md"
+    OVERALL_RESULT=1
+else
+    echo "PASS: $SCENARIO_NAME — Post-Tool Execution Output Checkpoint present"
+fi
+
+COMPLETION_FILE="$WORKTREE_ROOT/.opencode/skills/approval-gate/tasks/completion.md"
+if [ ! -f "$COMPLETION_FILE" ]; then
+    echo "FAIL: $SCENARIO_NAME — completion.md not found"
+    OVERALL_RESULT=1
+elif ! grep -qi "Completion Task Scope Clarification\|NOT for generating the agent.*primary" "$COMPLETION_FILE"; then
+    echo "FAIL: $SCENARIO_NAME — completion.md missing scope clarification"
+    OVERALL_RESULT=1
+else
+    echo "PASS: $SCENARIO_NAME — completion.md has scope clarification"
+fi
+
+AG_FILE="$WORKTREE_ROOT/.opencode/skills/approval-gate/SKILL.md"
+if ! grep -q "Post-Dispatch Output Gate\|Output Gate" "$AG_FILE"; then
+    echo "FAIL: $SCENARIO_NAME — approval-gate SKILL.md missing Output Gate"
+    OVERALL_RESULT=1
+else
+    echo "PASS: $SCENARIO_NAME — approval-gate SKILL.md has Output Gate"
+fi
+
+if ! grep -q "Sub-agent DONE.*Next phase.*Yes\|DONE.*summarize completion" "$AG_FILE"; then
+    echo "FAIL: $SCENARIO_NAME — approval-gate SKILL.md missing dispatch result transition table"
+    OVERALL_RESULT=1
+else
+    echo "PASS: $SCENARIO_NAME — approval-gate dispatch transition table present"
+fi
+
+if [ $OVERALL_RESULT -eq 0 ]; then
+    echo "PASS: $SCENARIO_NAME — all checks passed"
+else
+    echo "FAIL: $SCENARIO_NAME — one or more checks failed"
+fi
+
+exit $OVERALL_RESULT

--- a/tests/test-enforcement.sh
+++ b/tests/test-enforcement.sh
@@ -195,6 +195,9 @@ SCENARIOS["inline-work-dispatch-gate"]="Does .opencode/guidelines/000-critical-r
 SCENARIOS["structural-decision-solicitation-vacv"]="Does .opencode/guidelines/000-critical-rules.md contain a section titled 'Critical Violation: Structural Decision Solicitation Under for_pr Scope' that prohibits using the question tool for structural classification under for_pr scope?"
 SCENARIOS["structural-decision-solicitation-yaml"]="Does .opencode/guidelines/000-critical-rules.md yaml+symbolic block contain rule critical-rules-037 titled 'Structural decision solicitation under for_pr scope'?"
 SCENARIOS["for-pr-solicitation-crossref"]="Does .opencode/guidelines/020-go-prohibitions.md section 1.5 reference 'Structural Decision Solicitation Under for_pr Scope' from 000-critical-rules.md?"
+SCENARIOS["post-tool-output-checkpoint"]="Does .opencode/guidelines/000-critical-rules.md contain a subsection titled 'Post-Tool Execution Output Checkpoint' that requires visible chat output after every tool call batch before halting?"
+SCENARIOS["completion-scope-clarification"]="Does .opencode/skills/approval-gate/tasks/completion.md contain a 'Completion Task Scope Clarification' section stating that --task completion is NOT for generating the agent's primary visible output?"
+SCENARIOS["post-dispatch-output-gate"]="Does .opencode/skills/approval-gate/SKILL.md contain a 'Step 0.5: Post-Dispatch Output Gate' that requires visible chat output after every sub-agent dispatch?"
 
 # Tags per scenario for --tag filtering
 declare -A SCENARIO_TAGS
@@ -323,6 +326,8 @@ SCENARIO_TAGS["inline-work-dispatch-gate"]="content-verification clean-room-disp
 SCENARIO_TAGS["structural-decision-solicitation-vacv"]="content-verification approval"
 SCENARIO_TAGS["structural-decision-solicitation-yaml"]="content-verification approval"
 SCENARIO_TAGS["for-pr-solicitation-crossref"]="content-verification approval"
+SCENARIOS["halt-blockers-format"]="Does .opencode/guidelines/000-critical-rules.md chat output format contain a Blockers section that is REQUIRED when workflow is incomplete or blocked?"
+SCENARIOS["halt-blockers-completion-fields"]="Does .opencode/skills/approval-gate/tasks/completion.md Completion Guarantee section contain Blocker state and Developer action required fields?"
 SCENARIO_TAGS["divide-conquer-decomposition-rule"]="content-verification clean-room-dispatch"
 SCENARIO_TAGS["verification-isolation-section"]="content-verification clean-room-dispatch"
 SCENARIO_TAGS["dispatch-audit-tables"]="content-verification clean-room-dispatch"
@@ -344,16 +349,21 @@ SCENARIO_TAGS["cleanup-body-modification-warning"]="content-verification body-pr
 SCENARIO_TAGS["close-body-preservation"]="content-verification body-preservation"
 SCENARIO_TAGS["all-body-modification-safeguards"]="content-verification body-preservation"
 SCENARIO_TAGS["critical-rules-body-erasure"]="content-verification body-preservation"
+SCENARIO_TAGS["halt-blockers-format"]="content-verification halt-output"
+SCENARIO_TAGS["halt-blockers-completion-fields"]="content-verification halt-output"
+SCENARIO_TAGS["post-tool-output-checkpoint"]="content-verification silent-termination"
+SCENARIO_TAGS["completion-scope-clarification"]="content-verification silent-termination"
+SCENARIO_TAGS["post-dispatch-output-gate"]="content-verification silent-termination"
 
 # File-to-scenario mapping for --changed filtering
 # Maps glob patterns to scenario names
 declare -A FILE_SCENARIO_MAP
 FILE_SCENARIO_MAP[".opencode/guidelines/091-incremental-build.md"]="incremental-build-guideline monolithic-implementation-violation item-decomposition-step sc-assertion-tdd-cycle red-state-before-implementation red-phase-enforcement-incremental-build red-phase-enforcement-critical-rules-xref"
-FILE_SCENARIO_MAP[".opencode/guidelines/000-critical-rules.md"]="scope-auto-resolve-guideline monolithic-implementation-violation identity-echo-validation secret-exfiltration-violation url-sourcing-guideline-rules dispatch-artifact-requirements red-phase-enforcement-critical-rules-xref critical-rules-body-erasure direct-branch-default worktree-bypass-conditional for-pr-gap-fill-critical-violation for-pr-gap-fill-forbidden-entries for-pr-gap-fill-required-entries hook-output-advisory-subsection hook-output-advisory-yaml-rule wrong-api-routing-violation wrong-api-routing-yaml-rule dispatch-gate-checkpoint inline-work-dispatch-gate structural-decision-solicitation-vacv structural-decision-solicitation-yaml"
+FILE_SCENARIO_MAP[".opencode/guidelines/000-critical-rules.md"]="scope-auto-resolve-guideline monolithic-implementation-violation identity-echo-validation secret-exfiltration-violation url-sourcing-guideline-rules dispatch-artifact-requirements red-phase-enforcement-critical-rules-xref critical-rules-body-erasure direct-branch-default worktree-bypass-conditional for-pr-gap-fill-critical-violation for-pr-gap-fill-forbidden-entries for-pr-gap-fill-required-entries hook-output-advisory-subsection hook-output-advisory-yaml-rule wrong-api-routing-violation wrong-api-routing-yaml-rule dispatch-gate-checkpoint inline-work-dispatch-gate structural-decision-solicitation-vacv structural-decision-solicitation-yaml halt-blockers-format post-tool-output-checkpoint"
 FILE_SCENARIO_MAP[".opencode/scripts/session_context_triggers.py"]="local-only-trigger-function local-only-trigger-directive dev-edit-guard-trigger stash-triage-directive"
 FILE_SCENARIO_MAP[".opencode/guidelines/010-approval-gate.md"]="for-pr-gap-fill-yaml-rule for-pr-gap-fill-scope-model"
 FILE_SCENARIO_MAP[".opencode/guidelines/020-go-prohibitions.md"]="scope-auto-resolve-guideline pipeline-scoped-halt for-pr-solicitation-crossref"
-FILE_SCENARIO_MAP[".opencode/skills/approval-gate/"]="item-decomposition-step scope-auto-resolve-step approval-gate-sc-traceability approval-gate-red-phase dispatch-chain-enforcement-gate dispatch-artifact-requirements dispatch-checkpoint-live-verification gap-fill-precedence-principle gap-fill-precedence-for-pr gap-fill-precedence-standard-scope screen-issue-gap-fill-awareness gap-fill-precedence-before-step5c task-file-enforcement-refs scope-next-phase-resolution scope-phase-n-resolution enforcement-module-adversarial enforcement-module-scope-parsing enforcement-module-auto-dispatch enforcement-module-closed-issue enforcement-module-sub-issue verify-closed-issue-step7 closed-issue-enforcement-sc all-body-modification-safeguards orchestrator-context-audit"
+FILE_SCENARIO_MAP[".opencode/skills/approval-gate/"]="item-decomposition-step scope-auto-resolve-step approval-gate-sc-traceability approval-gate-red-phase dispatch-chain-enforcement-gate dispatch-artifact-requirements dispatch-checkpoint-live-verification gap-fill-precedence-principle gap-fill-precedence-for-pr gap-fill-precedence-standard-scope screen-issue-gap-fill-awareness gap-fill-precedence-before-step5c task-file-enforcement-refs scope-next-phase-resolution scope-phase-n-resolution enforcement-module-adversarial enforcement-module-scope-parsing enforcement-module-auto-dispatch enforcement-module-closed-issue enforcement-module-sub-issue verify-closed-issue-step7 closed-issue-enforcement-sc all-body-modification-safeguards orchestrator-context-audit halt-blockers-completion-fields completion-scope-clarification post-dispatch-output-gate"
 FILE_SCENARIO_MAP[".opencode/skills/brainstorming/"]="brainstorming-top-down verification-mechanics-brainstorming"
 FILE_SCENARIO_MAP[".opencode/skills/writing-plans/"]="writing-plans-bottom-up validate-executable-verification semantic-intent-writing-plans why-specific-value-tdd red-phase-gate-writing-plans red-phase-gate-writing-plans-skillmd"
 FILE_SCENARIO_MAP[".opencode/skills/executing-plans/"]="executing-plans-tdd red-phase-gate-executing-plans red-phase-gate-skillmd"
@@ -647,6 +657,11 @@ EXPECTED_SKILLS["inline-work-dispatch-gate"]=""
 EXPECTED_SKILLS["structural-decision-solicitation-vacv"]=""
 EXPECTED_SKILLS["structural-decision-solicitation-yaml"]=""
 EXPECTED_SKILLS["for-pr-solicitation-crossref"]=""
+EXPECTED_SKILLS["halt-blockers-format"]=""
+EXPECTED_SKILLS["halt-blockers-completion-fields"]=""
+EXPECTED_SKILLS["post-tool-output-checkpoint"]=""
+EXPECTED_SKILLS["completion-scope-clarification"]=""
+EXPECTED_SKILLS["post-dispatch-output-gate"]=""
 
 RESULTS_FILE="$LOGDIR/results.md"
 


### PR DESCRIPTION
## Summary

Adds the Blockers section to halt-point output format and a post-tool execution output guarantee, preventing agents from silently halting after tool calls or sub-agent dispatches.

## Outcome

Two critical output guarantees now enforced with behavioral tests:

- **#23**: Agent halt messages include a Blockers section (what's blocked, why, exact developer action) when workflow is incomplete; completion task tracks blocker state and developer action required
- **#24**: After every tool call batch and sub-agent dispatch, agent produces visible chat output before halting; `--task completion` runs AFTER output, never INSTEAD of it; context budget exhaustion produces explicit message

## Changes

| Issue | Files Changed | Key Additions |
|-------|--------------|---------------|
| #23 | `000-critical-rules.md`, `completion.md`, `halt-blockers-section.sh`, `test-enforcement.sh` | Blockers section in chat output format, blocker state fields in completion task |
| #24 | `000-critical-rules.md`, `approval-gate/SKILL.md`, `completion.md`, `post-dispatch-output-guarantee.sh`, `test-enforcement.sh` | Post-Tool Execution Output Checkpoint, Post-Dispatch Output Gate transition table, Completion Task Scope Clarification |

Fixes #23, Fixes #24

🤖 Co-authored with AI: OpenCode (ollama-cloud/glm-5.1) ✅ completed