### PR TITLE
[SPEC] add dispatch entry marker enforcement with pre-commit hook

### DIFF
--- a/guidelines/000-critical-rules.md
+++ b/guidelines/000-critical-rules.md
@@ -32,12 +32,12 @@ These mandates ensure disciplined workflow (spec-first, plan-before-implementati
 
 | Mandate | What Waiver Means |
 | -- | -- |
-| Spec before code | Developer authorization means "you may begin the process" — for complex work, still create a spec/plan; for clearly simple work (docs, runbooks, minor config), the developer's explicit authorization IS the process |
+| Spec before code | Developer authorization means "you may begin the process" — for complex work, still create a spec/plan |
 | Plan before implementation | Same as above — authorization authorizes the work, not necessarily every intermediate artifact |
 | `needs-approval` label present | Explicit auth overrides this label per `010-approval-gate.md` |
 | Sub-issue structure for multi-task plans | When developer authorizes a multi-task plan, sub-issue creation is auto-setup, not a separate gate |
 
-**For Tier 2 mandates, developer authorization does NOT mean "skip the process entirely"** — it means "you may begin." For complex work (new features, behavioral changes), the spec/plan workflow still produces value even when authorization exists. For clearly simple work (documentation, runbooks, minor configuration edits), the developer's explicit authorization IS sufficient process — no separate spec/plan is required.
+**For Tier 2 mandates, developer authorization does NOT mean "skip the process entirely"** — it means "you may begin." For complex work (new features, behavioral changes), the spec/plan workflow still produces value even when authorization exists.
 
 ### Interaction Rule
 
@@ -1207,46 +1207,6 @@ Every authorization follows the same pipeline regardless of issue count: `verify
 - ✅ REQUIRED: Follow the complete dispatch chain for every authorization
 
 **See `approval-gate` skill → "Unified Dispatch Path (Work-of-1)" and `divide-and-conquer` skill → `assemble-work` task for the complete dispatch procedure.**
-
-## Simple Work Dispatch Path (Tier 2 Waiver)
-
-When ALL of the following conditions are met:
-- Developer has given explicit authorization (approved/go)
-- Work is "clearly simple" (see classification table below)
-- No spec or plan is required (Tier 2 waiver applies)
-- File modifications ARE needed (Tier 1 worktree mandate applies)
-
-The agent follows this REDUCED dispatch path:
-
-1. `git-workflow --task pre-work` — Create worktree (Tier 1, MANDATORY)
-2. Direct implementation in worktree — No sub-agent dispatch needed for single-file changes
-3. `verification-before-completion` — Verify success criteria exist and pass
-4. `finishing-a-development-branch --task checklist` — Branch readiness check
-5. `git-workflow --task review-prep` — Push, generate compare URL, HALT
-
-Steps SKIPPED for simple work:
-- `verify-authorization` (Tier 2 waiver replaces this — authorization IS the process)
-- `pre-implementation-analysis` (no plan to analyze)
-- `divide-and-conquer/assemble-work` (single implementer, single concern)
-- `verification-before-completion` can be simplified for documentation-only changes
-
-### Classification: "Clearly Simple Work"
-
-Work qualifies as "clearly simple" when ALL criteria are met:
-
-| Criterion | Qualifies | Does Not Qualify |
-|-----------|-----------|------------------|
-| Scope localization | Changes limited to a single concern | Changes span multiple concerns |
-| Behavioral change | None (docs, config, runbooks) | Any behavioral change |
-| Architectural impact | None | Any impact on architecture |
-| Existing code interaction | None (new files, minor edits) | Modified function signatures, APIs |
-| Risk level | Zero rollback risk | Data loss, security, deployment risk |
-
-When work does NOT qualify as "clearly simple", the full dispatch path applies regardless of developer authorization.
-
-### Key Principle
-
-"Simple" describes the PROCESS burden (no spec/plan needed), NOT the SAFETY mechanism. Worktrees protect repository integrity regardless of task complexity. The reduced dispatch path still enforces all Tier 1 mandates — it only skips Tier 2 process steps that are waived by developer authorization.
 
 **⚠️ Leaving stale or uncleared todowrite state after task completion is a CRITICAL GUIDELINE VIOLATION.**
 

--- a/guidelines/010-approval-gate.md
+++ b/guidelines/010-approval-gate.md
@@ -82,22 +82,16 @@ The interaction between developer authorization and process mandates follows the
 | Developer authorization + Tier 1 safety mandate | Safety mandate wins | Worktree and branch protection protect repository integrity regardless of authorization |
 | No developer authorization + any mandate | Mandate holds | Authorization is always required for implementation |
 
-#### Decision Table: Simple Work + File Modifications
+#### Decision Table: Authorization + File Modifications
 
 | Authorization | Work Type | File Mods? | Dispatch Path |
 |---------------|-----------|-------------|---------------|
-| Explicit (approved/go) | Clearly simple | Yes | `pre-work → implement → VbC → checklist → review-prep` (simple work dispatch path) |
-| Explicit (approved/go) | Clearly simple | No | Create issue only, no worktree needed |
 | Explicit (approved/go) | Complex | Yes | Full dispatch chain |
 | None | Any | Any | HALT — wait for authorization |
 
-Key insight: "Simple" describes the PROCESS burden (no spec/plan), not the SAFETY mechanism. Worktrees protect repository integrity regardless of task complexity.
-
-**For clearly simple work** (documentation, runbooks, minor configuration edits, single-file non-behavioral changes), developer authorization IS sufficient process — no separate spec/plan is required. The developer's explicit "approved" or "go" serves as both the authorization and the process justification.
+Key insight: All authorized work proceeds through the unified dispatch chain regardless of complexity. The unified dispatch path (see `000-critical-rules.md` §Unified Dispatch Path) ensures consistent worktree creation, sub-agent dispatch, and verification.
 
 **For complex work** (new features, behavioral changes, multi-file modifications), developer authorization means "you may begin the process." The spec/plan workflow still produces value (traceability, review trail, edge case discovery) even when authorization exists. The agent should proceed through spec/plan creation as part of the authorized work.
-
-**This resolves the contradiction identified in #912:** "NO code WITHOUT approved spec" is a Tier 2 mandate that yields to explicit developer authorization, while "create worktree before editing" is a Tier 1 mandate that never yields.
 
 ### Explicit Authorization Priority (Critical)
 

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -123,11 +123,6 @@ if ls "$WORK_STATE_DIR"/work-*.md 1>/dev/null 2>&1; then
             break
         fi
     done
-        if grep -qE '^## chain-context' "$f" 2>/dev/null; then
-            WORK_FILE_FOUND=1
-            break
-        fi
-    done
 fi
 
 if [ "$WORK_FILE_FOUND" = "0" ]; then

--- a/skills/approval-gate/SKILL.md
+++ b/skills/approval-gate/SKILL.md
@@ -109,7 +109,7 @@ IF code changes are needed AND no spec/plan exists:
 ENDIF
 ```
 
-Violation: Writing code without a spec bypasses the review trail and edge case discovery. For clearly simple work (docs, minor config), developer authorization IS the process — but the gate still requires checking.
+Violation: Writing code without a spec bypasses the review trail and edge case discovery.
 
 ## Operating Protocol
 
@@ -167,16 +167,6 @@ Plan approved
    → verification-before-completion (VERIFY: SC results exist) [DISPATCH_GATE]
    → finishing-a-development-branch --task checklist (VERIFY: all items checked) [DISPATCH_GATE]
    → git-workflow --task review-prep (VERIFY: compare URL generated) [DISPATCH_GATE]
-
-Clearly simple work (Tier 2 waiver)
-  → git-workflow --task pre-work (MANDATORY: worktree creation) [DISPATCH_GATE]
-  → Direct implementation in worktree (no sub-agent dispatch for single-file changes)
-  → verification-before-completion (simplified for docs/config) [DISPATCH_GATE]
-  → finishing-a-development-branch --task checklist [DISPATCH_GATE]
-  → git-workflow --task review-prep [DISPATCH_GATE]
-  → HALT (compare URL output)
-
-  **Classification check:** Before using this dispatch path, verify work meets ALL "clearly simple" criteria per `000-critical-rules.md` → "Simple Work Dispatch Path (Tier 2 Waiver)" → "Classification: Clearly Simple Work" table. If ANY criterion fails, use the full dispatch chain instead.
 
 Already implemented
   → verify-authorization (all gates pass) [DISPATCH_GATE]

--- a/skills/divide-and-conquer/tasks/assemble-work.md
+++ b/skills/divide-and-conquer/tasks/assemble-work.md
@@ -39,6 +39,18 @@ Orchestrate work execution by dispatching sub-agents for each approved issue, us
 
 **Work-of-1.** There is no separate code path. The `assemble-work` task handles single-issue dispatch as the default. This eliminates forked execution paths.
 
+### Step 1.5: Create Dispatch Entry Marker (MANDATORY)
+
+Before any worktree creation or sub-agent dispatch, create the dispatch entry marker so the pre-commit hook Gate 2 can verify authorized dispatch:
+
+```bash
+CURRENT_BRANCH=$(git branch --show-current)
+SAFE_BRANCH=$(echo "$CURRENT_BRANCH" | tr '/' '-')
+touch .opencode/tmp/dispatch-"$SAFE_BRANCH".marker
+```
+
+This marker serves as dispatch entry proof. The pre-commit hook (`.opencode/hooks/pre-commit` lines 33-129) checks for this marker before allowing commits.
+
 ### Step 2: Create Feature Branches and Worktrees
 
 For each issue in the work set:

--- a/skills/git-workflow/tasks/cleanup/branch-cleanup.md
+++ b/skills/git-workflow/tasks/cleanup/branch-cleanup.md
@@ -122,6 +122,18 @@ Before deleting ANY merged branch, verify that all branch content is present on 
 - Content comparison table as evidence artifact before any deletion
 - HALT and flag for developer review when UNIQUE content is found
 
+### Step 3.2: Remove Dispatch Entry Marker
+
+After confirming content is safe to delete, remove the dispatch entry marker for the merged branch:
+
+```bash
+CLEANUP_BRANCH_NAME=$(git branch --show-current)
+SAFE_BRANCH=$(echo "$CLEANUP_BRANCH_NAME" | tr '/' '-')
+rm -f .opencode/tmp/dispatch-"$SAFE_BRANCH".marker
+```
+
+This marker was created by `assemble-work` Step 1.5 as dispatch entry proof for the pre-commit hook.
+
 ### Step 3.5: Delete Current Merged Branch
 
 ```bash

--- a/skills/using-git-worktrees/SKILL.md
+++ b/skills/using-git-worktrees/SKILL.md
@@ -79,35 +79,6 @@ Branch naming: `spec/<short-name>` for spec-driven work, `feature/<description>`
 
 **BASE_BRANCH parameter:** The `create-worktree` task supports creating worktrees from branches other than `dev`. Defaults to `dev` for standalone branches. In work execution workflows, set to a prior feature branch (for dependency merge) or the work branch. Agent decides at creation time based on context.
 
-## Simple Work Worktree
-
-When the authorization qualifies as "clearly simple work" (per `000-critical-rules.md` → "Simple Work Dispatch Path (Tier 2 Waiver)"), a worktree is ONLY required when `WORKTREE_REQUIRED` is set. In direct-branch mode (default), simple work uses a feature branch in the main repo directly.
-
-### Simple Work Procedure (Direct-Branch Mode — Default)
-
-1. **Branch naming:** Use `docs/`, `runbook/`, or `config/` as the branch prefix for clearly simple work
-2. **Feature branch creation:** `git checkout -b <branch-name> dev` directly in main repo
-3. **Direct implementation:** Implement directly without worktree or sub-agent dispatch
-4. **Completion steps:** Follow the simple work dispatch path: `verification-before-completion` → `finishing-a-development-branch --task checklist` → `git-workflow --task review-prep`
-
-### Simple Work Procedure (Worktree Mode — When WORKTREE_REQUIRED Set)
-
-1. **Branch naming:** Use `docs/`, `runbook/`, or `config/` as the branch prefix
-2. **Worktree creation:** Invoke `git-workflow --task pre-work` — worktree creation applies
-3. **Direct implementation:** After worktree creation, implement directly in the worktree without sub-agent dispatch
-4. **Completion steps:** Follow the simple work dispatch path: `verification-before-completion` → `finishing-a-development-branch --task checklist` → `git-workflow --task review-prep`
-
-### What Does NOT Change for Simple Work
-
-| Step | Simple Work (Direct-Branch) | Simple Work (Worktree) | Complex Work |
-|------|----------------------------|------------------------|--------------|
-| Worktree required? | NO (default mode) | YES (opt-in) | Only if `WORKTREE_REQUIRED` |
-| No commits to main/dev? | YES (Tier 1) | YES (Tier 1) | YES (Tier 1) |
-| Path rules apply? | NO (relative paths) | YES (prefix with worktree.path) | Depends on mode |
-| Spec/plan needed? | NO (Tier 2 waiver) | NO (Tier 2 waiver) | YES (Tier 2) |
-| Sub-agent dispatch? | NO (single concern) | NO (single concern) | YES (divide-and-conquer) |
-| Pre-implementation analysis? | NO (no plan) | NO (no plan) | YES (expand sub-issues) |
-
 ## Cross-References
 
 - **Called by:** `brainstorming` (Phase 4), `divide-and-conquer`, `executing-plans`


### PR DESCRIPTION
## Summary
Adds prescriptive commit-time enforcement for the dispatch-entry gate. Implementation branches now require a .opencode/tmp/dispatch-&lt;branch&gt;.marker file — created by assemble-work, consumed by the pre-commit hook, removed by cleanup.

## Outcome
- Pre-commit hook blocks commits on implementation branches without dispatch marker evidence
- assemble-work creates the marker at dispatch entry
- branch-cleanup removes the marker during post-merge cleanup
- Simple Work Dispatch Path bypass removed from guidelines (all work routes through unified dispatch chain)
- Net: +29/-95 across 7 files

## Fixes
#244

🤖 Co-authored with AI: OpenCode (unknown)