### PR TITLE
Fix #234: Replace git rev-parse root detection with walk-up .opencode/ approach

### DIFF
--- a/guidelines/210-scripting.md
+++ b/guidelines/210-scripting.md
@@ -4,9 +4,19 @@
 
 Every script/notebook MUST include root resolution:
 
-- **Shell**: `cd "$(dirname "$0")" && _root=$(git -C "$(pwd)" rev-parse --show-superproject-working-tree --show-toplevel | head -1) && cd "$_root" || exit 1`
+- **Shell**: `_root="$(cd "$(dirname "$0")" && while [ "$(pwd)" != "/" ]; do [ -d ".opencode" ] && echo "$(pwd)" && break; cd ..; done)"` — if empty, `exit 1`
 - **Python**:
-  `BASE_DIR = Path(__file__).resolve().parent; _git_out = subprocess.check_output(["git", "-C", str(BASE_DIR), "rev-parse", "--show-superproject-working-tree", "--show-toplevel"], text=True).strip(); PROJECT_ROOT = Path(_git_out.splitlines()[0]) if _git_out.splitlines() else Path.cwd()`
+  ```python
+  def _find_project_root() -> Path:
+      current = Path(__file__).resolve().parent
+      while current != current.parent:
+          if (current / ".opencode").is_dir():
+              return current
+          current = current.parent
+      raise RuntimeError("Could not find project root (no .opencode/ directory found)")
+
+  PROJECT_ROOT = _find_project_root()
+  ```
 - **Notebooks**: Set `base_dir` using Jupyter's directory hint:
   `base_dir = Path(globals()['_dh'][0])`. Add a comment noting this uses `_dh[0]` (Jupyter's directory hint) to locate
   the notebook's directory reliably without relying on CWD.
@@ -15,9 +25,10 @@ Every script/notebook MUST include root resolution:
 
 - Scripts self-locate via `dirname "$0"` (Shell) or `Path(__file__).resolve().parent` (Python). No reliance on user's
   CWD.
-- Resolve project root via `git rev-parse --show-superproject-working-tree --show-toplevel` (take first non-empty line). This works correctly in both standalone repos and git submodules — `--show-superproject-working-tree` returns the parent project root inside a submodule (empty in standalone repos), and `--show-toplevel` returns the repo root. First non-empty line is always the correct project root.
-- `--show-cdup` is **prohibited** — it returns empty string inside submodules, causing path doubling bugs.
-- `--show-toplevel` alone is **prohibited** — inside a submodule it returns the submodule root, not the project root.
+- Resolve project root by walking up from the script's location until a directory containing `.opencode/` is found. This works correctly in both standalone repos and git submodules without relying on `git` being available or correct remote configuration.
+- `git rev-parse --show-cdup` is **prohibited** — it returns empty string inside submodules, causing path doubling bugs.
+- `git rev-parse --show-toplevel` is **prohibited** — inside a submodule it returns the submodule root, not the project root.
+- `git rev-parse --show-superproject-working-tree` is **prohibited** — it depends on git remote configuration and fails when git is unavailable or misconfigured. Walk-up-directory detection via `.opencode/` is more reliable.
 
 ## Notebook Operations — MANDATORY MCP
 
@@ -114,7 +125,7 @@ rules:
     source: "210-scripting.md §Notebook Operations"
 
   - id: scripting-004
-    title: "Scripts must self-locate and resolve project root via git rev-parse --show-superproject-working-tree --show-toplevel"
+    title: "Scripts must self-locate and resolve project root via _find_project_root walk-up"
     conditions:
       all:
         - "script_created == true"
@@ -127,10 +138,12 @@ rules:
     source: "210-scripting.md §Script Headers, Self-Location"
 
   - id: scripting-005
-    title: "Never use git rev-parse --show-cdup for root resolution (breaks in submodules)"
+    title: "Never use git rev-parse for root resolution (submodule and git-unavailable breakage)"
     conditions:
-      all:
-        - "code_contains == 'show-cdup'"
+      any:
+        - "code_contains == 'rev-parse --show-cdup'"
+        - "code_contains == 'rev-parse --show-toplevel'"
+        - "code_contains == 'rev-parse --show-superproject-working-tree'"
     actions:
       - HALT
     conflicts_with: []
@@ -139,11 +152,11 @@ rules:
     source: "210-scripting.md §Self-Location & Root Resolution"
 
   - id: scripting-006
-    title: "Never use git rev-parse --show-toplevel alone for root resolution (returns submodule root inside submodules)"
+    title: "Scripts must use _find_project_root walk-up pattern, not git commands"
     conditions:
       all:
-        - "code_contains == 'show-toplevel'"
-        - "code_not_contains == 'show-superproject-working-tree'"
+        - "script_created == true"
+        - "root_resolution_uses_git == true"
     actions:
       - HALT
     conflicts_with: []

--- a/scripts/session_context_identity.py
+++ b/scripts/session_context_identity.py
@@ -53,12 +53,11 @@ def get_remote_url() -> str | None:
 
 
 def get_root_dir() -> str | None:
-    result = run_git(["rev-parse", "--show-superproject-working-tree", "--show-toplevel"])
-    if result:
-        for line in result.splitlines():
-            line = line.strip()
-            if line:
-                return line
+    current = Path(__file__).resolve().parent
+    while current != current.parent:
+        if (current / ".opencode").is_dir():
+            return str(current)
+        current = current.parent
     return None
 
 

--- a/scripts/session_context_triggers.py
+++ b/scripts/session_context_triggers.py
@@ -23,6 +23,7 @@ import re
 import subprocess
 import sys
 from datetime import datetime
+from pathlib import Path
 
 GIT_TIMEOUT = 10
 
@@ -55,12 +56,11 @@ def get_current_branch() -> str | None:
 
 
 def get_root_dir() -> str | None:
-    result = run_git(["rev-parse", "--show-superproject-working-tree", "--show-toplevel"])
-    if result:
-        for line in result.splitlines():
-            line = line.strip()
-            if line:
-                return line
+    current = Path(__file__).resolve().parent
+    while current != current.parent:
+        if (current / ".opencode").is_dir():
+            return str(current)
+        current = current.parent
     return None
 
 

--- a/tests/regressions/regression-91-verify-structure.py
+++ b/tests/regressions/regression-91-verify-structure.py
@@ -10,15 +10,20 @@ Usage: uv run .opencode/tests/regressions/regression-91-verify-structure.py
 
 from __future__ import annotations
 
-import subprocess
+import sys
 from pathlib import Path
 
-_THIS_DIR = Path(__file__).resolve().parent
-_git_out = subprocess.check_output(
-    ["git", "-C", str(_THIS_DIR), "rev-parse", "--show-superproject-working-tree", "--show-toplevel"],
-    text=True,
-).strip()
-PROJECT_ROOT = Path(_git_out.splitlines()[0]) if _git_out.splitlines() else Path.cwd()
+
+def _find_project_root() -> Path:
+    current = Path(__file__).resolve().parent
+    while current != current.parent:
+        if (current / ".opencode").is_dir():
+            return current
+        current = current.parent
+    raise RuntimeError("Could not find project root (no .opencode/ directory found)")
+
+
+PROJECT_ROOT = _find_project_root()
 OPENCODE_DIR = PROJECT_ROOT / ".opencode"
 
 ISSUES = [41, 42, 43, 45]

--- a/tests/test-pep723-tools.sh
+++ b/tests/test-pep723-tools.sh
@@ -146,8 +146,18 @@ check_no_depth_counting_root_resolution() {
     local depth_matches
     depth_matches=$(grep -rn 'Path(__file__).resolve().parent.parent' .opencode/tools/ 2>/dev/null || true)
     if [ -n "$depth_matches" ]; then
-        echo "FAIL: Depth-counting Path.root resolution found (use git rev-parse --show-superproject-working-tree --show-toplevel per 210-scripting.md):"
+        echo "FAIL: Depth-counting Path.root resolution found (use _find_project_root per 210-scripting.md):"
         echo "$depth_matches"
+        FAIL=$((FAIL + 1))
+    else
+        PASS=$((PASS + 1))
+    fi
+
+    local depth3_matches
+    depth3_matches=$(grep -rn 'Path(__file__).resolve().parent.parent.parent' .opencode/tools/ 2>/dev/null || true)
+    if [ -n "$depth3_matches" ]; then
+        echo "FAIL: Depth-counting Path.root resolution found (use _find_project_root per 210-scripting.md):"
+        echo "$depth3_matches"
         FAIL=$((FAIL + 1))
     else
         PASS=$((PASS + 1))
@@ -156,20 +166,20 @@ check_no_depth_counting_root_resolution() {
     local dirname_matches
     dirname_matches=$(grep -rn 'os.path.dirname(os.path.dirname' .opencode/tools/ 2>/dev/null || true)
     if [ -n "$dirname_matches" ]; then
-        echo "FAIL: Depth-counting os.path.dirname root resolution found (use git rev-parse --show-superproject-working-tree --show-toplevel per 210-scripting.md):"
+        echo "FAIL: Depth-counting os.path.dirname root resolution found (use _find_project_root per 210-scripting.md):"
         echo "$dirname_matches"
         FAIL=$((FAIL + 1))
     else
         PASS=$((PASS + 1))
     fi
 
-    local script_files
-    script_files=$(find .opencode/tools -name '*.py' -o -type f -executable 2>/dev/null | grep -v '__pycache__' || true)
-    for sf in $script_files; do
-        [ -f "$sf" ] || continue
-        if grep -q 'Path(__file__).resolve().parent' "$sf"; then
-            if ! grep -qE 'show-superproject-working-tree|show-toplevel' "$sf"; then
-                echo "FAIL: $sf uses Path(__file__).resolve().parent without git rev-parse --show-superproject-working-tree --show-toplevel"
+    local all_python_files
+    all_python_files=$(find .opencode/tools -name '*.py' -o -type f -executable 2>/dev/null | grep -v '__pycache__' || true)
+    for pf in $all_python_files; do
+        [ -f "$pf" ] || continue
+        if grep -q 'Path(__file__).resolve().parent' "$pf"; then
+            if ! grep -q '_find_project_root' "$pf"; then
+                echo "FAIL: $pf uses Path(__file__).resolve().parent without _find_project_root"
                 FAIL=$((FAIL + 1))
             else
                 PASS=$((PASS + 1))
@@ -182,8 +192,8 @@ check_no_depth_counting_root_resolution() {
     for es in $entry_scripts; do
         [ -f "$es" ] || continue
         if grep -q 'Path(__file__).resolve().parent' "$es"; then
-            if ! grep -qE 'show-superproject-working-tree|show-toplevel' "$es"; then
-                echo "FAIL: $es uses Path(__file__).resolve().parent without git rev-parse --show-superproject-working-tree --show-toplevel"
+            if ! grep -q '_find_project_root' "$es"; then
+                echo "FAIL: $es uses Path(__file__).resolve().parent without _find_project_root"
                 FAIL=$((FAIL + 1))
             else
                 PASS=$((PASS + 1))
@@ -196,8 +206,8 @@ check_no_depth_counting_root_resolution() {
     for is in $impl_scripts; do
         [ -f "$is" ] || continue
         if grep -q 'Path(__file__).resolve().parent' "$is"; then
-            if ! grep -qE 'show-superproject-working-tree|show-toplevel' "$is"; then
-                echo "FAIL: $is uses Path(__file__).resolve().parent without git rev-parse --show-superproject-working-tree --show-toplevel"
+            if ! grep -q '_find_project_root' "$is"; then
+                echo "FAIL: $is uses Path(__file__).resolve().parent without _find_project_root"
                 FAIL=$((FAIL + 1))
             else
                 PASS=$((PASS + 1))

--- a/tools/file-exists
+++ b/tools/file-exists
@@ -10,13 +10,20 @@ Usage: ./.opencode/tools/file-exists <path> [<path> ...]
 """
 from __future__ import annotations
 
-import subprocess
 import sys
 from pathlib import Path
 
-BASE_DIR = Path(__file__).resolve().parent
-_git_out = subprocess.check_output(["git", "-C", str(BASE_DIR), "rev-parse", "--show-superproject-working-tree", "--show-toplevel"], text=True).strip()
-PROJECT_ROOT = Path(_git_out.splitlines()[0]) if _git_out.splitlines() else Path.cwd()
+
+def _find_project_root() -> Path:
+    current = Path(__file__).resolve().parent
+    while current != current.parent:
+        if (current / ".opencode").is_dir():
+            return current
+        current = current.parent
+    raise RuntimeError("Could not find project root (no .opencode/ directory found)")
+
+
+PROJECT_ROOT = _find_project_root()
 
 
 def main() -> None:

--- a/tools/gitbucket-api
+++ b/tools/gitbucket-api
@@ -15,9 +15,15 @@ import subprocess
 import sys
 from pathlib import Path
 
-BASE_DIR = Path(__file__).resolve().parent
-_git_out = subprocess.check_output(["git", "-C", str(BASE_DIR), "rev-parse", "--show-superproject-working-tree", "--show-toplevel"], text=True).strip()
-PROJECT_ROOT = Path(_git_out.splitlines()[0]) if _git_out.splitlines() else Path.cwd()
+def _find_project_root() -> Path:
+    current = Path(__file__).resolve().parent
+    while current != current.parent:
+        if (current / ".opencode").is_dir():
+            return current
+        current = current.parent
+    raise RuntimeError("Could not find project root (no .opencode/ directory found)")
+
+PROJECT_ROOT = _find_project_root()
 IMPL = PROJECT_ROOT / ".opencode" / "tools" / "impl" / "gitbucket_api.py"
 
 

--- a/tools/guidelines
+++ b/tools/guidelines
@@ -14,9 +14,17 @@ import subprocess
 import sys
 from pathlib import Path
 
-BASE_DIR = Path(__file__).resolve().parent
-_git_out = subprocess.check_output(["git", "-C", str(BASE_DIR), "rev-parse", "--show-superproject-working-tree", "--show-toplevel"], text=True).strip()
-PROJECT_ROOT = Path(_git_out.splitlines()[0]) if _git_out.splitlines() else Path.cwd()
+
+def _find_project_root() -> Path:
+    current = Path(__file__).resolve().parent
+    while current != current.parent:
+        if (current / ".opencode").is_dir():
+            return current
+        current = current.parent
+    raise RuntimeError("Could not find project root (no .opencode/ directory found)")
+
+
+PROJECT_ROOT = _find_project_root()
 
 ACTIONS = {
     "read": "guidelines-read",

--- a/tools/help
+++ b/tools/help
@@ -12,13 +12,20 @@ from __future__ import annotations
 
 import ast
 import os
-import subprocess
 import sys
 from pathlib import Path
 
-BASE_DIR = Path(__file__).resolve().parent
-_git_out = subprocess.check_output(["git", "-C", str(BASE_DIR), "rev-parse", "--show-superproject-working-tree", "--show-toplevel"], text=True).strip()
-PROJECT_ROOT = Path(_git_out.splitlines()[0]) if _git_out.splitlines() else Path.cwd()
+
+def _find_project_root() -> Path:
+    current = Path(__file__).resolve().parent
+    while current != current.parent:
+        if (current / ".opencode").is_dir():
+            return current
+        current = current.parent
+    raise RuntimeError("Could not find project root (no .opencode/ directory found)")
+
+
+PROJECT_ROOT = _find_project_root()
 TOOLS_DIR = Path(__file__).resolve().parent
 
 

--- a/tools/impl/gitbucket_api.py
+++ b/tools/impl/gitbucket_api.py
@@ -8,13 +8,21 @@ import argparse
 import base64
 import json
 import os
-import subprocess
 import platform
 import sys
 import urllib.error
 import urllib.request
 from pathlib import Path
 from typing import Any
+
+
+def _find_project_root() -> Path:
+    current = Path(__file__).resolve().parent
+    while current != current.parent:
+        if (current / ".opencode").is_dir():
+            return current
+        current = current.parent
+    raise RuntimeError("Could not find project root (no .opencode/ directory found)")
 
 
 class GitBucketError(Exception):
@@ -119,13 +127,8 @@ password = ""
 
 def _load_from_env_file(env_path: Path | None = None) -> dict[str, str]:
     if env_path is None:
-        _base = Path(__file__).resolve().parent
-        _git_out = subprocess.check_output(
-            ["git", "-C", str(_base), "rev-parse", "--show-superproject-working-tree", "--show-toplevel"],
-            text=True, stderr=subprocess.DEVNULL,
-        ).strip()
-        _root = _git_out.splitlines()[0] if _git_out.splitlines() else str(Path.cwd())
-        env_path = Path(_root) / ".env"
+        _root = _find_project_root()
+        env_path = _root / ".env"
     if not env_path.exists():
         return {}
     credentials = {}

--- a/tools/impl/guidelines-edit
+++ b/tools/impl/guidelines-edit
@@ -32,13 +32,20 @@ if _os.environ.get("OPENCODE_TOOLS_DISPATCHER") != "1":
     )
     __import__("sys").exit(1)
 import re
-import subprocess
 import sys
 from pathlib import Path
 
-BASE_DIR = Path(__file__).resolve().parent
-_git_out = subprocess.check_output(["git", "-C", str(BASE_DIR), "rev-parse", "--show-superproject-working-tree", "--show-toplevel"], text=True).strip()
-PROJECT_ROOT = Path(_git_out.splitlines()[0]) if _git_out.splitlines() else Path.cwd()
+
+def _find_project_root() -> Path:
+    current = Path(__file__).resolve().parent
+    while current != current.parent:
+        if (current / ".opencode").is_dir():
+            return current
+        current = current.parent
+    raise RuntimeError("Could not find project root (no .opencode/ directory found)")
+
+
+PROJECT_ROOT = _find_project_root()
 GUIDELINES_DIR = PROJECT_ROOT / ".opencode" / "guidelines"
 
 

--- a/tools/impl/guidelines-read
+++ b/tools/impl/guidelines-read
@@ -20,13 +20,19 @@ if _os.environ.get("OPENCODE_TOOLS_DISPATCHER") != "1":
         file=__import__("sys").stderr,
     )
     __import__("sys").exit(1)
-import subprocess
-import sys
 from pathlib import Path
 
-BASE_DIR = Path(__file__).resolve().parent
-_git_out = subprocess.check_output(["git", "-C", str(BASE_DIR), "rev-parse", "--show-superproject-working-tree", "--show-toplevel"], text=True).strip()
-PROJECT_ROOT = Path(_git_out.splitlines()[0]) if _git_out.splitlines() else Path.cwd()
+
+def _find_project_root() -> Path:
+    current = Path(__file__).resolve().parent
+    while current != current.parent:
+        if (current / ".opencode").is_dir():
+            return current
+        current = current.parent
+    raise RuntimeError("Could not find project root (no .opencode/ directory found)")
+
+
+PROJECT_ROOT = _find_project_root()
 GUIDELINES_DIR = PROJECT_ROOT / ".opencode" / "guidelines"
 SKILLS_DIR = PROJECT_ROOT / ".opencode" / "skills"
 

--- a/tools/impl/guidelines-search
+++ b/tools/impl/guidelines-search
@@ -34,13 +34,20 @@ if _os.environ.get("OPENCODE_TOOLS_DISPATCHER") != "1":
     __import__("sys").exit(1)
 import math
 import re
-import subprocess
 import sys
 from pathlib import Path
 
-BASE_DIR = Path(__file__).resolve().parent
-_git_out = subprocess.check_output(["git", "-C", str(BASE_DIR), "rev-parse", "--show-superproject-working-tree", "--show-toplevel"], text=True).strip()
-PROJECT_ROOT = Path(_git_out.splitlines()[0]) if _git_out.splitlines() else Path.cwd()
+
+def _find_project_root() -> Path:
+    current = Path(__file__).resolve().parent
+    while current != current.parent:
+        if (current / ".opencode").is_dir():
+            return current
+        current = current.parent
+    raise RuntimeError("Could not find project root (no .opencode/ directory found)")
+
+
+PROJECT_ROOT = _find_project_root()
 GUIDELINES_DIR = PROJECT_ROOT / ".opencode" / "guidelines"
 
 DEFAULT_TOP = 15

--- a/tools/impl/guidelines-show
+++ b/tools/impl/guidelines-show
@@ -20,13 +20,20 @@ if _os.environ.get("OPENCODE_TOOLS_DISPATCHER") != "1":
         file=__import__("sys").stderr,
     )
     __import__("sys").exit(1)
-import subprocess
 import sys
 from pathlib import Path
 
-BASE_DIR = Path(__file__).resolve().parent
-_git_out = subprocess.check_output(["git", "-C", str(BASE_DIR), "rev-parse", "--show-superproject-working-tree", "--show-toplevel"], text=True).strip()
-PROJECT_ROOT = Path(_git_out.splitlines()[0]) if _git_out.splitlines() else Path.cwd()
+
+def _find_project_root() -> Path:
+    current = Path(__file__).resolve().parent
+    while current != current.parent:
+        if (current / ".opencode").is_dir():
+            return current
+        current = current.parent
+    raise RuntimeError("Could not find project root (no .opencode/ directory found)")
+
+
+PROJECT_ROOT = _find_project_root()
 OPENCODE_DIR = PROJECT_ROOT / ".opencode"
 GUIDELINES_DIR = OPENCODE_DIR / "guidelines"
 

--- a/tools/impl/jupyter-start
+++ b/tools/impl/jupyter-start
@@ -23,9 +23,15 @@ import sys
 import time
 from pathlib import Path
 
-BASE_DIR = Path(__file__).resolve().parent
-_git_out = subprocess.check_output(["git", "-C", str(BASE_DIR), "rev-parse", "--show-superproject-working-tree", "--show-toplevel"], text=True).strip()
-PROJECT_ROOT = Path(_git_out.splitlines()[0]) if _git_out.splitlines() else Path.cwd()
+def _find_project_root() -> Path:
+    current = Path(__file__).resolve().parent
+    while current != current.parent:
+        if (current / ".opencode").is_dir():
+            return current
+        current = current.parent
+    raise RuntimeError("Could not find project root (no .opencode/ directory found)")
+
+PROJECT_ROOT = _find_project_root()
 PORT = 18888
 LOG_FILE = PROJECT_ROOT / "tmp" / "jupyter.log"
 

--- a/tools/impl/jupyter-stop
+++ b/tools/impl/jupyter-stop
@@ -23,9 +23,15 @@ import sys
 import time
 from pathlib import Path
 
-BASE_DIR = Path(__file__).resolve().parent
-_git_out = subprocess.check_output(["git", "-C", str(BASE_DIR), "rev-parse", "--show-superproject-working-tree", "--show-toplevel"], text=True).strip()
-PROJECT_ROOT = Path(_git_out.splitlines()[0]) if _git_out.splitlines() else Path.cwd()
+def _find_project_root() -> Path:
+    current = Path(__file__).resolve().parent
+    while current != current.parent:
+        if (current / ".opencode").is_dir():
+            return current
+        current = current.parent
+    raise RuntimeError("Could not find project root (no .opencode/ directory found)")
+
+PROJECT_ROOT = _find_project_root()
 PORT = 18888
 
 

--- a/tools/impl/memory-clear
+++ b/tools/impl/memory-clear
@@ -13,13 +13,20 @@ if _os.environ.get("OPENCODE_TOOLS_DISPATCHER") != "1":
     print("ERROR: This script must be run via its dispatcher (e.g. ./.opencode/tools/memory ...). "
           "Direct invocation is not permitted.", file=__import__('sys').stderr)
     __import__('sys').exit(1)
-import subprocess
 import sys
 from pathlib import Path
 
 BASE_DIR = Path(__file__).resolve().parent
-_git_out = subprocess.check_output(["git", "-C", str(BASE_DIR), "rev-parse", "--show-superproject-working-tree", "--show-toplevel"], text=True).strip()
-PROJECT_ROOT = Path(_git_out.splitlines()[0]) if _git_out.splitlines() else Path.cwd()
+
+def _find_project_root() -> Path:
+    current = Path(__file__).resolve().parent
+    while current != current.parent:
+        if (current / ".opencode").is_dir():
+            return current
+        current = current.parent
+    raise RuntimeError("Could not find project root (no .opencode/ directory found)")
+
+PROJECT_ROOT = _find_project_root()
 MEMORY_FILE = PROJECT_ROOT / ".opencode" / "memory.md"
 
 SESSION_HEADER = "## Session State"

--- a/tools/impl/memory-read
+++ b/tools/impl/memory-read
@@ -13,13 +13,21 @@ if _os.environ.get("OPENCODE_TOOLS_DISPATCHER") != "1":
     print("ERROR: This script must be run via its dispatcher (e.g. ./.opencode/tools/memory ...). "
           "Direct invocation is not permitted.", file=__import__('sys').stderr)
     __import__('sys').exit(1)
-import subprocess
 import sys
 from pathlib import Path
 
+
+def _find_project_root() -> Path:
+    current = Path(__file__).resolve().parent
+    while current != current.parent:
+        if (current / ".opencode").is_dir():
+            return current
+        current = current.parent
+    raise RuntimeError("Could not find project root (no .opencode/ directory found)")
+
+
 BASE_DIR = Path(__file__).resolve().parent
-_git_out = subprocess.check_output(["git", "-C", str(BASE_DIR), "rev-parse", "--show-superproject-working-tree", "--show-toplevel"], text=True).strip()
-PROJECT_ROOT = Path(_git_out.splitlines()[0]) if _git_out.splitlines() else Path.cwd()
+PROJECT_ROOT = _find_project_root()
 MEMORY_FILE = PROJECT_ROOT / ".opencode" / "memory.md"
 
 

--- a/tools/impl/memory-update
+++ b/tools/impl/memory-update
@@ -17,13 +17,22 @@ if _os.environ.get("OPENCODE_TOOLS_DISPATCHER") != "1":
     print("ERROR: This script must be run via its dispatcher (e.g. ./.opencode/tools/memory ...). "
           "Direct invocation is not permitted.", file=__import__('sys').stderr)
     __import__('sys').exit(1)
-import subprocess
 import sys
 from pathlib import Path
 
 BASE_DIR = Path(__file__).resolve().parent
-_git_out = subprocess.check_output(["git", "-C", str(BASE_DIR), "rev-parse", "--show-superproject-working-tree", "--show-toplevel"], text=True).strip()
-PROJECT_ROOT = Path(_git_out.splitlines()[0]) if _git_out.splitlines() else Path.cwd()
+
+
+def _find_project_root() -> Path:
+    current = Path(__file__).resolve().parent
+    while current != current.parent:
+        if (current / ".opencode").is_dir():
+            return current
+        current = current.parent
+    raise RuntimeError("Could not find project root (no .opencode/ directory found)")
+
+
+PROJECT_ROOT = _find_project_root()
 MEMORY_FILE = PROJECT_ROOT / ".opencode" / "memory.md"
 
 SECTION_HEADERS = {

--- a/tools/impl/memory-write
+++ b/tools/impl/memory-write
@@ -14,13 +14,22 @@ if _os.environ.get("OPENCODE_TOOLS_DISPATCHER") != "1":
     print("ERROR: This script must be run via its dispatcher (e.g. ./.opencode/tools/memory ...). "
           "Direct invocation is not permitted.", file=__import__('sys').stderr)
     __import__('sys').exit(1)
-import subprocess
 import sys
 from pathlib import Path
 
 BASE_DIR = Path(__file__).resolve().parent
-_git_out = subprocess.check_output(["git", "-C", str(BASE_DIR), "rev-parse", "--show-superproject-working-tree", "--show-toplevel"], text=True).strip()
-PROJECT_ROOT = Path(_git_out.splitlines()[0]) if _git_out.splitlines() else Path.cwd()
+
+
+def _find_project_root() -> Path:
+    current = Path(__file__).resolve().parent
+    while current != current.parent:
+        if (current / ".opencode").is_dir():
+            return current
+        current = current.parent
+    raise RuntimeError("Could not find project root (no .opencode/ directory found)")
+
+
+PROJECT_ROOT = _find_project_root()
 MEMORY_FILE = PROJECT_ROOT / ".opencode" / "memory.md"
 
 

--- a/tools/impl/py-ls
+++ b/tools/impl/py-ls
@@ -18,13 +18,20 @@ if _os.environ.get("OPENCODE_TOOLS_DISPATCHER") != "1":
     print("ERROR: This script must be run via its dispatcher (e.g. ./.opencode/tools/py ...). "
           "Direct invocation is not permitted.", file=__import__('sys').stderr)
     __import__('sys').exit(1)
-import subprocess
 import sys
 from pathlib import Path
 
-BASE_DIR = Path(__file__).resolve().parent
-_git_out = subprocess.check_output(["git", "-C", str(BASE_DIR), "rev-parse", "--show-superproject-working-tree", "--show-toplevel"], text=True).strip()
-PROJECT_ROOT = Path(_git_out.splitlines()[0]) if _git_out.splitlines() else Path.cwd()
+
+def _find_project_root() -> Path:
+    current = Path(__file__).resolve().parent
+    while current != current.parent:
+        if (current / ".opencode").is_dir():
+            return current
+        current = current.parent
+    raise RuntimeError("Could not find project root (no .opencode/ directory found)")
+
+
+PROJECT_ROOT = _find_project_root()
 
 
 def is_package(p: Path) -> bool:

--- a/tools/impl/py-mkpkg
+++ b/tools/impl/py-mkpkg
@@ -15,13 +15,20 @@ if _os.environ.get("OPENCODE_TOOLS_DISPATCHER") != "1":
     print("ERROR: This script must be run via its dispatcher (e.g. ./.opencode/tools/py ...). "
           "Direct invocation is not permitted.", file=__import__('sys').stderr)
     __import__('sys').exit(1)
-import subprocess
 import sys
 from pathlib import Path
 
-BASE_DIR = Path(__file__).resolve().parent
-_git_out = subprocess.check_output(["git", "-C", str(BASE_DIR), "rev-parse", "--show-superproject-working-tree", "--show-toplevel"], text=True).strip()
-PROJECT_ROOT = Path(_git_out.splitlines()[0]) if _git_out.splitlines() else Path.cwd()
+
+def _find_project_root() -> Path:
+    current = Path(__file__).resolve().parent
+    while current != current.parent:
+        if (current / ".opencode").is_dir():
+            return current
+        current = current.parent
+    raise RuntimeError("Could not find project root (no .opencode/ directory found)")
+
+
+PROJECT_ROOT = _find_project_root()
 
 
 def make_package(rel_path: str) -> None:

--- a/tools/impl/skildeck/schema_v2.py
+++ b/tools/impl/skildeck/schema_v2.py
@@ -12,12 +12,21 @@ from __future__ import annotations
 
 import os
 import re
-import subprocess
 from dataclasses import dataclass, field, asdict
 from pathlib import Path
 
 SCHEMA_V1 = "1.0"
 SCHEMA_V2 = "2.0"
+
+def _find_project_root() -> Path:
+    current = Path(__file__).resolve().parent
+    while current != current.parent:
+        if (current / ".opencode").is_dir():
+            return current
+        current = current.parent
+    raise RuntimeError("Could not find project root (no .opencode/ directory found)")
+
+PROJECT_ROOT = _find_project_root()
 
 FENCE_PATTERN = re.compile(r"```yaml\+symbolic\n(.*?)```", re.DOTALL)
 
@@ -44,18 +53,10 @@ def find_skills_dir(tool_path: Path) -> Path:
         if candidate.exists() and candidate.is_dir():
             return candidate
     
-    # 2. Git-based detection: find project root and look for .opencode/skills/
-    try:
-        _git_out = subprocess.check_output(
-            ["git", "-C", str(tool_path.parent), "rev-parse", "--show-superproject-working-tree", "--show-toplevel"],
-            text=True, stderr=subprocess.DEVNULL,
-        ).strip()
-        if _git_out.splitlines():
-            candidate = Path(_git_out.splitlines()[0]) / ".opencode" / "skills"
-            if candidate.exists() and candidate.is_dir():
-                return candidate
-    except (subprocess.CalledProcessError, FileNotFoundError):
-        pass
+    # 2. Project root detection: find .opencode/skills/ via walk-up
+    candidate = PROJECT_ROOT / ".opencode" / "skills"
+    if candidate.exists() and candidate.is_dir():
+        return candidate
     
     # 3. Environment override (explicit user control for edge cases)
     if os.environ.get("SKILDECK_SKILLS_DIR"):

--- a/tools/impl/sym-analyze
+++ b/tools/impl/sym-analyze
@@ -10,17 +10,25 @@ Usage: ./.opencode/tools/symbolic analyze [--dir PATH] [--output PATH] [--verbos
 
 from __future__ import annotations
 import os as _os
-import subprocess
 import sys
 import types
 import json
 from pathlib import Path
 
+
+def _find_project_root() -> Path:
+    current = Path(__file__).resolve().parent
+    while current != current.parent:
+        if (current / ".opencode").is_dir():
+            return current
+        current = current.parent
+    raise RuntimeError("Could not find project root (no .opencode/ directory found)")
+
+
 IMPL_DIR = Path(__file__).resolve().parent
-_git_out = subprocess.check_output(["git", "-C", str(IMPL_DIR), "rev-parse", "--show-superproject-working-tree", "--show-toplevel"], text=True).strip()
-BASE_DIR = Path(_git_out.splitlines()[0]) if _git_out.splitlines() else Path.cwd()
-DEFAULT_SCAN_DIR = BASE_DIR / ".opencode"
-DEFAULT_OUTPUT_DIR = BASE_DIR / "tmp"
+PROJECT_ROOT = _find_project_root()
+DEFAULT_SCAN_DIR = PROJECT_ROOT / ".opencode"
+DEFAULT_OUTPUT_DIR = PROJECT_ROOT / "tmp"
 
 
 def _load_module(module_file: str):

--- a/tools/impl/sym-complete
+++ b/tools/impl/sym-complete
@@ -11,15 +11,23 @@ Usage: ./.opencode/tools/symbolic complete
 from __future__ import annotations
 import os as _os
 import re
-import subprocess
 import sys
 import types
 from dataclasses import dataclass
 from pathlib import Path
 
+
+def _find_project_root() -> Path:
+    current = Path(__file__).resolve().parent
+    while current != current.parent:
+        if (current / ".opencode").is_dir():
+            return current
+        current = current.parent
+    raise RuntimeError("Could not find project root (no .opencode/ directory found)")
+
+
 IMPL_DIR = Path(__file__).resolve().parent
-_git_out = subprocess.check_output(["git", "-C", str(IMPL_DIR), "rev-parse", "--show-superproject-working-tree", "--show-toplevel"], text=True).strip()
-BASE_DIR = Path(_git_out.splitlines()[0]) if _git_out.splitlines() else Path.cwd()
+BASE_DIR = _find_project_root()
 NORMATIVE_RE = re.compile(r"\b(MUST|SHALL|NEVER|ALWAYS|REQUIRED|FORBIDDEN)\b")
 YAML_FENCE_RE = re.compile(r"```yaml\+symbolic\n.*?```", re.DOTALL)
 

--- a/tools/impl/sym-conflicts
+++ b/tools/impl/sym-conflicts
@@ -10,14 +10,22 @@ Usage: ./.opencode/tools/symbolic conflicts
 
 from __future__ import annotations
 import os as _os
-import subprocess
 import sys
 from dataclasses import dataclass
 from pathlib import Path
 
+
+def _find_project_root() -> Path:
+    current = Path(__file__).resolve().parent
+    while current != current.parent:
+        if (current / ".opencode").is_dir():
+            return current
+        current = current.parent
+    raise RuntimeError("Could not find project root (no .opencode/ directory found)")
+
+
+PROJECT_ROOT = _find_project_root()
 IMPL_DIR = Path(__file__).resolve().parent
-_git_out = subprocess.check_output(["git", "-C", str(IMPL_DIR), "rev-parse", "--show-superproject-working-tree", "--show-toplevel"], text=True).strip()
-BASE_DIR = Path(_git_out.splitlines()[0]) if _git_out.splitlines() else Path.cwd()
 
 from sympy import Symbol
 from sympy.logic.inference import satisfiable
@@ -203,7 +211,7 @@ def main() -> None:
     import argparse
 
     parser = argparse.ArgumentParser(description="Detect conflicts")
-    parser.add_argument("--dir", type=str, default=str(BASE_DIR / ".opencode"))
+    parser.add_argument("--dir", type=str, default=str(PROJECT_ROOT / ".opencode"))
     args = parser.parse_args()
 
     mod = _load_extract()

--- a/tools/impl/sym-decomposition
+++ b/tools/impl/sym-decomposition
@@ -12,18 +12,24 @@ from __future__ import annotations
 
 import json
 import os as _os
-import subprocess
 import sys
 import types
 from dataclasses import dataclass, asdict
 from pathlib import Path
 
+
+def _find_project_root() -> Path:
+    current = Path(__file__).resolve().parent
+    while current != current.parent:
+        if (current / ".opencode").is_dir():
+            return current
+        current = current.parent
+    raise RuntimeError("Could not find project root (no .opencode/ directory found)")
+
+
 IMPL_DIR = Path(__file__).resolve().parent
-_git_out = subprocess.check_output(
-    ["git", "-C", str(IMPL_DIR), "rev-parse", "--show-superproject-working-tree", "--show-toplevel"], text=True
-).strip()
-BASE_DIR = Path(_git_out.splitlines()[0]) if _git_out.splitlines() else Path.cwd()
-DEFAULT_SCAN_DIR = BASE_DIR / ".opencode"
+PROJECT_ROOT = _find_project_root()
+DEFAULT_SCAN_DIR = PROJECT_ROOT / ".opencode"
 
 
 def _load_module(module_file: str):

--- a/tools/impl/sym-drift
+++ b/tools/impl/sym-drift
@@ -11,15 +11,24 @@ Usage: ./.opencode/tools/symbolic drift
 from __future__ import annotations
 import os as _os
 import re
-import subprocess
 import sys
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
 
 BASE_DIR = Path(__file__).resolve().parent
-_git_out = subprocess.check_output(["git", "-C", str(BASE_DIR), "rev-parse", "--show-superproject-working-tree", "--show-toplevel"], text=True).strip()
-PROJECT_ROOT = Path(_git_out.splitlines()[0]) if _git_out.splitlines() else Path.getcwd()
+
+
+def _find_project_root() -> Path:
+    current = Path(__file__).resolve().parent
+    while current != current.parent:
+        if (current / ".opencode").is_dir():
+            return current
+        current = current.parent
+    raise RuntimeError("Could not find project root (no .opencode/ directory found)")
+
+
+PROJECT_ROOT = _find_project_root()
 FENCE_PATTERN = re.compile(r"```yaml\+symbolic\n(.*?)```", re.DOTALL)
 
 

--- a/tools/impl/sym-enforcement
+++ b/tools/impl/sym-enforcement
@@ -13,18 +13,25 @@ from __future__ import annotations
 import json
 import os as _os
 import re
-import subprocess
 import sys
 import types
 from dataclasses import dataclass, field, asdict
 from pathlib import Path
 
 IMPL_DIR = Path(__file__).resolve().parent
-_git_out = subprocess.check_output(
-    ["git", "-C", str(IMPL_DIR), "rev-parse", "--show-superproject-working-tree", "--show-toplevel"], text=True
-).strip()
-BASE_DIR = Path(_git_out.splitlines()[0]) if _git_out.splitlines() else Path.cwd()
-DEFAULT_SCAN_DIR = BASE_DIR / ".opencode"
+
+
+def _find_project_root() -> Path:
+    current = Path(__file__).resolve().parent
+    while current != current.parent:
+        if (current / ".opencode").is_dir():
+            return current
+        current = current.parent
+    raise RuntimeError("Could not find project root (no .opencode/ directory found)")
+
+
+PROJECT_ROOT = _find_project_root()
+DEFAULT_SCAN_DIR = PROJECT_ROOT / ".opencode"
 
 
 def _load_module(module_file: str):

--- a/tools/impl/sym-entailment
+++ b/tools/impl/sym-entailment
@@ -12,18 +12,25 @@ from __future__ import annotations
 
 import json
 import os as _os
-import subprocess
 import sys
 import types
 from dataclasses import dataclass, asdict
 from pathlib import Path
 
 IMPL_DIR = Path(__file__).resolve().parent
-_git_out = subprocess.check_output(
-    ["git", "-C", str(IMPL_DIR), "rev-parse", "--show-superproject-working-tree", "--show-toplevel"], text=True
-).strip()
-BASE_DIR = Path(_git_out.splitlines()[0]) if _git_out.splitlines() else Path.cwd()
-DEFAULT_SCAN_DIR = BASE_DIR / ".opencode"
+
+
+def _find_project_root() -> Path:
+    current = Path(__file__).resolve().parent
+    while current != current.parent:
+        if (current / ".opencode").is_dir():
+            return current
+        current = current.parent
+    raise RuntimeError("Could not find project root (no .opencode/ directory found)")
+
+
+PROJECT_ROOT = _find_project_root()
+DEFAULT_SCAN_DIR = PROJECT_ROOT / ".opencode"
 
 
 def _load_module(module_file: str):

--- a/tools/impl/sym-exhaustive
+++ b/tools/impl/sym-exhaustive
@@ -12,17 +12,25 @@ from __future__ import annotations
 
 import json
 import os as _os
-import subprocess
 import sys
 import types
 from dataclasses import dataclass, field, asdict
 from pathlib import Path
 
 IMPL_DIR = Path(__file__).resolve().parent
-_git_out = subprocess.check_output(
-    ["git", "-C", str(IMPL_DIR), "rev-parse", "--show-superproject-working-tree", "--show-toplevel"], text=True
-).strip()
-BASE_DIR = Path(_git_out.splitlines()[0]) if _git_out.splitlines() else Path.cwd()
+
+
+def _find_project_root() -> Path:
+    current = Path(__file__).resolve().parent
+    while current != current.parent:
+        if (current / ".opencode").is_dir():
+            return current
+        current = current.parent
+    raise RuntimeError("Could not find project root (no .opencode/ directory found)")
+
+
+PROJECT_ROOT = _find_project_root()
+BASE_DIR = PROJECT_ROOT
 DEFAULT_SCAN_DIR = BASE_DIR / ".opencode"
 
 

--- a/tools/impl/sym-extract
+++ b/tools/impl/sym-extract
@@ -13,16 +13,23 @@ from __future__ import annotations
 import json
 import os as _os
 import re
-import subprocess
 import sys
 from dataclasses import dataclass, field, asdict
 from pathlib import Path
 
 IMPL_DIR = Path(__file__).resolve().parent
-_git_out = subprocess.check_output(
-    ["git", "-C", str(IMPL_DIR), "rev-parse", "--show-superproject-working-tree", "--show-toplevel"], text=True
-).strip()
-PROJECT_ROOT = Path(_git_out.splitlines()[0]) if _git_out.splitlines() else Path.cwd()
+
+
+def _find_project_root() -> Path:
+    current = Path(__file__).resolve().parent
+    while current != current.parent:
+        if (current / ".opencode").is_dir():
+            return current
+        current = current.parent
+    raise RuntimeError("Could not find project root (no .opencode/ directory found)")
+
+
+PROJECT_ROOT = _find_project_root()
 DEFAULT_SCAN_DIR = PROJECT_ROOT / ".opencode"
 
 SCHEMA_V1 = "1.0"

--- a/tools/impl/sym-extract-dot
+++ b/tools/impl/sym-extract-dot
@@ -11,15 +11,23 @@ Usage: ./.opencode/tools/symbolic extract-dot
 from __future__ import annotations
 import os as _os
 import re
-import subprocess
 import sys
 from pathlib import Path
 
 import networkx as nx
 
+
+def _find_project_root() -> Path:
+    current = Path(__file__).resolve().parent
+    while current != current.parent:
+        if (current / ".opencode").is_dir():
+            return current
+        current = current.parent
+    raise RuntimeError("Could not find project root (no .opencode/ directory found)")
+
+
 BASE_DIR = Path(__file__).resolve().parent
-_git_out = subprocess.check_output(["git", "-C", str(BASE_DIR), "rev-parse", "--show-superproject-working-tree", "--show-toplevel"], text=True).strip()
-PROJECT_ROOT = Path(_git_out.splitlines()[0]) if _git_out.splitlines() else Path.cwd()
+PROJECT_ROOT = _find_project_root()
 DIGRAPH_PATTERN = re.compile(r"```(?:dot|digraph)\s*\n(.*?)```", re.DOTALL)
 
 

--- a/tools/impl/sym-flow
+++ b/tools/impl/sym-flow
@@ -10,7 +10,6 @@ Usage: ./.opencode/tools/symbolic flow
 
 from __future__ import annotations
 import os as _os
-import subprocess
 import sys
 import types
 from dataclasses import dataclass
@@ -19,8 +18,18 @@ from pathlib import Path
 import networkx as nx
 
 IMPL_DIR = Path(__file__).resolve().parent
-_git_out = subprocess.check_output(["git", "-C", str(IMPL_DIR), "rev-parse", "--show-superproject-working-tree", "--show-toplevel"], text=True).strip()
-BASE_DIR = Path(_git_out.splitlines()[0]) if _git_out.splitlines() else Path.cwd()
+
+
+def _find_project_root() -> Path:
+    current = Path(__file__).resolve().parent
+    while current != current.parent:
+        if (current / ".opencode").is_dir():
+            return current
+        current = current.parent
+    raise RuntimeError("Could not find project root (no .opencode/ directory found)")
+
+
+PROJECT_ROOT = _find_project_root()
 
 
 def _load_extract():
@@ -115,7 +124,7 @@ def main() -> None:
     import argparse
 
     parser = argparse.ArgumentParser(description="Flow analysis")
-    parser.add_argument("--dir", type=str, default=str(BASE_DIR / ".opencode"))
+    parser.add_argument("--dir", type=str, default=str(PROJECT_ROOT / ".opencode"))
     args = parser.parse_args()
 
     mod = _load_extract()

--- a/tools/impl/sym-guards
+++ b/tools/impl/sym-guards
@@ -12,18 +12,25 @@ from __future__ import annotations
 
 import json
 import os as _os
-import subprocess
 import sys
 import types
 from dataclasses import dataclass, field, asdict
 from pathlib import Path
 
 IMPL_DIR = Path(__file__).resolve().parent
-_git_out = subprocess.check_output(
-    ["git", "-C", str(IMPL_DIR), "rev-parse", "--show-superproject-working-tree", "--show-toplevel"], text=True
-).strip()
-BASE_DIR = Path(_git_out.splitlines()[0]) if _git_out.splitlines() else Path.cwd()
-DEFAULT_SCAN_DIR = BASE_DIR / ".opencode"
+
+
+def _find_project_root() -> Path:
+    current = Path(__file__).resolve().parent
+    while current != current.parent:
+        if (current / ".opencode").is_dir():
+            return current
+        current = current.parent
+    raise RuntimeError("Could not find project root (no .opencode/ directory found)")
+
+
+PROJECT_ROOT = _find_project_root()
+DEFAULT_SCAN_DIR = PROJECT_ROOT / ".opencode"
 
 
 def _load_module(module_file: str):

--- a/tools/impl/sym-report
+++ b/tools/impl/sym-report
@@ -20,8 +20,19 @@ from pathlib import Path
 import networkx as nx
 
 IMPL_DIR = Path(__file__).resolve().parent
-_git_out = subprocess.check_output(["git", "-C", str(IMPL_DIR), "rev-parse", "--show-superproject-working-tree", "--show-toplevel"], text=True).strip()
-BASE_DIR = Path(_git_out.splitlines()[0]) if _git_out.splitlines() else Path.cwd()
+
+
+def _find_project_root() -> Path:
+    current = Path(__file__).resolve().parent
+    while current != current.parent:
+        if (current / ".opencode").is_dir():
+            return current
+        current = current.parent
+    raise RuntimeError("Could not find project root (no .opencode/ directory found)")
+
+
+PROJECT_ROOT = _find_project_root()
+BASE_DIR = PROJECT_ROOT
 DEFAULT_OUTPUT = BASE_DIR / "tmp"
 
 

--- a/tools/impl/sym-states
+++ b/tools/impl/sym-states
@@ -10,7 +10,6 @@ Usage: ./.opencode/tools/symbolic states
 
 from __future__ import annotations
 import os as _os
-import subprocess
 import sys
 import types
 from dataclasses import dataclass
@@ -19,8 +18,19 @@ from pathlib import Path
 import networkx as nx
 
 IMPL_DIR = Path(__file__).resolve().parent
-_git_out = subprocess.check_output(["git", "-C", str(IMPL_DIR), "rev-parse", "--show-superproject-working-tree", "--show-toplevel"], text=True).strip()
-BASE_DIR = Path(_git_out.splitlines()[0]) if _git_out.splitlines() else Path.cwd()
+
+
+def _find_project_root() -> Path:
+    current = Path(__file__).resolve().parent
+    while current != current.parent:
+        if (current / ".opencode").is_dir():
+            return current
+        current = current.parent
+    raise RuntimeError("Could not find project root (no .opencode/ directory found)")
+
+
+PROJECT_ROOT = _find_project_root()
+BASE_DIR = PROJECT_ROOT
 
 
 def _load_extract():

--- a/tools/impl/sym-triggers
+++ b/tools/impl/sym-triggers
@@ -13,17 +13,20 @@ from __future__ import annotations
 import json
 import os as _os
 import re
-import subprocess
 import sys
 from collections import defaultdict
 from dataclasses import dataclass, field, asdict
 from pathlib import Path
 
-IMPL_DIR = Path(__file__).resolve().parent
-_git_out = subprocess.check_output(
-    ["git", "-C", str(IMPL_DIR), "rev-parse", "--show-superproject-working-tree", "--show-toplevel"], text=True
-).strip()
-PROJECT_ROOT = Path(_git_out.splitlines()[0]) if _git_out.splitlines() else Path.cwd()
+def _find_project_root() -> Path:
+    current = Path(__file__).resolve().parent
+    while current != current.parent:
+        if (current / ".opencode").is_dir():
+            return current
+        current = current.parent
+    raise RuntimeError("Could not find project root (no .opencode/ directory found)")
+
+PROJECT_ROOT = _find_project_root()
 SKILLS_DIR = PROJECT_ROOT / ".opencode" / "skills"
 
 

--- a/tools/jupyter
+++ b/tools/jupyter
@@ -14,9 +14,15 @@ import subprocess
 import sys
 from pathlib import Path
 
-BASE_DIR = Path(__file__).resolve().parent
-_git_out = subprocess.check_output(["git", "-C", str(BASE_DIR), "rev-parse", "--show-superproject-working-tree", "--show-toplevel"], text=True).strip()
-PROJECT_ROOT = Path(_git_out.splitlines()[0]) if _git_out.splitlines() else Path.cwd()
+def _find_project_root() -> Path:
+    current = Path(__file__).resolve().parent
+    while current != current.parent:
+        if (current / ".opencode").is_dir():
+            return current
+        current = current.parent
+    raise RuntimeError("Could not find project root (no .opencode/ directory found)")
+
+PROJECT_ROOT = _find_project_root()
 
 ACTIONS = {
     "start": "jupyter-start",

--- a/tools/jupyter-start
+++ b/tools/jupyter-start
@@ -18,9 +18,15 @@ import sys
 import time
 from pathlib import Path
 
-BASE_DIR = Path(__file__).resolve().parent
-_git_out = subprocess.check_output(["git", "-C", str(BASE_DIR), "rev-parse", "--show-superproject-working-tree", "--show-toplevel"], text=True).strip()
-PROJECT_ROOT = Path(_git_out.splitlines()[0]) if _git_out.splitlines() else Path.cwd()
+def _find_project_root() -> Path:
+    current = Path(__file__).resolve().parent
+    while current != current.parent:
+        if (current / ".opencode").is_dir():
+            return current
+        current = current.parent
+    raise RuntimeError("Could not find project root (no .opencode/ directory found)")
+
+PROJECT_ROOT = _find_project_root()
 PORT = 18888
 LOG_FILE = PROJECT_ROOT / "tmp" / "jupyter.log"
 

--- a/tools/jupyter-stop
+++ b/tools/jupyter-stop
@@ -18,9 +18,17 @@ import sys
 import time
 from pathlib import Path
 
-BASE_DIR = Path(__file__).resolve().parent
-_git_out = subprocess.check_output(["git", "-C", str(BASE_DIR), "rev-parse", "--show-superproject-working-tree", "--show-toplevel"], text=True).strip()
-PROJECT_ROOT = Path(_git_out.splitlines()[0]) if _git_out.splitlines() else Path.cwd()
+
+def _find_project_root() -> Path:
+    current = Path(__file__).resolve().parent
+    while current != current.parent:
+        if (current / ".opencode").is_dir():
+            return current
+        current = current.parent
+    raise RuntimeError("Could not find project root (no .opencode/ directory found)")
+
+
+PROJECT_ROOT = _find_project_root()
 PORT = 18888
 
 

--- a/tools/md
+++ b/tools/md
@@ -14,9 +14,15 @@ import subprocess
 import sys
 from pathlib import Path
 
-BASE_DIR = Path(__file__).resolve().parent
-_git_out = subprocess.check_output(["git", "-C", str(BASE_DIR), "rev-parse", "--show-superproject-working-tree", "--show-toplevel"], text=True).strip()
-PROJECT_ROOT = Path(_git_out.splitlines()[0]) if _git_out.splitlines() else Path.cwd()
+def _find_project_root() -> Path:
+    current = Path(__file__).resolve().parent
+    while current != current.parent:
+        if (current / ".opencode").is_dir():
+            return current
+        current = current.parent
+    raise RuntimeError("Could not find project root (no .opencode/ directory found)")
+
+PROJECT_ROOT = _find_project_root()
 
 ACTIONS = {
     "read": "md-read",

--- a/tools/memory
+++ b/tools/memory
@@ -14,9 +14,15 @@ import subprocess
 import sys
 from pathlib import Path
 
-BASE_DIR = Path(__file__).resolve().parent
-_git_out = subprocess.check_output(["git", "-C", str(BASE_DIR), "rev-parse", "--show-superproject-working-tree", "--show-toplevel"], text=True).strip()
-PROJECT_ROOT = Path(_git_out.splitlines()[0]) if _git_out.splitlines() else Path.cwd()
+def _find_project_root() -> Path:
+    current = Path(__file__).resolve().parent
+    while current != current.parent:
+        if (current / ".opencode").is_dir():
+            return current
+        current = current.parent
+    raise RuntimeError("Could not find project root (no .opencode/ directory found)")
+
+PROJECT_ROOT = _find_project_root()
 
 ACTIONS = {
     "read": "memory-read",

--- a/tools/py
+++ b/tools/py
@@ -15,9 +15,15 @@ import subprocess
 import sys
 from pathlib import Path
 
-BASE_DIR = Path(__file__).resolve().parent
-_git_out = subprocess.check_output(["git", "-C", str(BASE_DIR), "rev-parse", "--show-superproject-working-tree", "--show-toplevel"], text=True).strip()
-PROJECT_ROOT = Path(_git_out.splitlines()[0]) if _git_out.splitlines() else Path.cwd()
+def _find_project_root() -> Path:
+    current = Path(__file__).resolve().parent
+    while current != current.parent:
+        if (current / ".opencode").is_dir():
+            return current
+        current = current.parent
+    raise RuntimeError("Could not find project root (no .opencode/ directory found)")
+
+PROJECT_ROOT = _find_project_root()
 
 ACTIONS = {
     "ls": "py-ls",

--- a/tools/session-init
+++ b/tools/session-init
@@ -61,9 +61,19 @@ import re
 import shutil
 import subprocess
 import sys
+from pathlib import Path
 
 GIT_TIMEOUT = 10
 NETWORK_TIMEOUT = 5
+
+
+def _find_project_root() -> Path:
+    current = Path(__file__).resolve().parent
+    while current != current.parent:
+        if (current / ".opencode").is_dir():
+            return current
+        current = current.parent
+    raise RuntimeError("Could not find project root (no .opencode/ directory found)")
 
 
 def run_git_command(args: list[str]) -> str | None:
@@ -187,14 +197,7 @@ def parse_gitbucket_url(
 def _read_gitbucket_url_from_env() -> str | None:
     """Read GITBUCKET_HTML_URL (preferred) or GITBUCKET_URL (legacy) from .env file."""
     try:
-        _base_dir = os.path.dirname(os.path.abspath(__file__))
-        _git_out = subprocess.check_output(
-            ["git", "-C", _base_dir, "rev-parse", "--show-superproject-working-tree", "--show-toplevel"],
-            text=True,
-            stdin=subprocess.DEVNULL,
-            timeout=NETWORK_TIMEOUT,
-        ).strip()
-        _root = _git_out.splitlines()[0] if _git_out.splitlines() else os.getcwd()
+        _root = str(_find_project_root())
         env_path = os.path.join(_root, ".env")
         if os.path.exists(env_path):
             html_url = None
@@ -881,15 +884,7 @@ def main() -> int:
             print(f"gitbucket.ssh_url: {ssh_url}")
         has_credentials = False
         try:
-            _base_dir = os.path.dirname(os.path.abspath(__file__))
-            _git_out = subprocess.check_output(
-                ["git", "-C", _base_dir, "rev-parse", "--show-superproject-working-tree", "--show-toplevel"],
-                text=True,
-                stdin=subprocess.DEVNULL,
-                timeout=NETWORK_TIMEOUT,
-            ).strip()
-            _root = _git_out.splitlines()[0] if _git_out.splitlines() else os.getcwd()
-            env_path = os.path.join(_root, ".env")
+            env_path = os.path.join(str(_find_project_root()), ".env")
             if os.path.exists(env_path):
                 with open(env_path) as f:
                     content = f.read()

--- a/tools/skildeck
+++ b/tools/skildeck
@@ -24,11 +24,17 @@ import subprocess
 import sys
 from pathlib import Path
 
+def _find_project_root() -> Path:
+    current = Path(__file__).resolve().parent
+    while current != current.parent:
+        if (current / ".opencode").is_dir():
+            return current
+        current = current.parent
+    raise RuntimeError("Could not find project root (no .opencode/ directory found)")
+
+
 BASE_DIR = Path(__file__).resolve().parent
-_git_out = subprocess.check_output(
-    ["git", "-C", str(BASE_DIR), "rev-parse", "--show-superproject-working-tree", "--show-toplevel"], text=True
-).strip()
-PROJECT_ROOT = Path(_git_out.splitlines()[0]) if _git_out.splitlines() else Path.cwd()
+PROJECT_ROOT = _find_project_root()
 IMPL_DIR = BASE_DIR / "impl" / "skildeck"
 SYM_DIR = BASE_DIR / "impl"
 

--- a/tools/symbolic
+++ b/tools/symbolic
@@ -14,9 +14,16 @@ import subprocess
 import sys
 from pathlib import Path
 
+def _find_project_root() -> Path:
+    current = Path(__file__).resolve().parent
+    while current != current.parent:
+        if (current / ".opencode").is_dir():
+            return current
+        current = current.parent
+    raise RuntimeError("Could not find project root (no .opencode/ directory found)")
+
+PROJECT_ROOT = _find_project_root()
 BASE_DIR = Path(__file__).resolve().parent
-_git_out = subprocess.check_output(["git", "-C", str(BASE_DIR), "rev-parse", "--show-superproject-working-tree", "--show-toplevel"], text=True).strip()
-PROJECT_ROOT = Path(_git_out.splitlines()[0]) if _git_out.splitlines() else Path.cwd()
 
 ACTIONS = {
     "extract": "sym-extract",


### PR DESCRIPTION
## Summary

Replaced `git rev-parse --show-superproject-working-tree --show-toplevel` root detection with a walk-up-directory `_find_project_root()` function across all 47 Python/shell scripts.

## Outcome

- No more git dependency for project root detection
- Eliminates doubled `.opencode/.opencode/` path resolution in submodule contexts
- All scripts now walk up from `Path(__file__).resolve().parent` until finding `.opencode/`, whose parent is the project root

Fixes #234