### PR TITLE
feat(skills): add MANDATORY TASKS checklist sections to 8 priority SKILL.md files

### DIFF
--- a/skills/approval-gate/SKILL.md
+++ b/skills/approval-gate/SKILL.md
@@ -649,6 +649,29 @@ Skills MUST check authorization for **implementation**, NOT for **issue creation
 
 The `verify-authorization` gate applies only to code/config/file modifications that alter system behavior. Issue creation is a tracking action — the agent MUST proceed without deliberating over authorization. See `010-approval-gate.md` §Issue Creation Is Reporting, Not Implementation for the complete exemption table.
 
+## MANDATORY TASKS
+
+- [ ] MANDATORY: Invoke `approval-gate --task verify-authorization` before ANY implementation (per Gate 1: Authorization Required Before Implementation)
+- [ ] MANDATORY: Verify spec or plan exists as GitHub Issue before proceeding (per Gate 2: Spec Required Before Code, per `010-approval-gate.md` §Authorization Requirements)
+- [ ] MANDATORY: Search GitHub Issues for existing `[SPEC]`, `[PLAN]`, `[SPEC-FIX]` candidates before Q/A halt (per `000-critical-rules.md` §Silent Halt Without Prompt, per `search-prompt-fail` task)
+- [ ] MANDATORY: Check `pr_boundaries` in plan yaml+symbolic block and verify required upstream PRs are merged via `github_pull_request_read(method=get)` before authorizing implementation (per PR Merge Boundary Gate)
+- [ ] MANDATORY: Invoke `git-workflow --task pre-work` after `verify-authorization` passes, before any implementation (per Dispatch Order Step: MANDATORY WORKTREE STEP)
+- [ ] MANDATORY: Verify sub-issue structure under plan: `github_issue_read(method=get_sub_issues)` count must match plan phase count (per `verify-authorization` Step 5, per `000-critical-rules.md` §Sub-issue Structure Bypass)
+- [ ] MANDATORY: Apply spec-to-plan approval cascade when spec is approved and faithful plan already exists — auto-approve plan, remove `needs-approval` label, add cascade comment (per `verify-authorization` Step 5b, per `010-approval-gate.md` §Spec-to-Plan Approval Cascade)
+- [ ] MANDATORY: Dispatch `screen-issue` sub-agents for EVERY approved issue — no inline screening regardless of set size (per `000-critical-rules.md` §Inline Screening of Authorization Sets, per `pre-implementation-analysis` Step -1)
+- [ ] MANDATORY: Run `pre-implementation-analysis` for all approvals (single or authorization set) — build dependency graph, classify issues, present analysis in chat (per `000-critical-rules.md` §Skipping Interdependency Analysis)
+- [ ] MANDATORY: Parse authorization scope from verb-prefix parsing table — do NOT ask developer for scope classification (per `010-approval-gate.md` §Authorization Scope Model, per `000-critical-rules.md` §Structural Decision Solicitation Under for_pr Scope)
+- [ ] MANDATORY: Execute gap-fill cascade autonomously when `authorization_scope >= for_plan` — do NOT halt for structural decisions that the scope model resolves (per `000-critical-rules.md` §for_pr Gap-Fill Halt)
+- [ ] MANDATORY: Do NOT halt after `pre-implementation-analysis` when `authorization_scope >= for_pr` — check scope and proceed to gap-fill cascade (per `000-critical-rules.md` §pre-implementation-analysis Halts Under for_pr Scope)
+- [ ] MANDATORY: Verify dispatch chain enforcement — confirm prior step's output artifacts before proceeding to next step; HALT and invoke skipped skill on missing artifact (per Dispatch Order Enforcement Checkpoint table)
+- [ ] MANDATORY: Produce visible chat output after every sub-agent dispatch — NEVER transition from dispatch to halt without output (per Step 0.5 Post-Dispatch Output Gate)
+- [ ] MANDATORY: Verify orchestrator has NOT performed inline file operations before dispatch (per Step 0 Orchestrator Purity Gate)
+- [ ] MANDATORY: Invoke `--task completion` on workflow halt at ANY point — idempotent, safe to invoke multiple times (per COMPLETION GUARANTEE)
+- [ ] MANDATORY: Verify bug reports have fix spec sub-issue before closure — invoke `verify-fix-spec` for bug report issues (per `000-critical-rules.md` §Bug Reports Without Fix Spec)
+- [ ] MANDATORY: Verify closed issues have merged PR evidence before treating as resolved — invoke `verify-closed-issue` (per `000-critical-rules.md` §Assuming Closed Issues Are Verified)
+- [ ] MANDATORY: Invoke `reconcile-issue-graph` when graph traversal finds inconsistent issue states — auto-close verified-complete, reopen verified-incomplete (per `000-critical-rules.md` §Process Gaps Are Bugs)
+- [ ] MANDATORY: Classify mandate tier before yielding — Tier 1 mandates (branch protection, human-only merge, no `/tmp/`) NEVER yield to developer authorization; Tier 2 mandates (spec-before-code, plan-before-implementation) yield to explicit authorization (per Mandate Tiering Enforcement table)
+
 ```yaml+symbolic
 schema_version: "2.0"
 last_updated: "2026-04-26T00:00:00Z"

--- a/skills/divide-and-conquer/SKILL.md
+++ b/skills/divide-and-conquer/SKILL.md
@@ -383,6 +383,25 @@ Use when spec has complex success criteria benefiting from independent verificat
 - Authorization classification: See `010-approval-gate.md` §Action Authorization Classification
 - Adapted from: `implementation-workflow`
 
+## MANDATORY TASKS
+
+- [ ] MANDATORY: Run `--task assess` (pre-flight context assessment) before ANY non-trivial implementation dispatch (per Operating Protocol §1)
+- [ ] MANDATORY: Dispatch ALL implementation via `--task assemble-work` — no direct implementation by orchestrator, no IMPLEMENT_DIRECTLY path (per Gate 2: Sub-Agent Dispatch Required, per `000-critical-rules.md` §Main Agent Implements Directly)
+- [ ] MANDATORY: Verify feature branch exists (`git branch --show-current`) and `worktree.path` is set before dispatching any sub-agent (per Pre-Dispatch Verification Checkpoint)
+- [ ] MANDATORY: Verify `git-workflow --task pre-work` was invoked — not manual worktree creation — before sub-agent dispatch (per `000-critical-rules.md` §Bypassing Mandatory Skill Invocations)
+- [ ] MANDATORY: Check PR merge boundaries via `github_pull_request_read(method=get)` for each `must_be_merged_before_starting: true` boundary before dispatching sub-agents (per Gate 3: PR Merge Boundary Check, per `000-critical-rules.md` §Implementing Before PR Merge Boundary)
+- [ ] MANDATORY: Each sub-agent handles ONE discrete step — never combine analyze+write, write+verify, or test+fix in a single dispatch (per Decomposition Rule)
+- [ ] MANDATORY: Sub-agents MUST run `verification-before-completion --task verify` and `finishing-a-development-branch --task checklist` before returning results (per Operating Protocol §10)
+- [ ] MANDATORY: Stack branches sequentially (merge-based dependency resolution) as the prerequisite approach — parallel dispatch is opportunistic only, requires documented justification (per Operating Protocol §11, per `000-critical-rules.md` §Treating Branch Stacking as Optional)
+- [ ] MANDATORY: Validate sub-agent result contract before accepting — check `status`, `files_changed`, `summary`, `phase_progress` fields (per Result Validation table, per `000-critical-rules.md` §Skipping Post-Flight Checks)
+- [ ] MANDATORY: On OVERFLOW signal from sub-agent: re-dispatch with reduced scope, NEVER silently halt (per Overflow Signal Contract, per `000-critical-rules.md` §Silent Agent Termination)
+- [ ] MANDATORY: On empty/malformed sub-agent result: FALLBACK to inline execution + warn in chat; on double failure: report + invoke `--task completion` + HALT with status (per Result Validation, per `000-critical-rules.md` §Post-Dispatch Output Guarantee)
+- [ ] MANDATORY: Log every sub-agent dispatch in work state file with timestamp, task name, and result contract summary (per Dispatch Logging in Work State File)
+- [ ] MANDATORY: Verify work state claims against live GitHub/git state before trusting them for workflow decisions (per Live Verification: Work State table, per `065-verification-honesty.md`)
+- [ ] MANDATORY: Verify `files_modified_count > 0` for `for_implementation` or `for_pr` scope before reporting dispatch complete — zero deliverables is a CRITICAL violation (per `000-critical-rules.md` §Implementation-First Gate)
+- [ ] MANDATORY: After authorization received, proceed to `git-workflow --task pre-work` within at most 3 tool calls — no unbounded research spiral (per `000-critical-rules.md` §Implementation-First Gate at Authorization Time)
+- [ ] MANDATORY: Invoke `--task completion` on workflow halt at ANY point — idempotent, safe to invoke multiple times (per COMPLETION GUARANTEE)
+
 ```yaml+symbolic
 schema_version: "2.0"
 last_updated: "2026-04-26T00:00:00Z"

