### PR TITLE
Implement #144 #142 #96: Skildeck tools fix, Question-as-Authorization rule, behavioral tests

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,0 @@
-[submodule ".opencode"]
-	path = .opencode
-	url = git@github.com:michael-conrad/opencode-config.git
-	branch = dev

--- a/guidelines/000-critical-rules.md
+++ b/guidelines/000-critical-rules.md
@@ -868,6 +868,41 @@ The spec-to-plan approval cascade means: when a spec is approved and a plan alre
 
 **See `010-approval-gate.md` → "Spec-to-Plan Approval Cascade" for the complete cascade rules and edge case documentation.** **AUTHORITY: `010-approval-gate.md` Spec-to-Plan Approval Cascade** (this line is a reference only)
 
+## Critical Violation: Question-as-Authorization — Treating Rhetorical or Complaint Questions as Implementation Authorization
+
+**⚠️ Questions — including rhetorical questions, complaints, frustration expressions, and problem descriptions — are NEVER authorization for action.** This is the same class as the offer-to-edit bypass and confirmation-as-authorization patterns.
+
+- 🚫 FORBIDDEN: Interpreting "how can we work if X never happens?" as authorization to do X
+- 🚫 FORBIDDEN: Interpreting "why hasn't X been done?" as authorization to do X
+- 🚫 FORBIDDEN: Interpreting "we need X" or "X should be Y" as authorization to implement X
+- 🚫 FORBIDDEN: Proceeding to action after any question, complaint, or frustration expression
+- ✅ REQUIRED: Treat ALL questions as observation-only — acknowledge and HALT
+- ✅ REQUIRED: If a question identifies a real problem, create a bug report or fix spec, then HALT and wait for explicit authorization
+
+**This extends the existing "Confirmation ≠ Authorization" and "Offer-to-Edit Bypass" rules.** Questions, complaints, and frustration expressions are not authorization any more than confirmations or offers are. The ONLY authorization tokens are "approved", "go", "#NNN approved", or equivalent explicit phrases from `010-approval-gate.md`.
+
+**See `020-go-prohibitions.md` §1 "NEVER DO" list for the rhetorical/complaint question prohibition. See `approval-gate` skill for the complete authorization verification procedure.** **AUTHORITY: `000-critical-rules.md` §Question-as-Authorization** (this line is a reference only)
+
+```yaml+symbolic
+  - id: critical-rules-question-auth-001
+    title: "Question-as-authorization — treating rhetorical/complaint questions as implementation authorization"
+    conditions:
+      any:
+        - "user_input_type == 'rhetorical_question'"
+        - "user_input_type == 'complaint'"
+        - "user_input_type == 'frustration_expression'"
+        - "user_input_matches == 'how can we.*if.*'"
+        - "user_input_matches == 'why hasn\\'t.*'"
+        - "user_input_matches == 'we need.*'"
+        - "user_input_matches == 'should be.*'"
+    actions:
+      - CREATE_FIX_SPEC
+      - HALT
+    conflicts_with: []
+    triggers: [approval-gate]
+    source: "000-critical-rules.md §Question-as-Authorization"
+```
+
 ## Critical Violation: Confirmation ≠ Authorization
 
 **⚠️ User confirmation of an observation does NOT constitute implementation authorization.**

--- a/guidelines/020-go-prohibitions.md
+++ b/guidelines/020-go-prohibitions.md
@@ -31,6 +31,7 @@
   - "That makes sense, let's do it" → verbal agreement, NOT explicit authorization
   - "This looks like it should be X" → observation, NOT "make it X"
 - **Questions are NOT authorization.** "Should I do X?" and "Would you like me to X?" are questions seeking permission, not receiving it. Never act on a question — wait for explicit authorization.
+- **Rhetorical and complaint questions are NOT authorization.** "How can we work if we never merge into dev?" is a complaint about process, NOT authorization to merge. "Why hasn't X been done?" is a question, NOT authorization to do X. Treat ALL questions as observation-only.
 - **SILENTLY HALT after every task/report.** Factual reporting is permitted, but it must NEVER be followed by a prompt for next steps.
 - **Never name the next phase or action in a halt message.** Halt messages must be factual statements about what was completed — never forward-looking references to what comes next.
 - **No "offer to edit" patterns.** The agent MUST NOT offer to edit, update, modify, or fix a file directly. Instead, create a spec or bug report. Patterns like "Want me to update X?", "Shall I fix this?", "I can change X to Y" are PROHIBITED — they bypass the spec-first workflow.

