### PR TITLE
feat(#161): Mandatory invocation language and callouts

### DIFF
--- a/skills/finishing-a-development-branch/SKILL.md
+++ b/skills/finishing-a-development-branch/SKILL.md
@@ -11,6 +11,8 @@ compatibility: opencode
 
 ## Overview
 
+**MANDATORY: The agent MUST invoke `finishing-a-development-branch --task checklist` after implementation and before PR creation. Skipping this invocation is a CRITICAL GUIDELINE VIOLATION per `000-critical-rules.md` §Bypassing Mandatory Skill Invocations.** Exempt: no implementation performed (spec-only sessions, plan-only sessions, pure Q/A).
+
 Branch completion workflow that ensures a feature branch is fully ready for PR creation. Verifies all changes are committed, tested, pushed, and reviewed before the developer creates a PR. Implementation tracks against plan sub-issues, not spec sub-issues. Adapted from the \<UPSTREAM_ORG>/\<UPSTREAM_REPO> workflow.
 
 **Source Attribution:** This skill is adapted from \<UPSTREAM_ORG>/\<UPSTREAM_REPO> workflow (branch: newsrx).

--- a/skills/git-workflow/SKILL.md
+++ b/skills/git-workflow/SKILL.md
@@ -11,6 +11,8 @@ compatibility: opencode
 
 ## Overview
 
+**MANDATORY: The agent MUST invoke `git-workflow --task pre-work` before any implementation, and `git-workflow --task review-prep` after implementation. Skipping these invocations is a CRITICAL GUIDELINE VIOLATION per `000-critical-rules.md` §Bypassing Mandatory Skill Invocations.** Exempt: no implementation performed (spec-only, plan-only, pure Q/A sessions).
+
 Git Workflow Enforcer ensuring all git operations follow the three-branch model: feature → dev → main. AI commits are blocked on protected branches. All feature branches merge to `dev` via PR. Squashing is ONLY at PR creation time, not during implementation.
 
 ## Persona

--- a/skills/guideline-auditor/SKILL.md
+++ b/skills/guideline-auditor/SKILL.md
@@ -17,6 +17,10 @@ compatibility: opencode
 |---|---|---|---|---|
 | `audit` | When guideline audit is invoked | Guideline file paths, audit scope | Implementation context, agent memory | NO |
 
+## Mandatory Invocation
+
+**MANDATORY: The agent MUST invoke `guideline-auditor` when auditing guideline files. Skipping this invocation is a CRITICAL GUIDELINE VIOLATION per `000-critical-rules.md` §Bypassing Mandatory Skill Invocations.** Exempt: no guideline audit requested.
+
 ## Role
 
 that are ambiguous, conflicting, or unlikely to be followed by an LLM agent.

--- a/skills/issue-review/SKILL.md
+++ b/skills/issue-review/SKILL.md
@@ -11,6 +11,8 @@ compatibility: opencode
 
 ## Overview
 
+**MANDATORY: The agent MUST invoke `issue-review` when reviewing a GitHub issue. Skipping this invocation is a CRITICAL GUIDELINE VIOLATION per `000-critical-rules.md` §Bypassing Mandatory Skill Invocations.** Exempt: no issue review requested.
+
 Unified "review" command for GitHub Issues. Gathers issue data, classifies the review path via content analysis (not label conventions), delegates to appropriate downstream skills, and handles Q/A for non-spec issues. One entry point replaces manual orchestration of comment reading, audit detection, and audit execution.
 
 ## Persona

--- a/skills/skill-creator/SKILL.md
+++ b/skills/skill-creator/SKILL.md
@@ -11,6 +11,8 @@ type: technique
 
 ## Overview
 
+**MANDATORY: The agent MUST invoke `skill-creator` when creating or updating skill cards. Skipping this invocation is a CRITICAL GUIDELINE VIOLATION per `000-critical-rules.md` §Bypassing Mandatory Skill Invocations.** Exempt: no skill creation/update task.
+
 Creating skills IS Test-Driven Development applied to process documentation. Write test cases (pressure scenarios with subagents), watch them fail (baseline behavior), write the skill (documentation), watch tests pass (agents comply), and refactor (close loopholes). If you didn't watch an agent fail without the skill, you don't know if the skill teaches the right thing.
 
 **Source attribution:** TDD methodology, CSO principles, rationalization resistance tables, red flags lists, skill type taxonomy, bulletproofing patterns, and anti-patterns adapted from [obra/superpowers `writing-skills`](https://github.com/obra/superpowers/blob/main/skills/writing-skills/SKILL.md).

--- a/skills/spec-auditor/SKILL.md
+++ b/skills/spec-auditor/SKILL.md
@@ -11,6 +11,8 @@ compatibility: opencode
 
 ## Overview
 
+**MANDATORY: The agent MUST invoke `spec-auditor` when auditing specs. Skipping this invocation is a CRITICAL GUIDELINE VIOLATION per `000-critical-rules.md` §Bypassing Mandatory Skill Invocations.** Exempt: no audit requested, no spec/plan being created or audited.
+
 Content-aware audit orchestrator that accepts any document type. Determines document type automatically (or via manual override), selects appropriate subtasks, runs the minimal baseline always, and applies auto-fixes for safe findings while flagging ambiguous findings for review.
 
 **Core v2 shift:** Spec-auditor is now the orchestrator. Plan-fidelity-auditor and concern-separation-auditor are no longer invoked directly — their logic lives as subtasks (`fidelity` and `concerns`) within spec-auditor.

--- a/skills/sre-runbook/SKILL.md
+++ b/skills/sre-runbook/SKILL.md
@@ -11,6 +11,8 @@ compatibility: opencode
 
 ## Overview
 
+**MANDATORY: The agent MUST invoke `sre-runbook` when generating operational runbooks for infrastructure incidents. Skipping this invocation is a CRITICAL GUIDELINE VIOLATION per `000-critical-rules.md` §Bypassing Mandatory Skill Invocations.** Exempt: no runbook generation requested, no incident/outage context.
+
 Discipline-enforcing skill that generates **operational runbooks** — step-by-step "do this, in this order" procedures that a sysop can execute without thinking. Every command is verified against live documentation before inclusion. Every value comes from the actual environment, not training data. Every step has ONE definitive path.
 
 **Source Attribution:** Adapted from <UPSTREAM_ORG>/<UPSTREAM_REPO> workflow (branch: newsrx).

--- a/skills/verification-before-completion/SKILL.md
+++ b/skills/verification-before-completion/SKILL.md
@@ -11,6 +11,8 @@ compatibility: opencode
 
 ## Overview
 
+**MANDATORY: The agent MUST invoke `verification-before-completion --task verify` before marking any task or phase complete. Skipping this invocation is a CRITICAL GUIDELINE VIOLATION per `000-critical-rules.md` §Bypassing Mandatory Skill Invocations.** Exempt: no implementation work performed (read-only sessions, pure Q/A, issue creation without code changes).
+
 Evidence-based verification workflow that prevents premature completion claims. This skill ensures ALL success criteria are verified with actual evidence before ANY task or phase is marked complete.
 
 **Source Attribution:** Adapted from <UPSTREAM_ORG>/<UPSTREAM_REPO> workflow (branch: newsrx).

--- a/skills/verification-enforcement/SKILL.md
+++ b/skills/verification-enforcement/SKILL.md
@@ -11,6 +11,8 @@ compatibility: opencode
 
 ## Overview
 
+**MANDATORY: The agent MUST invoke `verification-enforcement --task verify` before generating any content that makes factual claims (specs, plans, runbooks, docs, correspondence). Skipping this invocation is a CRITICAL GUIDELINE VIOLATION per `000-critical-rules.md` §Skipping verification-enforcement During Content Generation.** Exempt: authorized-exploration during brainstorming phases before content is committed to a document; casual chat responses that make no factual claims about code, APIs, or system state.
+
 Every content-generating skill must pass through a verification gate before producing output. This skill provides that shared gate: a mandatory pre-generation check that collects evidence artifacts for every factual claim the agent intends to make, and a mandatory post-generation pass that resolves any claims that could not be verified during generation. The gate prevents agents from writing content based on memory, training data, or unverified assumptions. When claims cannot be verified against live sources, they are marked as unverified and must either be resolved in a revisit pass or escalated to the developer.
 
 The verification lifecycle flows naturally through three stages. Before generation, the agent declares what it intends to claim and dispatches sub-agents to collect evidence for each content section. After generation, the agent scans for any remaining unverified markers and attempts resolution a second time. At the orchestrator level, the enforce task checks that sub-agents have returned evidence artifacts with their content — output without evidence is rejected and re-dispatched.

--- a/tests/content-verification/mandatory-invocation.sh
+++ b/tests/content-verification/mandatory-invocation.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+# Content-Verification Test: Mandatory Invocation
+# Issue #161 - Verifies mandatory invocation callouts exist in skill files
+# and critical violation text exists in 000-critical-rules.md
+#
+# SECONDARY enforcement (behavioral is PRIMARY per 091-incremental-build.md)
+#
+# Co-authored with AI: OpenCode (ollama-cloud/glm-5)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SKILLS_DIR="$(cd "$SCRIPT_DIR/../../skills" && pwd)"
+GUIDELINES_DIR="$(cd "$SCRIPT_DIR/../../guidelines" && pwd)"
+
+OVERALL_RESULT=0
+
+# SC-6: Content-verification test confirms mandatory language in all 10 skill files and critical-rules.md
+
+echo "=== Content-Verification Test: Mandatory Invocation ==="
+
+# Check each skill for mandatory invocation callout
+SKILLS=(
+  "test-driven-development"
+  "spec-auditor"
+  "guideline-auditor"
+  "skill-creator"
+  "sre-runbook"
+  "issue-review"
+  "verification-before-completion"
+  "verification-enforcement"
+  "finishing-a-development-branch"
+  "git-workflow"
+)
+
+for skill in "${SKILLS[@]}"; do
+  SKILL_FILE="$SKILLS_DIR/$skill/SKILL.md"
+  if [ ! -f "$SKILL_FILE" ]; then
+    echo "FAIL: $skill/SKILL.md not found"
+    OVERALL_RESULT=1
+    continue
+  fi
+
+  # Check for mandatory invocation callout pattern
+  if grep -q "MANDATORY.*MUST invoke\|MANDATORY.*agent MUST invoke\|MANDATORY: The agent MUST invoke" "$SKILL_FILE"; then
+    echo "PASS: $skill — mandatory invocation callout found"
+  else
+    echo "FAIL: $skill — mandatory invocation callout NOT found"
+    OVERALL_RESULT=1
+  fi
+
+  # Check for exemption criteria
+  if grep -qi "exempt\|exemption" "$SKILL_FILE"; then
+    echo "PASS: $skill — exemption criteria documented"
+  else
+    echo "FAIL: $skill — exemption criteria NOT documented"
+    OVERALL_RESULT=1
+  fi
+done
+
+# Check 000-critical-rules.md for Skipping Mandatory Skill Invocation violation
+CRITICAL_RULES="$GUIDELINES_DIR/000-critical-rules.md"
+if [ ! -f "$CRITICAL_RULES" ]; then
+  echo "FAIL: 000-critical-rules.md not found"
+  OVERALL_RESULT=1
+else
+  if grep -q "Skipping Mandatory Skill Invocation\|Skipping.*mandatory.*skill.*invocation\|skill.*invocation.*critic" "$CRITICAL_RULES"; then
+    echo "PASS: 000-critical-rules.md — mandatory skill invocation violation found"
+  else
+    echo "FAIL: 000-critical-rules.md — mandatory skill invocation violation NOT found"
+    OVERALL_RESULT=1
+  fi
+fi
+
+echo ""
+if [ "$OVERALL_RESULT" -eq 0 ]; then
+    echo "PASS: Content-verification — all mandatory invocation patterns found"
+else
+    echo "FAIL: Content-verification — some mandatory invocation patterns missing"
+fi
+
+exit $OVERALL_RESULT


### PR DESCRIPTION
## Summary

Standardizes mandatory invocation callouts across all 10 discipline-enforcing skills, replacing optional/contextual language with MANDATORY/REQUIRED/MUST terms per issue #161 Phase 1.

## Outcome

All 10 discipline skills now have standardized `MANDATORY: The agent MUST invoke` callouts with exemption criteria. Content-verification test confirms all 21 checks pass. Critical violation for skill invocation bypass verified in 000-critical-rules.md.

## Fixes

Closes #161 (Phase 1)

🤖 Co-authored with AI: OpenCode (ollama-cloud/glm-5)