### PR TITLE
docs: add submodule pointer handling guidance to cleanup and release-promotion

### DIFF
--- a/skills/git-workflow/tasks/cleanup/branch-cleanup.md
+++ b/skills/git-workflow/tasks/cleanup/branch-cleanup.md
@@ -299,6 +299,24 @@ evidence_artifacts:
     output: "dev"
 ```
 
+### Step 5.6: Submodule Pointer Is Expected Dirty — NOT a Separate PR
+
+After submodule-dev-restore, `git status --porcelain` will show `.opencode` as modified because the parent's tracked SHA differs from the submodule's dev tip. This is expected and correct — the submodule is now on the latest dev commit, but the parent repo still records the old SHA.
+
+**This dirty state does NOT warrant a separate PR.** The parent's submodule pointer advances naturally as part of the next feature branch that modifies `.opencode/` content. The pre-work step for that feature will stage and commit the updated pointer alongside the feature's changes.
+
+**🚫 FORBIDDEN:**
+- Creating a PR solely to update the submodule pointer SHA
+- Creating a "chore: update submodule pointer" commit/PR after cleanup
+- Treating the dirty `.opencode` status as an error that needs resolution
+
+**✅ EXPECTED:**
+- After cleanup, `.opencode` shows as modified in `git status` — this is the correct state
+- The next feature branch that touches `.opencode/` content will stage and commit the pointer update as part of its normal pre-work
+- The pointer update is atomic with the feature changes, not a separate operation
+
+**⚠️ `git submodule update` does NOT restore submodules to dev tip — it checks out the parent-recorded SHA, leaving submodules on detached HEAD. The restore must use `git checkout dev && git pull origin dev` inside each submodule.**
+
 ### Step 6: Succinct Confirmation
 
 **The `cleanup` task is THE END of the PR workflow. It MUST produce a one-line succinct confirmation and then HALT.**

--- a/skills/git-workflow/tasks/release-promotion.md
+++ b/skills/git-workflow/tasks/release-promotion.md
@@ -156,6 +156,8 @@ Invoke `submodule-liveness-check` sub-agent to verify reachability. The liveness
 
 **Key invariant:** Submodule dev → main PRs are NOT part of this workflow. Tags guarantee hash permanence. A submodule SHA referenced by the parent is already reachable via its issue/feature tags. A separate dev → main PR adds no reachability guarantee.
 
+**⚠️ Submodule pointer advancement is NOT a separate PR.** The parent repo's submodule pointer advances as a side effect of the next feature branch that modifies `.opencode/` content. The release tags guarantee hash permanence — the pointer will be updated when the next feature branch stages its changes. After Step 2, the parent repo may show `.opencode` as modified (the tracked SHA differs from the submodule's dev tip). This is expected and correct. No separate pointer-bump PR is needed.
+
 ### Step 2.5: Create Provenance Tracking
 
 After tagging submodule SHAs, invoke provenance tracking:


### PR DESCRIPTION
## Summary

Add explicit documentation to cleanup and release-promotion workflows that submodule pointer advancement after dev-restore/release-tagging does NOT warrant a separate PR.

## Outcome

- `branch-cleanup.md` Step 5.6: Documents that post-dev-restore submodule pointer dirty state is expected and correct; explicitly forbids pointer-bump PRs
- `branch-cleanup.md`: States that `git submodule update` is the WRONG command for dev-restore (causes detached HEAD)
- `release-promotion.md`: Adds advisory after Step 2 that submodule pointer advancement is NOT a separate PR

Fixes michael-conrad/.opencode#224
Fixes michael-conrad/.opencode#225

🤖 Co-authored with AI: OpenCode (ollama-cloud/glm-5.1)