--- a/skills/git-workflow/SKILL.md
+++ b/skills/git-workflow/SKILL.md
@@ -703,6 +703,26 @@ When `git rev-parse --show-toplevel` returns a path that is a descendant of a pa
 - Authorization classification: See `010-approval-gate.md` §Action Authorization Classification
 - Related skill tasks: `git-workflow --task pre-work` (branch creation), `git-workflow --task cleanup` (post-merge), `git-workflow --task pr-creation` (PR workflow), `git-workflow --task provenance` (submodule provenance tracking)
 
+## MANDATORY TASKS
+
+- [ ] MANDATORY: Invoke `git-workflow --task pre-work` before ANY implementation — skipping is a CRITICAL GUIDELINE VIOLATION (per Overview, per `000-critical-rules.md` §Bypassing Mandatory Skill Invocations, exempt: no implementation performed)
+- [ ] MANDATORY: Invoke `git-workflow --task review-prep` after implementation completes — skipping is a CRITICAL GUIDELINE VIOLATION (per Operating Protocol §3, per `000-critical-rules.md` §Skipping review-prep After Implementation)
+- [ ] MANDATORY: Invoke `git-workflow --task cleanup` after EVERY confirmed PR merge — never skip post-merge cleanup (per Operating Protocol §9, per `000-critical-rules.md` §Skipping Post-Merge Cleanup)
+- [ ] MANDATORY: Never create worktree or branch directly — invoke `pre-work` task which handles authorization check, dev sync, and worktree creation (per Gate 3: Skill Dispatch Before Worktree/Branch Creation)
+- [ ] MANDATORY: Never call `github_create_pull_request` directly — invoke `finishing-a-development-branch --task checklist` → `review-prep` → `pr-creation` in order (per Gate 2: Skill Dispatch Before PR Creation, per `000-critical-rules.md` §Dispatch Chain Enforcement)
+- [ ] MANDATORY: Never call `git push` directly after implementation — invoke `review-prep` which handles push verification and compare URL generation (per Gate 4: Skill Dispatch Before Push)
+- [ ] MANDATORY: Feature branches target `dev` — compare URLs use `compare/dev...<branch-name>`, release PRs only use `compare/main...dev` (per Operating Protocol §6, per `000-critical-rules.md` §Wrong Compare URL Base Branch)
+- [ ] MANDATORY: Squash to single commit before any PR — verify commit count at enforcement gate per `000-critical-rules.md` §Un-Squashed PR
+- [ ] MANDATORY: NEVER merge PRs — human-only operation (per Operating Protocol §8, per `000-critical-rules.md` §Tier 1 Non-Yielding Mandates)
+- [ ] MANDATORY: Verify actual git/GitHub state via tool calls before acting on claims — never trust cached branch names, assumed merge status, or claimed worktree paths (per Live Verification Requirements, per `065-verification-honesty.md`)
+- [ ] MANDATORY: Extract post-creation URLs (PR, Issue) from API response `html_url` field — NEVER construct from template variables (per `000-critical-rules.md` §Fabricating URLs, per `git-workflow-url-001` rule)
+- [ ] MANDATORY: Construct pre-creation URLs (compare URL) from verified session-init values with character-match verification — `github.owner` and `github.repo` must match character-for-character (per `000-critical-rules.md` §Fabricating URLs, per `git-workflow-url-002` rule)
+- [ ] MANDATORY: Chat output at halt points MUST follow: summary → outcome → URL (if applicable) → byline — NEVER put URL before summary (per Operating Protocol §5, per `000-critical-rules.md` §Wrong Chat Output at Halt Points)
+- [ ] MANDATORY: Cleanup scope is limited to the merged PR ONLY — report additional cleanup opportunities but do NOT act without explicit authorization (per Operating Protocol §10, per `000-critical-rules.md` §Question-as-Authorization)
+- [ ] MANDATORY: Content-verify branches before deletion — `git diff --stat origin/dev...` + per-file IDENTICAL/SUPERSEDED/UNIQUE status; NEVER delete based on PR merge status alone (per `000-critical-rules.md` §Content Verification Before Branch Deletion)
+- [ ] MANDATORY: When `check prs` is requested, invoke `--task check-pr` which routes to cleanup if merged PRs with local branches exist — NEVER just list PRs (per `000-critical-rules.md` §Listing Merged PRs Without Invoking Cleanup)
+- [ ] MANDATORY: Invoke `--task completion` on workflow halt at ANY point — idempotent, safe to invoke multiple times (per COMPLETION GUARANTEE)
+
 ```yaml+symbolic
 schema_version: "2.0"
 last_updated: "2026-04-26T00:00:00Z"

--- a/skills/issue-operations/SKILL.md
+++ b/skills/issue-operations/SKILL.md
@@ -530,6 +530,24 @@ Before invoking any cross-referenced skill:
 - Authorization classification: See `010-approval-gate.md` Action Authorization Classification
 - Platform sub-skills: `platforms/github-mcp/SKILL.md`, `platforms/gitbucket-api/SKILL.md`, `platforms/local/SKILL.md`
 
+## MANDATORY TASKS
+
+- [ ] MANDATORY: Route ALL issue operations through this skill — never call `github_issue_write`, `github_add_issue_comment`, or `github_sub_issue_write` directly — per §Hard Gates Gate 1
+- [ ] MANDATORY: Verify byline presence (`Co-authored with AI` or emoji byline) before any `github_issue_write` or `github_add_issue_comment` call with AI-authored content — per §Hard Gates Gate 2
+- [ ] MANDATORY: Run `pre-creation` task before creating any issue (conflict/superseded check) — per §Operating Protocol Step 2
+- [ ] MANDATORY: Run Step 0.5 title dedup gate before any issue creation — verify dedup evidence before proceeding — per §Critical Rules ALWAYS DO
+- [ ] MANDATORY: Apply `needs-approval` label to new specs — per §Critical Rules ALWAYS DO
+- [ ] MANDATORY: Add creation byline in issue body footer — per §Critical Rules ALWAYS DO
+- [ ] MANDATORY: Never close issues before PR merge is confirmed via live tool call — per §Critical Rules NEVER DO and yaml+symbolic issue-ops-003
+- [ ] MANDATORY: Never replace issue body with shorter content — verify `len(new_body) >= 0.8 * len(original_body)` before any `github_issue_write(method=update)` — per §Hard Gates and yaml+symbolic issue-ops-004
+- [ ] MANDATORY: Create sub-issues under the plan (NOT under the spec) — per §Critical Rules NEVER DO and yaml+symbolic issue-ops-005
+- [ ] MANDATORY: Include PR Merge Boundary section in sub-issue bodies when parent plan has `pr_boundaries` with `must_be_merged_before_starting: true` for the sub-issue's phase — per §PR Merge Boundary in Sub-Issue Bodies
+- [ ] MANDATORY: Detect platform from session init and route to correct platform sub-skill — per §Platform Routing and yaml+symbolic issue-ops-007
+- [ ] MANDATORY: Route submodule file targets to submodule repo (not parent repo) — per §Submodule Routing for Issue Operations and yaml+symbolic issue-ops-009
+- [ ] MANDATORY: Invoke `spec-auditor` for multi-task specs before approval — per §Interdependencies
+- [ ] MANDATORY: Post only substantive comments — skip non-substantive comments (approval tracking, "created by", hierarchy reports, step evidence, verification results, raw auditor reports) — per §Substantive Comment Gate
+- [ ] MANDATORY: Invoke `--task completion` before halting at any point — per completion task
+
 ```yaml+symbolic
 schema_version: "2.0"
 last_updated: "2026-04-25T00:00:00Z"