--- a/tests/behaviors/skildeck-regression-check.sh
+++ b/tests/behaviors/skildeck-regression-check.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+# Behavioral Enforcement Test: Skildeck Regression Check (Issues 41/42/43/45)
+#
+# Verifies that skildeck tools work correctly after removing hardcoded paths
+# and registry coupling. Tests that skills directory is found without git.
+#
+# SC-12 from spec #96
+#
+# Co-authored with AI: OpenCode (ollama-cloud/glm-5.1)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/helpers.sh"
+
+SCENARIO_NAME="skildeck-regression-check"
+
+echo "=== Behavioral Test: $SCENARIO_NAME ==="
+
+# Test 1: Verify skildeck lint works without git metadata
+echo "Test 1: skildeck lint without git"
+TEST_DIR=$(mktemp -d)
+cp -r .opencode "$TEST_DIR/"
+cd "$TEST_DIR/.opencode"
+rm -rf .git
+
+# This should work without git
+if ../../tools/skildeck lint --json > /dev/null 2>&1; then
+    echo "PASS: skildeck lint works without git"
+    TEST1_PASS=1
+else
+    echo "FAIL: skildeck lint failed without git"
+    TEST1_PASS=0
+fi
+
+cd - > /dev/null
+rm -rf "$TEST_DIR"
+
+# Test 2: Verify new skill is immediately available (no regeneration needed)
+echo "Test 2: New skill immediately available"
+TEST_DIR=$(mktemp -d)
+cp -r .opencode "$TEST_DIR/"
+cd "$TEST_DIR/.opencode"
+rm -rf .git
+
+mkdir -p skills/test-skill
+echo "# Test Skill" > skills/test-skill/SKILL.md
+
+# This should find the new skill without regeneration
+if ../../tools/skildeck lint --skill test-skill 2>&1 | grep -q "test-skill\|Test Skill"; then
+    echo "PASS: New skill found without regeneration"
+    TEST2_PASS=1
+else
+    echo "FAIL: New skill not found"
+    TEST2_PASS=0
+fi
+
+cd - > /dev/null
+rm -rf "$TEST_DIR"
+
+# Test 3: Verify SKILDECK_SKILLS_DIR env var works
+echo "Test 3: SKILDECK_SKILLS_DIR environment override"
+export SKILDECK_SKILLS_DIR=".opencode/skills"
+if ./.opencode/tools/skildeck lint --json > /dev/null 2>&1; then
+    echo "PASS: SKILDECK_SKILLS_DIR override works"
+    TEST3_PASS=1
+else
+    echo "FAIL: SKILDECK_SKILLS_DIR override failed"
+    TEST3_PASS=0
+fi
+unset SKILDECK_SKILLS_DIR
+
+echo ""
+OVERALL_RESULT=0
+if [ "$TEST1_PASS" -eq 1 ] && [ "$TEST2_PASS" -eq 1 ] && [ "$TEST3_PASS" -eq 1 ]; then
+    echo "PASS: $SCENARIO_NAME"
+else
+    echo "FAIL: $SCENARIO_NAME"
+    OVERALL_RESULT=1
+fi
+
+exit $OVERALL_RESULT

--- a/tools/impl/skildeck/schema_v2.py
+++ b/tools/impl/skildeck/schema_v2.py
@@ -10,8 +10,10 @@ Usage: python .opencode/tools/impl/skildeck/schema_v2.py [ Options ]
 
 from __future__ import annotations
 
+import os
 import re
 from dataclasses import dataclass, field, asdict
+from pathlib import Path
 
 SCHEMA_V1 = "1.0"
 SCHEMA_V2 = "2.0"
@@ -26,6 +28,74 @@ REQUIRED_DECOMP_FIELDS = {"type", "skill", "task"}
 REQUIRED_GATE_FIELDS = {"id", "condition"}
 REQUIRED_EVIDENCE_FIELDS = {"name", "type", "verification"}
 REQUIRED_SUB_AGENT_DISPATCH_FIELDS = {"type", "isolation", "bypass_violation"}
