### PR TITLE
feat(#244): Runtime enforcement gates — prescriptive pipeline checks

### DIFF
--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -1,11 +1,13 @@
 #!/bin/bash
-# Pre-commit hook: Block direct commits to main and dev branches
-# Enforces feature branch workflow for both humans and AI agents
+# Pre-commit hook: Branch protection + dispatch evidence enforcement
+# Gate 1: Block direct commits to main/dev branches
+# Gate 2: Block commits on implementation branches without dispatch evidence
 
 set -e
 
 CURRENT_BRANCH=$(git branch --show-current)
 
+# --- Gate 1: Branch protection (main/dev) ---
 if [ "$CURRENT_BRANCH" = "main" ] || [ "$CURRENT_BRANCH" = "dev" ]; then
     echo ""
     echo "ERROR: Direct commits to '$CURRENT_BRANCH' branch are blocked."
@@ -19,6 +21,132 @@ if [ "$CURRENT_BRANCH" = "main" ] || [ "$CURRENT_BRANCH" = "dev" ]; then
     echo "  2. Or create a hotfix branch: git checkout -b hotfix/<name>"
     echo ""
     echo "AI agent: If OPENCODE=1, relay this message to the developer."
+    echo ""
+    exit 1
+fi
+
+# --- Gate 2: Dispatch evidence check ---
+# Implementation branches (feature/*, spec/*, fix/*) require a work state file
+# in .opencode/tmp/ as evidence that the dispatch chain was followed.
+# Exemptions: pair-* (pair mode), rollback/* (rollback ops), .issues/ only,
+# merge commits, human escape hatch.
+
+SKIP_DISPATCH_CHECK="${SKIP_DISPATCH_CHECK:-}"
+if [ "$SKIP_DISPATCH_CHECK" = "1" ]; then
+    exit 0
+fi
+
+case "$CURRENT_BRANCH" in
+    pair-*|rollback/*|hotfix/*)
+        exit 0
+        ;;
+esac
+
+IS_IMPL_BRANCH=0
+case "$CURRENT_BRANCH" in
+    feature/*|spec/*|fix/*|phase/*)
+        IS_IMPL_BRANCH=1
+        ;;
+esac
+
+if [ "$IS_IMPL_BRANCH" = "0" ]; then
+    exit 0
+fi
+
+# Check for .issues/-only changes (non-behavioral metadata exempt)
+STAGED_FILES=$(git diff --cached --name-only 2>/dev/null)
+ALL_ISSUES_ONLY=1
+for f in $STAGED_FILES; do
+    case "$f" in
+        .issues/*)
+            ;;
+        *)
+            ALL_ISSUES_ONLY=0
+            break
+            ;;
+    esac
+done
+
+if [ "$ALL_ISSUES_ONLY" = "1" ]; then
+    exit 0
+fi
+
+# Allow merge commits
+if [ -f ".git/MERGE_MSG" ] || [ -n "$GIT_DIR" ] && [ -f "$GIT_DIR/MERGE_MSG" ]; then
+    exit 0
+fi
+
+# Allow rollback commits (commit message starts with "rollback")
+COMMIT_MSG_FILE=".git/COMMIT_EDITMSG"
+if [ -f "$COMMIT_MSG_FILE" ]; then
+    FIRST_LINE=$(head -1 "$COMMIT_MSG_FILE" 2>/dev/null)
+    case "$FIRST_LINE" in
+        rollback*|Merge\ pull\ request*|Merge\ branch*)
+            exit 0
+            ;;
+    esac
+fi
+
+# Check for work state file matching current branch
+PROJECT_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+WORK_STATE_DIR="$PROJECT_ROOT/.opencode/tmp"
+
+if [ ! -d "$WORK_STATE_DIR" ]; then
+    echo ""
+    echo "ERROR: Dispatch evidence check FAILED."
+    echo ""
+    echo "Branch '$CURRENT_BRANCH' is an implementation branch but no"
+    echo "work state directory exists at .opencode/tmp/."
+    echo ""
+    echo "The dispatch chain requires a work state file as evidence that"
+    echo "sub-agent dispatch occurred via divide-and-conquer/assemble-work."
+    echo ""
+    echo "To fix:"
+    echo "  1. Ensure divide-and-conquer --task assemble-work was invoked"
+    echo "  2. Or set SKIP_DISPATCH_CHECK=1 if committing as a human operator"
+    echo ""
+    echo "AI agent: This is a runtime gate, not an advisory rule."
+    echo ""
+    exit 1
+fi
+
+WORK_FILE_FOUND=0
+if ls "$WORK_STATE_DIR"/work-*.md 1>/dev/null 2>&1; then
+    BRANCH_PATTERN=$(echo "$CURRENT_BRANCH" | sed 's/[\/&]/\\&/g')
+    for f in "$WORK_STATE_DIR"/work-*.md; do
+        if grep -qE "(Branch:.*$CURRENT_BRANCH|^# Work State.*$CURRENT_BRANCH)" "$f" 2>/dev/null; then
+            WORK_FILE_FOUND=1
+            break
+        fi
+        if grep -qE '^## chain-context' "$f" 2>/dev/null; then
+            WORK_FILE_FOUND=1
+            break
+        fi
+    done
+        if grep -qE '^## chain-context' "$f" 2>/dev/null; then
+            WORK_FILE_FOUND=1
+            break
+        fi
+    done
+fi
+
+if [ "$WORK_FILE_FOUND" = "0" ]; then
+    echo ""
+    echo "ERROR: Dispatch evidence check FAILED."
+    echo ""
+    echo "Branch '$CURRENT_BRANCH' is an implementation branch but no"
+    echo "work state file in .opencode/tmp/ references this branch."
+    echo ""
+    echo "Work state files found: $(ls "$WORK_STATE_DIR"/work-*.md 2>/dev/null | wc -l)"
+    echo ""
+    echo "The dispatch chain requires a work state file as evidence that"
+    echo "sub-agent dispatch occurred via divide-and-conquer/assemble-work."
+    echo ""
+    echo "To fix:"
+    echo "  1. Ensure divide-and-conquer --task assemble-work was invoked"
+    echo "  2. Or set SKIP_DISPATCH_CHECK=1 if committing as a human operator"
+    echo ""
+    echo "AI agent: This is a runtime gate, not an advisory rule."
     echo ""
     exit 1
 fi

--- a/hooks/pre-push
+++ b/hooks/pre-push
@@ -1,13 +1,10 @@
 #!/bin/bash
-# Pre-push hook: Prevent pushing branches already merged into main/dev
-#
-# This hook prevents accidental pushes of branches that have been merged
-# into main or dev, which is typical after PR merge. Merged branches should
-# be deleted locally and remotely, not pushed.
+# Pre-push hook: Branch topology + commit count enforcement
+# Gate 1: Prevent pushing branches already merged into main/dev
+# Gate 2: Block single-issue branches with >1 commit (commit-per-issue invariant)
 
 set -e
 
-# Get the current branch name
 CURRENT_BRANCH=$(git branch --show-current)
 
 # Skip check for main and dev branches (they should always be pushable)
@@ -15,10 +12,10 @@ if [ "$CURRENT_BRANCH" = "main" ] || [ "$CURRENT_BRANCH" = "dev" ]; then
     exit 0
 fi
 
-# Check if branch is merged into dev
+# --- Gate 1: Merged branch topology check ---
 if git branch --merged dev 2>/dev/null | grep -q "^\s*$CURRENT_BRANCH$"; then
     echo ""
-    echo "❌ BLOCKED: Branch '$CURRENT_BRANCH' is already merged into 'dev'"
+    echo "BLOCKED: Branch '$CURRENT_BRANCH' is already merged into 'dev'"
     echo ""
     echo "This branch has been merged and should be deleted, not pushed."
     echo ""
@@ -27,16 +24,12 @@ if git branch --merged dev 2>/dev/null | grep -q "^\s*$CURRENT_BRANCH$"; then
     echo "  git branch -d $CURRENT_BRANCH"
     echo "  git push origin --delete $CURRENT_BRANCH  # if pushed remotely"
     echo ""
-    echo "If you need to continue working on this branch, create a new feature branch:"
-    echo "  git checkout dev && git checkout -b feature/new-branch-name"
-    echo ""
     exit 1
 fi
 
-# Check if branch is merged into main
 if git branch --merged main 2>/dev/null | grep -q "^\s*$CURRENT_BRANCH$"; then
     echo ""
-    echo "❌ BLOCKED: Branch '$CURRENT_BRANCH' is already merged into 'main'"
+    echo "BLOCKED: Branch '$CURRENT_BRANCH' is already merged into 'main'"
     echo ""
     echo "This branch has been merged and should be deleted, not pushed."
     echo ""
@@ -45,11 +38,55 @@ if git branch --merged main 2>/dev/null | grep -q "^\s*$CURRENT_BRANCH$"; then
     echo "  git branch -d $CURRENT_BRANCH"
     echo "  git push origin --delete $CURRENT_BRANCH  # if pushed remotely"
     echo ""
-    echo "If you need to continue working on this branch, create a new feature branch:"
-    echo "  git checkout dev && git checkout -b feature/new-branch-name"
+    exit 1
+fi
+
+# --- Gate 2: Commit count check (commit-per-issue invariant) ---
+SKIP_COMMIT_COUNT_CHECK="${SKIP_COMMIT_COUNT_CHECK:-}"
+if [ "$SKIP_COMMIT_COUNT_CHECK" = "1" ]; then
+    exit 0
+fi
+
+case "$CURRENT_BRANCH" in
+    pair-*|rollback/*|main|dev)
+        exit 0
+        ;;
+esac
+
+PROJECT_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+WORK_STATE_DIR="$PROJECT_ROOT/.opencode/tmp"
+
+# Work branches (work state file exists) have N commits for N work items — skip check
+if ls "$WORK_STATE_DIR"/work-*.md 1>/dev/null 2>&1; then
+    for f in "$WORK_STATE_DIR"/work-*.md; do
+        if grep -q "$CURRENT_BRANCH" "$f" 2>/dev/null; then
+            exit 0
+        fi
+    done
+fi
+
+# Single-issue branch: count commits ahead of dev
+COMMIT_COUNT=0
+if git rev-parse --verify origin/dev >/dev/null 2>&1; then
+    COMMIT_COUNT=$(git rev-list --count origin/dev..HEAD 2>/dev/null || echo "0")
+elif git rev-parse --verify dev >/dev/null 2>&1; then
+    COMMIT_COUNT=$(git rev-list --count dev..HEAD 2>/dev/null || echo "0")
+fi
+
+if [ "$COMMIT_COUNT" -gt 1 ]; then
+    echo ""
+    echo "BLOCKED: Commit-per-issue invariant violated."
+    echo ""
+    echo "Branch '$CURRENT_BRANCH' has $COMMIT_COUNT commits but no work state file."
+    echo "Single-issue branches must have exactly 1 commit."
+    echo ""
+    echo "To fix:"
+    echo "  1. Squash: git reset --soft origin/dev && git commit -m '<message>'"
+    echo "  2. Or set SKIP_COMMIT_COUNT_CHECK=1 if committing as a human operator"
+    echo ""
+    echo "AI agent: This is a runtime gate, not an advisory rule."
     echo ""
     exit 1
 fi
 
-# Branch is not merged - allow push
 exit 0

--- a/plugins/session-enforcement.ts
+++ b/plugins/session-enforcement.ts
@@ -180,6 +180,42 @@ See 000-critical-rules.md → "Git Configuration and Destructive Command Authori
 </NO_VERIFY_BLOCKED>`;
 }
 
+function buildInlineWorkDetectedBlock(editToolNames: string[], dispatchFound: boolean): string {
+  const editList = editToolNames.map(t => `- \`${t}\``).join("\n");
+  const dispatchNote = dispatchFound
+    ? "A sub-agent dispatch was found, but file edits occurred BEFORE the dispatch in this turn."
+    : "No sub-agent dispatch (task tool) was found in this turn.";
+  return `<INLINE_WORK_DETECTED>
+⚠️ CRITICAL: The orchestrator performed file operations without sub-agent dispatch evidence.
+
+File-editing tool calls detected in this turn:
+${editList}
+
+${dispatchNote}
+
+The orchestrator MUST be a pure router — all file modifications MUST be dispatched
+through divide-and-conquer/assemble-work sub-agents. See 000-critical-rules.md §Inline Work.
+
+Exemptions: pair-* branches, .issues/ file edits, simple-work single-file changes.
+If this is an exempt case, disregard this block.
+</INLINE_WORK_DETECTED>`;
+}
+
+function buildEvidenceGateBlock(): string {
+  return `<EVIDENCE_GATE_BLOCK>
+⚠️ CRITICAL: Issue closure attempted without verification evidence.
+
+A github_issue_write call with state=closed was detected, but no per-SC
+verification evidence table exists in recent assistant messages.
+
+Every issue closure requires a verification evidence table confirming each
+success criterion was met with a tool-call artifact. See 000-critical-rules.md
+§Verification Dishonesty and verification-before-completion skill.
+
+If the closure is exempt (not_planned, duplicate, rollback-reopen), disregard this block.
+</EVIDENCE_GATE_BLOCK>`;
+}
+
 interface PluginDiagnostic {
   source: string;
   level: "error" | "warning" | "info";
@@ -1512,6 +1548,103 @@ export default async function sessionEnforcementPlugin(input: PluginInput): Prom
                 nextUser.parts.push({ type: "text", text: blockedBlock });
               }
               break;
+            }
+          }
+        }
+      }
+
+      // --- Per-turn: Inline work detector (Gate 3) ---
+      // Detect when the orchestrator performed file-editing tool calls without
+      // a preceding sub-agent dispatch in the same turn. Exemptions: sub-agent
+      // sessions, pair-* branches, .issues/ only changes.
+      const currentBranchForInline = getCurrentBranch(projectDir);
+      const isPairBranch = currentBranchForInline ? isPairModeBranch(currentBranchForInline) : false;
+      if (!isSubAgent && !isPairBranch) {
+        for (const msg of assistantMessages) {
+          if (!msg.parts?.length) continue;
+          const editToolNames: string[] = [];
+          let dispatchFound = false;
+          let dispatchIndex = -1;
+          let issuesOnlyEdits = true;
+
+          for (const part of msg.parts) {
+            if (part.type === "text" && part.text) {
+              // Detect sub-agent dispatch (task tool)
+              if (part.text.includes("subagent_type") || part.text.includes('"task"') && part.text.includes("dispatch")) {
+                dispatchFound = true;
+                if (dispatchIndex === -1) dispatchIndex = msg.parts.indexOf(part);
+              }
+              // Detect file-editing tool calls
+              const editMatch = part.text.match(/"name"\s*:\s*"(edit|write|create_or_update_file)"/);
+              if (editMatch) {
+                editToolNames.push(editMatch[1]);
+                // Check if the edit targets .issues/ files
+                const filePathMatch = part.text.match(/"filePath"\s*:\s*"([^"]+)"/);
+                if (filePathMatch && !filePathMatch[1].startsWith(".issues/")) {
+                  issuesOnlyEdits = false;
+                }
+              }
+              // Also detect tool call patterns in assistant text (older format)
+              const toolCallMatch = part.text.match(/(edit|write)\(filePath/);
+              if (toolCallMatch) {
+                editToolNames.push(toolCallMatch[1]);
+                const filePathMatch = part.text.match(/filePath["']?\s*[:=]\s*["']([^"']+)/);
+                if (filePathMatch && !filePathMatch[1].startsWith(".issues/")) {
+                  issuesOnlyEdits = false;
+                }
+              }
+            }
+          }
+
+          if (editToolNames.length > 0 && !issuesOnlyEdits) {
+            // If dispatch was found, check if edits came before the dispatch
+            const editsBeforeDispatch = dispatchFound && dispatchIndex > -1
+              ? editToolNames.length > 0 // edits exist, check if any were before dispatch
+              : true;
+
+            if (!dispatchFound || editsBeforeDispatch) {
+              const block = buildInlineWorkDetectedBlock(editToolNames, dispatchFound);
+              const nextUser = userMessages[userMessages.length - 1];
+              if (nextUser?.parts?.length) {
+                nextUser.parts.push({ type: "text", text: block });
+              }
+            }
+          }
+        }
+      }
+
+      // --- Per-turn: Evidence gate (Gate 4) ---
+      // Detect issue closure attempts without verification evidence table.
+      // Exemptions: not_planned, duplicate, rollback-reopen state reasons.
+      for (const msg of assistantMessages) {
+        if (!msg.parts?.length) continue;
+        for (const part of msg.parts) {
+          if (part.type === "text" && part.text) {
+            // Detect github_issue_write with state=closed
+            const closureMatch = part.text.match(/state.*closed|state.*:.*"closed"/i);
+            if (closureMatch) {
+              // Check for exempt state reasons
+              const exemptReason = part.text.match(/state_reason.*(?:not_planned|duplicate)/i);
+              if (!exemptReason) {
+                // Check if a verification evidence table exists in recent messages
+                const allAssistantText = assistantMessages
+                  .map(m => m.parts?.filter(p => p.type === "text" && p.text).map(p => p.text).join(" ") || "")
+                  .join(" ");
+                const hasEvidence = allAssistantText.includes("PASS") &&
+                  (allAssistantText.includes("Success Criteria") || allAssistantText.includes("verification") || allAssistantText.includes("evidence"));
+
+                if (!hasEvidence) {
+                  // Also check for rollback-reopen marker
+                  const rollbackReopen = part.text.match(/\[ROLLBACK-REOPEN\]/i);
+                  if (!rollbackReopen) {
+                    const block = buildEvidenceGateBlock();
+                    const nextUser = userMessages[userMessages.length - 1];
+                    if (nextUser?.parts?.length) {
+                      nextUser.parts.push({ type: "text", text: block });
+                    }
+                  }
+                }
+              }
             }
           }
         }


### PR DESCRIPTION
## Summary

Adds four runtime enforcement gates that block at action boundaries, making pipeline checks prescriptive instead of advisory.

## Outcome

| Gate | Mechanism | Blocks |
|------|-----------|--------|
| Dispatch evidence | `pre-commit` hook | Commits on impl branches without work state file |
| Commit count | `pre-push` hook | Single-issue branches with >1 commit |
| Inline work | `session-enforcement.ts` | Orchestrator file edits without sub-agent dispatch |
| Evidence | `session-enforcement.ts` | Issue closure without verification evidence |

Descriptive rules ("CRITICAL VIOLATION" prose) now have prescriptive counterparts (exit code 1, injected blocks).

Fixes michael-conrad/.opencode#244

🤖 Co-authored with AI: OpenCode (ollama-cloud/glm-5.1)