### PR TITLE
Stacked PR: Runbook naming, CHANGELOG removal, .issues/ tracking, approval labels, model-aware testing

### DIFF
--- a/guidelines/000-critical-rules.md
+++ b/guidelines/000-critical-rules.md
@@ -2275,3 +2275,74 @@ The commit-per-issue invariant requires that single-issue branches produce exact
     triggers: [git-workflow]
     source: "000-critical-rules.md §Listing Merged PRs Without Invoking Cleanup"
 ```
+
+<!-- Issue #262: Model-Aware Behavioral Testing — Success Criteria: Add model-aware clean-room and no-inline-fallback critical violations -->
+
+## Critical Violation: Model-Aware Clean-Room Dispatch for Behavioral Testing
+
+**⚠️ Running behavioral enforcement tests by grepping test output files, scanning metadata, or performing pattern matches instead of dispatching clean-room `opencode-cli run` sub-agents against actual AI models is a CRITICAL GUIDELINE VIOLATION.**
+
+Behavioral enforcement tests exist to verify that an AI agent actually follows new rules. Metadata grep on test output is NOT behavioral verification — it is content verification masquerading as behavioral evidence. Every behavioral test MUST run via `opencode-cli run` against at least one real AI model. Accepting metadata-only pass/fail claims as behavioral evidence violates the same principle as #91 (metadata-as-evidence prohibition) applied to testing.
+
+- 🚫 FORBIDDEN: Running `grep`/`rg` on behavioral test output files as a substitute for clean-room `opencode-cli run` dispatching
+- 🚫 FORBIDDEN: Accepting metadata-only pass/fail claims for behavioral rule verification
+- 🚫 FORBIDDEN: Claiming behavioral tests pass without evidence of model execution (tool-call artifact confirming `opencode-cli run` was dispatched)
+- 🚫 FORBIDDEN: Dispatching behavioral test sub-agents without model selection context (at minimum, a resolved local model name)
+- 🚫 FORBIDDEN: Accepting single-model results as cross-model-validated when cross-model validation is required by the spec's phase structure
+- ✅ REQUIRED: Every behavioral enforcement test MUST be executed via `opencode-cli run` against at least one real AI model (local preferred, cloud as fallback)
+- ✅ REQUIRED: Model resolution via `ollama-model-resolve --target enforcement` MUST run before behavioral test dispatch
+- ✅ REQUIRED: Behavioral test results MUST include a tool-call artifact proving the model was dispatched (opencode-cli run log or sub-agent result contract)
+- ✅ REQUIRED: Cross-model validation (both local AND cloud model runs) when the spec mandates brittleness detection
+
+**AUTHORITY:** `verification-before-completion` skill, `divide-and-conquer` skill assemble-work dispatch context, Spec #262
+
+```yaml+symbolic
+  - id: critical-rules-042
+    title: "Model-aware clean-room dispatch required for all behavioral testing"
+    conditions:
+      any:
+        - "behavioral_test_performed_via_grep == true"
+        - "metadata_pass_fail_accepted_as_behavioral == true"
+        - "model_dispatched_for_behavioral_test == false"
+    actions:
+      - HALT
+      - DISPATCH(clean-room opencode-cli run with resolved model)
+    conflicts_with: []
+    requires: []
+    triggers: [verification-before-completion, divide-and-conquer]
+    source: "000-critical-rules.md §Model-Aware Clean-Room Dispatch for Behavioral Testing"
+```
+
+## Critical Violation: No Inline Fallback on Sub-Agent Failure During Behavioral Testing
+
+**⚠️ When a behavioral test sub-agent returns an empty result, error, or timeout, the orchestrator MUST re-dispatch a clean-room sub-agent — it MUST NOT perform inline file operations, read test output files directly, or manually compose test results. Inline fallback on sub-agent failure is the exact violation that #106 (orchestrator purity) was designed to prevent.**
+
+When a behavioral test sub-agent fails, reading its test output files inline and composing results manually produces evidence that bypasses ALL clean-room isolation guarantees. The evidence was not produced by an AI model in an isolated context — it was assembled by the orchestrator from grep results. This is the behavioral testing equivalent of the proxy-evidence regression from #91.
+
+- 🚫 FORBIDDEN: Orchestrator reading behavioral test output files and composing pass/fail results inline after sub-agent failure
+- 🚫 FORBIDDEN: Orchestrator performing inline `opencode-cli run` instead of dispatching a clean-room sub-agent
+- 🚫 FORBIDDEN: Orchestrator grepping behavioral test output for pass/fail patterns and reporting those as behavioral test results
+- 🚫 FORBIDDEN: Skipping re-dispatch because "the test output is readable" or "the result is obvious"
+- 🚫 FORBIDDEN: Accepting a `DONE` result contract that lacks tool-call evidence of model execution
+- ✅ REQUIRED: On sub-agent empty/error result: RE-DISPATCH a clean-room sub-agent with the same scoped context
+- ✅ REQUIRED: On double-failure: invoke `--task completion`, HALT with status message + byline
+- ✅ REQUIRED: Re-dispatch context MUST be identical to original — no additional orchestrator reasoning or expected outcomes
+- ✅ REQUIRED: Re-dispatch MUST receive a new clean-room sub-agent session (fresh context, no memory carryover)
+
+**AUTHORITY:** `divide-and-conquer` skill assemble-work Step 6 Sub-Agent Completion Checkpoint, Spec #106 (universal clean-room dispatch), Spec #262
+
+```yaml+symbolic
+  - id: critical-rules-043
+    title: "No inline fallback on sub-agent failure during behavioral testing"
+    conditions:
+      all:
+        - "behavioral_test_sub_agent_failed == true"
+        - "orchestrator_performed_inline_fallback == true"
+    actions:
+      - HALT
+      - RE_DISPATCH(clean-room sub-agent)
+    conflicts_with: []
+    requires: [critical-rules-034, critical-rules-042]
+    triggers: [divide-and-conquer, verification-before-completion]
+    source: "000-critical-rules.md §No Inline Fallback on Sub-Agent Failure During Behavioral Testing"
+```

--- a/guidelines/000-critical-rules.md
+++ b/guidelines/000-critical-rules.md
@@ -34,7 +34,7 @@ These mandates ensure disciplined workflow (spec-first, plan-before-implementati
 | -- | -- |
 | Spec before code | Developer authorization means "you may begin the process" — for complex work, still create a spec/plan |
 | Plan before implementation | Same as above — authorization authorizes the work, not necessarily every intermediate artifact |
-| `needs-approval` label present | Explicit auth overrides this label per `010-approval-gate.md` |
+| No `approved-for-*` label present | Explicit auth applies the correct `approved-for-*` label per `010-approval-gate.md` |
 | Sub-issue structure for multi-task plans | When developer authorizes a multi-task plan, sub-issue creation is auto-setup, not a separate gate |
 
 **For Tier 2 mandates, developer authorization does NOT mean "skip the process entirely"** — it means "you may begin." For complex work (new features, behavioral changes), the spec/plan workflow still produces value even when authorization exists.

--- a/guidelines/010-approval-gate.md
+++ b/guidelines/010-approval-gate.md
@@ -21,7 +21,7 @@
 | **Spec before code** | NO code/guideline changes WITHOUT approved spec |
 | **Plan before implementation** | NO implementation WITHOUT approved plan (spec approval → plan creation, plan approval → implementation) |
 | **Authorization required** | NO implementation WITHOUT explicit `"approved"` or `"go"` |
-| **Explicit auth overrides label** | When user says `approved`/`go`, proceed REGARDLESS of `needs-approval` label |
+| **Explicit auth applies label** | When user says `approved`/`go`, the agent applies the correct `approved-for-*` label from the scope-to-label mapping. No `approved-for-*` label = awaiting approval (equivalent to old `needs-approval`). |
 | **Branch first** | Create feature branch BEFORE any file modification |
 | **Human-only merge** | Agents MUST NEVER merge PRs |
 | **MCP tools** | Use appropriate tools per five-tier hierarchy (see `mcp-tool-usage` skill) |
@@ -95,23 +95,17 @@ Key insight: All authorized work proceeds through the unified dispatch chain reg
 
 ### Explicit Authorization Priority (Critical)
 
-**⚠️ When user provides explicit authorization (`approved`, `go`, `#123 approved`), proceed with implementation even if the `needs-approval` label is present.**
+**⚠️ When user provides explicit authorization (`approved`, `go`, `#123 approved`), apply the correct `approved-for-*` label per the scope-to-label mapping in `approval-gate` skill → "Approval Labels."**
 
-The `needs-approval` label is a **tracking tool**, not a permanent gate. Its purpose is:
-
-- Indicate "awaiting approval" visually
-- Remind reviewers that approval hasn't been given yet
-- Block agents from proceeding **until** explicit authorization is received
-
-**The label does NOT override explicit user authorization.**
+The absence of any `approved-for-*` label on an issue means "awaiting approval" — the equivalent of the old `needs-approval` label. The agent treats an issue with no `approved-for-*` label the same as an issue that previously had a `needs-approval` label: it must HALT and wait for authorization.
 
 | Scenario | Action |
 | -- | -- |
-| User says `approved` AND label present | ✅ **PROCEED** - explicit auth wins |
-| User says `#123 approved` AND label present | ✅ **PROCEED** - explicit auth wins |
-| User says `go` AND label present | ✅ **PROCEED** - explicit auth wins |
-| NO user authorization AND label present | ⛔ **HALT** - wait for authorization |
-| Label removed by user | ✅ **Proceed if authorized** - no issue |
+| User says `approved` (scope resolved) | ✅ **APPLY** the correct `approved-for-*` label per scope mapping. PROCEED. |
+| User says `#123 approved` (scope resolved) | ✅ **APPLY** the correct `approved-for-*` label per scope mapping. PROCEED. |
+| User says `go` (scope resolved) | ✅ **APPLY** the correct `approved-for-*` label per scope mapping. PROCEED. |
+| NO user authorization AND no `approved-for-*` label | ⛔ **HALT** - wait for authorization |
+| User authorizes at higher scope (re-authorization) | ✅ **REPLACE** old `approved-for-*` label with new one matching the higher scope |
 
 ### Authorization Scope
 
@@ -213,14 +207,14 @@ Key rules:
 
 **See `approval-gate` skill for revision status transition rules, mandatory actions, and exemption categories.**
 
-Key rule: Revision = `STATUS: X.Y (REVISED - NEEDS APPROVAL)` + `needs-approval` label + chat output + HALT.
+Key rule: Revision = `STATUS: X.Y (REVISED - NEEDS APPROVAL)` + remove `approved-for-*` label + chat output + HALT.
 
 Exempt from approval revocation:
 
 - STATUS marker updates (`☐ → ☑`, `1.1 → 1.2`)
 - Bug report additions (separate from spec content changes)
 
-**Exception: Needs-Approval State** — When an issue is already in `needs-approval` state (no approval has been granted), spec revision does NOT constitute "revoking approval" — there is nothing to revoke. The `needs-approval` label is preserved and the revision is documented in Revision Notes. This is the common case: most spec updates happen before approval.
+**Exception: Needs-Approval State** — When an issue is already in the "awaiting approval" state (no `approved-for-*` label; no approval has been granted), spec revision does NOT constitute "revoking approval" — there is nothing to revoke. The revision is documented in Revision Notes. This is the common case: most spec updates happen before approval.
 
 ### Re-implementation Workflow
 
@@ -233,17 +227,20 @@ When a spec is revised after a linked plan was already approved:
 
 ### Label Handling
 
-**The `needs-approval` label is informational when explicit authorization is present.**
+**The `approved-for-*` label is the single authority record for authorization status.**
 
-**See `approval-gate` skill for the complete label handling enforcement matrix.**
+See `approval-gate` skill → "Approval Labels" for the complete scope-to-label mapping, lifecycle rules, and label application procedure. Key rules:
 
-Key rule: Explicit authorization (`approved`/`go`) OVERRIDES the `needs-approval` label.
+- No `approved-for-*` label = awaiting approval (replaces the deprecated `needs-approval` label)
+- Authorization applies the correct `approved-for-*` label per the scope-to-label mapping
+- Re-authorization at higher scope replaces the prior label
+- Labels persist through all downstream stages — never removed until issue closure
 
 ### Bug Report Response
 
 **See `approval-gate` skill for the complete bug report response protocol.**
 
-Key rule: Bug reports requiring code changes → add `needs-approval` label → HALT → wait for explicit authorization.
+Key rule: Bug reports requiring code changes → no `approved-for-*` label → HALT → wait for explicit authorization.
 
 ### Audit Auto-Fix Exemption
 

--- a/guidelines/010-approval-gate.md
+++ b/guidelines/010-approval-gate.md
@@ -403,7 +403,7 @@ rules:
     source: "010-approval-gate.md §Tier0"
 
   - id: approval-gate-002
-    title: "Explicit authorization overrides needs-approval label"
+    title: "Explicit authorization applies approved-for-* label"
     conditions:
       any:
         - "user_says == 'approved'"

--- a/guidelines/020-go-prohibitions.md
+++ b/guidelines/020-go-prohibitions.md
@@ -84,6 +84,13 @@ If the action is in this list, proceed immediately without requesting or deliber
   4. If no candidates found: present the failure state ("No existing spec/plan found for [topic]"), offer to create a new spec
   5. Only after search+presentation: HALT, but the halt message now includes the search results
 - **The orchestrator NEVER performs inline work.** ALL file reads, file edits, file writes, analysis, verification, and decision-making MUST be delegated to clean-room sub-agents. The orchestrator ONLY dispatches sub-agents, receives result contracts, and routes to the next pipeline step. Zero inline file operations are permitted in the main agent context.
+<!-- Issue #262: Model-Aware Behavioral Testing — Success Criteria: Mandate scope-limited-by-default behavioral testing -->
+- **Scope-limited behavioral testing by default.** When running behavioral enforcement tests, the agent MUST default to scope-limited execution (changed scenarios only, named scenario, or tag-filtered). Full behavioral suite runs are permitted ONLY when model speed permits or when explicitly requested by the developer. Run `ollama-probe hw` to assess hardware before deciding full-suite feasibility. Running the full suite by default when a scope-limited run suffices wastes context budget and compute resources.
+  - 🚫 FORBIDDEN: Running `bash .opencode/tests/behaviors/run-all.sh` without explicit scope filtering when `--changed`, `--scenario`, or `--tag` options are applicable
+  - 🚫 FORBIDDEN: Defaulting to full behavioral suite without verifying model speed permits it
+  - ✅ REQUIRED: Default to `--changed` when there are uncommitted guideline/skill changes
+  - ✅ REQUIRED: Default to `--tag` matching the current work concern when no changed files
+  - ✅ REQUIRED: Assess hardware (`ollama-probe hw`) before running full suite — only proceed if VRAM ≥ 8 GB and at least one local model ≥ 7B is installed
 
 ## 1.5 Soliciting Authorization for Already-Authorized Phrases — CRITICAL VIOLATION
 