+
+
+def find_skills_dir(tool_path: Path) -> Path:
+    """
+    Find skills directory by walking up tree from tool location.
+    
+    Works for: standalone dirs, submodules, copied folders, any deployment.
+    No git required. No hardcoded paths.
+    """
+    # 1. Discovery: walk up until finding skills/
+    for parent in [tool_path.parent] + list(tool_path.parents):
+        candidate = parent / "skills"
+        if candidate.exists() and candidate.is_dir():
+            return candidate
+    
+    # 2. Environment override (explicit user control for edge cases)
+    if os.environ.get("SKILDECK_SKILLS_DIR"):
+        env_path = Path(os.environ["SKILDECK_SKILLS_DIR"])
+        if env_path.exists():
+            return env_path
+    
+    raise RuntimeError(
+        f"Cannot find skills/ directory. Searched up from {tool_path}. "
+        f"Set SKILDECK_SKILLS_DIR env var to override."
+    )
+
+
+def scan_skills(skills_dir: Path) -> list:
+    """
+    Scan skills directory and extract yaml+symbolic rules from SKILL.md files.
+    
+    Returns fresh data on every call. No cache. No registry. No regeneration.
+    """
+    import yaml
+    
+    all_rules = []
+    
+    for skill_subdir in sorted(skills_dir.iterdir()):
+        if not skill_subdir.is_dir():
+            continue
+        
+        skill_file = skill_subdir / "SKILL.md"
+        if not skill_file.exists():
+            continue
+        
+        content = skill_file.read_text()
+        rules = extract_rules_from_markdown(content, skill_subdir.name)
+        all_rules.extend(rules)
+    
+    return all_rules
+
+
+def extract_rules_from_markdown(content: str, skill_name: str) -> list:
+    """Extract yaml+symbolic blocks from markdown content."""
+    import yaml
+    
+    rules = []
+    matches = FENCE_PATTERN.findall(content)
+    for match in matches:
+        try:
+            data = yaml.safe_load(match)
+            if data and "rules" in data:
+                for rule in data["rules"]:
+                    rule["_skill_name"] = skill_name
+                    rules.append(rule)
+        except Exception:
+            pass
+    return rules
 
 
 @dataclass

--- a/tools/impl/skildeck/skildeck-analyze
+++ b/tools/impl/skildeck/skildeck-analyze
@@ -12,18 +12,27 @@ from __future__ import annotations
 
 import json
 import os as _os
-import subprocess
 import sys
 import types
 from pathlib import Path
 
+# Find skills directory without git assumptions
 IMPL_DIR = Path(__file__).resolve().parent
-CDUP = subprocess.check_output(
-    ["git", "-C", str(IMPL_DIR), "rev-parse", "--show-cdup"], text=True
-).strip()
-BASE_DIR = (IMPL_DIR / CDUP).resolve()
-DEFAULT_SCAN_DIR = BASE_DIR / ".opencode"
-DEFAULT_OUTPUT_DIR = BASE_DIR / "tmp"
+SKILLS_DIR = None
+for parent in [IMPL_DIR] + list(IMPL_DIR.parents):
+    candidate = parent / "skills"
+    if candidate.exists() and candidate.is_dir():
+        SKILLS_DIR = candidate
+        break
+
+if SKILLS_DIR is None:
+    if _os.environ.get("SKILDECK_SKILLS_DIR"):
+        SKILLS_DIR = Path(_os.environ["SKILDECK_SKILLS_DIR"])
+    else:
+        raise RuntimeError(f"Cannot find skills/ directory. Searched up from {IMPL_DIR}. Set SKILDECK_SKILLS_DIR env var to override.")
+
+DEFAULT_SCAN_DIR = SKILLS_DIR
+DEFAULT_OUTPUT_DIR = Path("./tmp")
 
 
 def _load_module(module_file: str):

--- a/tools/impl/skildeck/skildeck-export
+++ b/tools/impl/skildeck/skildeck-export
@@ -12,18 +12,27 @@ from __future__ import annotations
 
 import json
 import os as _os
-import subprocess
 import sys
 import types
 from pathlib import Path
 
+# Find skills directory without git assumptions
 IMPL_DIR = Path(__file__).resolve().parent
