### PR TITLE
feat(#152): Single Concern Principle — universal rule replacing fragmented concern-separation rules

### DIFF
--- a/guidelines/000-critical-rules.md
+++ b/guidelines/000-critical-rules.md
@@ -588,9 +588,55 @@ When authorization scope includes implementation (`for_implementation`, `for_cod
 
 **AUTHORITY: Bug #1231, #1232, #1233 — root cause is the same: agent spends all context on process steps and halts before producing deliverables. The implementation-first gate ensures the agent produces at least one tangible modification before it is allowed to report completion.**
 
+## Critical Violation: Single Concern Principle — Every Artifact Addresses Exactly One Concern
+
+**⚠️ Every artifact the agent produces — commits, PRs, issues, specs, plans, code changes, comments, sub-agents — must address exactly one concern. Violating this is a CRITICAL GUIDELINE VIOLATION.**
+
+A "concern" is a distinct problem area with its own root cause, affected scope, and verification criteria. Two things are separate concerns if you could implement, verify, and close one without the other.
+
+**The "discovered together" fallacy is explicitly prohibited.** Discovering problems in the same session, same workflow, same bug report, or same investigation does NOT make them related. Each concern gets its own artifact regardless of how it was found.
+
+**Applies to ALL artifacts:**
+
+| Artifact | Violation | Correct |
+| -- | -- | -- |
+| Issue | Combining auth error handling + issue routing in one spec | Separate issues for each |
+| Commit | Bundling correspondence template + submodule migration | Separate commits |
+| PR | Including unrelated file changes because "they're all part of the migration" | Separate PRs for separate concerns |
+| Plan | Mixing implementation phases for different subsystems | One phase per concern |
+| Comment | Combining status update + new bug discovery + authorization request | Separate comments for each purpose |
+| Spec | Multiple "Fix Approach" sections for different root causes | One spec per root cause |
+| Sub-agent | Dispatching an agent to handle two unrelated tasks | One sub-agent per concern |
+
+**Test for "unrelated":** Remove concern B from the artifact. If concern A remains complete and verifiable, they are unrelated and must be in separate artifacts.
+
+**Test for "related":** Two concerns share the same root cause, affect the same files/subsystem, and cannot be verified independently — they MAY be combined in one artifact.
+
+- 🚫 FORBIDDEN: Combining multiple unrelated concerns in a single artifact; treating "discovered together" as "related"; bundling fixes for different root causes in one PR/commit/issue; mixing purposes in a single comment (status + bug discovery + authorization request)
+- ✅ REQUIRED: One concern per artifact; separate artifacts for separate concerns; verify each concern can stand alone before combining; apply SCP universally across all artifact types, not just code
+
+```yaml+symbolic
+  - id: critical-rules-042
+    title: "Single Concern Principle — every artifact addresses exactly one concern"
+    conditions:
+      all:
+        - "artifact_addresses_multiple_unrelated_concerns == true"
+    actions:
+      - HALT
+      - SPLIT_INTO_SEPARATE_ARTIFACTS
+    conflicts_with: []
+    requires: []
+    triggers: [spec-creation, writing-plans, issue-operations, git-workflow, approval-gate]
+    source: "000-critical-rules.md §Single Concern Principle"
+```
+
+**AUTHORITY: Spec #152, NewsRx/.opencode#3 — Regression evidence: agent combined unrelated concerns four times in a single session because fragmented domain-specific rules failed when the agent switched between producing different artifact types.**
+
 ## Critical Violation: Monolithic Implementation — Skipping Item Decomposition
 
 **⚠️ Implementing multiple items in a single branch/commit without decomposition, or skipping the top-down → bottom-up → per-item TDD cycle, is a CRITICAL GUIDELINE VIOLATION.**
+
+**UNIVERSAL RULE: See `000-critical-rules.md` §Single Concern Principle for the universal composition rule. Monolithic Implementation is an implementation-specific instance of SCP — it addresses code commits and plans specifically. The universal rule covers all artifact types (issues, specs, PRs, comments, sub-agents).**
 
 **See `091-incremental-build.md` for the complete discipline rules, scope classification, and per-item TDD cycle. See `091-incremental-build.md` → "Enforcement Mechanism" section for RED phase verification requirements, execution checkpoint references, and plan template checkpoint references.** **AUTHORITY: `091-incremental-build.md`**
 
@@ -646,6 +692,8 @@ When authorization scope includes implementation (`for_implementation`, `for_cod
 ## Critical Violation: Scope Creep — NEVER Do Things Outside the Spec
 
 **⚠️ Implementing changes not explicitly called for in the spec is a CRITICAL GUIDELINE VIOLATION.** The spec defines EXACTLY what to implement.
+
+**UNIVERSAL RULE: See `000-critical-rules.md` §Single Concern Principle for the universal composition rule. Scope Creep is an implementation-specific instance of SCP — it addresses code changes that go beyond the spec's defined scope. The universal rule covers all artifact types (issues, specs, PRs, comments, sub-agents).**
 
 🚫 FORBIDDEN: Helper functions, improving nearby code, refactoring adjacent things, fixing similar issues, any change not in the spec
 
@@ -1798,6 +1846,7 @@ rules:
     conflicts_with: []
     requires: []
     triggers: []
+    superseded_by: critical-rules-042
     source: "000-critical-rules.md §Scope Creep"
 
   - id: critical-rules-015
@@ -1836,6 +1885,7 @@ rules:
     conflicts_with: []
     requires: []
     triggers: []
+    superseded_by: critical-rules-042
     source: "000-critical-rules.md §Monolithic Implementation"
 
   - id: critical-rules-018

--- a/skills/concern-separation-auditor/SKILL.md
+++ b/skills/concern-separation-auditor/SKILL.md
@@ -15,6 +15,8 @@ Concern Separation Auditor analyzes spec phase structures to identify deployment
 
 **Core v2 shift:** Report-only. Findings are presented to the agent, who decides whether to apply them given the context. No longer invoked directly — called by spec-auditor orchestrator when relevant.
 
+**Single Concern Principle (SCP):** The authoritative universal rule for concern separation is defined in `000-critical-rules.md` §Single Concern Principle. SCP applies to ALL artifacts the agent produces (issues, commits, PRs, plans, specs, comments, sub-agents). This skill enforces SCP as it applies to spec/plan phase structure — it is a domain-specific instance of the universal rule, not a substitute for it.
+
 ## Tasks
 
 | Task | Purpose | Words |
@@ -163,9 +165,10 @@ Action: [auto-fix|conditional|flag-for-review]
 
 ## Cross-References
 
+- **Authoritative rule:** `000-critical-rules.md` §Single Concern Principle — the universal SCP rule that this skill enforces for phase structure
 - Orchestrated by: `spec-auditor` (via `concerns` subtask, including `ground-truth` adversarial verification)
 - Related skills: `spec-auditor` (orchestrator), `writing-plans` (clean-room for fidelity), `programming-principles` (principle definitions for SoC and Blast Radius — this subtask checks structural separation, that skill defines the underlying principles)
-- Related guidelines: `000-critical-rules.md` (auditor enforcement), `065-verification-honesty.md` (metadata verification extension), `142-planning-archive-workflow.md`
+- Related guidelines: `000-critical-rules.md` (SCP universal rule and auditor enforcement), `065-verification-honesty.md` (metadata verification extension), `142-planning-archive-workflow.md`
 
 Co-authored with AI: <AgentName> (<ModelId>)
 
@@ -200,6 +203,19 @@ rules:
     requires: []
     triggers: []
     source: "concern-separation-auditor/SKILL.md §Live Verification"
+
+  - id: concern-separation-002
+    title: "SCP is the authoritative universal concern-separation rule"
+    conditions:
+      all:
+        - "scp_violation_detected == true"
+    actions:
+      - FLAG
+      - REPORT(single_concern_principle_violation)
+    conflicts_with: []
+    requires: [critical-rules-042]
+    triggers: [spec-auditor, concern-separation-auditor]
+    source: "concern-separation-auditor/SKILL.md §Single Concern Principle"
 
 tasks:
   - id: audit-phases

--- a/skills/spec-creation/SKILL.md
+++ b/skills/spec-creation/SKILL.md
@@ -60,13 +60,21 @@ You are a Spec Architect. Your focus is structuring investigation results into a
     - DO NOT skip to write without completing applicable prerequisite tasks
 
  2b. **Diagram generation gate (MANDATORY when dependencies exist):**
-    - After `decompose` task completes, check if dependencies exist (N > 1 items, or cross-issue dependencies)
-    - If dependencies exist: invoke `diagram` task to generate mermaid diagram
-    - Diagram MUST show approved structure only — NO workflow state markers (✅, 🔄, ❌, "implemented", "pending")
-    - If diagram contains workflow markers: auto-fix by removing markers, note in evidence
-    - Diagram is inserted in spec body after "Dependencies" section (if present) or before "Implementation Plan"
+     - After `decompose` task completes, check if dependencies exist (N > 1 items, or cross-issue dependencies)
+     - If dependencies exist: invoke `diagram` task to generate mermaid diagram
+     - Diagram MUST show approved structure only — NO workflow state markers (✅, 🔄, ❌, "implemented", "pending")
+     - If diagram contains workflow markers: auto-fix by removing markers, note in evidence
+     - Diagram is inserted in spec body after "Dependencies" section (if present) or before "Implementation Plan"
 
-3. **Select-existing pathway (MANDATORY before writing new spec):** Before creating a new spec, the agent MUST check whether an existing spec/plan already covers the request. This pathway is especially relevant when arriving from the `search-prompt-fail` workflow (see `approval-gate` skill → `verify-qa-mode` task → Step 2.5).
+ 2c. **Concern enumeration guard (MANDATORY before `write`):**
+     - Before the `write` task, enumerate the concerns the spec addresses
+     - For each concern, assess: does it have its own root cause, affected scope, and verification criteria?
+     - If more than one concern with different root causes is detected, flag as `conditional` in spec-auditor and recommend splitting into separate specs
+     - This check enforces the Single Concern Principle (SCP) from `000-critical-rules.md` §Single Concern Principle
+     - The "discovered together" fallacy is explicitly prohibited: discovering problems in the same session, workflow, or bug report does NOT make them related
+     - Concern enumeration result MUST be recorded in the evidence artifact table
+
+ 3. **Select-existing pathway (MANDATORY before writing new spec):** Before creating a new spec, the agent MUST check whether an existing spec/plan already covers the request. This pathway is especially relevant when arriving from the `search-prompt-fail` workflow (see `approval-gate` skill → `verify-qa-mode` task → Step 2.5).
    - Search GitHub Issues using labels `[SPEC]`, `[PLAN]`, `[SPEC-FIX]` and keywords from the request
    - If candidates found: present them to the user with URLs and relevance assessment
    - If user selects an existing candidate: transition to that issue's workflow (e.g., `approval-gate` if already approved, `brainstorming` Path B if approved, `brainstorming` Path A if not yet a spec)
@@ -139,13 +147,19 @@ You are a Spec Architect. Your focus is structuring investigation results into a
    - Record SC-to-phase mapping in the spec body for traceability
    - This validation step prevents over-verification at implementation time — per the "Phase-Scoped Test Assertions" mandate in `091-incremental-build.md`
 
-4. **After `write` task (issue creation):**
-   - GitHub Issue created with `[SPEC]` prefix and `needs-approval` label?
-   - Chat output is exec summary + URL + byline ONLY? (no full spec dump)
-   - Spec self-review completed? (placeholder scan, consistency check, ambiguity check)
-   - User directed to review on the GitHub Issue (not in chat)?
+ 4. **After `write` task (issue creation):**
+    - GitHub Issue created with `[SPEC]` prefix and `needs-approval` label?
+    - Chat output is exec summary + URL + byline ONLY? (no full spec dump)
+    - Spec self-review completed? (placeholder scan, consistency check, ambiguity check)
+    - User directed to review on the GitHub Issue (not in chat)?
 
-5. **What does NOT bypass spec-creation:**
+ 5. **Concern enumeration guard (MANDATORY before `write`):**
+    - Before writing the spec, enumerate the concerns it addresses
+    - If more than one concern with different root causes: flag as `conditional` in spec-auditor, recommend splitting
+    - Record concern enumeration result in evidence artifacts
+    - This enforces the Single Concern Principle (SCP) — see `000-critical-rules.md` §Single Concern Principle
+
+ 6. **What does NOT bypass spec-creation:**
    - "skip spec-creation" → NOT allowed (even simple specs need `requirements` + `write`)
    - "brainstorming already wrote the spec" → Brainstorming no longer writes specs; this skill does
    - "just show me the spec in chat" → NOT allowed; spec MUST be persisted as GitHub Issue
@@ -480,6 +494,21 @@ rules:
     requires: [spec-creation-002]
     triggers: [writing-plans]
     source: "spec-creation/SKILL.md §Interdependency Diagram Discipline"
+
+  - id: spec-creation-009
+    title: "Concern enumeration guard before write — Single Concern Principle"
+    conditions:
+      all:
+        - "concern_enumeration_performed == false"
+        - "write_task_pending == true"
+    actions:
+      - HALT
+      - ENUMERATE_CONCERNS
+      - FLAG_MULTI_CONCERN
+    conflicts_with: []
+    requires: []
+    triggers: [spec-creation]
+    source: "spec-creation/SKILL.md §Concern Enumeration Guard"
 
 tasks:
   - id: explore

--- a/tests/behaviors/single-concern-principle.sh
+++ b/tests/behaviors/single-concern-principle.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+# Behavioral Enforcement Test: Single Concern Principle
+#
+# Verifies the agent's behavior when presented with two unrelated concerns
+# in a single prompt. The agent should split them into separate artifacts
+# rather than combining them.
+#
+# SC #5 from Spec #152: behavioral enforcement test for multi-concern detection
+#
+# Co-authored with AI: OpenCode (ollama-cloud/glm-5.1)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/helpers.sh"
+
+SCENARIO_NAME="single-concern-principle"
+SCENARIO_PROMPT="I found a bug with auth errors and also the issue routing is wrong. Create a fix spec for both."
+
+echo "=== Behavioral Test: $SCENARIO_NAME ==="
+
+behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT"
+
+OVERALL_RESULT=0
+
+# SCP requires the agent to recognize two concerns and split them
+# The agent should NOT create a single combined spec for both issues
+# It should either create separate specs or flag the multi-concern violation
+
+# Verify the agent mentions "single concern" or "separate" or "split" --
+# indicating it recognized the two concerns as separate
+assert_required_pattern_present "Single Concern Principle\|separate\|split\|two.*concern\|multiple.*concern" \
+    "SCP awareness — agent should recognize two concerns" || OVERALL_RESULT=1
+
+# Verify the agent does NOT combine both concerns into one spec
+# The agent should not create a single spec that addresses both auth errors AND issue routing
+assert_forbidden_pattern_absent "both.*auth.*routing\|auth.*and.*routing.*spec\|fix spec.*both" \
+    "combined concern spec — agent should not create a single spec for unrelated concerns" || OVERALL_RESULT=1
+
+# Verify the agent references SCP or concern separation
+assert_required_pattern_present "concern\|SCP\|Single Concern" \
+    "SCP reference in output" || OVERALL_RESULT=1
+
+echo ""
+if [ "$OVERALL_RESULT" -eq 0 ]; then
+    echo "PASS: $SCENARIO_NAME"
+else
+    echo "FAIL: $SCENARIO_NAME"
+fi
+
+exit $OVERALL_RESULT


### PR DESCRIPTION
## Summary

Replaces the fragmented concern-separation rules (monolithic implementation, scope creep) with a single universal critical violation: the Single Concern Principle (SCP). Every artifact the agent produces must address exactly one concern.

## Outcome

- SCP critical violation added to `000-critical-rules.md` with artifact type table, "discovered together" fallacy prohibition, yaml+symbolic rule
- Monolithic Implementation and Scope Creep sections cross-referenced to SCP with `superseded_by` annotations
- Concern-enumeration guard added to `spec-creation` skill (Step 2c, Enforcement #5, yaml+symbolic rule)
- `concern-separation-auditor` updated to reference SCP as the authoritative rule
- Behavioral enforcement test added for multi-concern detection

Fixes #152

🤖 Co-authored with AI: OpenCode (ollama-cloud/glm-5.1)