--- a/skills/spec-auditor/SKILL.md
+++ b/skills/spec-auditor/SKILL.md
@@ -706,36 +706,23 @@ Co-authored with AI: <AgentName> (<ModelId>)
 
 **⚠️ COMPLETION GUARANTEE:** If this workflow halts at ANY point — including error, failure, or early termination — you MUST invoke `--task completion` before halting. The completion subtask ensures mandatory steps are never skipped. It is idempotent and safe to invoke multiple times.
 
-**⚠️ COMPLETION GUARANTEE:** If this workflow halts at ANY point — including error, failure, or early termination — you MUST invoke `--task completion` before halting. The completion subtask ensures mandatory steps are never skipped. It is idempotent and safe to invoke multiple times.
+## MANDATORY TASKS
 
-## Symbolic Engine Integration
-
-**Optional pre-step:** Before auditing, invoke the symbolic analysis engine for formal evidence:
-
-```bash
-./.opencode/tools/symbolic states
-./.opencode/tools/symbolic flow
-```
-
-- `sym-states`: Validates state machines extracted from yaml+symbolic blocks — checks reachability from start_state, detects dead/unreachable states, flags dangling references in transitions.
-- `sym-flow`: Builds a networkx DiGraph from rule triggers/requires and detects flow anomalies — unreachable nodes, cycles, orphan nodes with no edges.
-
-Results are used as **evidence** (not verdict) — they supplement prose-only analysis with formal state machine and flow validation.
-
-**Graceful degradation:** If the engine is unavailable or produces no results, fall back to prose-only analysis. Do NOT block the audit if the engine fails.
-
-**Import interface (for in-process usage):**
-```python
-import types, sys
-from pathlib import Path
-impl_dir = Path(".opencode/tools/impl")
-source = (impl_dir / "sym-states").read_text()
-mod = types.ModuleType("symstates")
-mod.__file__ = str(impl_dir / "sym-states")
-sys.modules["symstates"] = mod
-exec(compile(source, str(impl_dir / "sym-states"), "exec"), mod.__dict__)
-anomalies = mod.validate_state_machines(state_machines, rules)
-```
+- [ ] MANDATORY: Invoke spec-auditor for all new specs — per §Mandatory Invocation and yaml+symbolic spec-auditor-001
+- [ ] MANDATORY: Provide one of `--issue N`, `--file path`, or `--url URL` (except overview mode) — per §Operating Protocol #1
+- [ ] MANDATORY: Autodetect document type via signal scoring when `--type` is not specified — per §Operating Protocol #2; if confidence is Low, flag for user confirmation before proceeding
+- [ ] MANDATORY: Run baseline subtasks for the detected document type (Spec: `fresh-start`, `structure`, `fidelity`, `ground-truth`, `principles`, `sc-precision`; Plan: `fresh-start`, `structure`, `ground-truth`, `principles`; etc.) — per §Minimal Baseline
+- [ ] MANDATORY: Classify ALL findings into one of three tiers (auto-fix, conditional, flag-for-review) — per §Auto-Fix Model
+- [ ] MANDATORY: Apply auto-fix findings directly and verify each auto-fix was actually applied via re-read — per §Audit Findings Handling Step 4
+- [ ] MANDATORY: Apply conditional findings ONLY after safety check passes — per §Auto-Fix Model and yaml+symbolic spec-auditor-003
+- [ ] MANDATORY: NEVER apply flag-for-review findings — report in executive summary only — per §Auto-Fix Model and yaml+symbolic spec-auditor-004
+- [ ] MANDATORY: Verify `len(new_body) >= 0.8 * len(original_body)` before any `github_issue_write(method=update)` — per §Body-Preservation Safeguard and yaml+symbolic spec-auditor-005
+- [ ] MANDATORY: Run `ground-truth` subtask for ALL audits — per yaml+symbolic spec-auditor-006
+- [ ] MANDATORY: Post chat executive summary after every audit (even when zero findings) — per §Chat Executive Summary and yaml+symbolic spec-auditor-007
+- [ ] MANDATORY: Post revision comment ONLY for substantive changes (adding/removing phases, changing requirements, altering approach) — non-substantive auto-fixes get NO comment — per §Audit Findings Handling
+- [ ] MANDATORY: Verify cross-references against actual skill files before invoking — per §Cross-Reference Verification
+- [ ] MANDATORY: When audit finds issues for another spec (cross-spec-overlap with CONFLICT-RISK or FULL-SUPERSESSION), note the finding but do NOT modify the other spec — per §Auto-Fix Model flag-for-review
+- [ ] MANDATORY: Invoke `--task completion` before halting at any point — per completion task
 
 ```yaml+symbolic
 schema_version: "2.0"

--- a/skills/spec-creation/SKILL.md
+++ b/skills/spec-creation/SKILL.md
@@ -488,6 +488,23 @@ Co-authored with AI: <AgentName> (<ModelId>)
 
 **⚠️ COMPLETION GUARANTEE:** If this workflow halts at ANY point — including error, failure, or early termination — you MUST invoke `--task completion` before halting. The completion subtask ensures mandatory steps are never skipped. It is idempotent and safe to invoke multiple times.
 
+## MANDATORY TASKS
+
+- [ ] MANDATORY: Complete code inspection checklist from `015-pre-spec-inspection.md` before `requirements` task (exempt: greenfield features with no existing code interaction, trivial typos with no code interaction) — per §Operating Protocol #1
+- [ ] MANDATORY: Search GitHub Issues for existing specs/plans before creating a new spec — per §Operating Protocol #3 (select-existing pathway)
+- [ ] MANDATORY: Invoke `verification-enforcement --task verify` before spec content generation — per decomposition gate
+- [ ] MANDATORY: Complete `requirements` task before `write` task (except trivial specs) — per §Enforcement Mechanism #2 and yaml+symbolic spec-creation-004
+- [ ] MANDATORY: Enumerate concerns before `write` task — flag multi-concern specs as `conditional` for splitting — per §Enforcement Mechanism #5 and §Concern Enumeration Guard
+- [ ] MANDATORY: Validate SC-to-phase mapping after `write` — check each SC is scoped to exactly one phase deliverable — per §Enforcement Mechanism #3
+- [ ] MANDATORY: Create spec as GitHub Issue with `[SPEC]` prefix and `needs-approval` label — not chat output — per §Enforcement Mechanism #4 and yaml+symbolic spec-creation-005
+- [ ] MANDATORY: Self-review spec for placeholders, consistency, and ambiguity after creation — per §Evidence Artifact Requirements
+- [ ] MANDATORY: Generate mermaid dependency diagram when dependencies exist (N > 1 items or cross-issue dependencies) — per §Interdependency Diagram Discipline and yaml+symbolic spec-creation-008
+- [ ] MANDATORY: Verify diagram contains NO workflow state markers (✅, 🔄, ❌, "implemented", "pending") — per §Diagram Content Rules
+- [ ] MANDATORY: Include PR Merge Boundaries section when spec has dependencies on other specs/plans — per §PR Merge Boundaries and yaml+symbolic spec-creation-007
+- [ ] MANDATORY: Invoke `spec-auditor --issue N` after spec creation — per §Mandatory Invocation
+- [ ] MANDATORY: Report chat output as exec summary + URL + byline ONLY — no full spec dump — per §Enforcement Mechanism #4
+- [ ] MANDATORY: Invoke `--task completion` before halting at any point — per completion task
+
 ```yaml+symbolic
 schema_version: "2.0"
 last_updated: "2026-04-25T00:00:00Z"