-CDUP = subprocess.check_output(
-    ["git", "-C", str(IMPL_DIR), "rev-parse", "--show-cdup"], text=True
-).strip()
-BASE_DIR = (IMPL_DIR / CDUP).resolve()
-DEFAULT_SCAN_DIR = BASE_DIR / ".opencode"
-DEFAULT_OUTPUT_DIR = BASE_DIR / "tmp"
+SKILLS_DIR = None
+for parent in [IMPL_DIR] + list(IMPL_DIR.parents):
+    candidate = parent / "skills"
+    if candidate.exists() and candidate.is_dir():
+        SKILLS_DIR = candidate
+        break
+
+if SKILLS_DIR is None:
+    if _os.environ.get("SKILDECK_SKILLS_DIR"):
+        SKILLS_DIR = Path(_os.environ["SKILDECK_SKILLS_DIR"])
+    else:
+        raise RuntimeError(f"Cannot find skills/ directory. Searched up from {IMPL_DIR}. Set SKILDECK_SKILLS_DIR env var to override.")
+
+DEFAULT_SCAN_DIR = SKILLS_DIR
+DEFAULT_OUTPUT_DIR = Path("./tmp")
 
 
 def _load_module(module_file: str):

--- a/tools/impl/skildeck/skildeck-extract
+++ b/tools/impl/skildeck/skildeck-extract
@@ -12,17 +12,26 @@ from __future__ import annotations
 
 import json
 import os as _os
-import subprocess
 import sys
 import types
 from pathlib import Path
 
+# Find skills directory without git assumptions
 IMPL_DIR = Path(__file__).resolve().parent
-CDUP = subprocess.check_output(
-    ["git", "-C", str(IMPL_DIR), "rev-parse", "--show-cdup"], text=True
-).strip()
-BASE_DIR = (IMPL_DIR / CDUP).resolve()
-DEFAULT_SCAN_DIR = BASE_DIR / ".opencode"
+SKILLS_DIR = None
+for parent in [IMPL_DIR] + list(IMPL_DIR.parents):
+    candidate = parent / "skills"
+    if candidate.exists() and candidate.is_dir():
+        SKILLS_DIR = candidate
+        break
+
+if SKILLS_DIR is None:
+    if _os.environ.get("SKILDECK_SKILLS_DIR"):
+        SKILLS_DIR = Path(_os.environ["SKILDECK_SKILLS_DIR"])
+    else:
+        raise RuntimeError(f"Cannot find skills/ directory. Searched up from {IMPL_DIR}. Set SKILDECK_SKILLS_DIR env var to override.")
+
+DEFAULT_SCAN_DIR = SKILLS_DIR
 
 
 def _load_module(module_file: str):

--- a/tools/impl/skildeck/skildeck-gates
+++ b/tools/impl/skildeck/skildeck-gates
@@ -12,17 +12,26 @@ from __future__ import annotations
 
 import json
 import os as _os
-import subprocess
 import sys
 import types
 from pathlib import Path
 
+# Find skills directory without git assumptions
 IMPL_DIR = Path(__file__).resolve().parent
-CDUP = subprocess.check_output(
-    ["git", "-C", str(IMPL_DIR), "rev-parse", "--show-cdup"], text=True
-).strip()
-BASE_DIR = (IMPL_DIR / CDUP).resolve()
-DEFAULT_SCAN_DIR = BASE_DIR / ".opencode"
+SKILLS_DIR = None
+for parent in [IMPL_DIR] + list(IMPL_DIR.parents):
+    candidate = parent / "skills"
+    if candidate.exists() and candidate.is_dir():
+        SKILLS_DIR = candidate
+        break
+
+if SKILLS_DIR is None:
+    if _os.environ.get("SKILDECK_SKILLS_DIR"):
+        SKILLS_DIR = Path(_os.environ["SKILDECK_SKILLS_DIR"])
+    else:
+        raise RuntimeError(f"Cannot find skills/ directory. Searched up from {IMPL_DIR}. Set SKILDECK_SKILLS_DIR env var to override.")
+
+DEFAULT_SCAN_DIR = SKILLS_DIR
 
 
 def _load_module(module_file: str):

--- a/tools/impl/skildeck/skildeck-lint
+++ b/tools/impl/skildeck/skildeck-lint
@@ -18,12 +18,22 @@ import types
 from dataclasses import dataclass, asdict
 from pathlib import Path
 
+# Find skills directory without git assumptions
 IMPL_DIR = Path(__file__).resolve().parent
