### PR TITLE
feat(#118): Add Scala header format, fallback rule, and header-verification checkpoint

### DIFF
--- a/guidelines/080-code-standards.md
+++ b/guidelines/080-code-standards.md
@@ -302,6 +302,22 @@ provenance: AI-generated
 ---
 ```
 
+#### Scala Files (.scala)
+
+```scala
+// SPDX-FileCopyrightText: <year> <dev.name>
+// SPDX-License-Identifier: Apache-2.0
+// Provenance: AI-generated
+
+/** Module description.
+  *
+  * Co-authored with AI: <AgentName> (<ModelId>)
+  */
+package com.example...
+```
+
+Note: Scala projects may use Apache-2.0 (not MIT) — use the correct SPDX identifier for the project's license.
+
 #### Markdown Files (guidelines, docs)
 
 ```markdown
@@ -309,6 +325,19 @@ provenance: AI-generated
 <!-- SPDX-License-Identifier: MIT -->
 <!-- Provenance: AI-generated -->
 ```
+
+#### Other Languages (Fallback Rule)
+
+For languages not explicitly listed (Java, C++, Go, Rust, etc.), use the language's block comment syntax to include the same three SPDX/Provenance lines, then a doc comment with the AI byline:
+
+| Language | Block Comment | Doc Comment |
+|----------|--------------|-------------|
+| Java | `// SPDX-...` | `/** Co-authored with AI: ... */` |
+| C/C++ | `// SPDX-...` | `/** Co-authored with AI: ... */` |
+| Go | `// SPDX-...` | `// Co-authored with AI: ...` |
+| Rust | `// SPDX-...` | `//! Co-authored with AI: ...` |
+
+Pattern: `// SPDX-FileCopyrightText:` + `// SPDX-License-Identifier:` + `// Provenance:` + doc comment with `Co-authored with AI:`.
 
 ### Provenance + Byline Rules
 

--- a/skills/verification-before-completion/tasks/verify.md
+++ b/skills/verification-before-completion/tasks/verify.md
@@ -34,6 +34,26 @@ Verify all success criteria have evidence before allowing completion claims.
 
 **Dispatch as sub-agent:** When the verification context is the same agent that performed implementation, invoke `structural-verify` as a sub-agent to ensure clean-room isolation. The sub-agent receives ONLY the spec SC list and file paths — NOT implementation context.
 
+### 0.5. Header Verification Checkpoint (MANDATORY — For New Files)
+
+**For each new file added by the agent during implementation, verify it contains the required headers per its file type as defined in `080-code-standards.md` §"Header Format by File Type".**
+
+1. Identify all files added (not modified) during this implementation: `git diff --diff-filter=A --name-only dev`
+2. For each new file, determine its file type and check for required headers:
+   - Python (`.py`): SPDX copyright, SPDX license (MIT), Provenance header, AI byline in docstring
+   - SKILL.md: `license` and `provenance` fields in YAML frontmatter
+   - Markdown (`.md`): SPDX copyright, SPDX license, Provenance as HTML comments
+   - Scala (`.scala`): SPDX copyright, SPDX license (project-appropriate), Provenance header, AI byline in ScalaDoc
+   - Other languages: Fallback rule per `080-code-standards.md` §"Other Languages (Fallback Rule)"
+3. If ANY new file is missing required headers:
+   - Report as FAIL with specific file and missing header(s)
+   - Do NOT proceed to Step 1 until headers are added
+4. If ALL new files have required headers:
+   - Report as PASS
+   - Proceed to Step 1
+
+**Grandfather clause:** Pre-existing files modified by the agent are exempt from header verification — only newly created files require headers.
+
 ### 1. Query Success Criteria
 
 - Read plan issue for defined success criteria

--- a/tests/behaviors/header-verification-checkpoint.sh
+++ b/tests/behaviors/header-verification-checkpoint.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+# Behavioral Enforcement Test: Header Verification Checkpoint
+#
+# Verifies that the verification-before-completion skill includes a
+# header-verification checkpoint that checks new files for required
+# SPDX/Provenance/Byline headers per 080-code-standards.md.
+#
+# Issue #118: SC-3 and SC-6 — Missing copyright headers on new files
+#
+# Co-authored with AI: OpenCode (ollama-cloud/glm-5.1)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/helpers.sh"
+
+SCENARIO_NAME="header-verification-checkpoint"
+
+echo "=== Behavioral Test: $SCENARIO_NAME ==="
+
+OVERALL_RESULT=0
+
+WORKTREE_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+
+# Verify 1: 080-code-standards.md includes Scala header format
+# SC-1: Scala header format under "Header Format by File Type"
+STDARDS_FILE="$WORKTREE_ROOT/.opencode/guidelines/080-code-standards.md"
+if ! grep -qi "Scala Files" "$STDARDS_FILE"; then
+    echo "FAIL: $SCENARIO_NAME — SC-1: 080-code-standards.md missing Scala header format section"
+    OVERALL_RESULT=1
+else
+    echo "PASS: $SCENARIO_NAME — SC-1: 080-code-standards.md has Scala header format section"
+fi
+
+# Verify 2: 080-code-standards.md includes fallback rule for unlisted languages
+# SC-2: Fallback rule for unlisted languages
+if ! grep -qi "Other Languages.*Fallback\|Fallback Rule" "$STDARDS_FILE"; then
+    echo "FAIL: $SCENARIO_NAME — SC-2: 080-code-standards.md missing fallback rule for unlisted languages"
+    OVERALL_RESULT=1
+else
+    echo "PASS: $SCENARIO_NAME — SC-2: 080-code-standards.md has fallback rule for unlisted languages"
+fi
+
+# Verify 3: verification-before-completion verify task includes header-verification checkpoint
+# SC-3: Header-verification checkpoint in verification-before-completion
+VERIFY_TASK="$WORKTREE_ROOT/.opencode/skills/verification-before-completion/tasks/verify.md"
+if [ ! -f "$VERIFY_TASK" ]; then
+    echo "FAIL: $SCENARIO_NAME — SC-3: verify.md task file not found"
+    OVERALL_RESULT=1
+elif ! grep -qi "Header Verification Checkpoint\|header-verification" "$VERIFY_TASK"; then
+    echo "FAIL: $SCENARIO_NAME — SC-3: verify.md missing header-verification checkpoint"
+    OVERALL_RESULT=1
+else
+    echo "PASS: $SCENARIO_NAME — SC-3: verify.md has header-verification checkpoint"
+fi
+
+# Verify 4: The header-verification checkpoint references 080-code-standards.md
+if [ -f "$VERIFY_TASK" ]; then
+    if ! grep -qi "080-code-standards.md" "$VERIFY_TASK"; then
+        echo "FAIL: $SCENARIO_NAME — SC-3: verify.md header checkpoint does not reference 080-code-standards.md"
+        OVERALL_RESULT=1
+    else
+        echo "PASS: $SCENARIO_NAME — SC-3: verify.md header checkpoint references 080-code-standards.md"
+    fi
+fi
+
+# Verify 5: The header-verification checkpoint checks for SPDX, Provenance, and Byline
+if [ -f "$VERIFY_TASK" ]; then
+    if ! grep -qi "SPDX" "$VERIFY_TASK" || ! grep -qi "Provenance" "$VERIFY_TASK" || ! grep -qi "byline\|Co-authored" "$VERIFY_TASK"; then
+        echo "FAIL: $SCENARIO_NAME — SC-3: verify.md header checkpoint missing SPDX/Provenance/Byline checks"
+        OVERALL_RESULT=1
+    else
+        echo "PASS: $SCENARIO_NAME — SC-3: verify.md header checkpoint includes SPDX/Provenance/Byline checks"
+    fi
+fi
+
+# Verify 6: This behavioral test file exists (meta-verification for SC-6)
+if [ ! -f "$SCRIPT_DIR/header-verification-checkpoint.sh" ]; then
+    echo "FAIL: $SCENARIO_NAME — SC-6: Behavioral enforcement test file does not exist"
+    OVERALL_RESULT=1
+else
+    echo "PASS: $SCENARIO_NAME — SC-6: Behavioral enforcement test file exists"
+fi
+
+if [ $OVERALL_RESULT -eq 0 ]; then
+    echo "PASS: $SCENARIO_NAME — all checks passed"
+else
+    echo "FAIL: $SCENARIO_NAME — one or more checks failed"
+fi
+
+exit $OVERALL_RESULT


### PR DESCRIPTION
## Summary

Adds missing Scala provenance header format and generic language fallback rule to `080-code-standards.md`, plus a header-verification checkpoint in the verification-before-completion pipeline to prevent future regressions on new AI-authored files.

## Outcome

- Guideline `080-code-standards.md` now covers Scala and all other non-listed languages with SPDX/Provenance/Byline templates
- The verification-before-completion skill now checks new files for required headers before allowing completion
- Behavioral enforcement test validates the checkpoint exists and references the correct guidelines

**Scope note:** SC-4 and SC-5 (retroactive headers on GitBucketSwagger.scala and SwaggerResourcesApp.scala) target files in the `michael-conrad/gitbucket` repository and require a separate PR in that repo.

Fixes #118 (SC-1, SC-2, SC-3, SC-6)

🤖 Co-authored with AI: OpenCode (ollama-cloud/glm-5.1)