--- a/skills/verification-before-completion/SKILL.md
+++ b/skills/verification-before-completion/SKILL.md
@@ -356,6 +356,23 @@ Key adaptations for <AgentName>:
 - Dispatch table integration for mandatory invocation
 - Structured evidence collection and verification gates
 
+## MANDATORY TASKS
+
+- [ ] MANDATORY: Invoke `verification-before-completion --task verify` before marking any task or phase complete — skipping is a CRITICAL GUIDELINE VIOLATION (per `000-critical-rules.md` §Bypassing Mandatory Skill Invocations, exempt: no implementation performed)
+- [ ] MANDATORY: Run `structural-verify` BEFORE per-SC verification — HALT immediately if any structural component is missing (per Structural Completeness Gate)
+- [ ] MANDATORY: Every success criterion must have verifiable evidence (logs, test outputs, tool-call artifacts) — no placeholders or "trust me" claims (per Operating Protocol §2, per `000-critical-rules.md` §Soft-Passing Verification Mismatches)
+- [ ] MANDATORY: Use `exact` comparison mode as default for ALL external verifications (DNS, config, API responses, infrastructure state) — `semantic` mode requires explicit per-field justification per `065-verification-honesty.md` §Verification Comparison Semantics
+- [ ] MANDATORY: Verify completion claims against LIVE state via tool calls — never trust cached or claimed values (per Live Verification: Completion Claims table, per `000-critical-rules.md` §Verification Dishonesty)
+- [ ] MANDATORY: Verify cross-references against actual skill content before invoking — `ls .opencode/skills/<name>/SKILL.md` for existence, `grep` for task references (per Cross-Reference Verification table)
+- [ ] MANDATORY: Dispatch verification sub-agents with clean-room context — ONLY spec SC list + file paths, NO implementation context, NO prior verification results, NO agent memory (per Clean-Room Dispatch Protocol, per `000-critical-rules.md` §Skipping Clean-Room Dispatch for Sub-Agents)
+- [ ] MANDATORY: Verify per-SC evidence table shows ALL PASS before marking complete — any FAIL or MISSING row blocks completion (per Enforcement Mechanism matrix)
+- [ ] MANDATORY: Run behavioral RED tests in isolated sub-agent sessions via `with-test-home` — never in the same context as the implementation agent (per RED Test Isolation, per `000-critical-rules.md` §Skipping Behavioral Tests for Behavior Changes)
+- [ ] MANDATORY: The verifier sub-agent is ALWAYS different from the producer sub-agent — verifier receives ONLY file paths + SC list, NOT producer's reasoning or drafts (per Verification Isolation table)
+- [ ] MANDATORY: Load guideline `065-verification-honesty.md` before any verification claim — it is not permanently loaded (per Lazy-Loaded Guidelines)
+- [ ] MANDATORY: When worktree mode is active, prefix ALL file operation paths with `worktree.path` and verify `git rev-parse --show-toplevel` matches `worktree.path` before running any command (per Worktree Mode section)
+- [ ] MANDATORY: Produce chat output after every sub-agent dispatch — NEVER silently halt after dispatch (per `000-critical-rules.md` §Silent Agent Termination, §Post-Dispatch Output Guarantee)
+- [ ] MANDATORY: Invoke `--task completion` on workflow halt at ANY point — idempotent, safe to invoke multiple times (per COMPLETION GUARANTEE)
+
 ```yaml+symbolic
 schema_version: "2.0"
 last_updated: "2026-04-26T00:00:00Z"

--- a/skills/writing-plans/SKILL.md
+++ b/skills/writing-plans/SKILL.md
@@ -602,6 +602,25 @@ Action: [auto-fix|conditional|flag-for-review]
 
 **⚠️ COMPLETION GUARANTEE:** If this workflow halts at ANY point — including error, failure, or early termination — you MUST invoke `--task completion` before halting. The completion subtask ensures mandatory steps are never skipped. It is idempotent and safe to invoke multiple times.
 
+## MANDATORY TASKS
+
+- [ ] MANDATORY: Read approved spec from GitHub Issue — verify spec approval via live tool call (labels + authorization comment), not cached claims — per §Live Verification: Spec State
+- [ ] MANDATORY: Check for existing plans referencing the same spec before creating a new plan — per §Operating Protocol Step 1.5
+- [ ] MANDATORY: Evaluate combined vs separate plan using `single_task_determination` at decision gate — per §Operating Protocol Step 2
+- [ ] MANDATORY: Include TDD step structure (RED/GREEN/REFACTOR) in every task with Step 2 RED verification checkpoint — per §RED Verification Checkpoint and yaml+symbolic writing-plans-005
+- [ ] MANDATORY: Verify no placeholders (TBD, TODO, etc.) in plan content — per §No-Placeholders Rule and yaml+symbolic writing-plans-002
+- [ ] MANDATORY: Generate mermaid dependency diagram when plan has dependencies (multiple phases or cross-issue dependencies) — per §Interdependency Diagram Discipline and yaml+symbolic writing-plans-009
+- [ ] MANDATORY: Verify diagram contains NO workflow state markers (✅, 🔄, ❌, "implemented", "pending") — per §Diagram Format Rules and yaml+symbolic writing-plans-010
+- [ ] MANDATORY: Include PR Merge Boundaries section when spec has dependencies on other specs/plans — per §PR Merge Boundaries and yaml+symbolic writing-plans-009 (duplicate ID)
+- [ ] MANDATORY: Create sub-issues under the plan (NOT under the spec) for multi-task plans — per §Plan Issue Model and yaml+symbolic writing-plans-003
+- [ ] MANDATORY: Self-review plan for spec coverage, placeholders, and type consistency — per §Self-Review Checklist
+- [ ] MANDATORY: Verify cross-references against actual skill files before invoking — per §Cross-Reference Verification
+- [ ] MANDATORY: Invoke `verification-enforcement --task verify` before plan content generation — per decomposition gate
+- [ ] MANDATORY: Add `needs-approval` label to newly created plans in standard scope — per §Approval Cascade
+- [ ] MANDATORY: Scope-aware cascade: for `for_plan` or higher scope, remove `needs-approval` and document cascade — for `standard` scope, retain label — per §Approval Cascade
+- [ ] MANDATORY: Report chat output as exec summary + URL + byline — per §Operating Protocol Step 10
+- [ ] MANDATORY: Invoke `--task completion` before halting at any point — per completion task
+
 ```yaml+symbolic
 schema_version: "2.0"
 last_updated: "2026-04-25T00:00:00Z"

