### PR TITLE
feat(#43): formalize VbC skill card — dispatch-chain-mapped evidence_artifacts

### DIFF
--- a/skills/verification-before-completion/SKILL.md
+++ b/skills/verification-before-completion/SKILL.md
@@ -325,7 +325,7 @@ Key adaptations for <AgentName>:
 
 ```yaml+symbolic
 schema_version: "2.0"
-last_updated: "2026-04-25T00:00:00Z"
+last_updated: "2026-04-26T00:00:00Z"
 rules:
   - id: verification-before-completion-001
     title: "No completion claim without evidence"
@@ -518,14 +518,26 @@ gates:
 evidence_artifacts:
   - name: per_sc_evidence_table
     type: structured_output
+    dispatch_stage: verify
     verification: "all rows show PASS with live tool-call artifacts"
   - name: structural_completeness_result
     type: tool_call
+    dispatch_stage: structural-verify
     verification: "structural-verify task output confirms completeness"
   - name: test_results
     type: tool_call
+    dispatch_stage: verify
     verification: "pytest output confirms tests pass"
   - name: lint_results
     type: tool_call
+    dispatch_stage: verify
     verification: "ruff check output confirms zero errors"
+  - name: missing_evidence_collection
+    type: tool_call
+    dispatch_stage: collect
+    verification: "collect task output confirms all missing evidence gathered"
+  - name: completion_tasks_executed
+    type: tool_call
+    dispatch_stage: completion
+    verification: "completion task output confirms mandatory steps executed"
 ```

--- a/tests/behaviors/vbc-evidence-artifacts-dispatch-mapped.sh
+++ b/tests/behaviors/vbc-evidence-artifacts-dispatch-mapped.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+# Behavioral Enforcement Test: vbc-evidence-artifacts-dispatch-mapped
+# Verifies that verification-before-completion SKILL.md has dispatch-chain-mapped
+# evidence_artifacts — each artifact maps to a specific pipeline stage
+# (verify, collect, structural-verify, or completion), not just generic entries.
+#
+# Issue #43: Formalize verification-before-completion Skill Card to v2.0
+#
+# Co-authored with AI: <AgentName> (<ModelId>)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/helpers.sh"
+
+SCENARIO_NAME="vbc-evidence-artifacts-dispatch-mapped"
+SCENARIO_PROMPT="Verify the implementation of github issue #1 is complete. Use verification-before-completion."
+
+SKILL_FILE="$SCRIPT_DIR/../../skills/verification-before-completion/SKILL.md"
+
+echo "=== Behavioral Test: $SCENARIO_NAME ==="
+
+behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT"
+
+OVERALL_RESULT=0
+
+assert_skill_invoked "verification-before-completion" || OVERALL_RESULT=1
+
+# Content-verification: evidence_artifacts section exists and contains dispatch_stage
+if ! grep -q "evidence_artifacts:" "$SKILL_FILE"; then
+    echo "FAIL: content-check — evidence_artifacts section not found in SKILL.md"
+    OVERALL_RESULT=1
+else
+    echo "PASS: content-check — evidence_artifacts section found in SKILL.md"
+fi
+
+# Verify each evidence_artifact entry has a dispatch_stage field
+ARTIFACT_NAMES=$(grep -A3 '^\s*- name:' "$SKILL_FILE" | grep '^\s*- name:' | sed 's/.*name: *//' | tr -d ' ')
+EXPECTED_STAGES="verify collect structural-verify completion"
+STAGE_FOUND_COUNT=0
+
+for stage in $EXPECTED_STAGES; do
+    if grep -q "dispatch_stage:.*$stage" "$SKILL_FILE"; then
+        STAGE_FOUND_COUNT=$((STAGE_FOUND_COUNT + 1))
+        echo "PASS: content-check — dispatch_stage '$stage' found in evidence_artifacts"
+    else
+        echo "FAIL: content-check — dispatch_stage '$stage' NOT found in evidence_artifacts"
+        OVERALL_RESULT=1
+    fi
+done
+
+if [ "$STAGE_FOUND_COUNT" -lt 3 ]; then
+    echo "FAIL: content-check — expected at least 3 dispatch_stage values, found $STAGE_FOUND_COUNT"
+    OVERALL_RESULT=1
+fi
+
+# Verify evidence_artifacts entries have dispatch_stage (not just name/type/verification)
+ARTIFACT_ENTRIES=$(awk '/^evidence_artifacts:/,/^```/' "$SKILL_FILE")
+ENTRIES_WITHOUT_STAGE=$(echo "$ARTIFACT_ENTRIES" | grep -c '- name:' || true)
+ENTRIES_WITH_STAGE=$(echo "$ARTIFACT_ENTRIES" | grep -c 'dispatch_stage:' || true)
+
+if [ "$ENTRIES_WITH_STAGE" -lt "$ENTRIES_WITHOUT_STAGE" ]; then
+    echo "FAIL: content-check — not all evidence_artifacts have dispatch_stage ($ENTRIES_WITH_STAGE/$ENTRIES_WITHOUT_STAGE)"
+    OVERALL_RESULT=1
+else
+    echo "PASS: content-check — all $ENTRIES_WITH_STAGE evidence_artifacts have dispatch_stage"
+fi
+
+echo ""
+if [ "$OVERALL_RESULT" -eq 0 ]; then
+    echo "PASS: $SCENARIO_NAME"
+else
+    echo "FAIL: $SCENARIO_NAME"
+fi
+
+exit $OVERALL_RESULT


### PR DESCRIPTION
## Summary

Formalize the verification-before-completion skill card's `evidence_artifacts` section with dispatch-chain-mapped `dispatch_stage` fields, mapping each artifact to its pipeline stage (verify, collect, structural-verify, completion). Add behavioral enforcement test per 000-critical-rules mandate.

## Outcome

- `verification-before-completion/SKILL.md`: evidence_artifacts now have `dispatch_stage` field mapping each artifact to verify, collect, structural-verify, or completion pipeline stage
- Two new evidence_artifacts added: `missing_evidence_collection` (collect stage) and `completion_tasks_executed` (completion stage)
- Behavioral enforcement test created: `vbc-evidence-artifacts-dispatch-mapped.sh` — verifies dispatch-chain-mapped evidence_artifacts requirement
- Content-verification checks PASS for all 4 dispatch_stage values and all 6 evidence artifacts

Implements #43

🤖 Co-authored with AI: OpenCode (ollama-cloud/glm-5.1)