-CDUP = subprocess.check_output(
-    ["git", "-C", str(IMPL_DIR), "rev-parse", "--show-cdup"], text=True
-).strip()
-BASE_DIR = (IMPL_DIR / CDUP).resolve()
-DEFAULT_SCAN_DIR = BASE_DIR / ".opencode"
+SKILLS_DIR = None
+for parent in [IMPL_DIR] + list(IMPL_DIR.parents):
+    candidate = parent / "skills"
+    if candidate.exists() and candidate.is_dir():
+        SKILLS_DIR = candidate
+        break
+
+if SKILLS_DIR is None:
+    if _os.environ.get("SKILDECK_SKILLS_DIR"):
+        SKILLS_DIR = Path(_os.environ["SKILDECK_SKILLS_DIR"])
+    else:
+        raise RuntimeError(f"Cannot find skills/ directory. Searched up from {IMPL_DIR}. Set SKILDECK_SKILLS_DIR env var to override.")
+
+DEFAULT_SCAN_DIR = SKILLS_DIR
 
 FENCE_PATTERN = __import__("re").compile(
     r"```yaml\+symbolic\n(.*?)```", __import__("re").DOTALL

--- a/tools/impl/skildeck/skildeck-verify-acceptance
+++ b/tools/impl/skildeck/skildeck-verify-acceptance
@@ -13,16 +13,11 @@ from __future__ import annotations
 import json
 import os as _os
 import re
-import subprocess
 import sys
 from dataclasses import dataclass, field, asdict
 from pathlib import Path
 
-IMPL_DIR = Path(__file__).resolve().parent
-CDUP = subprocess.check_output(
-    ["git", "-C", str(IMPL_DIR), "rev-parse", "--show-cdup"], text=True
-).strip()
-BASE_DIR = (IMPL_DIR / CDUP).resolve()
+# No hardcoded base dir - filesystem-first, no git assumptions
 
 # Acceptance criteria patterns
 SC_PREFIX_PATTERN = re.compile(r"^- \*\*SC-\d+:\*\*\s+(.+)$", re.MULTILINE)

--- a/tools/impl/skildeck/skildeck-verify-issue
+++ b/tools/impl/skildeck/skildeck-verify-issue
@@ -14,16 +14,11 @@ from __future__ import annotations
 import json
 import os as _os
 import re
-import subprocess
 import sys
 from dataclasses import dataclass, field, asdict
 from pathlib import Path
 
-IMPL_DIR = Path(__file__).resolve().parent
-CDUP = subprocess.check_output(
-    ["git", "-C", str(IMPL_DIR), "rev-parse", "--show-cdup"], text=True
-).strip()
-BASE_DIR = (IMPL_DIR / CDUP).resolve()
+# No hardcoded base dir - filesystem-first, no git assumptions
 
 SC_PREFIX_PATTERN = re.compile(r"^- \*\*SC-\d+:\*\*\s+(.+)$", re.MULTILINE)
 SC_PREFIX_PATTERN_ALT = re.compile(r"^- SC-\d+:\s+(.+)$", re.MULTILINE)

--- a/tools/impl/skildeck/skildeck-verify-structure
+++ b/tools/impl/skildeck/skildeck-verify-structure
@@ -13,18 +13,27 @@ from __future__ import annotations
 import json
 import os as _os
 import re
-import subprocess
 import sys
 import types
 from dataclasses import dataclass, field, asdict
 from pathlib import Path
 
+# Find skills directory without git assumptions
 IMPL_DIR = Path(__file__).resolve().parent
-CDUP = subprocess.check_output(
-    ["git", "-C", str(IMPL_DIR), "rev-parse", "--show-cdup"], text=True
-).strip()
-BASE_DIR = (IMPL_DIR / CDUP).resolve()
-DEFAULT_SCAN_DIR = BASE_DIR / ".opencode"
+SKILLS_DIR = None
+for parent in [IMPL_DIR] + list(IMPL_DIR.parents):
+    candidate = parent / "skills"
+    if candidate.exists() and candidate.is_dir():
+        SKILLS_DIR = candidate
+        break
+
+if SKILLS_DIR is None:
+    if _os.environ.get("SKILDECK_SKILLS_DIR"):
+        SKILLS_DIR = Path(_os.environ["SKILDECK_SKILLS_DIR"])
+    else:
+        raise RuntimeError(f"Cannot find skills/ directory. Searched up from {IMPL_DIR}. Set SKILDECK_SKILLS_DIR env var to override.")
+
+DEFAULT_SCAN_DIR = SKILLS_DIR
 
 FENCE_PATTERN = re.compile(r"```yaml\+symbolic\n(.*?)```", re.DOTALL)
 

--- a/tools/impl/skildeck/skildeck-watch
+++ b/tools/impl/skildeck/skildeck-watch
@@ -8,23 +8,30 @@ DESCRIPTION: Watch work-state and auto-regenerate HTML report. Polls for changes
 Usage: ./.opencode/tools/skildeck watch [--dir PATH] [--output PATH] [--interval SECONDS]
 """
 
-from __future__ import annotations
-
 import hashlib
 import os as _os
-import subprocess
 import sys
 import time
 import types
 from pathlib import Path
 
+# Find skills directory without git assumptions
 IMPL_DIR = Path(__file__).resolve().parent
-CDUP = subprocess.check_output(
-    ["git", "-C", str(IMPL_DIR), "rev-parse", "--show-cdup"], text=True
-).strip()
-BASE_DIR = (IMPL_DIR / CDUP).resolve()
-DEFAULT_SCAN_DIR = BASE_DIR / ".opencode"
-DEFAULT_OUTPUT_DIR = BASE_DIR / "tmp"
+SKILLS_DIR = None
+for parent in [IMPL_DIR] + list(IMPL_DIR.parents):
+    candidate = parent / "skills"
+    if candidate.exists() and candidate.is_dir():
+        SKILLS_DIR = candidate
+        break
+
+if SKILLS_DIR is None:
+    if _os.environ.get("SKILDECK_SKILLS_DIR"):
+        SKILLS_DIR = Path(_os.environ["SKILDECK_SKILLS_DIR"])
+    else:
+        raise RuntimeError(f"Cannot find skills/ directory. Searched up from {IMPL_DIR}. Set SKILDECK_SKILLS_DIR env var to override.")
+
+DEFAULT_SCAN_DIR = SKILLS_DIR
+DEFAULT_OUTPUT_DIR = Path("./tmp")
 DEFAULT_INTERVAL = 30
 
 


### PR DESCRIPTION
## Summary

Implements three fixes for authorization handling and skildeck tools:

- **#142**: Added Question-as-Authorization critical violation rule — treats rhetorical/complaint questions as observation-only, not action authorization
- **#144**: Fixed skildeck tools — removed hardcoded paths and git-based resolution, added filesystem-first discovery that works in any deployment (standalone, submodule, copied folder)
- **#96**: Added skildeck regression behavioral test (SC-12); SC-10 and SC-11 tests already existed

## Outcome

- Agents now correctly halt and create fix specs when encountering rhetorical/complaint questions instead of treating them as authorization
- Skildeck tools work without git metadata, no registry coupling, new skills immediately available
- Behavioral test coverage for skildeck regression

## Implementation Details

**#142 Changes:**
- Added `Question-as-Authorization` critical violation section to `.opencode/guidelines/000-critical-rules.md`
- Added rhetorical/complaint question prohibition to `.opencode/guidelines/020-go-prohibitions.md`
- Added symbolic rule `critical-rules-question-auth-001` to yaml+symbolic block

**#144 Changes:**
- Added `find_skills_dir()` function to `schema_v2.py` — walks up directory tree to find skills/
- Added `scan_skills()` function — scans filesystem directly, no registry
- Updated 9 skildeck tools to use filesystem-first approach
- Removed `.gitmodules` nested submodule registration
- Removed JSON registry files

**#96 Changes:**
- Created `tests/behaviors/skildeck-regression-check.sh` behavioral test
- Verifies tools work without git, new skills immediately available, env var override works

## Files Changed

**Modified:**
- `.opencode/guidelines/000-critical-rules.md`
- `.opencode/guidelines/020-go-prohibitions.md`
- `.opencode/tools/impl/skildeck/schema_v2.py`
- `.opencode/tools/impl/skildeck/skildeck-*` (9 files)

**Created:**
- `.opencode/tests/behaviors/skildeck-regression-check.sh`

**Deleted:**
- `.opencode/.gitmodules`

🤖 Co-authored with AI: OpenCode (ollama-cloud/qwen3.5:397b)