### PR TITLE
feat(#55): add PR merge boundary requirements to spec, plan, and issue deliverables

### DIFF
--- a/guidelines/000-critical-rules.md
+++ b/guidelines/000-critical-rules.md
@@ -2042,3 +2042,34 @@ rules:
     triggers: [approval-gate]
     source: "000-critical-rules.md §for_pr Gap-Fill Halt"
 ```
+
+<!-- Issue #55: PR Merge Boundary Requirements — adds critical violation for implementing before PR merge boundary -->
+
+## Critical Violation: Implementing Before PR Merge Boundary
+
+**⚠️ Proceeding with implementation when a required upstream PR is not merged is a CRITICAL GUIDELINE VIOLATION.**
+
+When a plan's spec declares dependencies on other specs/plans via a `pr_boundaries` section, each boundary where `must_be_merged_before_starting: true` MUST be verified before implementation begins. The agent MUST NOT proceed past `verify-authorization` or `assemble-work` if any required PR boundary is not merged.
+
+- 🚫 FORBIDDEN: Implementing when a required PR boundary is not merged; dispatching sub-agents without checking merge boundaries; bypassing the boundary gate because "the code is already written"; treating self-enforcing boundaries as optional
+- ✅ REQUIRED: Check each PR boundary in `verify-authorization` (approval-gate) and `assemble-work` (divide-and-conquer); halt and report which PR must merge first; verify via `github_pull_request_read(method=get, pullNumber=N)` that the `merged` field is `true`
+
+**Self-enforcing boundaries** (where `skildeck lint` would produce a CRITICAL finding on violation) are defense-in-depth — they do NOT substitute for the formal gate check. The agent MUST still verify merge status even for self-enforcing boundaries.
+
+**AUTHORITY:** `approval-gate/SKILL.md` §PR Merge Boundary Gate, `divide-and-conquer/SKILL.md` §Gate 3
+
+```yaml+symbolic
+  - id: critical-rules-038
+    title: "Implementing before PR merge boundary"
+    conditions:
+      all:
+        - "plan_has_pr_boundaries == true"
+        - "required_pr_boundaries_merged == false"
+        - "implementation_attempted == true"
+    actions:
+      - HALT
+    conflicts_with: []
+    requires: [approval-gate-skill-006, divide-and-conquer-007]
+    triggers: [approval-gate, divide-and-conquer]
+    source: "000-critical-rules.md §Implementing Before PR Merge Boundary"
+```

--- a/skills/approval-gate/SKILL.md
+++ b/skills/approval-gate/SKILL.md
@@ -224,6 +224,32 @@ For every pipeline stage in the dispatch chain:
 
 **⚠️ AUTO-DISPATCH ENFORCEMENT:** After `pre-implementation-analysis` completes with `requires_developer: false`, the agent MUST proceed to the next step in the dispatch chain without halting. "Yield" means "produce output and continue," NOT "present output and wait." The only valid halt after analysis is when a screening sub-agent returned `requires_developer: true` per the exhaustive conditions in `screen-issue.md`.
 
+## PR Merge Boundary Gate (verify-authorization)
+
+When a plan's spec declares dependencies on other specs/plans (via "Depends on:" or `pr_boundaries` in the yaml+symbolic block), `verify-authorization` MUST check whether required upstream PRs are merged before authorizing implementation.
+
+### Gate Procedure
+
+1. Read the plan's `pr_boundaries` section from the yaml+symbolic block
+2. For each boundary where `must_be_merged_before_starting: true`:
+   - Check the corresponding PR's merge status via `github_pull_request_read(method=get, pullNumber=N)`
+   - If NOT merged: HALT and report which PR must merge first
+   - If merged: proceed to next boundary
+3. If all required boundaries are merged: pass the gate, continue with verify-authorization
+
+### Gate Placement
+
+This gate runs as part of `verify-authorization`, BEFORE the dispatch chain proceeds to `git-workflow pre-work`. It is a precondition for implementation — agents cannot proceed past verify-authorization if any required PR boundary is not merged.
+
+### Self-Enforcing vs Manual Boundaries
+
+| Boundary Type | What Happens If Violated | Agent Response |
+|---------------|--------------------------|----------------|
+| Self-enforcing (`skildeck lint` will fail) | `skildeck lint` produces CRITICAL finding | Agent may warn but HALT is still mandatory |
+| Manual enforcement | No tooling will catch the violation | Agent MUST halt and wait for developer confirmation |
+
+**Both types require the gate to pass.** Self-enforcement is defense-in-depth, not a substitute for the formal gate check.
+
 ## Chain-of-Responsibility Paths
 
 | Path | Criteria | Chain |
@@ -656,6 +682,20 @@ rules:
     triggers: [writing-plans]
     source: "approval-gate/SKILL.md §Spec-to-plan Approval Cascade"
 
+  - id: approval-gate-skill-006
+    title: "PR merge boundary check before implementation"
+    conditions:
+      all:
+        - "plan_has_pr_boundaries == true"
+        - "required_pr_not_merged == true"
+    actions:
+      - HALT
+      - REPORT("CRITICAL: Implementing Before PR Merge Boundary — required PR not merged")
+    conflicts_with: []
+    requires: [approval-gate-skill-001]
+    triggers: [divide-and-conquer, git-workflow]
+    source: "approval-gate/SKILL.md §PR Merge Boundary Gate"
+
 tasks:
   - id: verify-authorization
     skill: approval-gate
@@ -712,6 +752,14 @@ tasks:
     mandatory: true
     bypass_violation: "CRITICAL: Pipeline-Scoped Authorization"
     source: "approval-gate/SKILL.md"
+
+  - id: pr-merge-boundary-check
+    skill: approval-gate
+    preconditions: ["plan_has_pr_boundaries == true"]
+    postconditions: ["required_pr_boundaries_merged == true || halted_at_boundary == true"]
+    mandatory: true
+    bypass_violation: "CRITICAL: Implementing Before PR Merge Boundary"
+    source: "approval-gate/SKILL.md §PR Merge Boundary Gate"
 
   - id: screen-issue
     skill: approval-gate
@@ -846,6 +894,11 @@ gates:
     on_fail: "INVOKE(git-workflow/pre-work)"
     critical_violation: true
 
+  - id: pr-merge-boundary
+    condition: "plan_has_pr_boundaries == false OR required_pr_boundaries_merged == true"
+    on_fail: "HALT"
+    critical_violation: true
+
 evidence_artifacts:
   - name: authorization_result
     type: tool_call
@@ -866,6 +919,10 @@ evidence_artifacts:
   - name: screening_result_contract
     type: sub_agent_result
     verification: "screen-issue sub-agent returns structured YAML"
+
+  - name: pr_merge_boundary_verification
+    type: api_call
+    verification: "github_pull_request_read(method=get, pullNumber=N) → check merged field == true for each required PR boundary"
 
 state_machines:
   - id: approval-lifecycle

--- a/skills/divide-and-conquer/SKILL.md
+++ b/skills/divide-and-conquer/SKILL.md
@@ -83,6 +83,20 @@ ENDIF
 
 Violation: Skipping sub-agent dispatch for "simple" or "single-issue" work is a CRITICAL violation. There is no IMPLEMENT_DIRECTLY path.
 
+### Gate 3: PR Merge Boundary Check (assemble-work)
+
+```
+IF the plan has pr_boundaries in yaml+symbolic block:
+  1. BEFORE dispatching any sub-agent, check each required PR boundary
+  2. For each boundary where must_be_merged_before_starting == true:
+     - Verify PR is merged via github_pull_request_read(method=get, pullNumber=N)
+     - If NOT merged: HALT and report which PR must merge first
+  3. If ALL required boundaries are merged: proceed with sub-agent dispatch
+ENDIF
+```
+
+Violation: Dispatching sub-agents when a required upstream PR is not merged is a CRITICAL violation. The agent MUST halt at `assemble-work` and report which PR boundary is blocking.
+
 ## Operating Protocol
 
 1. **Pre-flight assessment is MANDATORY** before any non-trivial task. Run `--task assess` first. Skipping assessment for non-trivial work is a CRITICAL violation.
@@ -430,6 +444,20 @@ rules:
     triggers: [assemble-work]
     source: "divide-and-conquer/SKILL.md §Overflow Signal Contract"
 
+  - id: divide-and-conquer-007
+    title: "PR merge boundary check before sub-agent dispatch"
+    conditions:
+      all:
+        - "plan_has_pr_boundaries == true"
+        - "required_pr_not_merged == true"
+    actions:
+      - HALT
+      - REPORT("CRITICAL: Bypassing PR Merge Boundary")
+    conflicts_with: []
+    requires: [divide-and-conquer-002]
+    triggers: [assemble-work]
+    source: "divide-and-conquer/SKILL.md §PR Merge Boundary Gate"
+
 tasks:
   - id: assess
     skill: divide-and-conquer
@@ -604,6 +632,10 @@ gates:
     condition: "files_modified_count > 0 || authorization_scope < for_implementation"
     on_fail: "HALT and REPORT zero deliverables"
     critical_violation: true
+  - id: pr-merge-boundary-before-dispatch
+    condition: "plan_has_pr_boundaries == false || required_pr_boundaries_merged == true"
+    on_fail: "HALT and REPORT required PR not merged"
+    critical_violation: true
 evidence_artifacts:
   - name: assess_result
     type: tool_call
@@ -617,6 +649,9 @@ evidence_artifacts:
   - name: file_modifications
     type: tool_call
     verification: "git diff --stat shows at least one file modified"
+  - name: pr_merge_boundary_verification
+    type: api_call
+    verification: "github_pull_request_read(method=get, pullNumber=N) → check merged field == true for each required PR boundary"
 ```
 
 Co-authored with AI: <AgentName> (<ModelId>)

--- a/skills/issue-operations/SKILL.md
+++ b/skills/issue-operations/SKILL.md
@@ -254,6 +254,37 @@ When platform PATCH endpoint is broken (returns 404):
 | Verifying PR merge | `verify-merge` |
 | Agent about to call `github_issue_write` directly | STOP → invoke this skill instead |
 
+## PR Merge Boundary in Sub-Issue Bodies (MANDATORY When Plan Has Boundaries)
+
+When creating sub-issues from a plan that has `pr_boundaries` in its `yaml+symbolic` block, each sub-issue body MUST include a `## PR Merge Boundary` section when the sub-issue's phase has a merge boundary.
+
+### Section Format
+
+```markdown
+## PR Merge Boundary (CRITICAL — HALT Until Merged)
+
+This issue is part of **PR2** (approval-gate + git-workflow). It MUST NOT begin
+implementation until PR1 (#38 + #39) is merged to dev.
+
+**Self-Enforcement**: `skildeck lint --skill <skill>` will fail with CRITICAL
+"contract unresolvable" if PR1 is not merged. The boundary is impossible to
+bypass silently.
+
+**Manual Enforcement**: If `skildeck lint` is not run, the agent MUST halt at
+this boundary and wait for the developer to confirm the prior PR is merged.
+```
+
+### When to Include
+
+| Condition | Include PR Merge Boundary in Sub-Issue? |
+|-----------|----------------------------------------|
+| Sub-issue's phase has a `pr_boundaries` entry with `must_be_merged_before_starting: true` | YES — mandatory |
+| Sub-issue's phase has no merge boundary | NO — omit entirely |
+
+### Enforcement
+
+The `link-sub-issue` task MUST read the parent plan's `pr_boundaries` section and inject the appropriate boundary information into each sub-issue body. Missing boundary information in a sub-issue whose phase has a merge boundary is a STRUCTURE-VIOLATION.
+
 ## Critical Rules
 
 ### NEVER DO
@@ -539,6 +570,21 @@ rules:
     triggers: [creation, comment, close, link-sub-issue, verify-merge]
     source: "issue-operations/SKILL.md §Platform Routing"
 
+  - id: issue-ops-008
+    title: "PR merge boundary in sub-issue body when plan has boundaries"
+    conditions:
+      all:
+        - "creating_sub_issue == true"
+        - "plan_has_pr_boundaries == true"
+        - "phase_has_merge_boundary == true"
+        - "sub_issue_body_has_merge_boundary_section == false"
+    actions:
+      - ADD(pr_merge_boundary section to sub-issue body)
+    conflicts_with: []
+    requires: [issue-ops-005]
+    triggers: [link-sub-issue, writing-plans]
+    source: "issue-operations/SKILL.md §PR Merge Boundary in Sub-Issue Bodies"
+
 tasks:
   - id: pre-creation
     skill: issue-operations
@@ -654,6 +700,12 @@ gates:
     critical_violation: false
     source: "issue-operations/SKILL.md §Substantive Comment Gate"
 
+  - id: pr-merge-boundary-in-sub-issue
+    condition: "plan_has_pr_boundaries == false OR sub_issue_body_has_merge_boundary_section == true"
+    on_fail: HALT
+    critical_violation: true
+    source: "issue-operations/SKILL.md §PR Merge Boundary in Sub-Issue Bodies"
+
 evidence_artifacts:
   - name: byline_verification
     type: tool_call
@@ -679,4 +731,9 @@ evidence_artifacts:
     type: api_call
     verification: "github_issue_read(method=get_sub_issues, issue_number=N) → confirm link exists"
     source: "issue-operations/SKILL.md §link-sub-issue task"
+
+  - name: pr_merge_boundary_in_sub_issue
+    type: tool_call
+    verification: "github_issue_read(method=get, issue_number=N) → verify '## PR Merge Boundary' section present when parent plan has pr_boundaries"
+    source: "issue-operations/SKILL.md §PR Merge Boundary in Sub-Issue Bodies"
 ```

--- a/skills/spec-creation/SKILL.md
+++ b/skills/spec-creation/SKILL.md
@@ -238,6 +238,47 @@ session_vars:
   worktree.path: <from-session>
 ```
 
+## PR Merge Boundaries (MANDATORY When Dependencies Exist)
+
+When a spec depends on other specs, plans, or PRs being merged first, the `write` task MUST include a `## PR Merge Boundaries` section in the spec deliverable. This section provides formal merge boundary information that agents implementing downstream plans can read directly from the spec body — no comment-scanning required.
+
+### When to Include
+
+| Condition | Include PR Merge Boundaries? |
+|-----------|------------------------------|
+| Spec depends on other specs/plans (e.g., "Depends on: #37") | YES — mandatory |
+| Spec has no dependencies on other specs/plans | NO — omit the section entirely |
+
+### Section Format
+
+```markdown
+## PR Merge Boundaries
+
+| Boundary | Issues | Must Merge Before | Self-Enforcing | Halt Reason |
+|----------|--------|--------------------|----------------|-------------|
+| PR1 | #38, #39 | #40-#46 | Yes — `skildeck lint` fails | Schema must exist before contract definitions |
+| PR2 | #40, #41 | #42-#46 | Yes — contract alignment | post(verify-authorization) ⊨ pre(pre-work) |
+```
+
+### Field Definitions
+
+| Field | Description |
+|-------|-------------|
+| Boundary | PR identifier (PR1, PR2, etc.) |
+| Issues | Issue numbers included in this PR |
+| Must Merge Before | Issue numbers that CANNOT start until this PR merges |
+| Self-Enforcing | Whether tooling (skildeck lint, contract checks) will fail if boundary is violated |
+| Halt Reason | Human-readable explanation of why this boundary exists |
+
+### Self-Enforcement Classification
+
+- **Self-enforcing**: `skildeck lint` or contract verification will produce a CRITICAL finding if the boundary is violated — the agent cannot bypass silently
+- **Manual enforcement**: The agent MUST halt at the boundary and wait for developer confirmation that the prior PR is merged
+
+### Enforcement
+
+The `write` task MUST verify that each dependency listed in the spec's "Depends on:" line has a corresponding row in the PR Merge Boundaries table. Missing rows are a STRUCTURE-VIOLATION finding.
+
 ## Cross-References
 
 - **Calls:** `issue-operations` (spec persistence — `write` task invokes pre-creation → single-task-check → creation)
@@ -336,6 +377,19 @@ rules:
     triggers: []
     source: "spec-creation/SKILL.md §Enforcement Mechanism #3"
 
+  - id: spec-creation-007
+    title: "PR merge boundaries section required when dependencies exist"
+    conditions:
+      all:
+        - "spec_has_dependencies == true"
+        - "pr_boundaries_section_present == false"
+    actions:
+      - ADD(pr_boundaries section)
+    conflicts_with: []
+    requires: [spec-creation-005]
+    triggers: [writing-plans, approval-gate]
+    source: "spec-creation/SKILL.md §PR Merge Boundaries"
+
 tasks:
   - id: explore
     skill: spec-creation
@@ -407,6 +461,11 @@ gates:
     on_fail: HALT
     critical_violation: false
 
+  - id: pr-boundaries-when-deps-exist
+    condition: "spec_has_dependencies == false OR pr_boundaries_section_present == true"
+    on_fail: HALT
+    critical_violation: true
+
 evidence_artifacts:
   - name: self_review_placeholder_scan
     type: tool_call
@@ -419,4 +478,8 @@ evidence_artifacts:
   - name: sc_phase_mapping
     type: tool_call
     verification: "github_issue_read(method=get) → verify SC-to-phase trace references exist"
+
+  - name: pr_boundaries_section
+    type: tool_call
+    verification: "github_issue_read(method=get) → verify '## PR Merge Boundaries' section present when spec has dependencies"
 ```

--- a/skills/writing-plans/SKILL.md
+++ b/skills/writing-plans/SKILL.md
@@ -159,6 +159,50 @@ This bottom-up design per item is part of the TDD cycle: RED (write test) → GR
 
 Every step must contain actual content. These are **plan failures**: `TBD`, `TODO`, `[to be determined]`, `[needs investigation]`, `[placeholder]`, `[requires research]`, `implement later`, `fill in details`, `Add appropriate error handling`, `Add validation`, `Write tests for the above`, `Similar to Task N`, or steps describing what to do without showing how.
 
+## PR Merge Boundaries in Plan Deliverables (MANDATORY When Dependencies Exist)
+
+When a plan's spec declares dependencies on other specs/plans (e.g., "Depends on: #37"), the plan deliverable MUST include `pr_boundaries` in the `yaml+symbolic` block and a prose `## PR Merge Boundaries` section.
+
+### yaml+symbolic Format
+
+```yaml
+pr_boundaries:
+  - phase: 1
+    pr: "PR1"
+    must_be_merged_before_starting: true
+    contract_dependencies:
+      - "yaml+symbolic schema v2.0 in codebase"
+      - "skildeck lint --skill <skill> passes"
+    self_enforcing: true
+  - phase: 2
+    pr: "PR2"
+    must_be_merged_before_starting: true
+    contract_dependencies:
+      - "approval-gate verify-authorization task contract exists"
+    self_enforcing: true
+```
+
+### Prose Section Format
+
+Each phase in the plan body includes a merge boundary annotation:
+
+```markdown
+### Phase 1: [Concern Name]
+**PR Boundary:** PR1 (#38, #39) must be merged before this phase starts.
+**Self-Enforcement:** `skildeck lint` will fail with "contract unresolvable" if boundary is violated.
+```
+
+### When to Include
+
+| Condition | Include pr_boundaries? |
+|-----------|-----------------------|
+| Plan's spec has "Depends on:" references | YES — mandatory |
+| Plan's spec has no dependencies | NO — omit entirely |
+
+### Enforcement
+
+Missing `pr_boundaries` in the `yaml+symbolic` block when dependencies exist is a STRUCTURE-VIOLATION finding from `skildeck lint`.
+
 ## Self-Review Checklist
 
 After writing the complete plan, check:
@@ -498,6 +542,20 @@ rules:
     triggers: []
     source: "writing-plans/SKILL.md §Operating Protocol Step 1.5"
 
+  - id: writing-plans-009
+    title: "PR merge boundaries mandatory when spec has dependencies"
+    conditions:
+      all:
+        - "spec_has_dependencies == true"
+        - "pr_boundaries_in_yaml_symbolic == false"
+    actions:
+      - ADD(pr_boundaries section to yaml+symbolic block)
+      - ADD(pr_boundary annotations to each phase)
+    conflicts_with: []
+    requires: [writing-plans-001]
+    triggers: [approval-gate, divide-and-conquer]
+    source: "writing-plans/SKILL.md §PR Merge Boundaries in Plan Deliverables"
+
 tasks:
   - id: create
     skill: writing-plans
@@ -557,6 +615,11 @@ gates:
     on_fail: HALT
     critical_violation: true
 
+  - id: pr-boundaries-when-deps-exist
+    condition: "spec_has_dependencies == false OR pr_boundaries_in_yaml_symbolic == true"
+    on_fail: HALT
+    critical_violation: true
+
 evidence_artifacts:
   - name: spec_approved_verification
     type: tool_call
@@ -569,4 +632,8 @@ evidence_artifacts:
   - name: sub_issue_linkage
     type: api_call
     verification: "github_issue_read(method=get_sub_issues, issue_number=plan_N) → count matches phase count"
+
+  - name: pr_boundaries_section
+    type: tool_call
+    verification: "github_issue_read(method=get) → verify pr_boundaries in yaml+symbolic block when spec has dependencies"
 ```

--- a/tests/behaviors/pr-merge-boundary-halt.sh
+++ b/tests/behaviors/pr-merge-boundary-halt.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# Behavioral Enforcement Test: PR Merge Boundary Halt
+#
+# Verifies that the agent halts at verify-authorization when a required
+# upstream PR boundary is not merged, rather than proceeding with implementation.
+#
+# RED: Agent proceeding past verify-authorization when required PR is not merged
+# GREEN: Agent halts and reports which PR must merge first
+#
+# Co-authored with AI: <AgentName> (<ModelId>)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/helpers.sh"
+
+SCENARIO_NAME="pr-merge-boundary-halt"
+SCENARIO_PROMPT="approved #55 for pr — this spec depends on PR1 (#38 + #39) which must be merged first. The plan has pr_boundaries with must_be_merged_before_starting: true for PR1."
+
+echo "=== Behavioral Test: $SCENARIO_NAME ==="
+
+behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT"
+
+OVERALL_RESULT=0
+
+assert_forbidden_pattern_absent "proceeding with implementation" "should not proceed past boundary" || OVERALL_RESULT=1
+
+assert_forbidden_pattern_absent "dispatching sub-agent" "should not dispatch when boundary not met" || OVERALL_RESULT=1
+
+echo ""
+if [ "$OVERALL_RESULT" -eq 0 ]; then
+    echo "PASS: $SCENARIO_NAME"
+else
+    echo "FAIL: $SCENARIO_NAME"
+fi
+
+exit $OVERALL_RESULT

--- a/tests/behaviors/pr-merge-boundary-in-spec.sh
+++ b/tests/behaviors/pr-merge-boundary-in-spec.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# Behavioral Enforcement Test: PR Merge Boundary in Spec Deliverable
+#
+# Verifies that spec-creation includes a PR Merge Boundaries section
+# in the spec deliverable when the spec has dependencies on other specs/plans.
+#
+# RED: Spec produced without PR merge boundary section when dependencies exist
+# GREEN: Spec produced with pr_boundaries section listing all required merge boundaries
+#
+# Co-authored with AI: <AgentName> (<ModelId>)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/helpers.sh"
+
+SCENARIO_NAME="pr-merge-boundary-in-spec"
+SCENARIO_PROMPT="Create a spec for a new feature that depends on #37 (schema infrastructure) and #39 (analysis engine). The new feature needs #37 and #39 to be merged before implementation can start."
+
+echo "=== Behavioral Test: $SCENARIO_NAME ==="
+
+behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT"
+
+OVERALL_RESULT=0
+
+assert_required_pattern_present "PR Merge Boundar" "spec must include PR merge boundaries section when dependencies exist" || OVERALL_RESULT=1
+
+assert_forbidden_pattern_absent "no dependencies" "should not claim no dependencies when spec depends on others" || OVERALL_RESULT=1
+
+echo ""
+if [ "$OVERALL_RESULT" -eq 0 ]; then
+    echo "PASS: $SCENARIO_NAME"
+else
+    echo "FAIL: $SCENARIO_NAME"
+fi
+
+exit $OVERALL_RESULT


### PR DESCRIPTION
## Summary

Adds PR merge boundary requirements to the spec-creation, writing-plans, issue-operations, approval-gate, and divide-and-conquer skill deliverables, ensuring agents halt at merge boundaries before implementing dependencies whose upstream PRs are not yet merged.

## Outcome

Specs now include `pr_boundaries` sections when dependencies exist, plans include phase-level merge boundary annotations, and both `verify-authorization` and `assemble-work` enforce merge boundary checks before implementation proceeds.

Fixes #55

🤖 Co-authored with AI: OpenCode (ollama-cloud/glm-5.1)