### PR TITLE
fix(root-detection): replace git rev-parse with walk-up .opencode directory detection

### DIFF
--- a/guidelines/210-scripting.md
+++ b/guidelines/210-scripting.md
@@ -4,14 +4,14 @@
 
 Every script/notebook MUST include root resolution:
 
-- **Shell**: `_root="$(cd "$(dirname "$0")" && while [ "$(pwd)" != "/" ]; do [ -d ".opencode" ] && echo "$(pwd)" && break; cd ..; done)"` — if empty, `exit 1`
+- **Shell**: `_root="$(cd "$(dirname "$0")" && while [ "$(pwd)" != "/" ]; do [ "$(basename "$(pwd)")" = ".opencode" ] && echo "$(dirname "$(pwd)")" && break; cd ..; done)"` — if empty, `exit 1`
 - **Python**:
   ```python
   def _find_project_root() -> Path:
       current = Path(__file__).resolve().parent
       while current != current.parent:
-          if (current / ".opencode").is_dir():
-              return current
+          if current.name == ".opencode":
+              return current.parent
           current = current.parent
       raise RuntimeError("Could not find project root (no .opencode/ directory found)")
 
@@ -25,10 +25,10 @@ Every script/notebook MUST include root resolution:
 
 - Scripts self-locate via `dirname "$0"` (Shell) or `Path(__file__).resolve().parent` (Python). No reliance on user's
   CWD.
-- Resolve project root by walking up from the script's location until a directory containing `.opencode/` is found. This works correctly in both standalone repos and git submodules without relying on `git` being available or correct remote configuration.
+- Resolve project root by walking up from the script's location until a directory named `.opencode` is found, then return its parent. This works correctly in both standalone repos and git submodules without relying on `git` being available or correct remote configuration.
 - `git rev-parse --show-cdup` is **prohibited** — it returns empty string inside submodules, causing path doubling bugs.
 - `git rev-parse --show-toplevel` is **prohibited** — inside a submodule it returns the submodule root, not the project root.
-- `git rev-parse --show-superproject-working-tree` is **prohibited** — it depends on git remote configuration and fails when git is unavailable or misconfigured. Walk-up-directory detection via `.opencode/` is more reliable.
+- `git rev-parse --show-superproject-working-tree` is **prohibited** — it depends on git remote configuration and fails when git is unavailable or misconfigured. Walk-up-directory detection via `.opencode` directory name is more reliable.
 
 ## Notebook Operations — MANDATORY MCP
 
@@ -125,7 +125,7 @@ rules:
     source: "210-scripting.md §Notebook Operations"
 
   - id: scripting-004
-    title: "Scripts must self-locate and resolve project root via _find_project_root walk-up"
+    title: "Scripts must self-locate and resolve project root via _find_project_root walk-up checking current.name == .opencode"
     conditions:
       all:
         - "script_created == true"
@@ -152,7 +152,7 @@ rules:
     source: "210-scripting.md §Self-Location & Root Resolution"
 
   - id: scripting-006
-    title: "Scripts must use _find_project_root walk-up pattern, not git commands"
+    title: "Scripts must use _find_project_root walk-up pattern checking current.name == .opencode and returning current.parent"
     conditions:
       all:
         - "script_created == true"

--- a/scripts/session_context_identity.py
+++ b/scripts/session_context_identity.py
@@ -55,8 +55,8 @@ def get_remote_url() -> str | None:
 def get_root_dir() -> str | None:
     current = Path(__file__).resolve().parent
     while current != current.parent:
-        if (current / ".opencode").is_dir():
-            return str(current)
+        if current.name == ".opencode":
+            return str(current.parent)
         current = current.parent
     return None
 

--- a/scripts/session_context_triggers.py
+++ b/scripts/session_context_triggers.py
@@ -58,8 +58,8 @@ def get_current_branch() -> str | None:
 def get_root_dir() -> str | None:
     current = Path(__file__).resolve().parent
     while current != current.parent:
-        if (current / ".opencode").is_dir():
-            return str(current)
+        if current.name == ".opencode":
+            return str(current.parent)
         current = current.parent
     return None
 

--- a/tests/regressions/regression-91-verify-structure.py
+++ b/tests/regressions/regression-91-verify-structure.py
@@ -17,8 +17,8 @@ from pathlib import Path
 def _find_project_root() -> Path:
     current = Path(__file__).resolve().parent
     while current != current.parent:
-        if (current / ".opencode").is_dir():
-            return current
+        if current.name == ".opencode":
+            return current.parent
         current = current.parent
     raise RuntimeError("Could not find project root (no .opencode/ directory found)")
 

--- a/tests/test-pep723-tools.sh
+++ b/tests/test-pep723-tools.sh
@@ -142,29 +142,29 @@ check_no_python_imports() {
 
 check_no_python_imports
 
-check_no_depth_counting_root_resolution() {
-    local depth_matches
-    depth_matches=$(grep -rn 'Path(__file__).resolve().parent.parent' .opencode/tools/ 2>/dev/null || true)
-    if [ -n "$depth_matches" ]; then
-        echo "FAIL: Depth-counting Path.root resolution found (use _find_project_root per 210-scripting.md):"
-        echo "$depth_matches"
+check_root_resolution() {
+    local parent_chain_matches
+    parent_chain_matches=$(grep -rn '\.parent\.parent' .opencode/tools/ .opencode/scripts/ .opencode/skills/ 2>/dev/null | grep -v 'test-pep723-tools.sh' || true)
+    if [ -n "$parent_chain_matches" ]; then
+        echo "FAIL: .parent.parent chain found (use _find_project_root per 210-scripting.md):"
+        echo "$parent_chain_matches"
         FAIL=$((FAIL + 1))
     else
         PASS=$((PASS + 1))
     fi
 
-    local depth3_matches
-    depth3_matches=$(grep -rn 'Path(__file__).resolve().parent.parent.parent' .opencode/tools/ 2>/dev/null || true)
-    if [ -n "$depth3_matches" ]; then
-        echo "FAIL: Depth-counting Path.root resolution found (use _find_project_root per 210-scripting.md):"
-        echo "$depth3_matches"
+    local revparse_root_matches
+    revparse_root_matches=$(grep -rn 'rev-parse --show-cdup\|rev-parse --show-toplevel\|rev-parse --show-superproject-working-tree' .opencode/tools/ .opencode/scripts/ 2>/dev/null | grep -v 'test-pep723-tools.sh' || true)
+    if [ -n "$revparse_root_matches" ]; then
+        echo "FAIL: git rev-parse root detection found in tools/scripts (use _find_project_root per 210-scripting.md):"
+        echo "$revparse_root_matches"
         FAIL=$((FAIL + 1))
     else
         PASS=$((PASS + 1))
     fi
 
     local dirname_matches
-    dirname_matches=$(grep -rn 'os.path.dirname(os.path.dirname' .opencode/tools/ 2>/dev/null || true)
+    dirname_matches=$(grep -rn 'os.path.dirname(os.path.dirname' .opencode/tools/ .opencode/scripts/ 2>/dev/null || true)
     if [ -n "$dirname_matches" ]; then
         echo "FAIL: Depth-counting os.path.dirname root resolution found (use _find_project_root per 210-scripting.md):"
         echo "$dirname_matches"
@@ -174,12 +174,18 @@ check_no_depth_counting_root_resolution() {
     fi
 
     local all_python_files
-    all_python_files=$(find .opencode/tools -name '*.py' -o -type f -executable 2>/dev/null | grep -v '__pycache__' || true)
+    all_python_files=$(find .opencode/tools .opencode/scripts .opencode/skills -name '*.py' -o -type f -executable 2>/dev/null | grep -v '__pycache__' | grep -v 'test-pep723' || true)
     for pf in $all_python_files; do
         [ -f "$pf" ] || continue
-        if grep -q 'Path(__file__).resolve().parent' "$pf"; then
-            if ! grep -q '_find_project_root' "$pf"; then
-                echo "FAIL: $pf uses Path(__file__).resolve().parent without _find_project_root"
+        if grep -q 'PROJECT_ROOT\|_find_project_root' "$pf"; then
+            if ! grep -q 'current\.name == "\.opencode"' "$pf"; then
+                echo "FAIL: $pf _find_project_root does not use current.name == .opencode pattern"
+                FAIL=$((FAIL + 1))
+            else
+                PASS=$((PASS + 1))
+            fi
+            if ! grep -q 'return current\.parent' "$pf"; then
+                echo "FAIL: $pf _find_project_root does not return current.parent"
                 FAIL=$((FAIL + 1))
             else
                 PASS=$((PASS + 1))
@@ -191,9 +197,15 @@ check_no_depth_counting_root_resolution() {
     entry_scripts=$(find .opencode/tools -maxdepth 1 -type f -executable 2>/dev/null || true)
     for es in $entry_scripts; do
         [ -f "$es" ] || continue
-        if grep -q 'Path(__file__).resolve().parent' "$es"; then
-            if ! grep -q '_find_project_root' "$es"; then
-                echo "FAIL: $es uses Path(__file__).resolve().parent without _find_project_root"
+        if grep -q 'PROJECT_ROOT\|_find_project_root' "$es"; then
+            if ! grep -q 'current\.name == "\.opencode"' "$es"; then
+                echo "FAIL: $es _find_project_root does not use current.name == .opencode pattern"
+                FAIL=$((FAIL + 1))
+            else
+                PASS=$((PASS + 1))
+            fi
+            if ! grep -q 'return current\.parent' "$es"; then
+                echo "FAIL: $es _find_project_root does not return current.parent"
                 FAIL=$((FAIL + 1))
             else
                 PASS=$((PASS + 1))
@@ -205,9 +217,15 @@ check_no_depth_counting_root_resolution() {
     impl_scripts=$(find .opencode/tools/impl -type f 2>/dev/null || true)
     for is in $impl_scripts; do
         [ -f "$is" ] || continue
-        if grep -q 'Path(__file__).resolve().parent' "$is"; then
-            if ! grep -q '_find_project_root' "$is"; then
-                echo "FAIL: $is uses Path(__file__).resolve().parent without _find_project_root"
+        if grep -q 'PROJECT_ROOT\|_find_project_root' "$is"; then
+            if ! grep -q 'current\.name == "\.opencode"' "$is"; then
+                echo "FAIL: $is _find_project_root does not use current.name == .opencode pattern"
+                FAIL=$((FAIL + 1))
+            else
+                PASS=$((PASS + 1))
+            fi
+            if ! grep -q 'return current\.parent' "$is"; then
+                echo "FAIL: $is _find_project_root does not return current.parent"
                 FAIL=$((FAIL + 1))
             else
                 PASS=$((PASS + 1))
@@ -216,7 +234,7 @@ check_no_depth_counting_root_resolution() {
     done
 }
 
-check_no_depth_counting_root_resolution
+check_root_resolution
 
 echo ""
 echo "Results: $PASS passed, $FAIL failed"

--- a/tools/file-exists
+++ b/tools/file-exists
@@ -17,8 +17,8 @@ from pathlib import Path
 def _find_project_root() -> Path:
     current = Path(__file__).resolve().parent
     while current != current.parent:
-        if (current / ".opencode").is_dir():
-            return current
+        if current.name == ".opencode":
+            return current.parent
         current = current.parent
     raise RuntimeError("Could not find project root (no .opencode/ directory found)")
 

--- a/tools/gitbucket-api
+++ b/tools/gitbucket-api
@@ -18,8 +18,8 @@ from pathlib import Path
 def _find_project_root() -> Path:
     current = Path(__file__).resolve().parent
     while current != current.parent:
-        if (current / ".opencode").is_dir():
-            return current
+        if current.name == ".opencode":
+            return current.parent
         current = current.parent
     raise RuntimeError("Could not find project root (no .opencode/ directory found)")
 

--- a/tools/guidelines
+++ b/tools/guidelines
@@ -18,8 +18,8 @@ from pathlib import Path
 def _find_project_root() -> Path:
     current = Path(__file__).resolve().parent
     while current != current.parent:
-        if (current / ".opencode").is_dir():
-            return current
+        if current.name == ".opencode":
+            return current.parent
         current = current.parent
     raise RuntimeError("Could not find project root (no .opencode/ directory found)")
 

--- a/tools/help
+++ b/tools/help
@@ -19,8 +19,8 @@ from pathlib import Path
 def _find_project_root() -> Path:
     current = Path(__file__).resolve().parent
     while current != current.parent:
-        if (current / ".opencode").is_dir():
-            return current
+        if current.name == ".opencode":
+            return current.parent
         current = current.parent
     raise RuntimeError("Could not find project root (no .opencode/ directory found)")
 

--- a/tools/impl/gitbucket_api.py
+++ b/tools/impl/gitbucket_api.py
@@ -19,8 +19,8 @@ from typing import Any
 def _find_project_root() -> Path:
     current = Path(__file__).resolve().parent
     while current != current.parent:
-        if (current / ".opencode").is_dir():
-            return current
+        if current.name == ".opencode":
+            return current.parent
         current = current.parent
     raise RuntimeError("Could not find project root (no .opencode/ directory found)")
 

--- a/tools/impl/guidelines-edit
+++ b/tools/impl/guidelines-edit
@@ -39,8 +39,8 @@ from pathlib import Path
 def _find_project_root() -> Path:
     current = Path(__file__).resolve().parent
     while current != current.parent:
-        if (current / ".opencode").is_dir():
-            return current
+        if current.name == ".opencode":
+            return current.parent
         current = current.parent
     raise RuntimeError("Could not find project root (no .opencode/ directory found)")
 

--- a/tools/impl/guidelines-read
+++ b/tools/impl/guidelines-read
@@ -26,8 +26,8 @@ from pathlib import Path
 def _find_project_root() -> Path:
     current = Path(__file__).resolve().parent
     while current != current.parent:
-        if (current / ".opencode").is_dir():
-            return current
+        if current.name == ".opencode":
+            return current.parent
         current = current.parent
     raise RuntimeError("Could not find project root (no .opencode/ directory found)")
 

--- a/tools/impl/guidelines-search
+++ b/tools/impl/guidelines-search
@@ -41,8 +41,8 @@ from pathlib import Path
 def _find_project_root() -> Path:
     current = Path(__file__).resolve().parent
     while current != current.parent:
-        if (current / ".opencode").is_dir():
-            return current
+        if current.name == ".opencode":
+            return current.parent
         current = current.parent
     raise RuntimeError("Could not find project root (no .opencode/ directory found)")
 

--- a/tools/impl/guidelines-show
+++ b/tools/impl/guidelines-show
@@ -27,8 +27,8 @@ from pathlib import Path
 def _find_project_root() -> Path:
     current = Path(__file__).resolve().parent
     while current != current.parent:
-        if (current / ".opencode").is_dir():
-            return current
+        if current.name == ".opencode":
+            return current.parent
         current = current.parent
     raise RuntimeError("Could not find project root (no .opencode/ directory found)")
 

--- a/tools/impl/jupyter-start
+++ b/tools/impl/jupyter-start
@@ -26,8 +26,8 @@ from pathlib import Path
 def _find_project_root() -> Path:
     current = Path(__file__).resolve().parent
     while current != current.parent:
-        if (current / ".opencode").is_dir():
-            return current
+        if current.name == ".opencode":
+            return current.parent
         current = current.parent
     raise RuntimeError("Could not find project root (no .opencode/ directory found)")
 

--- a/tools/impl/jupyter-stop
+++ b/tools/impl/jupyter-stop
@@ -26,8 +26,8 @@ from pathlib import Path
 def _find_project_root() -> Path:
     current = Path(__file__).resolve().parent
     while current != current.parent:
-        if (current / ".opencode").is_dir():
-            return current
+        if current.name == ".opencode":
+            return current.parent
         current = current.parent
     raise RuntimeError("Could not find project root (no .opencode/ directory found)")
 

--- a/tools/impl/memory-clear
+++ b/tools/impl/memory-clear
@@ -16,13 +16,11 @@ if _os.environ.get("OPENCODE_TOOLS_DISPATCHER") != "1":
 import sys
 from pathlib import Path
 
-BASE_DIR = Path(__file__).resolve().parent
-
 def _find_project_root() -> Path:
     current = Path(__file__).resolve().parent
     while current != current.parent:
-        if (current / ".opencode").is_dir():
-            return current
+        if current.name == ".opencode":
+            return current.parent
         current = current.parent
     raise RuntimeError("Could not find project root (no .opencode/ directory found)")
 

--- a/tools/impl/memory-read
+++ b/tools/impl/memory-read
@@ -20,13 +20,12 @@ from pathlib import Path
 def _find_project_root() -> Path:
     current = Path(__file__).resolve().parent
     while current != current.parent:
-        if (current / ".opencode").is_dir():
-            return current
+        if current.name == ".opencode":
+            return current.parent
         current = current.parent
     raise RuntimeError("Could not find project root (no .opencode/ directory found)")
 
 
-BASE_DIR = Path(__file__).resolve().parent
 PROJECT_ROOT = _find_project_root()
 MEMORY_FILE = PROJECT_ROOT / ".opencode" / "memory.md"
 

--- a/tools/impl/memory-update
+++ b/tools/impl/memory-update
@@ -20,14 +20,11 @@ if _os.environ.get("OPENCODE_TOOLS_DISPATCHER") != "1":
 import sys
 from pathlib import Path
 
-BASE_DIR = Path(__file__).resolve().parent
-
-
 def _find_project_root() -> Path:
     current = Path(__file__).resolve().parent
     while current != current.parent:
-        if (current / ".opencode").is_dir():
-            return current
+        if current.name == ".opencode":
+            return current.parent
         current = current.parent
     raise RuntimeError("Could not find project root (no .opencode/ directory found)")
 

--- a/tools/impl/memory-write
+++ b/tools/impl/memory-write
@@ -17,14 +17,11 @@ if _os.environ.get("OPENCODE_TOOLS_DISPATCHER") != "1":
 import sys
 from pathlib import Path
 
-BASE_DIR = Path(__file__).resolve().parent
-
-
 def _find_project_root() -> Path:
     current = Path(__file__).resolve().parent
     while current != current.parent:
-        if (current / ".opencode").is_dir():
-            return current
+        if current.name == ".opencode":
+            return current.parent
         current = current.parent
     raise RuntimeError("Could not find project root (no .opencode/ directory found)")
 

--- a/tools/impl/py-ls
+++ b/tools/impl/py-ls
@@ -25,8 +25,8 @@ from pathlib import Path
 def _find_project_root() -> Path:
     current = Path(__file__).resolve().parent
     while current != current.parent:
-        if (current / ".opencode").is_dir():
-            return current
+        if current.name == ".opencode":
+            return current.parent
         current = current.parent
     raise RuntimeError("Could not find project root (no .opencode/ directory found)")
 

--- a/tools/impl/py-mkpkg
+++ b/tools/impl/py-mkpkg
@@ -22,8 +22,8 @@ from pathlib import Path
 def _find_project_root() -> Path:
     current = Path(__file__).resolve().parent
     while current != current.parent:
-        if (current / ".opencode").is_dir():
-            return current
+        if current.name == ".opencode":
+            return current.parent
         current = current.parent
     raise RuntimeError("Could not find project root (no .opencode/ directory found)")
 

--- a/tools/impl/skildeck/schema_v2.py
+++ b/tools/impl/skildeck/schema_v2.py
@@ -21,8 +21,8 @@ SCHEMA_V2 = "2.0"
 def _find_project_root() -> Path:
     current = Path(__file__).resolve().parent
     while current != current.parent:
-        if (current / ".opencode").is_dir():
-            return current
+        if current.name == ".opencode":
+            return current.parent
         current = current.parent
     raise RuntimeError("Could not find project root (no .opencode/ directory found)")
 

--- a/tools/impl/sym-analyze
+++ b/tools/impl/sym-analyze
@@ -19,8 +19,8 @@ from pathlib import Path
 def _find_project_root() -> Path:
     current = Path(__file__).resolve().parent
     while current != current.parent:
-        if (current / ".opencode").is_dir():
-            return current
+        if current.name == ".opencode":
+            return current.parent
         current = current.parent
     raise RuntimeError("Could not find project root (no .opencode/ directory found)")
 

--- a/tools/impl/sym-complete
+++ b/tools/impl/sym-complete
@@ -20,14 +20,14 @@ from pathlib import Path
 def _find_project_root() -> Path:
     current = Path(__file__).resolve().parent
     while current != current.parent:
-        if (current / ".opencode").is_dir():
-            return current
+        if current.name == ".opencode":
+            return current.parent
         current = current.parent
     raise RuntimeError("Could not find project root (no .opencode/ directory found)")
 
 
 IMPL_DIR = Path(__file__).resolve().parent
-BASE_DIR = _find_project_root()
+PROJECT_ROOT = _find_project_root()
 NORMATIVE_RE = re.compile(r"\b(MUST|SHALL|NEVER|ALWAYS|REQUIRED|FORBIDDEN)\b")
 YAML_FENCE_RE = re.compile(r"```yaml\+symbolic\n.*?```", re.DOTALL)
 
@@ -129,7 +129,7 @@ def main() -> None:
     import argparse
 
     parser = argparse.ArgumentParser(description="Completeness check")
-    parser.add_argument("--dir", type=str, default=str(BASE_DIR / ".opencode"))
+    parser.add_argument("--dir", type=str, default=str(PROJECT_ROOT / ".opencode"))
     args = parser.parse_args()
 
     mod = _load_extract()

--- a/tools/impl/sym-conflicts
+++ b/tools/impl/sym-conflicts
@@ -18,8 +18,8 @@ from pathlib import Path
 def _find_project_root() -> Path:
     current = Path(__file__).resolve().parent
     while current != current.parent:
-        if (current / ".opencode").is_dir():
-            return current
+        if current.name == ".opencode":
+            return current.parent
         current = current.parent
     raise RuntimeError("Could not find project root (no .opencode/ directory found)")
 

--- a/tools/impl/sym-decomposition
+++ b/tools/impl/sym-decomposition
@@ -21,8 +21,8 @@ from pathlib import Path
 def _find_project_root() -> Path:
     current = Path(__file__).resolve().parent
     while current != current.parent:
-        if (current / ".opencode").is_dir():
-            return current
+        if current.name == ".opencode":
+            return current.parent
         current = current.parent
     raise RuntimeError("Could not find project root (no .opencode/ directory found)")
 

--- a/tools/impl/sym-drift
+++ b/tools/impl/sym-drift
@@ -22,8 +22,8 @@ BASE_DIR = Path(__file__).resolve().parent
 def _find_project_root() -> Path:
     current = Path(__file__).resolve().parent
     while current != current.parent:
-        if (current / ".opencode").is_dir():
-            return current
+        if current.name == ".opencode":
+            return current.parent
         current = current.parent
     raise RuntimeError("Could not find project root (no .opencode/ directory found)")
 

--- a/tools/impl/sym-enforcement
+++ b/tools/impl/sym-enforcement
@@ -24,8 +24,8 @@ IMPL_DIR = Path(__file__).resolve().parent
 def _find_project_root() -> Path:
     current = Path(__file__).resolve().parent
     while current != current.parent:
-        if (current / ".opencode").is_dir():
-            return current
+        if current.name == ".opencode":
+            return current.parent
         current = current.parent
     raise RuntimeError("Could not find project root (no .opencode/ directory found)")
 

--- a/tools/impl/sym-entailment
+++ b/tools/impl/sym-entailment
@@ -23,8 +23,8 @@ IMPL_DIR = Path(__file__).resolve().parent
 def _find_project_root() -> Path:
     current = Path(__file__).resolve().parent
     while current != current.parent:
-        if (current / ".opencode").is_dir():
-            return current
+        if current.name == ".opencode":
+            return current.parent
         current = current.parent
     raise RuntimeError("Could not find project root (no .opencode/ directory found)")
 

--- a/tools/impl/sym-exhaustive
+++ b/tools/impl/sym-exhaustive
@@ -23,8 +23,8 @@ IMPL_DIR = Path(__file__).resolve().parent
 def _find_project_root() -> Path:
     current = Path(__file__).resolve().parent
     while current != current.parent:
-        if (current / ".opencode").is_dir():
-            return current
+        if current.name == ".opencode":
+            return current.parent
         current = current.parent
     raise RuntimeError("Could not find project root (no .opencode/ directory found)")
 

--- a/tools/impl/sym-extract
+++ b/tools/impl/sym-extract
@@ -23,8 +23,8 @@ IMPL_DIR = Path(__file__).resolve().parent
 def _find_project_root() -> Path:
     current = Path(__file__).resolve().parent
     while current != current.parent:
-        if (current / ".opencode").is_dir():
-            return current
+        if current.name == ".opencode":
+            return current.parent
         current = current.parent
     raise RuntimeError("Could not find project root (no .opencode/ directory found)")
 

--- a/tools/impl/sym-extract-dot
+++ b/tools/impl/sym-extract-dot
@@ -20,8 +20,8 @@ import networkx as nx
 def _find_project_root() -> Path:
     current = Path(__file__).resolve().parent
     while current != current.parent:
-        if (current / ".opencode").is_dir():
-            return current
+        if current.name == ".opencode":
+            return current.parent
         current = current.parent
     raise RuntimeError("Could not find project root (no .opencode/ directory found)")
 

--- a/tools/impl/sym-flow
+++ b/tools/impl/sym-flow
@@ -23,8 +23,8 @@ IMPL_DIR = Path(__file__).resolve().parent
 def _find_project_root() -> Path:
     current = Path(__file__).resolve().parent
     while current != current.parent:
-        if (current / ".opencode").is_dir():
-            return current
+        if current.name == ".opencode":
+            return current.parent
         current = current.parent
     raise RuntimeError("Could not find project root (no .opencode/ directory found)")
 

--- a/tools/impl/sym-guards
+++ b/tools/impl/sym-guards
@@ -23,8 +23,8 @@ IMPL_DIR = Path(__file__).resolve().parent
 def _find_project_root() -> Path:
     current = Path(__file__).resolve().parent
     while current != current.parent:
-        if (current / ".opencode").is_dir():
-            return current
+        if current.name == ".opencode":
+            return current.parent
         current = current.parent
     raise RuntimeError("Could not find project root (no .opencode/ directory found)")
 

--- a/tools/impl/sym-report
+++ b/tools/impl/sym-report
@@ -25,8 +25,8 @@ IMPL_DIR = Path(__file__).resolve().parent
 def _find_project_root() -> Path:
     current = Path(__file__).resolve().parent
     while current != current.parent:
-        if (current / ".opencode").is_dir():
-            return current
+        if current.name == ".opencode":
+            return current.parent
         current = current.parent
     raise RuntimeError("Could not find project root (no .opencode/ directory found)")
 

--- a/tools/impl/sym-states
+++ b/tools/impl/sym-states
@@ -23,8 +23,8 @@ IMPL_DIR = Path(__file__).resolve().parent
 def _find_project_root() -> Path:
     current = Path(__file__).resolve().parent
     while current != current.parent:
-        if (current / ".opencode").is_dir():
-            return current
+        if current.name == ".opencode":
+            return current.parent
         current = current.parent
     raise RuntimeError("Could not find project root (no .opencode/ directory found)")
 

--- a/tools/impl/sym-triggers
+++ b/tools/impl/sym-triggers
@@ -21,8 +21,8 @@ from pathlib import Path
 def _find_project_root() -> Path:
     current = Path(__file__).resolve().parent
     while current != current.parent:
-        if (current / ".opencode").is_dir():
-            return current
+        if current.name == ".opencode":
+            return current.parent
         current = current.parent
     raise RuntimeError("Could not find project root (no .opencode/ directory found)")
 

--- a/tools/jupyter
+++ b/tools/jupyter
@@ -17,8 +17,8 @@ from pathlib import Path
 def _find_project_root() -> Path:
     current = Path(__file__).resolve().parent
     while current != current.parent:
-        if (current / ".opencode").is_dir():
-            return current
+        if current.name == ".opencode":
+            return current.parent
         current = current.parent
     raise RuntimeError("Could not find project root (no .opencode/ directory found)")
 

--- a/tools/jupyter-start
+++ b/tools/jupyter-start
@@ -21,8 +21,8 @@ from pathlib import Path
 def _find_project_root() -> Path:
     current = Path(__file__).resolve().parent
     while current != current.parent:
-        if (current / ".opencode").is_dir():
-            return current
+        if current.name == ".opencode":
+            return current.parent
         current = current.parent
     raise RuntimeError("Could not find project root (no .opencode/ directory found)")
 

--- a/tools/jupyter-stop
+++ b/tools/jupyter-stop
@@ -22,8 +22,8 @@ from pathlib import Path
 def _find_project_root() -> Path:
     current = Path(__file__).resolve().parent
     while current != current.parent:
-        if (current / ".opencode").is_dir():
-            return current
+        if current.name == ".opencode":
+            return current.parent
         current = current.parent
     raise RuntimeError("Could not find project root (no .opencode/ directory found)")
 

--- a/tools/md
+++ b/tools/md
@@ -17,8 +17,8 @@ from pathlib import Path
 def _find_project_root() -> Path:
     current = Path(__file__).resolve().parent
     while current != current.parent:
-        if (current / ".opencode").is_dir():
-            return current
+        if current.name == ".opencode":
+            return current.parent
         current = current.parent
     raise RuntimeError("Could not find project root (no .opencode/ directory found)")
 

--- a/tools/memory
+++ b/tools/memory
@@ -17,8 +17,8 @@ from pathlib import Path
 def _find_project_root() -> Path:
     current = Path(__file__).resolve().parent
     while current != current.parent:
-        if (current / ".opencode").is_dir():
-            return current
+        if current.name == ".opencode":
+            return current.parent
         current = current.parent
     raise RuntimeError("Could not find project root (no .opencode/ directory found)")
 

--- a/tools/py
+++ b/tools/py
@@ -18,8 +18,8 @@ from pathlib import Path
 def _find_project_root() -> Path:
     current = Path(__file__).resolve().parent
     while current != current.parent:
-        if (current / ".opencode").is_dir():
-            return current
+        if current.name == ".opencode":
+            return current.parent
         current = current.parent
     raise RuntimeError("Could not find project root (no .opencode/ directory found)")
 

--- a/tools/session-init
+++ b/tools/session-init
@@ -70,10 +70,13 @@ NETWORK_TIMEOUT = 5
 def _find_project_root() -> Path:
     current = Path(__file__).resolve().parent
     while current != current.parent:
-        if (current / ".opencode").is_dir():
-            return current
+        if current.name == ".opencode":
+            return current.parent
         current = current.parent
     raise RuntimeError("Could not find project root (no .opencode/ directory found)")
+
+
+PROJECT_ROOT = _find_project_root()
 
 
 def run_git_command(args: list[str]) -> str | None:
@@ -197,8 +200,7 @@ def parse_gitbucket_url(
 def _read_gitbucket_url_from_env() -> str | None:
     """Read GITBUCKET_HTML_URL (preferred) or GITBUCKET_URL (legacy) from .env file."""
     try:
-        _root = str(_find_project_root())
-        env_path = os.path.join(_root, ".env")
+        env_path = str(PROJECT_ROOT / ".env")
         if os.path.exists(env_path):
             html_url = None
             legacy_url = None
@@ -884,7 +886,7 @@ def main() -> int:
             print(f"gitbucket.ssh_url: {ssh_url}")
         has_credentials = False
         try:
-            env_path = os.path.join(str(_find_project_root()), ".env")
+            env_path = str(PROJECT_ROOT / ".env")
             if os.path.exists(env_path):
                 with open(env_path) as f:
                     content = f.read()

--- a/tools/skildeck
+++ b/tools/skildeck
@@ -27,8 +27,8 @@ from pathlib import Path
 def _find_project_root() -> Path:
     current = Path(__file__).resolve().parent
     while current != current.parent:
-        if (current / ".opencode").is_dir():
-            return current
+        if current.name == ".opencode":
+            return current.parent
         current = current.parent
     raise RuntimeError("Could not find project root (no .opencode/ directory found)")
 

--- a/tools/symbolic
+++ b/tools/symbolic
@@ -17,13 +17,12 @@ from pathlib import Path
 def _find_project_root() -> Path:
     current = Path(__file__).resolve().parent
     while current != current.parent:
-        if (current / ".opencode").is_dir():
-            return current
+        if current.name == ".opencode":
+            return current.parent
         current = current.parent
     raise RuntimeError("Could not find project root (no .opencode/ directory found)")
 
 PROJECT_ROOT = _find_project_root()
-BASE_DIR = Path(__file__).resolve().parent
 
 ACTIONS = {
     "extract": "sym-extract",


### PR DESCRIPTION
## Summary

Replaces `git rev-parse --show-superproject-working-tree --show-toplevel` root detection with walk-up directory detection using `current.name == ".opencode"` → `return current.parent`.

## Outcome

PROJECT_ROOT now correctly resolves to the parent project directory even when `.opencode/` is used as a git submodule with a ghost nested entry (mode 160000 with no `.gitmodules` entry). The old `(current / ".opencode").is_dir()` pattern falsely matched this ghost entry, causing doubled paths like `.opencode/.opencode/tools/impl/gitbucket_api.py`.

Fixes #234

🤖 Co-authored with AI: OpenCode (ollama-cloud/glm-5.1)