--- a/tests/behaviors/mandatory-tasks-checklist.sh
+++ b/tests/behaviors/mandatory-tasks-checklist.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+# Behavioral Enforcement Test: MANDATORY TASKS Checklist Pattern
+#
+# Verifies that when a skill with MANDATORY TASKS is invoked,
+# the agent recognizes and follows the checklist format.
+# Tests the core behavior change from issue #219: skill cards
+# now contain `- [ ] MANDATORY:` executable checklists that
+# agents must process during skill execution.
+#
+# RED phase: Verify agent acknowledges MANDATORY TASKS items
+# when executing spec-creation skill.
+#
+# Co-authored with AI: <AgentName> (<ModelId>)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/helpers.sh"
+
+SCENARIO_NAME="mandatory-tasks-checklist"
+SCENARIO_PROMPT="I need to create a spec for adding a dark mode toggle to the settings page. The codebase uses React with TypeScript. Please invoke the spec-creation skill to write this spec."
+
+echo "=== Behavioral Test: $SCENARIO_NAME ==="
+
+behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT"
+
+OVERALL_RESULT=0
+
+# Verify the agent mentions MANDATORY TASKS or mandatory checklist items
+# when processing the spec-creation skill
+assert_required_pattern_present "MANDATORY" "MANDATORY keyword in skill execution" || OVERALL_RESULT=1
+
+# Verify the agent does NOT skip directly to writing without
+# acknowledging pre-conditions (code inspection checklist)
+assert_required_pattern_present "inspection\|checklist\|pre-spec" "pre-conditions acknowledgment" || OVERALL_RESULT=1
+
+# Verify the agent invokes spec-auditor after creation (a MANDATORY TASKS item)
+assert_skill_invoked "spec-auditor" || {
+    echo "WARN: spec-auditor not invoked — may be acceptable if spec creation did not complete"
+}
+
+echo ""
+if [ "$OVERALL_RESULT" -eq 0 ]; then
+    echo "PASS: $SCENARIO_NAME"
+else
+    echo "FAIL: $SCENARIO_NAME"
+fi
+
+exit $OVERALL_RESULT

