### PR TITLE
feat(#45): formalize finishing-branch skill card — dispatch-chain-mapped evidence_artifacts

### DIFF
--- a/skills/finishing-a-development-branch/SKILL.md
+++ b/skills/finishing-a-development-branch/SKILL.md
@@ -177,7 +177,7 @@ Before invoking any cross-referenced skill:
 
 ```yaml+symbolic
 schema_version: "2.0"
-last_updated: "2026-04-26T00:00:00Z"
+last_updated: "2026-04-27T00:00:00Z"
 rules:
   - id: finishing-a-development-branch-001
     title: "All changes must be committed before branch completion"
@@ -246,16 +246,6 @@ tasks:
     mandatory: true
     bypass_violation: "CRITICAL: Uncommitted/Unpushed Changes After Implementation"
     source: "finishing-a-development-branch/SKILL.md"
-    evidence_artifacts:
-      - gate: lint
-        verification: "uvx ruff check src/ test/"
-        expected: "zero errors"
-      - gate: test
-        verification: "uv run pytest test/"
-        expected: "all tests pass"
-      - gate: push
-        verification: "git log origin/<branch>..HEAD"
-        expected: "empty (all commits pushed)"
 
   - id: completion
     skill: finishing-a-development-branch
@@ -334,14 +324,22 @@ gates:
 evidence_artifacts:
   - name: lint_output
     type: tool_call
+    dispatch_stage: checklist
     verification: "uvx ruff check src/ test/ returns zero errors"
   - name: test_output
     type: tool_call
+    dispatch_stage: checklist
     verification: "uv run pytest test/ passes"
   - name: push_confirmation
     type: tool_call
+    dispatch_stage: prepare
     verification: "git push output confirms branch pushed"
   - name: compare_url
     type: constructed_url
+    dispatch_stage: checklist
     verification: "URL format matches dev...branch pattern"
+  - name: completion_tasks_executed
+    type: tool_call
+    dispatch_stage: completion
+    verification: "completion task output confirms mandatory steps executed"
 ```

--- a/tests/behaviors/finishing-branch-evidence-artifacts-dispatch-mapped.sh
+++ b/tests/behaviors/finishing-branch-evidence-artifacts-dispatch-mapped.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+# Behavioral Enforcement Test: finishing-branch-evidence-artifacts-dispatch-mapped
+# Verifies that finishing-a-development-branch SKILL.md has dispatch-chain-mapped
+# evidence_artifacts — each artifact maps to a specific pipeline stage
+# (prepare, checklist, or completion), not just generic entries.
+#
+# Issue #45: Formalize finishing-a-development-branch Skill Card to v2.0
+#
+# Co-authored with AI: <AgentName> (<ModelId>)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/helpers.sh"
+
+SCENARIO_NAME="finishing-branch-evidence-artifacts-dispatch-mapped"
+SCENARIO_PROMPT="Implementation is complete on this branch. Run the finishing-a-development-branch checklist."
+
+SKILL_FILE="$SCRIPT_DIR/../../skills/finishing-a-development-branch/SKILL.md"
+
+echo "=== Behavioral Test: $SCENARIO_NAME ==="
+
+behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT"
+
+OVERALL_RESULT=0
+
+assert_skill_invoked "finishing-a-development-branch" || OVERALL_RESULT=1
+
+# Content-verification: evidence_artifacts section exists and contains dispatch_stage
+if ! grep -q "evidence_artifacts:" "$SKILL_FILE"; then
+    echo "FAIL: content-check — evidence_artifacts section not found in SKILL.md"
+    OVERALL_RESULT=1
+else
+    echo "PASS: content-check — evidence_artifacts section found in SKILL.md"
+fi
+
+# Verify each expected dispatch_stage value is present
+EXPECTED_STAGES="prepare checklist completion"
+STAGE_FOUND_COUNT=0
+
+for stage in $EXPECTED_STAGES; do
+    if grep -q "dispatch_stage:.*$stage" "$SKILL_FILE"; then
+        STAGE_FOUND_COUNT=$((STAGE_FOUND_COUNT + 1))
+        echo "PASS: content-check — dispatch_stage '$stage' found in evidence_artifacts"
+    else
+        echo "FAIL: content-check — dispatch_stage '$stage' NOT found in evidence_artifacts"
+        OVERALL_RESULT=1
+    fi
+done
+
+if [ "$STAGE_FOUND_COUNT" -lt 2 ]; then
+    echo "FAIL: content-check — expected at least 2 dispatch_stage values, found $STAGE_FOUND_COUNT"
+    OVERALL_RESULT=1
+fi
+
+# Verify evidence_artifacts entries have dispatch_stage (not just name/type/verification)
+ARTIFACT_ENTRIES=$(awk '/^evidence_artifacts:/,/^```/' "$SKILL_FILE")
+ENTRIES_WITHOUT_STAGE=$(echo "$ARTIFACT_ENTRIES" | grep -c '- name:' || true)
+ENTRIES_WITH_STAGE=$(echo "$ARTIFACT_ENTRIES" | grep -c 'dispatch_stage:' || true)
+
+if [ "$ENTRIES_WITH_STAGE" -lt "$ENTRIES_WITHOUT_STAGE" ]; then
+    echo "FAIL: content-check — not all evidence_artifacts have dispatch_stage ($ENTRIES_WITH_STAGE/$ENTRIES_WITHOUT_STAGE)"
+    OVERALL_RESULT=1
+else
+    echo "PASS: content-check — all $ENTRIES_WITH_STAGE evidence_artifacts have dispatch_stage"
+fi
+
+echo ""
+if [ "$OVERALL_RESULT" -eq 0 ]; then
+    echo "PASS: $SCENARIO_NAME"
+else
+    echo "FAIL: $SCENARIO_NAME"
+fi
+
+exit $OVERALL_RESULT


### PR DESCRIPTION
## Summary

Formalize the finishing-a-development-branch skill card's `evidence_artifacts` section with dispatch-chain-mapped `dispatch_stage` fields, remove duplicate inline evidence_artifacts from checklist task, and add behavioral enforcement test per 000-critical-rules mandate.

## Outcome

- `finishing-a-development-branch/SKILL.md`: evidence_artifacts now have `dispatch_stage` field mapping each artifact to prepare, checklist, or completion pipeline stage
- Inline `evidence_artifacts` removed from checklist task entry (was duplicating top-level section)
- New evidence_artifact added: `completion_tasks_executed` (completion stage)
- Behavioral enforcement test created: `finishing-branch-evidence-artifacts-dispatch-mapped.sh`
- Content-verification checks PASS for all 3 dispatch_stage values and all 5 evidence artifacts

Implements #45

🤖 Co-authored with AI: OpenCode (ollama-cloud/glm-5.1)