### PR TITLE
feat: Clean-Room Sub-Agent Mandate and Pre/Post-Flight Checks (#101)

### DIFF
--- a/tests/regressions/regression-91-verify-structure.py
+++ b/tests/regressions/regression-91-verify-structure.py
@@ -26,10 +26,10 @@ ISSUE_SPEC_FILES = {
 }
 
 MISSING_COMPONENTS = {
-    41: ["state_machines", "evidence_artifacts", "gates"],
-    42: ["state_machines", "evidence_artifacts", "gates"],
-    43: ["state_machines", "evidence_artifacts", "gates"],
-    45: ["state_machines", "gates"],
+    41: ["state_machines", "evidence_artifacts", "gates", "dispatch_context"],
+    42: ["state_machines", "evidence_artifacts", "gates", "dispatch_context"],
+    43: ["state_machines", "evidence_artifacts", "gates", "dispatch_context"],
+    45: ["state_machines", "gates", "dispatch_context"],
 }
 
 
@@ -41,6 +41,7 @@ def _extract_yaml_components(filepath: Path) -> dict:
         "gates": False,
         "evidence_artifacts": False,
         "decomposition": False,
+        "dispatch_context": False,
     }
     try:
         text = filepath.read_text()
@@ -58,6 +59,18 @@ def _extract_yaml_components(filepath: Path) -> dict:
             continue
         if isinstance(data, dict):
             for key in components:
+                if key == "dispatch_context":
+                    decomp = data.get("decomposition", [])
+                    if isinstance(decomp, list):
+                        for entry in decomp:
+                            if (
+                                isinstance(entry, dict)
+                                and entry.get("type") == "sub-agent-dispatch"
+                                and "isolation" in entry
+                            ):
+                                components["dispatch_context"] = True
+                                break
+                    continue
                 entries = data.get(key, [])
                 if isinstance(entries, list) and len(entries) > 0:
                     components[key] = True


### PR DESCRIPTION
## Summary

Implements the Clean-Room Sub-Agent Mandate (Plan #101) across all pipeline stages, adding pre-flight check protocols, post-flight check protocols, dispatch context isolation requirements, and behavioral enforcement tests to ensure sub-agent integrity across the entire approval-gate dispatch chain.

## Outcome

All 20 success criteria verified:
- **SC-1–SC-3**: Skill card dispatch context isolation tables in verification-before-completion, divide-and-conquer, git-workflow, finishing-a-development-branch, requesting-code-review, pr-creation-workflow, and approval-gate SKILL.md files
- **SC-4–SC-5**: Pre-flight and post-flight check protocols in `000-critical-rules.md`
- **SC-6–SC-9**: Critical violation sections for clean-room dispatch, pre-flight checks, post-flight checks, and verification evidence in `000-critical-rules.md`
- **SC-10–SC-18**: Nine behavioral enforcement tests in `.opencode/tests/behaviors/`
- **SC-19**: All skill SKILL.md files include `isolation: clean-room` with `must_receive`/`must_not_receive` in yaml+symbolic decomposition
- **SC-20**: `schema_v2.py` recognizes `dispatch_context` as a structural component type via `_get_structural_component_names()` and validates `isolation`/`must_receive`/`must_not_receive` fields on `sub-agent-dispatch` decomposition entries

Fixes #101

🤖 Co-authored with AI: OpenCode (ollama-cloud/glm-5.1)