--- a/tests/content-verification/mandatory-tasks-checklist.sh
+++ b/tests/content-verification/mandatory-tasks-checklist.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+# Content-Verification Test: MANDATORY TASKS Checklist Sections
+# Issue #219 - Verifies MANDATORY TASKS sections exist in priority skill cards
+# with `- [ ] MANDATORY:` checkbox format
+#
+# SECONDARY enforcement (behavioral is PRIMARY per 091-incremental-build.md)
+#
+# Co-authored with AI: <AgentName> (<ModelId>)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SKILLS_DIR="$(cd "$SCRIPT_DIR/../../skills" && pwd)"
+
+OVERALL_RESULT=0
+
+echo "=== Content-Verification Test: MANDATORY TASKS Checklist Sections ==="
+
+# The 8 priority skills from issue #219 Phase 1
+PRIORITY_SKILLS=(
+  "spec-creation"
+  "writing-plans"
+  "issue-operations"
+  "spec-auditor"
+  "approval-gate"
+  "divide-and-conquer"
+  "verification-before-completion"
+  "git-workflow"
+)
+
+for skill in "${PRIORITY_SKILLS[@]}"; do
+  SKILL_FILE="$SKILLS_DIR/$skill/SKILL.md"
+  if [ ! -f "$SKILL_FILE" ]; then
+    echo "FAIL: $skill/SKILL.md not found"
+    OVERALL_RESULT=1
+    continue
+  fi
+
+  # Check for ## MANDATORY TASKS section heading
+  if grep -q "^## MANDATORY TASKS" "$SKILL_FILE"; then
+    echo "PASS: $skill — MANDATORY TASKS section heading found"
+  else
+    echo "FAIL: $skill — MANDATORY TASKS section heading NOT found"
+    OVERALL_RESULT=1
+    continue
+  fi
+
+  # Check for at least one `- [ ] MANDATORY:` checkbox
+  COUNT=$(grep -c "^- \[ \] MANDATORY:" "$SKILL_FILE" 2>/dev/null || true)
+  COUNT=${COUNT:-0}
+  COUNT=$(echo "$COUNT" | head -1 | tr -d '[:space:]')
+  if [ "$COUNT" -ge 1 ]; then
+    echo "PASS: $skill — $COUNT MANDATORY checkbox items found"
+  else
+    echo "FAIL: $skill — no MANDATORY checkbox items found"
+    OVERALL_RESULT=1
+  fi
+
+  # Check for traceability references (guideline or skill references)
+  if grep -q "^- \[ \] MANDATORY:.*per §\|^- \[ \] MANDATORY:.*per " "$SKILL_FILE"; then
+    echo "PASS: $skill — traceability references found in MANDATORY items"
+  else
+    echo "FAIL: $skill — no traceability references in MANDATORY items"
+    OVERALL_RESULT=1
+  fi
+done
+
+echo ""
+if [ "$OVERALL_RESULT" -eq 0 ]; then
+    echo "PASS: Content-verification — all 8 priority skills have MANDATORY TASKS sections"
+else
+    echo "FAIL: Content-verification — some MANDATORY TASKS sections missing or incomplete"
+fi
+
+exit $OVERALL_RESULT