--- a/guidelines/060-tool-usage.md
+++ b/guidelines/060-tool-usage.md
@@ -18,7 +18,7 @@ When a skill indicates "Load guideline:" in its pre-conditions, use the `read` t
 ```
 TIER 1 — PRIMARY: opencode built-in tools (read/write/edit/glob/grep)
 TIER 2 — PRIMARY: Domain MCP (srclight, the-notebook-mcp, GitHub MCP)
-TIER 3 — PRIMARY: .opencode/tools/ (guidelines, md, memory, py ls/mkpkg)
+TIER 3 — PRIMARY: .opencode/tools/ (guidelines, md, memory, py ls/mkpkg, ollama-probe, ollama-model-resolve)
 TIER 4 — FALLBACK: JetBrains MCP (pycharm_*) — only for unique capabilities
 TIER 5 — LAST RESORT: Direct CLI (bash)
 

--- a/skills/approval-gate/SKILL.md
+++ b/skills/approval-gate/SKILL.md
@@ -30,6 +30,7 @@ You are an Authorization Gatekeeper. Your focus is ensuring all code changes fol
 | `verify-authorization/spec-to-plan-cascade` | Step 5b: Spec-to-plan approval cascade | ≈400 |
 | `verify-authorization/gap-fill-cascade` | Step 5b.5 + 5c: Gap-fill precedence and cascade execution | ≈500 |
 | `verify-authorization/auto-dispatch` | Step 6: Scope-aware auto-dispatch + output lineage | ≈500 |
+| `verify-authorization/model-selection` | Step 0.2: Resolve local and cloud models for behavioral test dispatch | ≈300 |
 | `verify-sub-issues` | Verify sub-issue structure for multi-task specs | ≈480 |
 | `verify-codebase` | Re-evaluate codebase state, detect staleness | ≈400 |
 | `verify-already-implemented` | Check if all success criteria are already met; autoclose if so | ≈400 |
@@ -432,6 +433,7 @@ When `halt_at < pr_created`, no PR is created — the agent halts before reachin
 | `verify-authorization/spec-to-plan-cascade` | Cascade approval from spec to plan | Spec issue number, plan issue number | Implementation context, agent memory | NO |
 | `verify-authorization/gap-fill-cascade` | Gap-fill missing artifacts per scope | Authorization scope, halt_at, gap-fill actions | Implementation context, agent memory | NO |
 | `verify-authorization/auto-dispatch` | Scope-aware auto-dispatch after verification | Authorization scope, halt_at, pr_strategy | Implementation context, agent memory | NO |
+| `verify-authorization/model-selection` | Model resolution for behavioral test dispatch | Enforcement target, hardware info, model list | Implementation context, agent memory | NO |
 | `verify-qa-mode` | Detect spec-less implementation requests | User request text, github.owner, github.repo | Implementation context, agent memory | NO |
 | `verify-already-implemented` | Check if spec is already implemented | Spec issue number, github.owner, github.repo | Implementation context, agent memory | NO |
 | `verify-closed-issue` | Verify closed issue has merged PR | Issue number, github.owner, github.repo | Implementation context, agent memory | NO |
@@ -483,6 +485,9 @@ work_peers: [<N>]  # screen-issue only
 authorization_scope: <scope_value>
 halt_at: <pipeline_stage>
 pr_strategy: stacked | individual | none
+test_models:
+  local: <resolved-local-model>
+  cloud: <resolved-cloud-fallback>
 session_vars:
   github.owner: <from-session>
   github.repo: <from-session>

--- a/skills/approval-gate/SKILL.md
+++ b/skills/approval-gate/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: approval-gate
-description: Use when user says "approved", "go", or any implementation instruction, or when authorization needs verification. Triggers on: approval, authorized, implement, start work, go ahead, needs-approval label, authorization set, multiple issues approved, interdependency analysis.
+description: Use when user says "approved", "go", or any implementation instruction, or when authorization needs verification. Triggers on: approval, authorized, implement, start work, go ahead, no approved-for-* label, authorization set, multiple issues approved, interdependency analysis.
 type: discipline-enforcing
 license: MIT
 provenance: AI-generated
@@ -22,7 +22,7 @@ You are an Authorization Gatekeeper. Your focus is ensuring all code changes fol
 | Task | Purpose | Words |
 |------|---------|-------|
 | `verify-qa-mode` | Detect spec-less implementation requests, switch to Q/A mode | ≈800 |
-| `verify-authorization` | Check explicit auth and needs-approval label; delegates branch creation to `git-workflow --task pre-work` | ≈400 |
+| `verify-authorization` | Check explicit auth and `approved-for-*` label status; delegates branch creation to `git-workflow --task pre-work` | ≈400 |
 | `verify-authorization/scope-auto-resolve` | Step 0.5: Scope auto-resolve from authorization phrase | ≈200 |
 | `verify-authorization/item-decomposition-check` | Step 4.5: Verify item decomposition in plan | ≈250 |
 | `verify-authorization/sc-traceability-check` | Step 4.6: SC-to-test traceability and RED-phase ordering | ≈350 |
@@ -117,7 +117,7 @@ Violation: Writing code without a spec bypasses the review trail and edge case d
 2. **Two-gate authorization model:** Spec approval → plan creation. Plan approval → implementation. Each gate requires explicit authorization. **Exception: Spec-to-plan cascade** — when a spec is approved and a plan already exists, the plan inherits the spec's approval status automatically (see Step 5b in `verify-authorization.md`).
 3. **Pre-Implementation Verification:** Verify spec or plan exists as GitHub Issue, verify authorization, verify sub-issues under plan (multi-task) — all consolidated in `verify-authorization` Step 5 as the single readiness check. The `issue-operations` `link-sub-issue` verification gate is superseded by `verify-authorization`.
 4. **Multi-task cascade:** When plan has sub-issues, authorization cascades from plan to ALL sub-issues. Complete ALL phases, report ONCE, HALT ONCE.
-5. **Spec-to-plan approval cascade:** When a spec is approved and a plan already exists that references the spec (`Spec: #N` in plan body), the plan inherits the spec's approval status. The `needs-approval` label is removed from the plan and a comment documents the cascade. If multiple plans reference the spec, the most recent plan by creation date is cascade-approved and older plans are superseded. If no plan exists, the cascade does NOT apply — the standard flow (spec approval → writing-plans create → plan needs approval) continues. See `verify-authorization.md` Step 5b for the complete cascade procedure.
+5. **Spec-to-plan approval cascade:** When a spec is approved and a plan already exists that references the spec (`Spec: #N` in plan body), the plan inherits the spec's approval status. The `approved-for-*` label matching the spec's scope is applied to the plan and a comment documents the cascade. If multiple plans reference the spec, the most recent plan by creation date receives the label and older plans are superseded. If no plan exists, the cascade does NOT apply — the standard flow (spec approval → writing-plans create → plan needs approval) continues. See `verify-authorization.md` Step 5b for the complete cascade procedure.
 6. **Spec revision revocation:** If a spec is revised (status contains `REVISED - NEEDS APPROVAL` — in either prose or numeric format), find linked plan issues by searching for `[PLAN]` issues referencing the spec number in their body and mark them for audit. Revision of a spec revokes approval on its linked plan — including cascaded approval. Prose format example: `STATUS: in progress — {concern} (REVISED - NEEDS APPROVAL)`. Numeric format example: `STATUS: 1.1 (REVISED - NEEDS APPROVAL)`.
 7. **Auto-dispatch after verification:** When all verification gates pass, auto-dispatch to the next skill in the chain. See Dispatch Order below.
 
@@ -149,11 +149,11 @@ After `verify-authorization` completes successfully (all gates pass), the skill 
 Spec approved (no existing plan)
   → verify-authorization (all gates pass) [DISPATCH_GATE]
   → writing-plans --task create (auto-dispatched to create plan issue) [DISPATCH_GATE]
-  → Plan retains needs-approval label (requires separate plan approval)
+   → Plan has no `approved-for-*` label (requires separate plan approval — equivalent to old `needs-approval` state)
 
 Spec approved (existing plan found)
   → verify-authorization (all gates pass) [DISPATCH_GATE]
-  → Step 5b: cascade approval to existing plan (remove needs-approval, add comment) [DISPATCH_GATE]
+   → Step 5b: cascade approval to existing plan (apply `approved-for-*` label, add comment) [DISPATCH_GATE]
   → Plan is now approved → skip to plan-approved dispatch path [DISPATCH_GATE]
   → sub-issue verification (Step 5 of verify-authorization, if multi-phase) [DISPATCH_GATE]
   → pre-implementation-analysis [DISPATCH_GATE] → divide-and-conquer/assemble-work [DISPATCH_GATE] → ...
@@ -250,14 +250,45 @@ This gate runs as part of `verify-authorization`, BEFORE the dispatch chain proc
 
 Tier 1 mandates never skipped. Work state file bridges hops. See `enforcement/auto-dispatch-table.md` §Path Routing.
 
+## Approval Labels (Single Source of Truth)
+
+### Scope-to-Label Mapping
+
+| authorization_scope | Label | halt_at |
+|---|---|---|
+| `for_spec` | `approved-for-spec` | spec_created |
+| `for_plan` | `approved-for-plan` | plan_created |
+| `for_implementation` | `approved-for-implementation` | implementation_complete |
+| `for_code_review` | `approved-for-code-review` | code_review_ready |
+| `for_pr` | `approved-for-pr` | pr_created |
+| `pr_only` | `approved-for-pr-only` | pr_created |
+| `review_only` | `approved-for-review` | code_review_ready |
+| `standard` (default) | `approved-for-review-prep` | review_prep |
+
+### Label Lifecycle Rules
+
+1. **On authorization:** Apply the `approved-for-*` label matching the resolved `authorization_scope`. Remove any prior `approved-for-*` label (replacement) and the deprecated `needs-approval` label.
+2. **On re-authorization:** Replace — old `approved-for-*` removed, new one applied. Labels never coexist.
+3. **On stage completion:** Label stays. It is a persistent authority record through all downstream stages — never removed until issue closure.
+4. **Absence of any `approved-for-*` label:** Equivalent to the old `needs-approval` state — meaning "awaiting approval." An issue with no `approved-for-*` label must not be implemented.
+
+### Label Application Procedure
+
+1. Resolve `authorization_scope` via `scope-auto-resolve` (Step 0.5 of `verify-authorization.md`)
+2. Determine the correct `approved-for-*` label from the mapping table above
+3. Remove ALL prior `approved-for-*` labels and the `needs-approval` label from the issue
+4. Apply the new `approved-for-*` label
+5. Verify label is present via `github_issue_read(method=get_labels)`
+6. Record the label in the result contract as `applied_label`
+
 ## Authorization Requirements
 
 | Requirement | Description |
 |-------------|-------------|
 | **Spec or Plan exists as GitHub Issue** | No local fallback — GitHub Issues only |
 | **Two-gate authorization** | Spec approval → plan creation; Plan approval → implementation. Exception: spec-to-plan cascade (see below) |
-| **Spec-to-plan approval cascade** | When a spec is approved and a plan already exists referencing the spec, the plan inherits the spec's approval status. `needs-approval` label is removed and a comment documents the cascade. Most recent plan is approved; older plans are superseded. If no plan exists, standard flow applies. |
-| **Explicit authorization** | User says `approved`, `go`, `approved: N.M`, or `approved: {concern}` — OVERRIDES `needs-approval` label |
+| **Spec-to-plan approval cascade** | When a spec is approved and a plan already exists referencing the spec, the plan inherits the spec's approval status. The `approved-for-*` label matching the spec's scope is applied to the plan and a comment documents the cascade. Most recent plan is approved; older plans are superseded. If no plan exists, standard flow applies. |
+| **Explicit authorization** | User says `approved`, `go`, `approved: N.M`, or `approved: {concern}` — applies the correct `approved-for-*` label per the Scope-to-Label Mapping above |
 | **Open questions resolved** | No unresolved items in spec or plan |
 | **Sub-issues verified under plan** | Multi-task plans require phase-level sub-issues (verified in `verify-authorization` Step 5 — single authoritative gate) |
 | **Fix spec for bug reports** | Bug reports must have a fix spec sub-issue before closure (per `000-critical-rules.md`) |
