### PR TITLE
feat(#211): Rename completion-core.md to SKILL.md with frontmatter

### DIFF
--- a/skills/completion-core/SKILL.md
+++ b/skills/completion-core/SKILL.md
@@ -1,3 +1,12 @@
+---
+name: completion-core
+description: Use when completing a skill task — shared completion operations (push branch, generate URL, post status, executive summary) referenced by per-skill completion tasks
+type: pattern
+license: MIT
+provenance: AI-generated
+compatibility: opencode
+---
+
 # Completion Core — Shared Completion Operations
 
 Reference this file from per-skill `tasks/completion.md` files for common completion operations.


### PR DESCRIPTION
## Summary

Renames `completion-core.md` to `SKILL.md` with proper YAML frontmatter, fixing skill discovery invisibility.

## Outcome

- completion-core is now discoverable by opencode-cli's native skill scanner
- Adds `name: completion-core`, `description: Use when...`, `type`, `license`, `provenance`, `compatibility` fields
- No behavioral changes — content is identical, only the filename and frontmatter differ

Fixes michael-conrad/.opencode#211