### PR TITLE
feat(#171): add implementation-first gate at authorization time

### DIFF
--- a/guidelines/000-critical-rules.md
+++ b/guidelines/000-critical-rules.md
@@ -620,6 +620,41 @@ When authorization scope includes implementation (`for_implementation`, `for_cod
 
 **AUTHORITY: Bug #1231, #1232, #1233 — root cause is the same: agent spends all context on process steps and halts before producing deliverables. The implementation-first gate ensures the agent produces at least one tangible modification before it is allowed to report completion.**
 
+## Critical Violation: Implementation-First Gate at Authorization Time — Post-Auth Research Spiral
+
+**⚠️ Entering a read-only research spiral after receiving authorization — performing unlimited tool calls that produce zero file modifications — is a CRITICAL GUIDELINE VIOLATION.** This extends the completion-time implementation-first gate to cover the authorization-to-implementation gap.
+
+The completion-time gate (above) catches the agent halting without deliverables. But the same root cause — context spent on process overhead instead of implementation — also manifests as an unbounded research spiral between authorization receipt and the first file modification. The agent receives "approved" and then makes 5, 10, or 20+ read-only tool calls (re-fetching issues, re-reading specs, parsing JSON sub-agent dispatches for data already in context) before producing any deliverable.
+
+**The authorization-time gate closes this gap:** after explicit authorization is received, the agent MUST transition to implementation dispatch within a bounded number of tool calls. Unbounded metadata gathering between authorization and the first file modification is prohibited.
+
+- 🚫 FORBIDDEN: Making more than 3 tool calls between `verify-authorization` returning `authorized` and invoking `git-workflow --task pre-work`
+- 🚫 FORBIDDEN: Dispatching sub-agents to parse or re-fetch data already available in the current context after authorization
+- 🚫 FORBIDDEN: Re-reading issues, specs, or plans that were already read during verification after authorization is received
+- 🚫 FORBIDDEN: Using `task(subagent_type="general")` for JSON parsing, metadata extraction, or any read-only operation on data already in context after authorization
+- ✅ REQUIRED: After `verify-authorization` returns `authorized`, proceed to `git-workflow --task pre-work` within at most 3 tool calls
+- ✅ REQUIRED: If more than 3 tool calls occur without reaching `pre-work`, HALT and report the delay as a critical violation — include the tool call sequence in the report
+- ✅ REQUIRED: Sub-agents after authorization are for implementation dispatch ONLY — file modifications, code generation, and heavy analysis that produces deliverables
+
+```yaml+symbolic
+  - id: critical-rules-045
+    title: "Implementation-First Gate at Authorization Time — post-auth research spiral"
+    conditions:
+      all:
+        - "authorization_received == true"
+        - "tool_calls_since_authorization > 3"
+        - "first_file_modification_not_reached == true"
+    actions:
+      - HALT
+      - REPORT_DELAY_WITH_TOOL_CALL_SEQUENCE
+    conflicts_with: []
+    requires: []
+    triggers: [approval-gate, divide-and-conquer]
+    source: "000-critical-rules.md §Implementation-First Gate at Authorization Time"
+```
+
+**See `approval-gate/tasks/verify-authorization/auto-dispatch.md` §Post-Authorization Dispatch Window for the operational enforcement of the 3-tool-call bound. See `060-tool-usage.md` §Sub-Agent Dispatch Restriction After Authorization for the sub-agent restriction. AUTHORITY: Spec #171**
+
 ## Critical Violation: Single Concern Principle — Every Artifact Addresses Exactly One Concern
 
 **⚠️ Every artifact the agent produces — commits, PRs, issues, specs, plans, code changes, comments, sub-agents — must address exactly one concern. Violating this is a CRITICAL GUIDELINE VIOLATION.**

--- a/guidelines/060-tool-usage.md
+++ b/guidelines/060-tool-usage.md
@@ -175,7 +175,36 @@ Invoke skills when their trigger keywords match the current task. Each skill def
 | **Skill self-describes boundary** | Each SKILL.md defines what it covers; when in doubt, check `Triggers on:` line |
 | **Sub-agent dispatch priority** | When a SKILL.md Sub-Agent Tasks section marks a task as `sub-agent`, the main agent dispatches via `task()` instead of loading the task file inline. This keeps heavy task files out of the main agent context. Result contracts (≈100-500 words) are read instead of the full task file (>1,000 words) |
 
-## 9. Identity Source Semantics
+## 9. Sub-Agent Dispatch Restriction After Authorization
+
+**⚠️ After explicit authorization is received, sub-agent dispatch for read-only parsing of already-fetched data is a CRITICAL GUIDELINE VIOLATION.**
+
+This prevents the post-authorization research spiral documented in Spec #171. When a user says "approved" or "go", the agent must transition to implementation dispatch, not re-read data already in context via sub-agents.
+
+### 🚫 FORBIDDEN (After Authorization)
+
+- Dispatching `task(subagent_type="general")` to parse JSON from `github_issue_read` output already in context
+- Dispatching sub-agents to extract metadata from data the orchestrator already has
+- Dispatching sub-agents for any read-only operation on data already available in the current session
+- Re-reading issues, specs, or plans that were already fetched during verification
+
+### ✅ PERMITTED (After Authorization)
+
+- Dispatching sub-agents for implementation work (file modifications, code generation, heavy analysis)
+- Dispatching via `divide-and-conquer --task assemble-work` for work orchestration
+- Heavy sub-agent analysis that produces NEW deliverables not available in context
+
+### Before Authorization
+
+Before authorization is received, sub-agents may be used freely for research, analysis, and investigation. The restriction applies ONLY after `verify-authorization` returns `authorized`.
+
+### Enforcement
+
+This restriction is enforced by the 3-tool-call bound in `000-critical-rules.md` §"Implementation-First Gate at Authorization Time" and `approval-gate/tasks/verify-authorization/auto-dispatch.md` §Post-Authorization Dispatch Window. Sub-agent dispatch for read-only parsing counts toward the bound and is prohibited.
+
+**AUTHORITY: Spec #171, `000-critical-rules.md` §Implementation-First Gate at Authorization Time**
+
+## 10. Identity Source Semantics
 
 The `github.identity_source` value (emitted by session-init) determines the agent's relationship to git remotes and GitHub API routing.
 

--- a/skills/approval-gate/tasks/verify-authorization.md
+++ b/skills/approval-gate/tasks/verify-authorization.md
@@ -99,6 +99,35 @@ When `verify-authorization` is dispatched as a sub-agent and returns empty or wh
 - Closed-issue verification: see `enforcement/closed-issue-verification.md`
 - Sub-issue graph traversal: see `enforcement/sub-issue-graph-traversal.md`
 
+## Post-Authorization Dispatch Window (MANDATORY)
+
+**After `verify-authorization` returns `authorized`, the agent MUST invoke `git-workflow --task pre-work` within at most 3 subsequent tool calls.** This bound prevents the post-authorization research spiral documented in Spec #171.
+
+### 3-Tool-Call Bound
+
+| Tool Call Position After Authorization | Permitted Actions |
+|----------------------------------------|-------------------|
+| 1st | `git-workflow --task pre-work` (target), or contextual transition calls |
+| 2nd | `git-workflow --task pre-work` (target), or contextual transition calls |
+| 3rd | `git-workflow --task pre-work` (target), or contextual transition calls |
+| >3rd without reaching `pre-work` | **CRITICAL VIOLATION** — HALT and report |
+
+### Self-Correction Protocol
+
+If more than 3 tool calls occur after `verify-authorization` returns `authorized` without the agent reaching `git-workflow --task pre-work`:
+
+1. HALT immediately
+2. Report the delay as a critical violation in chat output
+3. Include the tool call sequence in the report (tool names and parameters)
+4. Do NOT continue with any further read-only operations
+5. State explicitly: "Post-authorization dispatch window exceeded — 3-tool-call bound violated"
+
+### Rationale
+
+The research spiral occurs because the agent re-fetches issues, re-reads specs, dispatches sub-agents for JSON parsing, and performs other read-only operations that consume context budget without producing file modifications. The 3-tool-call bound is generous enough to allow legitimate transition calls (e.g., `pre-implementation-analysis` for multi-issue sets) while preventing unbounded metadata gathering.
+
+**See `000-critical-rules.md` §"Implementation-First Gate at Authorization Time" for the top-level critical violation. See `060-tool-usage.md` §"Sub-Agent Dispatch Restriction After Authorization" for the sub-agent restriction.**
+
 ## Result Contract
 
 ```yaml

--- a/skills/approval-gate/tasks/verify-authorization/auto-dispatch.md
+++ b/skills/approval-gate/tasks/verify-authorization/auto-dispatch.md
@@ -115,3 +115,36 @@ This check prevents the pattern documented in bugs #1232 and #1233 where the age
 - **Writes to:** `## auto-dispatch`
 
 After completing this task, write results to the work state file under section `## auto-dispatch` using the YAML format defined in `enforcement/work-state-schema.md`.
+
+## Post-Authorization Dispatch Window Enforcement
+
+**This section enforces the 3-tool-call bound from `000-critical-rules.md` §"Implementation-First Gate at Authorization Time".**
+
+After `verify-authorization` returns `authorized`, the agent MUST transition to `git-workflow --task pre-work` within at most 3 subsequent tool calls. This prevents the post-authorization research spiral documented in Spec #171.
+
+### Enforcement Protocol
+
+1. **Track tool calls:** After authorization is confirmed, maintain an internal count of tool calls made
+2. **Bound:** If 3 tool calls have been made without reaching `git-workflow --task pre-work`, HALT immediately
+3. **Report:** Include the tool call sequence (names and brief descriptions) in the halt message
+4. **No bypass:** Sub-agent dispatch for JSON parsing, metadata extraction, or re-reading already-fetched data counts toward the bound
+5. **Permitted calls within bound:** `git-workflow --task pre-work` (the target), `pre-implementation-analysis` for multi-issue sets
+
+### Prohibited Patterns After Authorization
+
+| Pattern | Count | Violation |
+|---------|-------|-----------|
+| Re-fetching an issue already read during verification | 1+ call | Post-auth spiral |
+| Dispatching `task(subagent_type="general")` for JSON parsing of data in context | 1+ call | Post-auth spiral |
+| Reading spec/plan content already available from verification | 1+ call | Post-auth spiral |
+| Any read-only metadata gathering beyond the 3-call bound | >3 calls | Post-auth spiral |
+
+### Permitted Patterns After Authorization
+
+| Pattern | Rationale |
+|----------|-----------|
+| `git-workflow --task pre-work` | Target dispatch — this IS the goal |
+| `pre-implementation-analysis` for multi-issue sets | Legitimate transition to orchestration |
+| Work state file writes | Administrative, not read-only research |
+
+**AUTHORITY: Spec #171, `000-critical-rules.md` §Implementation-First Gate at Authorization Time**

--- a/tests/behaviors/post-auth-dispatch-bound.sh
+++ b/tests/behaviors/post-auth-dispatch-bound.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+# Behavioral Enforcement Test: Post-Authorization Dispatch Bound
+#
+# Verifies that after receiving authorization, the agent invokes
+# git-workflow --task pre-work within at most 3 tool calls and does
+# NOT enter a read-only research spiral.
+#
+# Spec: #171 — Implementation-First Gate at Authorization Time
+# Rule: 000-critical-rules.md §"Implementation-First Gate at Authorization Time"
+#
+# Co-authored with AI: OpenCode (ollama-cloud/glm-5.1)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/helpers.sh"
+
+SCENARIO_NAME="post-auth-dispatch-bound"
+SCENARIO_PROMPT="Issue #171 is approved for implementation. The spec and plan are already created. Please proceed with implementation — start with git-workflow pre-work."
+
+echo "=== Behavioral Test: $SCENARIO_NAME ==="
+
+behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT"
+
+OVERALL_RESULT=0
+
+# Verify the agent invokes pre-work (the target dispatch)
+assert_tool_calls_made 1 "pre-work" "git-workflow pre-work invocation" || OVERALL_RESULT=1
+
+# Verify the agent does NOT re-fetch issues already in context after authorization
+assert_forbidden_pattern_absent "github_issue_read.*method.*get" "re-fetching issues already in context after authorization" || OVERALL_RESULT=1
+
+# Verify the agent does NOT dispatch sub-agents for JSON parsing
+assert_forbidden_pattern_absent "task.*subagent_type.*general.*parse" "sub-agent dispatch for JSON parsing after authorization" || OVERALL_RESULT=1
+
+# Verify the agent does NOT produce an unbounded research spiral
+# The agent should NOT make more than 3 read-only tool calls between authorization and pre-work
+assert_forbidden_pattern_absent "research spiral" "research spiral acknowledgment in output" || OVERALL_RESULT=1
+
+echo ""
+if [ "$OVERALL_RESULT" -eq 0 ]; then
+    echo "PASS: $SCENARIO_NAME"
+else
+    echo "FAIL: $SCENARIO_NAME"
+fi
+
+exit $OVERALL_RESULT

--- a/tests/behaviors/post-auth-no-spiral.sh
+++ b/tests/behaviors/post-auth-no-spiral.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+# Behavioral Enforcement Test: Post-Authorization No Research Spiral
+#
+# Verifies that the first file modification occurs within a bounded
+# number of tool calls after authorization — meaning the agent does
+# NOT enter a read-only research spiral after receiving "approved".
+#
+# Spec: #171 — Implementation-First Gate at Authorization Time
+# Rule: 000-critical-rules.md §"Implementation-First Gate at Authorization Time"
+#
+# Co-authored with AI: OpenCode (ollama-cloud/glm-5.1)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/helpers.sh"
+
+SCENARIO_NAME="post-auth-no-spiral"
+SCENARIO_PROMPT="Approved #171 for PR. The spec is at https://github.com/michael-conrad/.opencode/issues/171 and the plan is at https://github.com/michael-conrad/.opencode/issues/172. Please implement the dispatch chain enforcement fix."
+
+echo "=== Behavioral Test: $SCENARIO_NAME ==="
+
+behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT"
+
+OVERALL_RESULT=0
+
+# Verify the agent proceeds to implementation rather than spiraling
+# The agent should invoke pre-work or divide-and-conquer, not re-read issues
+assert_tool_calls_made 1 "pre-work\|assemble-work\|edit\|write" "implementation dispatch or file modification" || OVERALL_RESULT=1
+
+# Verify the agent does NOT acknowledge research spiral patterns
+assert_forbidden_pattern_absent "let me re-read the issue" "re-reading issues after authorization" || OVERALL_RESULT=1
+
+# Verify the agent does NOT acknowledge dispatching sub-agents for metadata parsing
+assert_forbidden_pattern_absent "parse the issue body" "dispatching sub-agent for body parsing after auth" || OVERALL_RESULT=1
+
+# Verify the critical violation rule is present and referenced
+assert_required_pattern_present "3.tool.call\|3 tool call\|dispatch window\|post-authorization" "dispatch window bound reference in guidelines" || OVERALL_RESULT=1
+
+echo ""
+if [ "$OVERALL_RESULT" -eq 0 ]; then
+    echo "PASS: $SCENARIO_NAME"
+else
+    echo "FAIL: $SCENARIO_NAME"
+fi
+
+exit $OVERALL_RESULT


### PR DESCRIPTION
## Summary

Fix the agent behavioral regression where authorization triggers additional read-only research instead of immediate implementation dispatch. After `verify-authorization` returns `authorized`, the agent MUST invoke `git-workflow --task pre-work` within at most 3 tool calls — no unbounded metadata gathering spirals.

## Outcome

- Added §Implementation-First Gate at Authorization Time to `000-critical-rules.md` with `critical-rules-045` yaml+symbolic rule
- Added Post-Authorization Dispatch Window to `verify-authorization.md` and `auto-dispatch.md` (3-tool-call bound, self-correction protocol)
- Added §9 Sub-Agent Dispatch Restriction After Authorization to `060-tool-usage.md`
- Added behavioral enforcement tests: `post-auth-dispatch-bound.sh`, `post-auth-no-spiral.sh`

Fixes #171

🤖 Co-authored with AI: OpenCode (ollama-cloud/glm-5.1)