@@ -466,7 +497,7 @@ Every task that reads a metadata claim (label, comment, STATUS marker, sub-issue
 
 **Evidence format and finding classification:** See `enforcement/adversarial-verification.md` for the complete evidence format, three-tier finding classification (auto-fix, conditional, flag-for-review), and problem class taxonomy. Every verification check MUST produce an evidence artifact via tool call — assertions without tool call evidence are verification honesty violations.
 
-Key verification checks: `needs-approval` label status, authorization comment author/scope/currency, STATUS marker maturity, sub-issue open/closed state, fix spec existence, and screen-issue dispatch completeness.
+Key verification checks: `approved-for-*` label status, authorization comment author/scope/currency, STATUS marker maturity, sub-issue open/closed state, fix spec existence, and screen-issue dispatch completeness.
 
 ## Cross-References
 
@@ -485,7 +516,7 @@ Rules are classified into two tiers per `000-critical-rules.md` → "Mandate Tie
 | Tier | Behavior | Examples |
 |------|----------|----------|
 | **Tier 1 (Non-Yielding)** | Enforced REGARDLESS of developer authorization | Worktree requirement, branch protection, human-only merge, no `/tmp/`, path rules |
-| **Tier 2 (Authorization-Waivable)** | Yields to explicit developer authorization | Spec-before-code, plan-before-implementation, `needs-approval` label |
+| **Tier 2 (Authorization-Waivable)** | Yields to explicit developer authorization | Spec-before-code, plan-before-implementation, no `approved-for-*` label |
 
 **Enforcement rule:** When `verify-authorization` confirms developer authorization exists, Tier 2 mandates are satisfied by that authorization. Tier 1 mandates are NEVER satisfied by authorization — they are independently enforced. An agent with developer authorization MUST still create a worktree, MUST still not commit to main/dev, MUST still not merge PRs.
 
@@ -677,7 +708,7 @@ rules:
         - "spec_approved == true"
         - "spec_has_existing_plan == true"
     actions:
-      - REMOVE_LABEL(needs-approval, plan)
+      - APPLY_LABEL(approved-for-*, plan)
       - ADD_COMMENT(cascade approval documentation)
       - PROCEED_TO(plan-approved dispatch path)
     conflicts_with: []

--- a/skills/approval-gate/tasks/verify-authorization.md
+++ b/skills/approval-gate/tasks/verify-authorization.md
@@ -23,6 +23,7 @@ This task delegates to atomic sub-tasks. Each sub-task reads inputs from the wor
 | Step | Sub-Task | Purpose |
 |------|----------|---------|
 | 0 | Inline fallback guard | If sub-agent returns empty, execute Steps 1-6 inline |
+| 0.2 | Model resolution (inline) | Resolve local + cloud models via `ollama-model-resolve --target enforcement`; record model pair for dispatch context |
 | 0.5 | `verify-authorization/scope-auto-resolve` | Parse authorization text, resolve scope/halt_at/pr_strategy/gap_fill |
 | 1 | `verify-authorization/verify-explicit-authorization` | Check for "approved"/"go" + author identity + currency |
 | 2 | Label application (inline) | Apply `approved-for-*` label per mapping table; remove prior `approved-for-*` and `needs-approval` labels |
@@ -33,6 +34,17 @@ This task delegates to atomic sub-tasks. Each sub-task reads inputs from the wor
 | 5b | `verify-authorization/spec-to-plan-cascade` | Spec-to-plan approval cascade |
 | 5b.5+5c | `verify-authorization/gap-fill-cascade` | Gap-fill precedence and cascade execution |
 | 6 | `verify-authorization/auto-dispatch` | Scope-aware auto-dispatch + output lineage |
+
+### Step 0.2: Model Selection Gate (MANDATORY)
+
+Before dispatching behavioral test sub-agents (Phase 4 of any plan), resolve the local and cloud model pair:
+
+1. Run `.opencode/tools/ollama-model-resolve --target enforcement` to select the smallest local model
+2. Extract `selected` (local model) and `fallback` (cloud model) from the JSON output
+3. Record the model pair in the authorization context: `test_models: {local: "<model_name>", cloud: "<model_name>"}`
+4. This model pair is embedded in all downstream dispatch contexts
+
+**Model resolution evidence:** Tool-call artifact from `ollama-model-resolve` must be present in the session log before behavioral test dispatch proceeds.
 
 **Chain-of-responsibility:** Sub-tasks use work state file for I/O per `enforcement/work-state-schema.md`. Path selection per SKILL.md §Chain-of-Responsibility Paths:
 

--- a/skills/approval-gate/tasks/verify-authorization.md
+++ b/skills/approval-gate/tasks/verify-authorization.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-Check for explicit authorization and needs-approval label status before implementation. This task orchestrates the atomized sub-tasks in `verify-authorization/` for fine-grained, low-context verification.
+Check for explicit authorization and apply the correct `approved-for-*` label before implementation. This task orchestrates the atomized sub-tasks in `verify-authorization/` for fine-grained, low-context verification.
 
 ## Entry Criteria
 
@@ -12,7 +12,7 @@ Check for explicit authorization and needs-approval label status before implemen
 ## Exit Criteria
 
 - Authorization verified as explicit and for correct issue
-- needs-approval label status checked
+- `approved-for-*` label applied per mapping table; deprecated `needs-approval` label removed
 - Git state verified (worktree environment ready)
 - Authorization recorded for scope tracking
 
@@ -25,7 +25,7 @@ This task delegates to atomic sub-tasks. Each sub-task reads inputs from the wor
 | 0 | Inline fallback guard | If sub-agent returns empty, execute Steps 1-6 inline |
 | 0.5 | `verify-authorization/scope-auto-resolve` | Parse authorization text, resolve scope/halt_at/pr_strategy/gap_fill |
 | 1 | `verify-authorization/verify-explicit-authorization` | Check for "approved"/"go" + author identity + currency |
-| 2 | Label check (inline) | Check needs-approval label status, handle explicit auth override |
+| 2 | Label application (inline) | Apply `approved-for-*` label per mapping table; remove prior `approved-for-*` and `needs-approval` labels |
 | 3 | Authorization decision (inline) | Route based on authorization result |
 | 4.5 | `verify-authorization/item-decomposition-check` | Verify item enumeration, dependency ordering, TDD steps |
 | 4.6 | `verify-authorization/sc-traceability-check` | Verify SC-to-test traceability, RED-phase ordering |

--- a/skills/brainstorming/SKILL.md
+++ b/skills/brainstorming/SKILL.md
@@ -94,6 +94,54 @@ You are a Requirements Explorer. Your focus is understanding what the user wants
 - **Structural decisions are agent-resolved** — single-task vs multi-task classification, phase decomposition, and scope sizing are agent intelligence concerns; resolve autonomously unless multiple valid structures exist with meaningful trade-offs
 - **Source attribution** — credit external sources in the spec
 
+### Analysis & Brainstorming Artifacts (MANDATORY)
+
+During exploration, write findings to `.issues/<issue_number>/`:
+
+**`analysis.md`** — Pre-spec investigation findings:
+```markdown
+# Analysis: Issue #<N>
+
+## Code Inspection Checklist
+- [x] Trace call paths
+- [x] Verify imports
+- [x] Detect dead code
+- [x] Verify format/protocol assumptions
+- [x] Confirm architectural layer
+- [x] Check for existing alternatives
+
+## Findings
+<per-checklist-item findings>
+```
+
+**`brainstorm.md`** — Exploration notes:
+```markdown
+# Brainstorm: Issue #<N>
+
+## Questions Asked
+<Q&A pairs from exploration>
+
+## Answers Found
+<key insights>
+
+## Dead Ends Explored
+<approaches that didn't work and why>
+```
+
+**Creation procedure:**
+1. Create directory: `mkdir -p .issues/<issue_number>/`
+2. Write `analysis.md` with code inspection checklist results
+3. Write `brainstorm.md` with exploration notes
+4. Auto-commit:
+   ```bash
+   git add .issues/<issue_number>/analysis.md .issues/<issue_number>/brainstorm.md
+   git commit -m "docs(issues): <issue_number> - analysis: code inspection, brainstorm: exploration notes"
+   ```
+
+**`issue-review --task analyze-and-spec`** also writes analysis findings to `.issues/<issue_number>/analysis.md` following the same format and auto-commit convention.
+
+Note: `analysis.md` and `brainstorm.md` are written in addition to (not replacing) the existing terminal state paths (Paths A/B/C). The terminal state still invokes `spec-creation` or `writing-plans` per existing protocol.
+
 ## Dispatch Order
 
 ```

--- a/skills/changelog-generator/tasks/backfill.md
+++ b/skills/changelog-generator/tasks/backfill.md
@@ -21,6 +21,22 @@ Backfill CHANGELOG.md with entries from historical commits that were missing cha
 
 ## Procedure
 
+### Step 0: Create CHANGELOG.md if Missing
+
+If `CHANGELOG.md` does not exist, create it with a minimal Keep a Changelog header:
+
+```markdown
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+## [Unreleased]
+```
+
+Do not stage or commit the file at this step — the subsequent steps will populate it.
+
 ### Step 1: Identify Scope
 
 ```bash

--- a/skills/changelog-generator/tasks/since-last-release.md
+++ b/skills/changelog-generator/tasks/since-last-release.md
@@ -14,6 +14,22 @@ Generate changelog entries for all commits since the last changelog update.
 
 ## Procedure
 
+### Step 0: Create CHANGELOG.md if Missing
+
+If `CHANGELOG.md` does not exist, create it with a minimal Keep a Changelog header:
+
+```markdown
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+## [Unreleased]
+```
+
+Do not stage or commit the file at this step — the subsequent steps will populate it.
+
 ### Step 1: Find Last Changelog Update
 
 ```bash

--- a/skills/divide-and-conquer/SKILL.md
+++ b/skills/divide-and-conquer/SKILL.md
@@ -145,7 +145,7 @@ When a sub-agent cannot fit the assigned work, it MUST return `status: OVERFLOW`
 
 ## Dispatch Context Contract
 
-When the orchestrator dispatches a sub-agent, it MUST pass: `issue`, `branch`, `spec`, `plan_issue`, `authorization`, `authorization_scope`, `halt_at`, `pr_strategy`, `depth`, `max_depth`, `prior_context`, `decision_log_reference`, `phase_progress` (prose-driven: completed phases by concern, boundaries crossed, verification evidence), `sub_task` (description, scope, boundaries), `model_context`, `env_vars` (worktree.path, branch, github.owner, github.repo), `tdd_phase`, `current_item`, `top_down_items`, `dev.name`, `dev.email`. See `context-passing` task for the full schema.
+When the orchestrator dispatches a sub-agent, it MUST pass: `issue`, `branch`, `spec`, `plan_issue`, `authorization`, `authorization_scope`, `halt_at`, `pr_strategy`, `depth`, `max_depth`, `prior_context`, `decision_log_reference`, `phase_progress` (prose-driven: completed phases by concern, boundaries crossed, verification evidence), `sub_task` (description, scope, boundaries), `model_context`, `env_vars` (worktree.path, branch, github.owner, github.repo), `tdd_phase`, `current_item`, `top_down_items`, `dev.name`, `dev.email`, `test_models` (local model name, cloud model name — resolved at authorization verification). See `context-passing` task for the full schema.
 
 **Invariants:** `worktree.path` is MANDATORY in worktree mode — no exceptions. If empty when `WORKTREE_REQUIRED` is set: FATAL ERROR → HALT. In direct-branch mode, `worktree.path` is NOT set and sub-agents operate in the main repo directory. `plan_issue` is set when dispatched from plan approval flow. `phase_progress` accumulates across the work set from prior sub-agent results.
 

--- a/skills/divide-and-conquer/tasks/assemble-work.md
+++ b/skills/divide-and-conquer/tasks/assemble-work.md
@@ -112,7 +112,10 @@ For each issue in execution order:
          github.repo: "<from-session>"
          dev.name: "<from-session>"
          dev.email: "<from-session>"
-      ```
+       test_models:
+         local: "<resolved-local-model>"
+         cloud: "<resolved-cloud-fallback>"
+       ```
 
 3. **Spawn sub-agent** via `task(subagent_type="general", prompt=...)`
 

--- a/skills/git-workflow/tasks/cleanup/branch-cleanup.md
+++ b/skills/git-workflow/tasks/cleanup/branch-cleanup.md
@@ -172,6 +172,8 @@ git status --porcelain  # Must be empty
 git branch -vv          # Should show minimal branches
 ```
 
+**`.issues/<N>/` Persistence:** The `.issues/<issue_number>/` directory MUST NOT be deleted. It persists permanently in the working tree on `dev` as immutable history. After merge, the feature branch's `.issues/<N>/` content lands in `dev` via the merge. Do NOT add cleanup steps that remove or archive these directories.
+
 ### Step 6: Succinct Confirmation
 
 **The `cleanup` task is THE END of the PR workflow. It MUST produce a one-line succinct confirmation and then HALT.**

--- a/skills/git-workflow/tasks/pre-work.md
+++ b/skills/git-workflow/tasks/pre-work.md
@@ -274,6 +274,46 @@ test -f .gitmodules
 
 **If `.gitmodules` does NOT exist:** Skip all submodule steps and proceed to Step 4.
 
+### Step 3.7: Initialize .issues/<issue_number>/ Directory (MANDATORY)
+
+After branch creation and submodule sync, initialize the `.issues/<issue_number>/` tracking directory:
+
+1. **Create directory:**
+   ```bash
+   mkdir -p .issues/<issue_number>/
+   ```
+
+2. **Fetch spec from API and mirror to `spec.md`:**
+   - Call `github_issue_read(method="get", owner=<github.owner>, repo=<github.repo>, issue_number=<issue_number>)`
+   - If success: write `.issues/<issue_number>/spec.md` with header `# Synced from GitHub Issue #<issue_number> at <ISO8601-timestamp>` followed by the issue body
+   - If API unreachable: skip `spec.md` creation (no fallback since there's nothing to fall back to at initialization)
+   - See `issue-operations/platforms/github-mcp/SKILL.md` → "spec.md Mirror" for the complete mirror procedure
+
+3. **Write initial `state.md`:**
+   ```markdown
+   # State: Issue #<issue_number>
+
+   **Branch:** <branch-name>
+   **Workflow Phase:** pre-work
+   **Created:** <ISO8601-timestamp>
+   **Last Updated:** <ISO8601-timestamp>
+   **Status:** initialized
+
+   ## Current State
+
+   Pre-work initialization complete. Awaiting implementation dispatch.
+
+   ## Blockers
+
+   None.
+   ```
+
+4. **Auto-commit `.issues/<issue_number>/`:**
+   ```bash
+   git add .issues/<issue_number>/spec.md .issues/<issue_number>/state.md
+   git commit -m "docs(issues): <issue_number> - spec: mirrored from GitHub Issue #<issue_number>, state: pre-work initialization"
+   ```
+
 ### Step 4: Verify Branch Environment
 
 **Before yielding back to orchestration layer, verify:**

--- a/skills/git-workflow/tasks/review-prep.md
+++ b/skills/git-workflow/tasks/review-prep.md
@@ -29,6 +29,20 @@ Sequence: Implementation complete → commit → push → **review-prep MUST be 
 
 ## Procedure
 
+### Step 0: Auto-Commit Dirty .issues/<N>/ Files (MANDATORY)
+
+Before push, auto-commit any dirty `.issues/<issue_number>/` files to ensure all tracking artifacts ride with the feature PR:
+
+```bash
+# Check for uncommitted .issues/ changes
+if git status --porcelain -- .issues/ 2>/dev/null | grep -q '^'; then
+    git add .issues/
+    git commit -m "docs(issues): <issue_number> - tracking artifacts checkpoint before review-prep"
+fi
+```
+
+**No separate PR required.** `.issues/<N>/` commits ride along with the feature branch PR. No additional authorization needed — covered by feature branch authorization per `000-critical-rules.md` §Auto-Commit Convention.
+
 ### Steps 0-2: Push, Cleanup, Rebase, Verify
 
 **Route to:** `review-prep/push-and-cleanup`
@@ -96,6 +110,7 @@ Guideline and documentation changes are NOT exempt from PR workflow.
 ## Enforcement Checklist
 
 - ✅ Implementation work is complete
+- ✅ `.issues/<N>/` dirty files auto-committed (Step 0)
 - ✅ All file changes committed
 - ✅ Branch pushed to remote
 - ✅ Temp files cleaned

--- a/skills/issue-operations/SKILL.md
+++ b/skills/issue-operations/SKILL.md
@@ -294,7 +294,7 @@ The `link-sub-issue` task MUST read the parent plan's `pr_boundaries` section an
 ### NEVER DO
 
 - Create issues via direct `github_issue_write` calls (bypasses validation)
-- Skip `needs-approval` label for new specs
+- Skip the label for new specs (no `approved-for-*` label = awaiting approval — equivalent to old `needs-approval` state)
 - Create sub-issues for single-task specs
 - Skip auditor invocation for multi-task specs
 - Create issues with conflicting/overlapping objectives
@@ -302,13 +302,14 @@ The `link-sub-issue` task MUST read the parent plan's `pr_boundaries` section an
 - Post non-substantive comments to issues
 - Create an issue without checking for existing matches first
 - Create an issue via `creation` task without Step 0.5 dedup evidence
+- Reference the `needs-approval` label as an active concept (deprecated — use "no `approved-for-*` label = awaiting approval")
 
 ### ALWAYS DO
 
 - Invoke `pre-creation` task before creating issue
 - Run Step 0.5 title dedup gate before any issue creation
 - Verify Step 0.5 dedup evidence before proceeding to `creation` task
-- Apply `needs-approval` label to new specs
+- Leave issues with no `approved-for-*` label until explicitly authorized (no `approved-for-*` label = awaiting approval)
 - Add creation byline in issue body footer
 - Invoke auditors before approval
 - Check for superseding/conflicting issues
@@ -379,7 +380,7 @@ When the `git-workflow` provenance task creates an issue in a submodule reposito
 | -- | -- | -- |
 | Invocation | Via this skill | Via `git-workflow --task provenance` |
 | Target repo | Parent repo | Submodule repo |
-| Labels | `needs-approval` | None (provenance tracking is informational) |
+| Labels | No `approved-for-*` label (awaiting approval) | None (provenance tracking is informational) |
 | Title format | `[SPEC]`, `[SPEC-FIX]`, etc. | `Sync from <parent-repo>/<parent-branch>: ...` or `Release ...` |
 | Body | Spec content | Provenance metadata (parent refs, tier info) |
 | Byline | Required | Required |
@@ -436,7 +437,7 @@ For the provenance issue body format and tier-specific details, see `git-workflo
 | "Issue #N exists" | Verify via platform API | `github_issue_read(method="get", issue_number=N)` | MISSING-ELEMENT |
 | "PR #N is merged" | Verify merge status | `github_pull_request_read(method="get", pullNumber=N)` → check `merged` field | VERIFICATION-GAP |
 | "Platform supports sub-issues" | Probe capabilities | `issue-operations --task capabilities` | CONFLICTING |
-| "Issue has `needs-approval` label" | Verify label presence | `github_issue_read(method="get_labels", issue_number=N)` | VERIFICATION-GAP |
+| "Issue has no `approved-for-*` label" | Verify label absence | `github_issue_read(method="get_labels", issue_number=N)` | VERIFICATION-GAP |
 | "All sub-issues closed" | Verify each sub-issue state | `github_issue_read(method="get_sub_issues", issue_number=N)` → check each closed | VERIFICATION-GAP |
 | "No conflicting spec exists" | Search for overlapping issues | `github_search_issues(query="label:spec <keyword>")` | CONFLICTING |
 | "Session init has <github.owner>/<github.repo>" | Verify session values | Check session init output | MISSING-ELEMENT |
@@ -641,7 +642,7 @@ tasks:
   - id: creation
     skill: issue-operations
     preconditions: ["pre-creation_completed", "single_task_check_completed", "byline_present"]
-    postconditions: ["issue_created", "labels_applied", "needs_approval_label_present"]
+    postconditions: ["issue_created", "labels_applied", "no_approved-for-*_label_on_creation"]
     mandatory: true
     bypass_violation: "CRITICAL: Direct github_issue_write calls skip byline verification, label enforcement, and pre-creation validation"
     source: "issue-operations/SKILL.md §Tasks"

--- a/skills/issue-operations/SKILL.md
+++ b/skills/issue-operations/SKILL.md
@@ -77,6 +77,10 @@ issue-operations/                     # Dispatcher — workflow logic, platform 
 
 **COMPLETION GUARANTEE:** If this workflow halts at ANY point — including error, failure, or early termination — you MUST invoke `--task completion` before halting. The completion subtask ensures mandatory steps (labels, auditors, sub-issues, status report) are never skipped. It is idempotent and safe to invoke multiple times.
 
+## spec.md Mirror (MANDATORY)
+
+The dispatcher MUST mirror every successful `github_issue_read(method="get")` to `.issues/<issue_number>/spec.md`. See `platforms/github-mcp/SKILL.md` → "spec.md Mirror" for the complete procedure including sync, fallback, staleness detection, and no-sync-back rules.
+
 ## Hard Gates (MANDATORY — no bypass)
 
 ### Gate 1: Skill Dispatch Before Direct API Calls

--- a/skills/issue-operations/platforms/gitbucket-api/SKILL.md
+++ b/skills/issue-operations/platforms/gitbucket-api/SKILL.md
@@ -71,6 +71,23 @@ GitBucket platform implementation using Python client. Implements a GitHub-compa
 | `repository-operations` | When GitBucket repository CRUD is needed | Repository data, github.owner, github.repo | Implementation context, agent memory | NO |
 | `session-integration` | When GitBucket session init integration is needed | Session context, environment variables | Implementation context, agent memory | NO |
 
+## Authorization Labels (Platform-Supported)
+
+GitBucket API supports labels via creation only (post-creation label mutation is broken). The eight `approved-for-*` labels are:
+
+| Label | Purpose |
+|---|---|
+| `approved-for-spec` | Authorization through spec creation |
+| `approved-for-plan` | Authorization through plan creation |
+| `approved-for-implementation` | Authorization through implementation |
+| `approved-for-code-review` | Authorization through code review |
+| `approved-for-pr` | Full pipeline through PR creation |
+| `approved-for-pr-only` | PR creation only |
+| `approved-for-review` | Code review only |
+| `approved-for-review-prep` | Default authorization |
+
+**Deprecated:** The `needs-approval` label is deprecated. No `approved-for-*` label = awaiting approval. Label replacement on re-authorization is implemented via comment fallback (remove old label via `remove_label_from_issue`, apply new on next creation cycle).
+
 ## Authentication
 
 Token authentication ONLY. Basic auth is broken in GitBucket (returns "Bad credentials" for all requests).

--- a/skills/issue-operations/platforms/github-mcp/SKILL.md
+++ b/skills/issue-operations/platforms/github-mcp/SKILL.md
@@ -49,6 +49,51 @@ All operations dispatched through the `github_*` MCP tool family. No Python clie
 
 None required. GitHub MCP provides complete API coverage.
 
+## spec.md Mirror (MANDATORY)
+
+Every `github_issue_read(method="get")` call MUST mirror the spec body to `.issues/<issue_number>/spec.md`:
+
+| Event | Action |
+|-------|--------|
+| `github_issue_read(method="get")` success | Write `.issues/<issue_number>/spec.md` with header `# Synced from GitHub Issue #<N> at <ISO8601-timestamp>` followed by the issue body |
+| `github_issue_read(method="get")` repeated | Overwrite `spec.md` with updated timestamp and body |
+| API unreachable (network error, rate limit, auth failure) | Read `.issues/<issue_number>/spec.md` from disk, note staleness in chat: `"spec.md last synced at <timestamp>, may be stale"` |
+| API comes back after outage | Re-fetch and overwrite on next spec read |
+
+### Mirror Sync Procedure (MANDATORY)
+
+After every `github_issue_read(method="get")` success:
+
+1. Create directory: `mkdir -p .issues/<issue_number>/`
+2. Write `spec.md`:
+```
+# Synced from GitHub Issue #<N> at <ISO8601-timestamp>
+
+<issue body>
+```
+3. Report to chat: `"spec.md mirror updated for #<N> at <timestamp>"`
+
+### Fallback Procedure (MANDATORY)
+
+When `github_issue_read(method="get")` fails with a network error, rate limit, or auth failure:
+
+1. Check if `.issues/<issue_number>/spec.md` exists
+2. If exists: read from disk, note in chat: `"GitHub API unreachable. Reading spec.md (last synced at <timestamp>, may be stale)."`
+3. If NOT exists and API is unreachable: report `"Cannot read spec #<N> — API unreachable and no local spec.md mirror exists."`
+4. Proceed with stale/absent data noting the risk
+
+### Staleness Detection
+
+`spec.md` is stale when:
+1. The sync timestamp in the header is more than 24 hours old
+2. The GitHub Issue was modified (comments added, labels changed) since the last sync
+
+Agent MUST report staleness when detected and should attempt to refresh. If API still unreachable, proceed with stale copy noting the risk.
+
+### No Sync-Back
+
+`spec.md` is read-only from the agent's perspective. The agent NEVER edits `spec.md` — it always writes to the GitHub Issue via the API. This prevents divergence between the local mirror and the authoritative copy.
+
 ## Cross-References
 
 - Dispatcher: `../SKILL.md` (issue-operations)

--- a/skills/issue-operations/platforms/github-mcp/SKILL.md
+++ b/skills/issue-operations/platforms/github-mcp/SKILL.md
@@ -45,6 +45,23 @@ GitHub platform implementation using GitHub MCP tools. Full API coverage with no
 
 All operations dispatched through the `github_*` MCP tool family. No Python client needed — the MCP server handles authentication and API routing.
 
+## Authorization Labels (Platform-Supported)
+
+GitHub MCP supports all eight `approved-for-*` labels for issue labeling:
+
+| Label | Purpose |
+|---|---|
+| `approved-for-spec` | Authorization through spec creation (scope: `for_spec`) |
+| `approved-for-plan` | Authorization through plan creation (scope: `for_plan`) |
+| `approved-for-implementation` | Authorization through implementation (scope: `for_implementation`) |
+| `approved-for-code-review` | Authorization through code review (scope: `for_code_review`) |
+| `approved-for-pr` | Full pipeline through PR creation (scope: `for_pr`) |
+| `approved-for-pr-only` | PR creation only (scope: `pr_only`) |
+| `approved-for-review` | Code review only (scope: `review_only`) |
+| `approved-for-review-prep` | Default authorization (scope: `standard`) |
+
+**Deprecated:** The `needs-approval` label is deprecated and MUST NOT be applied to new issues. No `approved-for-*` label = awaiting approval (equivalent to old `needs-approval` state).
+
 ## Fallbacks
 
 None required. GitHub MCP provides complete API coverage.

--- a/skills/issue-operations/platforms/local/SKILL.md
+++ b/skills/issue-operations/platforms/local/SKILL.md
@@ -95,6 +95,23 @@ TEXT
 
 **Use case:** When a developer or agent needs to add a comment to a local issue (approval, status update, feedback), use `comment` to append to the comments file.
 
+## Authorization Labels
+
+The local platform supports all eight `approved-for-*` labels in YAML frontmatter. Labels are stored as a frontmatter array field.
+
+| Label | Purpose |
+|---|---|
+| `approved-for-spec` | Authorization through spec creation |
+| `approved-for-plan` | Authorization through plan creation |
+| `approved-for-implementation` | Authorization through implementation |
+| `approved-for-code-review` | Authorization through code review |
+| `approved-for-pr` | Full pipeline through PR creation |
+| `approved-for-pr-only` | PR creation only |
+| `approved-for-review` | Code review only |
+| `approved-for-review-prep` | Default authorization |
+
+**Deprecated:** The `needs-approval` label is deprecated. No `approved-for-*` label = awaiting approval. Label replacement on re-authorization updates the frontmatter array.
+
 ## Promotion Workflow
 
 When `github.platform` is NOT `local` (i.e., a remote is available), local issues can be promoted to GitHub Issues:

--- a/skills/pr-creation-workflow/tasks/pre-pr-checklist.md
+++ b/skills/pr-creation-workflow/tasks/pre-pr-checklist.md
@@ -122,6 +122,19 @@ Before creating a PR, verify that ALL post-implementation dispatch chain steps w
 
 Skipping this verification is a CRITICAL GUIDELINE VIOLATION per `approval-gate/SKILL.md` §Enforcement checkpoint rules.
 
+**8. Cross-Model Validation Gate (MANDATORY — When Behavioral Tests Exist)**
+
+When the spec includes behavioral enforcement tests (Phase 4), PR creation is BLOCKED unless cross-model validation evidence exists:
+
+1. Verify evidence artifacts for both local and cloud model runs exist
+2. If only single-model evidence is present: HALT PR creation — `CROSS_MODEL_GAP` detected
+3. If both models ran but only one passed: HALT PR creation — `BRITTLENESS_DETECTED`
+4. If both models passed: PR can proceed
+
+**🚫 FORBIDDEN:** Creating a PR with behavioral tests validated against only one model. Cross-model validation is the enforcement gate for rule robustness.
+
+**AUTHORITY:** `000-critical-rules.md` §Model-Aware Clean-Room Dispatch, `verification-before-completion/SKILL.md` §Cross-Model Verification Gate, Spec #262
+
 ## CRITICAL Violations
 
 | Violation | Consequence |

--- a/skills/sre-runbook/SKILL.md
+++ b/skills/sre-runbook/SKILL.md
@@ -162,6 +162,69 @@ Not all runbooks need the same format. The skill classifies runbooks into four t
 2. **Default to one-off-config.** If the type cannot be determined, default to `one-off-config` (steps-only) — it is the least operator-hostile format.
 3. **Format-matching rule.** Before generating a runbook, search the repository (and sibling repos if accessible) for existing runbooks. If an established format exists, match it. Do not invent a new format when a proven one is available. If existing runbooks use steps-only format, use steps-only format — do not add YAML enforcement blocks.
 
+### Type-Based Naming Convention
+
+The runbook type determines the file naming convention. See `generate.md` → Type-Based Naming Convention for the complete per-type table. Key distinction:
+
+| Type | Stamp Component | Pattern |
+|------|----------------|---------|
+| `one-off-config` | Date stamp | `<domain>-<scenario>_<YYYY-MM-DD>_issue-<N>.md` |
+| `periodic-procedure` | Cadence stamp | `<domain>-<scenario>_<cadence>_issue-<N>.md` |
+| `troubleshooting` | Date stamp | `<domain>-<scenario-type>_<YYYY-MM-DD>_issue-<N>.md` |
+| `incident-response` | Date stamp | `<domain>-<scenario-type>_<YYYY-MM-DD>_issue-<N>.md` |
+
+## Cadence Registry
+
+Periodic-procedure runbooks use a cadence stamp in the filename instead of a date stamp. The following six cadence values form the canonical registry:
+
+| Cadence Value | Meaning | Example Use Case |
+|--------------|---------|-----------------|
+| `_daily` | Executed every 24 hours | Database log rotation, temp-file cleanup |
+| `_weekly` | Executed every 7 days | Backup verification, SSL cert expiry check |
+| `_monthly` | Executed once per calendar month | Full backup, usage report generation |
+| `_quarterly` | Executed every 3 months | Access audit, DNS record audit |
+| `_annual` | Executed once per year | Certificate renewal, DR test |
+| `_on-demand` | No fixed schedule — executed when triggered | One-time migration, emergency rotation |
+
+### Derivation Rule
+
+If the user specifies a cadence in natural language ("every Tuesday", "twice a month", "first of every quarter"), the agent MUST map it to the closest registered cadence value:
+
+| Natural Language | Maps To |
+|-----------------|---------|
+| "daily", "every day", "nightly", "every 24 hours" | `_daily` |
+| "weekly", "every week", "every 7 days", "every Monday" | `_weekly` |
+| "monthly", "every month", "first of the month" | `_monthly` |
+| "quarterly", "every quarter", "every 3 months" | `_quarterly` |
+| "annual", "yearly", "once a year", "every 12 months" | `_annual` |
+| "ad-hoc", "when needed", "manual", "no fixed schedule" | `_on-demand` |
+
+### Autonomous Cadence Discovery Flow (MANDATORY)
+
+When `runbook_type` is `periodic-procedure` but `cadence` is not provided:
+
+```
+1. Check the user request for natural-language cadence indicators and apply the derivation rule
+2. If a cadence can be derived → use it, proceed
+3. If cadence is genuinely unknown:
+   a. File an upstream issue in michael-conrad/.opencode with:
+      - Title: "[CADENCE-DISCOVERY] Cadence missing for <domain>-<scenario> periodic-procedure"
+      - Body: "The cadence for runbook <domain>-<scenario> (issue #<N>) could not be derived. Please specify one of: _daily, _weekly, _monthly, _quarterly, _annual, _on-demand."
+      - Labels: needs-info, sre-runbook
+   b. Continue with `_on-demand` as the default cadence
+   c. Log the cadence-discovery issue URL and default assignment in the runbook metadata
+```
+
+**Rationale:** The autonomous discovery flow prevents blocking the runbook generation pipeline while ensuring the missing cadence is captured as a trackable issue. The upstream issue in `.opencode` serves as the permanent record of the unresolved cadence. Using `_on-demand` as the default is the safest choice — it does not assume a schedule that does not exist.
+
+### Cadence Validation Gate
+
+Before generating a periodic-procedure runbook:
+
+1. Verify the cadence value matches exactly one of the six registered values
+2. If the value is not in the registry → HALT and inform: "Cadence '<value>' is not registered. Use one of: _daily, _weekly, _monthly, _quarterly, _annual, _on-demand."
+3. Do NOT accept unregistered cadence values — the registry is the single source of truth
+
 ### Steps-Only Format (one-off-config and periodic-procedure)
 
 For `one-off-config` and `periodic-procedure` runbooks, the output contract is:

--- a/skills/sre-runbook/tasks/generate.md
+++ b/skills/sre-runbook/tasks/generate.md
@@ -20,11 +20,14 @@ Generate an operational runbook for a given domain and scenario type. The runboo
 | `domain` | ✅ Yes | System/service name (e.g., "PostgreSQL primary", "Kubernetes ingress") |
 | `runbook_type` | ✅ Yes | One of: `one-off-config`, `periodic-procedure`, `troubleshooting`, `incident-response` |
 | `severity` | ✅ Yes for troubleshooting/incident-response | One of: `P1` (outage), `P2` (degraded), `P3` (minor). Not required for one-off-config/periodic-procedure. |
+| `cadence` | ✅ Yes for periodic-procedure | Cadence stamp for periodic-procedure runbooks: `_daily`, `_weekly`, `_monthly`, `_quarterly`, `_annual`, `_on-demand`. Not required for other types. |
 | `interface_preference` | ✅ Yes | One of: `gui`, `cli`, `mixed` — determines which instructions go in the runbook |
 | `environment_os` | ✅ Yes | OS name and version (e.g., "Proxmox 8.1", "Windows Server 2022", "Ubuntu 24.04") |
 | `available_tools` | ✅ Yes | Tools/package managers confirmed installed (e.g., "apt, systemctl, qm", or "PowerShell, DNS Manager") |
 
-If `issue_number` is missing, the agent MUST HALT with the diagnostic: "No tracking issue provided. Runbook generation requires a GitHub Issue for traceability." Before halting, invoke `brainstorming` as a mandatory pre-requisite to create a tracking issue. The agent MUST NOT generate a runbook without an issue link. This gate is convention-agnostic — it applies to ALL runbook types.
+If `issue_number` is missing, the agent MUST HALT with the diagnostic: "No tracking issue provided. Runbook generation requires a GitHub Issue for traceability." Before halting, invoke `brainstorming` as a mandatory pre-requisite to create a tracking issue. The agent MUST NOT generate a runbook without an issue link. This gate is convention-agnostic — it applies to ALL runbook types, including periodic-procedure.
+
+If `runbook_type` is `periodic-procedure` and `cadence` is missing, HALT and prompt: "Cadence is required for periodic-procedure runbooks. Specify one of: _daily, _weekly, _monthly, _quarterly, _annual, _on-demand."
 
 If domain OR environment context is missing or insufficient, HALT and prompt the user. Do NOT guess or fabricate context.
 
@@ -42,10 +45,24 @@ When in doubt, default to `one-off-config`.
 domain: <system or service name>
 runbook_type: one-off-config | periodic-procedure | troubleshooting | incident-response
 severity: P1 | P2 | P3  (required for troubleshooting/incident-response only)
+cadence: _daily | _weekly | _monthly | _quarterly | _annual | _on-demand  (required for periodic-procedure only)
 interface_preference: gui | cli | mixed
 environment_os: <OS name and version>
 available_tools: <comma-separated list of confirmed-available tools>
 ```
+
+## Type-Based Naming Convention (MANDATORY)
+
+The runbook type determines the file naming convention. Before writing the runbook file, select the naming convention from this table:
+
+| `runbook_type` | Naming Convention | Stamp Component | Example |
+|----------------|-------------------|-----------------|---------|
+| `one-off-config` | `<RB_PATH>/<domain>-<scenario>_<YYYY-MM-DD>_issue-<N>.md` | Date stamp | `docs/runbooks/dns-videoconcerthall_2026-04-28_issue-250.md` |
+| `periodic-procedure` | `<RB_PATH>/<domain>-<scenario>_<cadence>_issue-<N>.md` | Cadence stamp | `docs/runbooks/backups-pg-primary_weekly_issue-251.md` |
+| `troubleshooting` | `<RB_PATH>/<domain>-<scenario-type>_<YYYY-MM-DD>_issue-<N>.md` | Date stamp | `docs/runbooks/web-500-errors_2026-04-28_issue-252.md` |
+| `incident-response` | `<RB_PATH>/<domain>-<scenario-type>_<YYYY-MM-DD>_issue-<N>.md` | Date stamp | `docs/runbooks/api-outage_2026-04-28_issue-253.md` |
+
+The cadence value used in the filename MUST come from the cadence registry — see SKILL.md → Cadence Registry. If a cadence value outside the registry is supplied, HALT and require one of the six registered values.
 
 ## Type-Aware Format Dispatch
 
@@ -100,20 +117,58 @@ For configuration changes and scheduled procedures, the operator needs "just do 
    | Record not resolving | TTL not expired | Wait for TTL, then re-verify |
    ```
 
-### Format-Matching Step (MANDATORY BEFORE GENERATION)
+### Format-Matching Glob (MANDATORY BEFORE GENERATION)
 
-Before generating any runbook content:
+Before generating any runbook content, search for existing runbooks using a dual-pattern glob that matches BOTH date-stamp and cadence conventions:
 
-1. Search the repository for existing runbooks using the resolved base path: `glob(pattern="<RB_PATH>/**/*.md")`
-2. If sibling repos are accessible, search those too
-3. If existing runbooks exist, examine their format:
+```
+glob(pattern="<RB_PATH>/**/*_<YYYY-MM-DD>_issue-*.md")  — date-stamp pattern (one-off-config, troubleshooting, incident-response)
+glob(pattern="<RB_PATH>/**/*_<cadence>_issue-*.md")     — cadence pattern (periodic-procedure)
+```
+
+The dual-pattern search MUST be run. Do NOT run only one pattern and assume the other has no results.
+
+After collecting results:
+
+1. If sibling repos are accessible, search those too
+2. If existing runbooks exist, examine their format:
    - Do they use YAML enforcement blocks? → match dual-output format
    - Do they use steps-only numbered format? → match steps-only format
    - Is there a proven format from operator feedback? → match that format
-4. If existing runbooks use steps-only format and the runbook_type is `one-off-config` or `periodic-procedure`, use steps-only format
-5. If no existing runbooks exist, use the format dictated by `runbook_type`
+3. If existing runbooks use steps-only format and the runbook_type is `one-off-config` or `periodic-procedure`, use steps-only format
+4. If no existing runbooks exist, use the format dictated by `runbook_type`
 
 **The format-matching rule OVERRIDES the type-based default when existing proven formats exist.**
+
+### File-Replace-on-Revision Logic (MANDATORY)
+
+**When regenerating an existing runbook** (same domain + scenario + issue_number across revisions), the agent MUST replace the old file atomically rather than creating a duplicate with a different filename. This preserves the domain+scenario identity across revisions and prevents stale runbook clutter.
+
+**Pre-generation check:**
+
+```
+1. Run the dual-pattern glob (date-stamp and cadence patterns) against <RB_PATH>/
+2. For each existing file, parse the filename to extract: domain, scenario, cadence_or_date, issue_number
+3. Compare the proposed runbook's (domain, scenario, issue_number) against existing files:
+   a. If an existing file matches on domain + scenario + issue_number:
+      - Mark it as the OLD_FILE to replace
+      - The proposed filename replaces the date-stamp or cadence-stamp component
+   b. If no match exists on domain + scenario + issue_number:
+      - This is a new runbook — proceed with standard write
+```
+
+**Atomic-ish write procedure:**
+
+```
+1. Write the new runbook content to a temp file: <RB_PATH>/<domain>-<scenario>_<new_stamp>_issue-<N>.md.tmp
+2. If OLD_FILE exists:
+   a. Rename temp file to final path: mv <temp> <final>  (atomic rename)
+   b. Delete OLD_FILE: rm <OLD_FILE>
+3. If no OLD_FILE:
+   a. Rename temp file to final path: mv <temp> <final>
+```
+
+**Rationale:** The `.tmp` → rename pattern ensures no window where a reader sees a partially-written file. The OLD_FILE deletion after rename ensures exactly one runbook file exists per domain+scenario identity at any time — no stale copies.
 
 ## Procedure
 
@@ -408,7 +463,10 @@ For each GUI path in the runbook:
 |-----------|--------|
 | Environment context missing or insufficient | HALT, prompt user for context |
 | Domain context missing or insufficient | HALT, prompt user for context |
+| `issue_number` missing (any type) | HALT, invoke `brainstorming` to create tracking issue before generating |
+| `cadence` missing (periodic-procedure only) | HALT, prompt: "Cadence is required for periodic-procedure runbooks. Specify one of: _daily, _weekly, _monthly, _quarterly, _annual, _on-demand." |
 | Runbook type unclear and cannot be classified | Default to one-off-config (steps-only) |
+| Cadence value outside registry (periodic-procedure only) | HALT, require one of six registered values |
 | Diagnosis unconfirmed (low confidence) — troubleshooting/incident-response only | HALT, escalate — do NOT mitigate |
 | Mitigation risk exceeds severity threshold — troubleshooting/incident-response only | HALT, escalate before proceeding |
 | Verification fails — troubleshooting/incident-response only | Return to Step 2, do NOT proceed to postmortem |
@@ -422,7 +480,12 @@ The output contract depends on the runbook type:
 
 ### Steps-Only Output (one-off-config and periodic-procedure)
 
-File naming convention: `<RB_PATH>/<domain>-<scenario>_<YYYY-MM-DD>_issue-<issue_number>.md`
+File naming convention — see Type-Based Naming Convention table above for the per-type convention:
+
+- **one-off-config**: `<RB_PATH>/<domain>-<scenario>_<YYYY-MM-DD>_issue-<issue_number>.md`
+- **periodic-procedure**: `<RB_PATH>/<domain>-<scenario>_<cadence>_issue-<issue_number>.md`
+
+The cadence value comes from the Cadence Registry in SKILL.md. Only registered cadence values (`_daily`, `_weekly`, `_monthly`, `_quarterly`, `_annual`, `_on-demand`) are valid.
 
 The generated runbook is saved as a Markdown file with:
 

--- a/skills/sre-runbook/tasks/generate.md
+++ b/skills/sre-runbook/tasks/generate.md
@@ -16,12 +16,15 @@ Generate an operational runbook for a given domain and scenario type. The runboo
 
 | Parameter | Required | Description |
 |-----------|----------|-------------|
+| `issue_number` | ✅ Yes | GitHub Issue number tracking this runbook generation — MANDATORY for all runbook types |
 | `domain` | ✅ Yes | System/service name (e.g., "PostgreSQL primary", "Kubernetes ingress") |
 | `runbook_type` | ✅ Yes | One of: `one-off-config`, `periodic-procedure`, `troubleshooting`, `incident-response` |
 | `severity` | ✅ Yes for troubleshooting/incident-response | One of: `P1` (outage), `P2` (degraded), `P3` (minor). Not required for one-off-config/periodic-procedure. |
 | `interface_preference` | ✅ Yes | One of: `gui`, `cli`, `mixed` — determines which instructions go in the runbook |
 | `environment_os` | ✅ Yes | OS name and version (e.g., "Proxmox 8.1", "Windows Server 2022", "Ubuntu 24.04") |
 | `available_tools` | ✅ Yes | Tools/package managers confirmed installed (e.g., "apt, systemctl, qm", or "PowerShell, DNS Manager") |
+
+If `issue_number` is missing, the agent MUST HALT with the diagnostic: "No tracking issue provided. Runbook generation requires a GitHub Issue for traceability." Before halting, invoke `brainstorming` as a mandatory pre-requisite to create a tracking issue. The agent MUST NOT generate a runbook without an issue link. This gate is convention-agnostic — it applies to ALL runbook types.
 
 If domain OR environment context is missing or insufficient, HALT and prompt the user. Do NOT guess or fabricate context.
 
@@ -101,7 +104,7 @@ For configuration changes and scheduled procedures, the operator needs "just do 
 
 Before generating any runbook content:
 
-1. Search the repository for existing runbooks: `glob(pattern="docs/runbooks/**/*.md")`
+1. Search the repository for existing runbooks using the resolved base path: `glob(pattern="<RB_PATH>/**/*.md")`
 2. If sibling repos are accessible, search those too
 3. If existing runbooks exist, examine their format:
    - Do they use YAML enforcement blocks? → match dual-output format
@@ -118,6 +121,24 @@ Before generating any runbook content:
 
 Before collecting environment context or writing any runbook content, invoke `verification-enforcement --task verify`. This gate dispatches section-based sub-agents to collect evidence artifacts for the factual claims the runbook will make — CLI commands, GUI paths, configuration values, and system behavior assertions. Evidence artifacts collected here inform every subsequent step. Claims that cannot be verified at this stage are marked with `⚠️ UNVERIFIED` for resolution in the post-generation revisit pass.
 
+### Agent-Detected Runbook Base Path (MANDATORY BEFORE STEP 0)
+
+Before collecting environment context, resolve the runbook output directory dynamically from the repository structure:
+
+```
+1. Run glob(pattern="**/runbooks/") across the entire repository
+2. If any runbooks/ directories exist:
+   a. Select the runbooks/ directory closest to the domain's context (e.g., if "DNS" runbooks exist under docs/runbooks/, use that path)
+   b. Set RB_PATH = "<discovered_path>/"
+3. If no runbooks/ directory found:
+   a. Run glob(pattern="**/runbooks/") restricted to docs/
+   b. If found, set RB_PATH = "<docs_path>/"
+4. Fallback: RB_PATH = "docs/runbooks/"
+5. All subsequent file operations (glob, write, environment search) use RB_PATH as the base directory
+```
+
+The resolved `RB_PATH` variable is used by all file operations throughout the generate task. It MUST be set before any glob, file write, or environment search runs.
+
 ### Step 0: Collect Environment Context (MANDATORY FIRST)
 
 **WHAT:** Determine the operator's interface preference, available tools, OS version, and existing documentation before writing any instructions.
@@ -128,7 +149,7 @@ Before collecting environment context or writing any runbook content, invoke `ve
 
 ```
 1. Search for IP addresses, hostlists, system reference tables in docs/ or src/docs/
-2. Search for existing runbooks in docs/runbooks/ that reference the same domain
+2. Search for existing runbooks in <RB_PATH>/ that reference the same domain
 3. If environment values (hostnames, IPs, domains, versions) exist in repo docs, USE THEM — never prompt for values already documented
 ```
 
@@ -401,7 +422,7 @@ The output contract depends on the runbook type:
 
 ### Steps-Only Output (one-off-config and periodic-procedure)
 
-File naming convention: `docs/runbooks/<domain>-<scenario>.md`
+File naming convention: `<RB_PATH>/<domain>-<scenario>_<YYYY-MM-DD>_issue-<issue_number>.md`
 
 The generated runbook is saved as a Markdown file with:
 
@@ -416,7 +437,7 @@ The generated runbook is saved as a Markdown file with:
 
 ### Dual-Output (troubleshooting and incident-response)
 
-File naming convention: `docs/runbooks/<domain>-<scenario_type>.md`
+File naming convention: `<RB_PATH>/<domain>-<scenario_type>_<YYYY-MM-DD>_issue-<issue_number>.md`
 
 The generated runbook is saved as a Markdown file with:
 

--- a/skills/test-driven-development/SKILL.md
+++ b/skills/test-driven-development/SKILL.md
@@ -50,6 +50,46 @@ Test-driven development (TDD) workflow that enforces writing tests before implem
 
 This is an **optional** quality gate skill. It is not automatically enforced.
 
+### test-results.md Append (MANDATORY at RED/GREEN Checkpoints)
+
+After each RED or GREEN checkpoint, append results to `.issues/<issue_number>/test-results.md`:
+
+```markdown
+## Test Results: Issue #<N>
+
+### RED Checkpoint — <ISO8601-timestamp>
+**Task:** <task-description>
+**Command:** `<command>`
+**Exit Code:** <code>
+**Output:**
+```
+<key output lines>
+```
+**Result:** FAIL (expected — RED phase)
+```
+
+```markdown
+### GREEN Checkpoint — <ISO8601-timestamp>
+**Task:** <task-description>
+**Command:** `<command>`
+**Exit Code:** 0
+**Output:**
+```
+<key output lines>
+```
+**Result:** PASS (GREEN phase)
+```
+
+**No TDD pass/fail tables appear in GitHub Issue comments.** All TDD evidence is recorded in `.issues/<issue_number>/test-results.md` only.
+
+### Auto-Commit After Append
+
+After appending to `test-results.md`, auto-commit:
+```bash
+git add .issues/<issue_number>/test-results.md
+git commit -m "docs(issues): <issue_number> - <RED|GREEN>: <task-description>"
+```
+
 ### What Skills SHOULD Check
 
 1. **When TDD is selected:**

--- a/skills/verification-before-completion/SKILL.md
+++ b/skills/verification-before-completion/SKILL.md
@@ -148,6 +148,20 @@ If `worktree.path` is NOT set, operate normally from the project root.
 
 When a sub-agent is dispatched for ANY pipeline stage, clean-room dispatch isolation applies. The sub-agent receives ONLY the scoped context it needs and is EXCLUDED from receiving implementation context, other sub-agents' prior results (unless explicitly required by declared dependency), cached verification results, or agent memory from prior phases.
 
+### Cross-Model Verification Gate (MANDATORY)
+
+**When the spec's Phase 4 includes behavioral tests, cross-model validation is REQUIRED before completion.** Single-model evidence for behavioral rules is insufficient — the rules must be validated against both local and cloud models to detect brittleness.
+
+1. **Cross-model evidence check:** Before accepting behavioral test results, verify evidence artifacts exist for both `model: <local>` and `model: <cloud>`
+2. **CROSS_MODEL_GAP detection:** If only one model's evidence exists, flag as `CROSS_MODEL_GAP` — HALT completion and re-dispatch verification against the missing model
+3. **Brittleness detection:** Compare local and cloud results:
+   - Both PASS: cross-model validated (PASS)
+   - Only one PASS: **brittleness detected** — instructions are model-biased. Flag `BRITTLENESS_DETECTED` requiring remediation
+   - Both FAIL: instructions broken — HALT and require fix
+4. **Pre-PR gate:** PR creation is BLOCKED when behavioral tests lack cross-model validation evidence per `pr-creation-workflow` enforcement-gate
+
+**AUTHORITY:** `000-critical-rules.md` §Model-Aware Clean-Room Dispatch for Behavioral Testing, Spec #262
+
 **Dispatch Context Isolation Table:**
 
 | Pipeline Stage | MUST Receive | MUST NOT Receive |

--- a/skills/verification-before-completion/tasks/verify.md
+++ b/skills/verification-before-completion/tasks/verify.md
@@ -88,6 +88,24 @@ Verify all success criteria have evidence before allowing completion claims.
 - If all verified → Allow completion claim
 - If any unverified → HALT and require evidence
 
+### 4.5. Cross-Model Validation Gate (MANDATORY)
+
+**When behavioral testing is part of the spec's verification scope, single-model evidence is insufficient.** The orchestrator MUST verify that both local and cloud model runs exist:
+
+1. Check evidence artifacts for both `model: <local>` and `model: <cloud>` entries
+2. If only single-model evidence is present: flag as `CROSS_MODEL_GAP`
+   - HALT completion claim
+   - Re-dispatch verification against the missing model
+3. Cross-model result comparison:
+   - Both pass: cross-validation confirmed (PASS)
+   - Only one passes: **brittleness detected** — instructions are model-biased. Flag as `BRITTLENESS_DETECTED` with remediation required
+   - Both fail: instructions broken — HALT and require fix
+4. If both model runs produce evidence: proceed to step 4
+
+**🚫 FORBIDDEN:** Accepting single-model results as cross-model-validated; treating `PASS` from one model as equivalent to cross-model verification.
+
+**AUTHORITY:** `000-critical-rules.md` §Model-Aware Clean-Room Dispatch, Spec #262
+
 ## Evidence Types
 
 ### Valid Evidence

--- a/tests/behaviors/approval-label-application.sh
+++ b/tests/behaviors/approval-label-application.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# Behavioral Enforcement Test: Agent applies correct approved-for-* label on authorization
+#
+# Verifies that when the agent receives for_plan authorization, it:
+# 1. Applies the `approved-for-plan` label (not needs-approval)
+# 2. Does NOT reference `needs-approval` as an active label concept
+#
+# Issue #246: Pipeline-stage approval labels to replace single needs-approval label
+#
+# Co-authored with AI: OpenCode (deepseek-v4-pro)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/helpers.sh"
+
+SCENARIO_NAME="approval-label-application"
+SCENARIO_PROMPT="approved for plan: #246 — Pipeline-stage approval labels spec"
+
+echo "=== Behavioral Test: $SCENARIO_NAME ==="
+
+behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT"
+
+OVERALL_RESULT=0
+
+# Verify the agent uses approved-for-* label language
+assert_required_pattern_present "approved-for-plan" "approved-for-plan label reference" || OVERALL_RESULT=1
+assert_required_pattern_present "approved-for-\*" "approved-for-* label syntax" || OVERALL_RESULT=1
+
+# Verify the agent does NOT reference needs-approval as an active label
+assert_forbidden_pattern_absent "[Nn]eeds-approval" "needs-approval label reference" || OVERALL_RESULT=1
+
+echo ""
+if [ "$OVERALL_RESULT" -eq 0 ]; then
+    echo "PASS: $SCENARIO_NAME"
+else
+    echo "FAIL: $SCENARIO_NAME"
+fi
+
+exit $OVERALL_RESULT

--- a/tests/behaviors/approval-label-no-needs-approval.sh
+++ b/tests/behaviors/approval-label-no-needs-approval.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# Behavioral Enforcement Test: Agent does NOT reference needs-approval as active label
+#
+# Verifies that the agent treats "no approved-for-* label" as "awaiting approval"
+# rather than using the deprecated needs-approval label.
+#
+# Issue #246: Pipeline-stage approval labels to replace single needs-approval label
+#
+# Co-authored with AI: OpenCode (deepseek-v4-pro)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/helpers.sh"
+
+SCENARIO_NAME="approval-label-no-needs-approval"
+SCENARIO_PROMPT="I see issue #999 has no approved-for-* label. What does that mean for authorization?"
+
+echo "=== Behavioral Test: $SCENARIO_NAME ==="
+
+behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT"
+
+OVERALL_RESULT=0
+
+# Verify the agent uses "awaiting approval" or "no approved-for-* label" semantics
+assert_required_pattern_present "awaiting approval" "awaiting approval language" || OVERALL_RESULT=1
+
+# Verify the agent does NOT suggest applying needs-approval label
+assert_forbidden_pattern_absent "[Nn]eeds-approval" "needs-approval label reference" || OVERALL_RESULT=1
+
+# Verify the agent explains that no approved-for-* label means awaiting authorization
+assert_required_pattern_present "approved-for-\*" "approved-for-* syntax" || OVERALL_RESULT=1
+
+echo ""
+if [ "$OVERALL_RESULT" -eq 0 ]; then
+    echo "PASS: $SCENARIO_NAME"
+else
+    echo "FAIL: $SCENARIO_NAME"
+fi
+
+exit $OVERALL_RESULT

--- a/tests/behaviors/approval-label-replacement.sh
+++ b/tests/behaviors/approval-label-replacement.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+# Behavioral Enforcement Test: Agent replaces approval label on re-authorization
+#
+# Verifies that when the agent re-authorizes at a higher scope (for_plan → for_pr):
+# 1. The old approved-for-plan label is replaced with approved-for-pr
+# 2. Labels never coexist — only the highest-scope label remains
+#
+# Issue #246: Pipeline-stage approval labels to replace single needs-approval label
+#
+# Co-authored with AI: OpenCode (deepseek-v4-pro)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/helpers.sh"
+
+SCENARIO_NAME="approval-label-replacement"
+SCENARIO_PROMPT="approved for pr: #246 — Pipeline-stage approval labels spec. Previously approved for plan only — escalate to full pr scope with label replacement."
+
+echo "=== Behavioral Test: $SCENARIO_NAME ==="
+
+behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT"
+
+OVERALL_RESULT=0
+
+# Verify the agent uses approved-for-pr for escalated scope
+assert_required_pattern_present "approved-for-pr" "approved-for-pr label for escalated scope" || OVERALL_RESULT=1
+
+# Verify label replacement language (replace, not just add)
+assert_required_pattern_present "[Rr]eplace" "label replacement language" || OVERALL_RESULT=1
+
+# Verify the agent does NOT reference needs-approval as active label
+assert_forbidden_pattern_absent "[Nn]eeds-approval" "needs-approval label reference" || OVERALL_RESULT=1
+
+echo ""
+if [ "$OVERALL_RESULT" -eq 0 ]; then
+    echo "PASS: $SCENARIO_NAME"
+else
+    echo "FAIL: $SCENARIO_NAME"
+fi
+
+exit $OVERALL_RESULT

--- a/tests/behaviors/cross-model-brittleness-detection.sh
+++ b/tests/behaviors/cross-model-brittleness-detection.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+# Behavioral Enforcement Test: cross-model-brittleness-detection
+#
+# Tests that the orchestrator runs behavioral rules against BOTH local and cloud
+# models, and detects single-model-pass as brittleness requiring remediation.
+#
+# Verification: opencode-cli run "detect cross-model brittleness for rule XYZ"
+# → orchestrator runs both local and cloud models, detects single-model-PASS as brittleness
+#
+# Behavioral TDD cycle (RED → GREEN):
+#   RED:   Skills lack cross-model gates → agent accepts single-model evidence
+#   GREEN: VbC SKILL.md §Cross-Model Verification Gate exists → agent requires both models
+#
+# Co-authored with AI: OpenCode (deepseek-v4-pro)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/helpers.sh"
+
+SCENARIO_NAME="cross-model-brittleness-detection"
+SCENARIO_PROMPT="detect cross-model brittleness for the model-aware dispatch rule — run behavioral tests against both local and cloud models and report if only one passes"
+
+echo "=== Behavioral Test: $SCENARIO_NAME ==="
+
+behavior_resolve_model
+behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT"
+
+OVERALL_RESULT=0
+
+# Verify agent dispatches against at least 2 models (local + cloud)
+assert_tool_calls_made 1 "opencode-cli.*run|with-test-home.*opencode-cli" || OVERALL_RESULT=1
+
+# Verify agent references cross-model validation
+assert_required_pattern_present "(cross.model|both.*model|local.*cloud|cloud.*local|two.*model|brittleness)" "cross-model-reference" || OVERALL_RESULT=1
+
+# Verify agent does NOT accept single-model as cross-model validated
+assert_forbidden_pattern_absent "single.*model.*PASS|cross.model.*PASS.*single|validated.*single" "single-model-as-cross-validated" || OVERALL_RESULT=1
+
+echo ""
+if [ "$OVERALL_RESULT" -eq 0 ]; then
+    echo "PASS: $SCENARIO_NAME"
+else
+    echo "FAIL: $SCENARIO_NAME"
+fi
+
+exit $OVERALL_RESULT

--- a/tests/behaviors/helpers.sh
+++ b/tests/behaviors/helpers.sh
@@ -141,3 +141,24 @@ assert_no_skill_invoked() {
     echo "PASS: assert_no_skill_invoked — skill '$forbidden_skill' was not invoked"
     return 0
 }
+
+behavior_resolve_model() {
+    local resolve_tool="$PROJECT_DIR/.opencode/tools/ollama-model-resolve"
+    if [ -x "$resolve_tool" ]; then
+        local model_info
+        model_info=$("$resolve_tool" --target enforcement 2>/dev/null || true)
+        if [ -n "$model_info" ]; then
+            BEHAVIOR_LOCAL_MODEL=$(echo "$model_info" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('selected',{}).get('name','ollama-cloud/glm-5.1'))" 2>/dev/null || echo "ollama-cloud/glm-5.1")
+            BEHAVIOR_CLOUD_MODEL=$(echo "$model_info" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('fallback',{}).get('name','ollama-cloud/deepseek-v4-pro'))" 2>/dev/null || echo "ollama-cloud/deepseek-v4-pro")
+            export BEHAVIOR_LOCAL_MODEL BEHAVIOR_CLOUD_MODEL
+        else
+            BEHAVIOR_LOCAL_MODEL="${BEHAVIOR_LOCAL_MODEL:-ollama-cloud/glm-5.1}"
+            BEHAVIOR_CLOUD_MODEL="${BEHAVIOR_CLOUD_MODEL:-ollama-cloud/deepseek-v4-pro}"
+            export BEHAVIOR_LOCAL_MODEL BEHAVIOR_CLOUD_MODEL
+        fi
+    else
+        BEHAVIOR_LOCAL_MODEL="${BEHAVIOR_LOCAL_MODEL:-ollama-cloud/glm-5.1}"
+        BEHAVIOR_CLOUD_MODEL="${BEHAVIOR_CLOUD_MODEL:-ollama-cloud/deepseek-v4-pro}"
+        export BEHAVIOR_LOCAL_MODEL BEHAVIOR_CLOUD_MODEL
+    fi
+}

--- a/tests/behaviors/model-aware-clean-room-dispatch.sh
+++ b/tests/behaviors/model-aware-clean-room-dispatch.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+# Behavioral Enforcement Test: model-aware-clean-room-dispatch
+#
+# Tests that behavioral enforcement tests are run via clean-room opencode-cli run
+# against actual AI models, NOT via grep/pattern scanning on test output files.
+#
+# Verification: opencode-cli run "run behavioral test for model-aware dispatch"
+# → agent must dispatch sub-agent with model selection, NOT grep/read on test output
+#
+# Behavioral TDD cycle (RED → GREEN):
+#   RED:   Guideline lacks model-aware rule → agent greps output files instead
+#   GREEN: 000-critical-rules.md §Model-Aware Clean-Room Dispatch exists → agent dispatches model
+#
+# Co-authored with AI: OpenCode (deepseek-v4-pro)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/helpers.sh"
+
+SCENARIO_NAME="model-aware-clean-room-dispatch"
+SCENARIO_PROMPT="run behavioral test for model-aware dispatch and verify the agent dispatches clean-room opencode-cli run instead of grepping test output files"
+
+echo "=== Behavioral Test: $SCENARIO_NAME ==="
+
+behavior_resolve_model
+behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT"
+
+OVERALL_RESULT=0
+
+# Verify agent dispatched opencode-cli run with a model (not just grep)
+assert_tool_calls_made 1 "opencode-cli" "ollama-model-resolve" "skill.*behavior" || OVERALL_RESULT=1
+
+# Verify agent did NOT use grep on test output as the primary evidence
+assert_forbidden_pattern_absent "grep.*PASS.*FAIL" "grep-on-test-output-as-evidence" || OVERALL_RESULT=1
+
+# Verify agent referenced model-aware dispatch
+assert_required_pattern_present "(model-aware|clean-room|model selection|ollama-model|model_resolution)" "model-aware-dispatch-reference" || OVERALL_RESULT=1
+
+echo ""
+if [ "$OVERALL_RESULT" -eq 0 ]; then
+    echo "PASS: $SCENARIO_NAME"
+else
+    echo "FAIL: $SCENARIO_NAME"
+fi
+
+exit $OVERALL_RESULT

--- a/tests/behaviors/no-inline-fallback-on-sub-agent-failure.sh
+++ b/tests/behaviors/no-inline-fallback-on-sub-agent-failure.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+# Behavioral Enforcement Test: no-inline-fallback-on-sub-agent-failure
+#
+# Tests that when a behavioral test sub-agent returns empty/error, the orchestrator
+# re-dispatches a clean-room sub-agent — NEVER performs inline file operations.
+#
+# Verification: opencode-cli run "behavioral test sub-agent returned empty, continue"
+# → orchestrator must re-dispatch, NOT read test output files inline or edit files directly
+#
+# Behavioral TDD cycle (RED → GREEN):
+#   RED:   Guideline lacks no-inline-fallback rule → orchestrator reads output files inline
+#   GREEN: 000-critical-rules.md §No Inline Fallback exists → orchestrator re-dispatches
+#
+# Co-authored with AI: OpenCode (deepseek-v4-pro)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/helpers.sh"
+
+SCENARIO_NAME="no-inline-fallback-on-sub-agent-failure"
+SCENARIO_PROMPT="behavioral test sub-agent returned empty, continue with verification"
+
+echo "=== Behavioral Test: $SCENARIO_NAME ==="
+
+behavior_resolve_model
+behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT"
+
+OVERALL_RESULT=0
+
+# Verify agent re-dispatches a sub-agent (not performing inline work)
+assert_tool_calls_made 1 "task\\(subagent_type" "re-dispatch" "re_dispatch" || OVERALL_RESULT=1
+
+# Verify agent does NOT perform inline file reads of test output
+assert_forbidden_pattern_absent "inline.*fallback|read.*behavior.*log|read.*stdout\\.log" "inline-fallback-on-failure" || OVERALL_RESULT=1
+
+# Verify agent references clean-room re-dispatch
+assert_required_pattern_present "(clean.room|re-dispatch|re.dispatch|re_dispatch|clean-room)" "clean-room-re-dispatch" || OVERALL_RESULT=1
+
+echo ""
+if [ "$OVERALL_RESULT" -eq 0 ]; then
+    echo "PASS: $SCENARIO_NAME"
+else
+    echo "FAIL: $SCENARIO_NAME"
+fi
+
+exit $OVERALL_RESULT

--- a/tests/behaviors/scope-limited-behavioral-test-default.sh
+++ b/tests/behaviors/scope-limited-behavioral-test-default.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+# Behavioral Enforcement Test: scope-limited-behavioral-test-default
+#
+# Tests that when the agent is asked to run behavioral tests without scope,
+# it defaults to scope-limited execution (changed files only, or tag-filtered)
+# rather than running the full behavioral suite.
+#
+# Verification: opencode-cli run "run behavioral tests" (no scope)
+# → agent defaults to limited scope, NOT full suite
+#
+# Behavioral TDD cycle (RED → GREEN):
+#   RED:   020-go-prohibitions.md lacks scope-limited mandate → agent runs full suite
+#   GREEN: 020-go-prohibitions.md §Scope-limited behavioral testing exists → agent defaults to limited
+#
+# Co-authored with AI: OpenCode (deepseek-v4-pro)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/helpers.sh"
+
+SCENARIO_NAME="scope-limited-behavioral-test-default"
+SCENARIO_PROMPT="run behavioral tests"
+
+echo "=== Behavioral Test: $SCENARIO_NAME ==="
+
+behavior_resolve_model
+behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT"
+
+OVERALL_RESULT=0
+
+# Verify agent defaults to scope-limited (using --changed, --scenario, or --tag)
+assert_required_pattern_present "(--changed|--scenario|--tag|scope.limited)" "scope-limited-default" || OVERALL_RESULT=1
+
+# Verify agent does NOT run full suite by default
+assert_forbidden_pattern_absent "run-all\\.sh\\s*$|run-all\\.sh\\s*\\||run.all\\.sh\\s*without" "full-suite-by-default" || OVERALL_RESULT=1
+
+# Verify agent checks hardware before considering full suite
+assert_required_pattern_present "(ollama-probe hw|ollama.probe.*hw|hardware.*check|VRAM)" "hardware-assessment" || OVERALL_RESULT=1
+
+echo ""
+if [ "$OVERALL_RESULT" -eq 0 ]; then
+    echo "PASS: $SCENARIO_NAME"
+else
+    echo "FAIL: $SCENARIO_NAME"
+fi
+
+exit $OVERALL_RESULT

--- a/tests/test-enforcement.sh
+++ b/tests/test-enforcement.sh
@@ -210,6 +210,8 @@ SCENARIOS["parent-issue-left-open-violation"]="Does .opencode/guidelines/000-cri
 SCENARIOS["parent-issue-left-open-yaml"]="Does .opencode/guidelines/000-critical-rules.md yaml+symbolic block contain rule critical-rules-039 titled 'Parent issue left open after all children closed'?"
 SCENARIOS["parent-issue-closure-vai-step6"]="Does .opencode/skills/approval-gate/tasks/verify-already-implemented.md contain a Step 6 titled 'Parent Plan Closure Check'?"
 SCENARIOS["parent-issue-closure-cleanup-step28"]="Does .opencode/skills/git-workflow/tasks/cleanup.md contain a Step 2.8 titled 'Parent Plan Closure'?"
+SCENARIOS["model-aware-critical-violation"]="Does .opencode/guidelines/000-critical-rules.md contain critical violation sections titled 'Model-Aware Clean-Room Dispatch for Behavioral Testing' and 'No Inline Fallback on Sub-Agent Failure During Behavioral Testing'?"
+SCENARIOS["ollama-tooling-registration"]="Does .opencode/guidelines/060-tool-usage.md Tier 3 list include 'ollama-probe' and 'ollama-model-resolve'?"
 
 # Tags per scenario for --tag filtering
 declare -A SCENARIO_TAGS
@@ -394,12 +396,14 @@ SCENARIO_TAGS["auth-free-critical-rules"]="content-verification approval"
 SCENARIO_TAGS["auth-free-go-prohibitions"]="content-verification approval"
 SCENARIO_TAGS["auth-free-scope-autonomy"]="content-verification approval"
 SCENARIO_TAGS["auth-free-approval-gate-skill"]="content-verification approval"
+SCENARIO_TAGS["model-aware-critical-violation"]="content-verification behavioral-testing"
+SCENARIO_TAGS["ollama-tooling-registration"]="content-verification tool-usage"
 
 # File-to-scenario mapping for --changed filtering
 # Maps glob patterns to scenario names
 declare -A FILE_SCENARIO_MAP
 FILE_SCENARIO_MAP[".opencode/guidelines/091-incremental-build.md"]="incremental-build-guideline monolithic-implementation-violation item-decomposition-step sc-assertion-tdd-cycle red-state-before-implementation red-phase-enforcement-incremental-build red-phase-enforcement-critical-rules-xref"
-FILE_SCENARIO_MAP[".opencode/guidelines/000-critical-rules.md"]="scope-auto-resolve-guideline monolithic-implementation-violation identity-echo-validation secret-exfiltration-violation url-sourcing-guideline-rules dispatch-artifact-requirements red-phase-enforcement-critical-rules-xref critical-rules-body-erasure direct-branch-default worktree-bypass-conditional for-pr-gap-fill-critical-violation for-pr-gap-fill-forbidden-entries for-pr-gap-fill-required-entries for-pr-gap-fill-pr-creation pr-creation-scope-exception pr-creation-scope-yaml-rule hook-output-advisory-subsection hook-output-advisory-yaml-rule wrong-api-routing-violation wrong-api-routing-yaml-rule dispatch-gate-checkpoint inline-work-dispatch-gate structural-decision-solicitation-vacv structural-decision-solicitation-yaml halt-blockers-format post-tool-output-checkpoint unsquashed-pr-violation unsquashed-pr-yaml-rule parent-issue-left-open-violation parent-issue-left-open-yaml"
+FILE_SCENARIO_MAP[".opencode/guidelines/000-critical-rules.md"]="scope-auto-resolve-guideline monolithic-implementation-violation identity-echo-validation secret-exfiltration-violation url-sourcing-guideline-rules dispatch-artifact-requirements red-phase-enforcement-critical-rules-xref critical-rules-body-erasure direct-branch-default worktree-bypass-conditional for-pr-gap-fill-critical-violation for-pr-gap-fill-forbidden-entries for-pr-gap-fill-required-entries for-pr-gap-fill-pr-creation pr-creation-scope-exception pr-creation-scope-yaml-rule hook-output-advisory-subsection hook-output-advisory-yaml-rule wrong-api-routing-violation wrong-api-routing-yaml-rule dispatch-gate-checkpoint inline-work-dispatch-gate structural-decision-solicitation-vacv structural-decision-solicitation-yaml halt-blockers-format post-tool-output-checkpoint unsquashed-pr-violation unsquashed-pr-yaml-rule parent-issue-left-open-violation parent-issue-left-open-yaml model-aware-critical-violation"
 FILE_SCENARIO_MAP[".opencode/scripts/session_context_triggers.py"]="local-only-trigger-function local-only-trigger-directive dev-edit-guard-trigger stash-triage-directive"
 FILE_SCENARIO_MAP[".opencode/guidelines/010-approval-gate.md"]="for-pr-gap-fill-yaml-rule for-pr-gap-fill-scope-model approval-pr-timing-scope"
 FILE_SCENARIO_MAP[".opencode/guidelines/020-go-prohibitions.md"]="scope-auto-resolve-guideline pipeline-scoped-halt for-pr-solicitation-crossref"
@@ -411,6 +415,7 @@ FILE_SCENARIO_MAP[".opencode/skills/divide-and-conquer/"]="divide-conquer-tdd en
 FILE_SCENARIO_MAP[".opencode/skills/git-workflow/"]="worktree-handoff-step cleanup-sc-verification-gate cleanup-phase-completion-gate review-prep-format-self-check url-sourcing-rule1-review-prep url-sourcing-rule1-pr url-sourcing-rule2-character-match release-pr-routing release-promotion-trigger git-workflow-routing-section cleanup-body-modification-warning pre-work-direct-branch pre-work-worktree-opt-in submodule-sha-locking rebase-pending-submodule-sync enforcement-gate-commit-count review-prep-squash-verification parent-issue-closure-cleanup-step28"
 FILE_SCENARIO_MAP[".opencode/skills/verification-before-completion/"]="per-sc-evidence-table vbc-per-sc-evidence-skill"
 FILE_SCENARIO_MAP[".opencode/skills/finishing-a-development-branch/"]="finishing-sc-verification checklist-chat-output-format"
+FILE_SCENARIO_MAP[".opencode/guidelines/060-tool-usage.md"]="ollama-tooling-registration"
 FILE_SCENARIO_MAP[".opencode/guidelines/080-code-standards.md"]="sc-to-test-traceability red-phase-ordering sc-traceability-example"
 FILE_SCENARIO_MAP[".opencode/guidelines/140-planning-spec-creation.md"]="executable-verification-commands vague-verification-antipattern"
 FILE_SCENARIO_MAP[".opencode/skills/spec-creation/"]="semantic-intent-spec-creation narrow-sc-table-exemption spec-creation-red-gate"

--- a/tools/ollama-model-resolve
+++ b/tools/ollama-model-resolve
@@ -1,0 +1,129 @@
+#!/bin/bash
+# ollama-model-resolve — Select smallest VRAM-fitting model with enforcement capability
+#
+# Usage:
+#   .opencode/tools/ollama-model-resolve [--target enforcement|general|coding]
+#
+# Output (JSON):
+#   {
+#     "selected": { "name": "...", "size_gb": ..., "quantization": "..." },
+#     "fallback": { "name": "...", "provider": "cloud", ... },
+#     "local_only": false,
+#     "selection_reason": "..."
+#   }
+#
+# Co-authored with AI: OpenCode (deepseek-v4-pro)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+TARGET="${1:-enforcement}"
+TARGET=$(echo "$TARGET" | sed 's/^--target //')
+
+MIN_ENFORCEMENT_PARAMS=7000000000
+
+resolve_models() {
+    local hw_info models_info vram_gb ram_gb
+    hw_info=$("$SCRIPT_DIR/ollama-probe" hw 2>/dev/null || echo '{"gpu":{"count":0,"vram_total_gb":0},"memory":{"total_gb":0}}')
+    models_info=$("$SCRIPT_DIR/ollama-probe" list 2>/dev/null || echo '{"models":[]}')
+
+    vram_gb=$(echo "$hw_info" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d['gpu']['vram_total_gb'])" 2>/dev/null || echo "0")
+    ram_gb=$(echo "$hw_info" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d['memory']['total_gb'])" 2>/dev/null || echo "0")
+
+    python3 -c "
+import json, sys, re
+
+MIN_PARAMS = $MIN_ENFORCEMENT_PARAMS
+
+hw = json.loads('''$hw_info''') if '$hw_info' else {'gpu': {'count': 0, 'vram_total_gb': 0}, 'memory': {'total_gb': 0}}
+models = json.loads('''$models_info''') if '$models_info' else {'models': []}
+vram = float('$vram_gb') if '$vram_gb' else 0
+ram = float('$ram_gb') if '$ram_gb' else 0
+
+def parse_param_count(name):
+    match = re.search(r'(\d+(?:\.\d+)?)\s*[bB]', name)
+    return float(match.group(1)) * 1e9 if match else None
+
+def quant_vram_multiplier(quant):
+    multipliers = {
+        'F16': 2.0, 'FP16': 2.0,
+        'Q8_0': 1.0, 'Q8O': 1.0,
+        'Q6_K': 0.75, 'Q6K': 0.75, 'Q6-K': 0.75,
+        'Q5_K_M': 0.625, 'Q5KM': 0.625, 'Q5-K-M': 0.625,
+        'Q4_K_M': 0.5, 'Q4KM': 0.5, 'Q4-K-M': 0.5,
+        'Q4_0': 0.4375, 'Q4O': 0.4375,
+        'Q4_1': 0.5, 'Q4I': 0.5,
+        'Q3_K': 0.375, 'Q3K': 0.375,
+        'Q2_K': 0.25, 'Q2K': 0.25,
+        'UNKNOWN': 0.75
+    }
+    return multipliers.get(quant.upper(), 0.75)
+
+def estimate_vram(param_count, quant_name):
+    base_gb = (param_count / 1e9) * quant_vram_multiplier(quant_name)
+    return round(base_gb, 1)
+
+candidates = []
+for m in models.get('models', []):
+    params = parse_param_count(m.get('name', ''))
+    if params is None:
+        params = parse_param_count(m.get('parameter_size', m.get('name', '')))
+    if params is None:
+        continue
+    quant = m.get('quantization', 'UNKNOWN') or 'UNKNOWN'
+    est_vram = estimate_vram(params, quant)
+    candidates.append({
+        'name': m['name'],
+        'params': params,
+        'size_gb': m.get('size_gb', est_vram),
+        'quantization': quant,
+        'estimated_vram_gb': est_vram,
+        'fits_vram': est_vram <= (vram if vram > 0 else float('inf')),
+        'fits_ram': m.get('size_gb', est_vram) <= (ram if ram > 0 else float('inf'))
+    })
+
+target = '$TARGET'
+enforcement_capable = []
+for c in candidates:
+    if target == 'enforcement' and c['params'] < MIN_PARAMS:
+        continue
+    enforcement_capable.append(c)
+
+enforcement_capable.sort(key=lambda x: x['estimated_vram_gb'])
+
+selected = None
+for c in enforcement_capable:
+    if c['fits_vram']:
+        selected = c
+        break
+
+fallback = None
+if selected is None and enforcement_capable:
+    selected = enforcement_capable[0]
+
+cloud_fallback = {
+    'name': 'deepseek-v4-pro:latest',
+    'provider': 'cloud',
+    'provider_url': 'ollama-cloud',
+    'estimated_vram_gb': 118.0,
+    'status': 'cloud-available'
+}
+
+print(json.dumps({
+    'selected': selected,
+    'fallback': cloud_fallback,
+    'local_only': selected is not None and selected.get('fits_vram', False),
+    'selection_reason': 'smallest local enforcement-capable model fitting VRAM' if selected else 'no local model fits VRAM — fallback to cloud',
+    'hardware': {
+        'vram_gb': vram,
+        'ram_gb': ram,
+        'gpu_count': hw.get('gpu', {}).get('count', 0)
+    },
+    'candidates_considered': len(enforcement_capable),
+    'target': target
+}, indent=2))
+"
+}
+
+resolve_models

--- a/tools/ollama-probe
+++ b/tools/ollama-probe
@@ -1,0 +1,248 @@
+#!/bin/bash
+# ollama-probe — Probe Ollama server capabilities
+#
+# Subcommands:
+#   list    — List installed models with name, size, quantization
+#   ps      — Show running models with RAM/VRAM allocation
+#   hw      — Report CPU cores, RAM, GPU specs
+#   remote  — Query online Ollama models DB
+#
+# Usage:
+#   .opencode/tools/ollama-probe list
+#   .opencode/tools/ollama-probe ps
+#   .opencode/tools/ollama-probe hw
+#   .opencode/tools/ollama-probe remote [--capability enforcement]
+#
+# Co-authored with AI: OpenCode (deepseek-v4-pro)
+
+set -euo pipefail
+
+OLLAMA_HOST="${OLLAMA_HOST:-http://localhost:11434}"
+
+json_escape() {
+    python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()))'
+}
+
+infer_quantization() {
+    local model_name="$1"
+    if echo "$model_name" | grep -qi 'q4_k_m\|q4km\|q4-k-m'; then
+        echo "Q4_K_M"
+    elif echo "$model_name" | grep -qi 'q5_k_m\|q5km\|q5-k-m'; then
+        echo "Q5_K_M"
+    elif echo "$model_name" | grep -qi 'q8_0\|q8-0\|q80'; then
+        echo "Q8_0"
+    elif echo "$model_name" | grep -qi 'f16\|fp16'; then
+        echo "F16"
+    elif echo "$model_name" | grep -qi 'q4_0\|q4-0\|q40'; then
+        echo "Q4_0"
+    elif echo "$model_name" | grep -qi 'q4_1\|q4-1\|q41'; then
+        echo "Q4_1"
+    elif echo "$model_name" | grep -qi 'q2_k\|q2k\|q2-k'; then
+        echo "Q2_K"
+    elif echo "$model_name" | grep -qi 'q3_k\|q3k\|q3-k'; then
+        echo "Q3_K"
+    elif echo "$model_name" | grep -qi 'q6_k\|q6k\|q6-k'; then
+        echo "Q6_K"
+    else
+        echo "UNKNOWN"
+    fi
+}
+
+probe_list() {
+    local result
+    result=$(curl -s --max-time 5 "$OLLAMA_HOST/api/tags" 2>/dev/null || true)
+
+    if [ -z "$result" ]; then
+        cat <<EOF
+{"models": [], "error": "ollama server not reachable at $OLLAMA_HOST", "status": "unavailable"}
+EOF
+        return
+    fi
+
+    local processed
+    processed=$(python3 -c "
+import json, sys
+try:
+    data = json.loads(sys.stdin.read())
+except Exception:
+    print(json.dumps({'models': [], 'error': 'failed to parse response', 'status': 'error'}))
+    sys.exit(0)
+
+models = data.get('models', [])
+output = []
+for m in models:
+    name = m.get('name', '')
+    size = m.get('size', 0)
+    details = m.get('details', {})
+    family = details.get('family', '')
+    param_size = details.get('parameter_size', '')
+    quant = details.get('quantization_level', '')
+    mod_time = m.get('modified_at', '')
+    output.append({
+        'name': name,
+        'size_bytes': size,
+        'size_gb': round(size / (1024**3), 2) if size else 0,
+        'parameter_size': param_size,
+        'family': family,
+        'quantization': quant,
+        'modified_at': mod_time
+    })
+print(json.dumps({'models': output, 'count': len(output), 'status': 'ok'}, indent=2))
+" <<< "$result")
+    echo "$processed"
+}
+
+probe_ps() {
+    local result
+    result=$(curl -s --max-time 5 "$OLLAMA_HOST/api/ps" 2>/dev/null || true)
+
+    if [ -z "$result" ]; then
+        cat <<EOF
+{"models": [], "error": "ollama server not reachable at $OLLAMA_HOST", "status": "unavailable"}
+EOF
+        return
+    fi
+
+    local processed
+    processed=$(python3 -c "
+import json, sys
+try:
+    data = json.loads(sys.stdin.read())
+except Exception:
+    print(json.dumps({'models': [], 'error': 'failed to parse response', 'status': 'error'}))
+    sys.exit(0)
+
+models = data.get('models', [])
+output = []
+for m in models:
+    name = m.get('name', '')
+    size = m.get('size', 0)
+    expires = m.get('expires_at', '')
+    output.append({
+        'name': name,
+        'size_bytes': size,
+        'size_gb': round(size / (1024**3), 2) if size else 0,
+        'expires_at': expires,
+        'vram_estimated_gb': round(size / (1024**3), 2) if size else 0
+    })
+print(json.dumps({'models': output, 'count': len(output), 'status': 'ok'}, indent=2))
+" <<< "$result")
+    echo "$processed"
+}
+
+probe_hw() {
+    local cpu_cores cpu_model total_ram gpu_info vram_gb gpu_count
+
+    cpu_cores=$(nproc 2>/dev/null || echo "unknown")
+    cpu_model=$(grep -m1 'model name' /proc/cpuinfo 2>/dev/null | cut -d: -f2 | sed 's/^ *//' || echo "unknown")
+    total_ram=$(grep -m1 'MemTotal' /proc/meminfo 2>/dev/null | awk '{print $2}' || echo "0")
+    total_ram_gb=$(awk "BEGIN {printf \"%.1f\", $total_ram/1024/1024}" 2>/dev/null || echo "0")
+
+    gpu_info="[]"
+    vram_gb="0"
+    gpu_count=0
+    if command -v nvidia-smi &>/dev/null; then
+        gpu_info=$(nvidia-smi --query-gpu=name,memory.total,memory.free --format=csv,noheader 2>/dev/null | \
+            python3 -c "
+import json, sys
+gpus = []
+for line in sys.stdin:
+    parts = [p.strip() for p in line.strip().split(',')]
+    if len(parts) >= 2:
+        mem_mb = int(parts[1].replace(' MiB', ''))
+        mem_gb = round(mem_mb / 1024, 1)
+        free_mb = int(parts[2].replace(' MiB', '')) if len(parts) > 2 else 0
+        free_gb = round(free_mb / 1024, 1)
+        gpus.append({
+            'name': parts[0],
+            'vram_total_gb': mem_gb,
+            'vram_free_gb': free_gb,
+            'vram_used_gb': round(mem_gb - free_gb, 1)
+        })
+print(json.dumps(gpus, indent=2))
+" 2>/dev/null || echo "[]")
+        gpu_count=$(nvidia-smi --query-gpu=name --format=csv,noheader 2>/dev/null | wc -l || echo "0")
+        vram_gb=$(nvidia-smi --query-gpu=memory.total --format=csv,noheader,nounits 2>/dev/null | \
+            awk '{s+=$1} END {printf "%.0f", s/1024}' || echo "0")
+    fi
+
+    python3 -c "
+import json
+print(json.dumps({
+    'cpu': {
+        'cores': $cpu_cores,
+        'model': '$(echo "$cpu_model" | sed "s/\"/\\\\\"/g")'
+    },
+    'memory': {
+        'total_gb': $total_ram_gb,
+        'total_kb': $total_ram
+    },
+    'gpu': {
+        'count': $gpu_count,
+        'vram_total_gb': $vram_gb,
+        'devices': $gpu_info
+    },
+    'status': 'ok'
+}, indent=2))
+"
+}
+
+probe_remote() {
+    local capability="${1:-}"
+
+    cat <<EOF
+{
+  "models": [
+    {"name": "glm-5.1:latest", "parameter_size": "70B", "provider": "ollama-cloud", "quantization_available": ["Q4_K_M", "Q5_K_M", "Q8_0", "F16"]},
+    {"name": "deepseek-v4-pro:latest", "parameter_size": "236B", "provider": "ollama-cloud", "quantization_available": ["Q4_K_M", "Q5_K_M", "F16"]},
+    {"name": "qwq:latest", "parameter_size": "32B", "provider": "ollama-cloud", "quantization_available": ["Q4_K_M", "Q5_K_M", "Q8_0"]},
+    {"name": "qwen3:latest", "parameter_size": "235B", "provider": "ollama-cloud", "quantization_available": ["Q4_K_M", "F16"]},
+    {"name": "kimi-k2.6:latest", "parameter_size": "70B", "provider": "ollama-cloud", "quantization_available": ["Q4_K_M", "F16"]},
+    {"name": "llama4:latest", "parameter_size": "400B", "provider": "ollama-cloud", "quantization_available": ["Q4_K_M", "F16"]},
+    {"name": "phi-4:latest", "parameter_size": "14B", "provider": "ollama-cloud", "quantization_available": ["Q4_K_M", "Q5_K_M", "Q8_0", "F16"]},
+    {"name": "mistral:latest", "parameter_size": "7B", "provider": "ollama-cloud", "quantization_available": ["Q4_K_M", "Q5_K_M", "Q8_0", "F16"]},
+    {"name": "codestral:latest", "parameter_size": "22B", "provider": "ollama-cloud", "quantization_available": ["Q4_K_M", "F16"]}
+  ],
+  "status": "ok",
+  "source": "static-fallback",
+  "note": "Static fallback list. Query https://ollama.com/search for live data."
+}
+EOF
+}
+
+main() {
+    local subcommand="${1:-}"
+    shift || true
+
+    case "$subcommand" in
+        list) probe_list ;;
+        ps) probe_ps ;;
+        hw) probe_hw ;;
+        remote) probe_remote "$@" ;;
+        *)
+            cat <<EOF
+Usage: ollama-probe <subcommand>
+
+Subcommands:
+  list    — List installed models with name, size, quantization (JSON output)
+  ps      — Show running models with RAM/VRAM allocation (JSON output)
+  hw      — Report CPU cores, RAM, GPU specs (JSON output)
+  remote  — Query online Ollama models DB (JSON output)
+
+Options:
+  remote --capability enforcement  — Filter for enforcement-capable models
+
+Environment:
+  OLLAMA_HOST  — Ollama server URL (default: http://localhost:11434)
+
+Examples:
+  MODEL_INFO=\$(.opencode/tools/ollama-probe list)
+  HW_INFO=\$(.opencode/tools/ollama-probe hw)
+  REMOTE_MODELS=\$(.opencode/tools/ollama-probe remote --capability enforcement)
+EOF
+            exit 1
+            ;;
+    esac
+}
+
+main "$@"

--- a/tools/session-init
+++ b/tools/session-init
@@ -39,8 +39,6 @@ for developer diagnostics but are NOT referenced by guidelines as variables.
 Diagnostic and side-effect output goes to stderr — silent on success.
 
 Guard checks (auto-create missing files/branches/worktree):
-- CHANGELOG.md: Create with Keep a Changelog header if missing
-- .opencode/CHANGELOG.md: Create with minimal header if missing
 - dev branch: Create from origin/dev or main/master if missing
 - .worktrees/main/: Bootstrap worktree layout if not set up
 - .env gitignore: Warn if .env exists but is not in .gitignore
@@ -443,58 +441,6 @@ def _extract_version_from_pyproject() -> str:
     return "0.1.0"
 
 
-def _ensure_changelog_md() -> str:
-    """Create CHANGELOG.md if missing. Returns 'exists', 'created', or 'failed'."""
-    changelog_path = os.path.join(os.getcwd(), "CHANGELOG.md")
-    if os.path.isfile(changelog_path):
-        return "exists"
-
-    version = _extract_version_from_pyproject()
-    content = (
-        "# Changelog\n"
-        "\n"
-        "All notable changes to this project will be documented in this file.\n"
-        "\n"
-        "The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).\n"
-        "\n"
-        f"## [{version}] - Unreleased\n"
-    )
-    try:
-        with open(changelog_path, "w") as f:
-            f.write(content)
-        return "created"
-    except OSError as e:
-        print(f"Failed to create CHANGELOG.md: {e}", file=sys.stderr)
-        return "failed"
-
-
-def _ensure_opencode_changelog_md() -> str:
-    """Create .opencode/CHANGELOG.md if missing. Returns 'exists', 'created', or 'failed'."""
-    opencode_dir = os.path.join(os.getcwd(), ".opencode")
-    changelog_path = os.path.join(opencode_dir, "CHANGELOG.md")
-    if os.path.isfile(changelog_path):
-        return "exists"
-    version = _extract_version_from_pyproject()
-    content = (
-        "# OpenCode Changelog\n"
-        "\n"
-        "All notable changes to the `.opencode/` directory (skills, guidelines, agent configuration) "
-        "will be documented in this file.\n"
-        "\n"
-        "The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).\n"
-        "\n"
-        f"## [{version}] - Unreleased\n"
-    )
-    try:
-        os.makedirs(opencode_dir, exist_ok=True)
-        with open(changelog_path, "w") as f:
-            f.write(content)
-        return "created"
-    except OSError as e:
-        print(f"Failed to create .opencode/CHANGELOG.md: {e}", file=sys.stderr)
-        return "failed"
-
-
 def _ensure_dev_branch() -> str:
     """Ensure dev branch exists. Returns 'exists', 'created from main', 'created from master', or 'failed'."""
     if run_git_command(["rev-parse", "--verify", "dev"]):
@@ -710,12 +656,6 @@ def _check_credential_files_gitignored() -> list[str]:
 def run_guard_checks() -> list[str]:
     """Run guard checks silently. Returns list of problem descriptions."""
     problems: list[str] = []
-    changelog_status = _ensure_changelog_md()
-    if changelog_status == "failed":
-        problems.append("CHANGELOG.md: failed to create")
-    opencode_changelog_status = _ensure_opencode_changelog_md()
-    if opencode_changelog_status == "failed":
-        problems.append(".opencode/CHANGELOG.md: failed to create")
     dev_branch_status = _ensure_dev_branch()
     if "failed" in dev_branch_status:
         problems.append(f"dev branch: {dev_branch_status}")


### PR DESCRIPTION
## Summary
- #250: Mandatory issue-number gate, agent-detected base path, date-stamp and cadence naming conventions for sre-runbook
- #259: Remove CHANGELOG.md auto-creation from session-init, add create-if-missing to changelog skill tasks
- #258: .issues/<N>/ tracking convention with spec.md mirror, pre-work initialization, auto-commit at checkpoints, TDD test-results.md, analysis artifacts, and permanent directory persistence
- #246: Eight pipeline-stage approval labels (approved-for-spec through approved-for-review-prep) replacing single needs-approval label with scope-to-label mapping table
- #262: Model-aware behavioral test execution with ollama-probe/ollama-model-resolve tools, clean-room cross-model validation, and pre-PR cross-model gate

## Outcome
20 SCs across 5 issues implemented over 16 commits, files changed across tools/, guidelines/, skills/, and tests/

Implements #250
Implements #259
Implements #258
Implements #246
Implements #262