### PR DESCRIPTION
## Summary

Adds `- [ ] MANDATORY:` executable checklist sections to 8 priority skill cards, establishing the pattern for making mandatory actions unskippable during skill execution. This is Phase 1 of issue #219.

## Outcome

Skill cards now contain concrete, verifiable execution checklists extracted from Operating Protocols, ALWAYS DO/NEVER DO lists, and yaml+symbolic enforcement blocks — giving agents an actionable pattern to model spec/plan MANDATORY TASKS sections after.

**Files modified (8 SKILL.md):**
- `spec-creation`: 14 mandatory tasks
- `writing-plans`: 16 mandatory tasks
- `issue-operations`: 15 mandatory tasks
- `spec-auditor`: 15 mandatory tasks
- `approval-gate`: 20 mandatory tasks
- `divide-and-conquer`: 16 mandatory tasks
- `verification-before-completion`: 14 mandatory tasks
- `git-workflow`: 17 mandatory tasks

**Tests added (2):**
- Behavioral: `tests/behaviors/mandatory-tasks-checklist.sh`
- Content-verification: `tests/content-verification/mandatory-tasks-checklist.sh`

Fixes #219 (Phase 1 — skill card MANDATORY TASKS as prerequisite reference implementation)

🤖 Co-authored with AI: <AgentName> (<ModelId>)