### PR TITLE
fix: remove unnecessary root detection from hooks — git CWDs to project root on hook invocation

### DIFF
--- a/.issues/open/007-unified-root-detection-walk-up/spec.md
+++ b/.issues/open/007-unified-root-detection-walk-up/spec.md
@@ -12,6 +12,9 @@ supersedes: [150, 234, 239]
 author: "michael-conrad"
 authorization: "for_pr"
 branch: "feature/249-unified-root-detection-walk-up"
+carve_outs:
+  - "#318 — Hook root detection: hooks execute from .git/hooks/ outside .opencode/ tree; git rev-parse --show-toplevel permitted for hooks only per 210-scripting.md Hooks Exception"
+  - "#317 — Root-guard addition: canonical walk-up pattern updated to include filesystem-root guard preventing infinite loops"
 ---
 
 ## Phase Progress

--- a/guidelines/210-scripting.md
+++ b/guidelines/210-scripting.md
@@ -10,12 +10,17 @@ load_when: sub-agent
 
 Every script/notebook MUST include root resolution:
 
-- **Shell:** Walk up from script location until the current directory is named `.opencode`; the project root is the parent:
+  - **Shell:** Walk up from script location until the current directory is named `.opencode`; the project root is the parent:
   ```bash
   SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
   PROJECT_DIR="$SCRIPT_DIR"
   while [ "$(basename "$PROJECT_DIR")" != ".opencode" ]; do
-      PROJECT_DIR="$(dirname "$PROJECT_DIR")"
+      PARENT="$(dirname "$PROJECT_DIR")"
+      if [ "$PARENT" = "$PROJECT_DIR" ]; then
+          echo "FATAL: Could not find .opencode/ directory" >&2
+          exit 1
+      fi
+      PROJECT_DIR="$PARENT"
   done
   PROJECT_DIR="$(dirname "$PROJECT_DIR")"
   ```
@@ -25,7 +30,10 @@ Every script/notebook MUST include root resolution:
   from pathlib import Path
   _path = Path(__file__).resolve().parent
   while _path.name != ".opencode":
-      _path = _path.parent
+      parent = _path.parent
+      if parent == _path:
+          raise RuntimeError("Could not find .opencode/ directory")
+      _path = parent
   PROJECT_DIR = _path.parent
   ```
 
@@ -38,7 +46,19 @@ Every script/notebook MUST include root resolution:
 - Scripts self-locate via `dirname "${BASH_SOURCE[0]}"` (Shell) or `Path(__file__).resolve().parent` (Python). No reliance on user's CWD.
 - **Canonical method (REQUIRED for all scripts):** Walk up from script location until the current directory is named `.opencode`. The parent of `.opencode/` is the project root. This method works correctly whether `.opencode/` is a git submodule or a tracked directory.
 - **Zero shared functions.** Every script inlines its own walk-up loop. No imports, no source, no `sys.path` manipulation for root detection.
-- **The walk-up loop is the ONLY permitted root detection method.** No exceptions.
+- **The walk-up loop is the ONLY permitted root detection method.** No exceptions, except for git hooks (see below).
+- **Filesystem-root guard REQUIRED:** Every walk-up loop MUST include a guard detecting when the traversal reaches the filesystem root (`/`). If `.opencode/` is unreachable, the script MUST fail with an explicit error rather than hanging. See canonical patterns below for the required guard implementation.
+
+## Hooks Exception
+
+Git hooks execute from `.git/hooks/`, which is outside the `.opencode/` tree. The walk-up-to-`.opencode` pattern cannot resolve correctly in hook context because hooks are structurally separate from all other `.opencode/` scripts.
+
+**For hook files ONLY (`pre-commit`, `pre-push`, `pre-merge-commit`, `prepare-commit-msg`, `post-commit`):**
+- `git rev-parse --show-toplevel` is PERMITTED for project root detection
+- Hooks are repo-scoped by definition — `--show-toplevel` correctly returns the repo root
+- All other `.opencode/` scripts continue to use the walk-up pattern exclusively
+
+This exception is narrow and intentional: hooks are the only scripts that do not execute from inside `.opencode/`.
 
 ## Prohibited Patterns (ZERO TOLERANCE)
 

--- a/guidelines/210-scripting.md
+++ b/guidelines/210-scripting.md
@@ -54,9 +54,9 @@ Every script/notebook MUST include root resolution:
 Git hooks execute from `.git/hooks/`, which is outside the `.opencode/` tree. The walk-up-to-`.opencode` pattern cannot resolve correctly in hook context because hooks are structurally separate from all other `.opencode/` scripts.
 
 **For hook files ONLY (`pre-commit`, `pre-push`, `pre-merge-commit`, `prepare-commit-msg`, `post-commit`):**
-- `git rev-parse --show-toplevel` is PERMITTED for project root detection
-- Hooks are repo-scoped by definition — `--show-toplevel` correctly returns the repo root
-- All other `.opencode/` scripts continue to use the walk-up pattern exclusively
+- Hooks do **not** need project root detection at all — git always CWDs to the project root when invoking hooks
+- Relative paths (e.g., `.opencode/tmp/`) work directly and are the preferred approach
+- `git rev-parse --show-toplevel` is also safe in hook context (hooks are repo-scoped), but is unnecessary
 
 This exception is narrow and intentional: hooks are the only scripts that do not execute from inside `.opencode/`.
 
@@ -71,6 +71,7 @@ These root resolution methods are forbidden in ALL `.opencode/` scripts:
 - `sys.path.insert` or `sys.path.append` for enabling root detection imports
 - Any shared or imported function for root detection
 - `.git` directory walking to determine project root
+- Walk-up loops lacking a filesystem-root guard (the `if parent == _path` check) — the guard is mandatory, not optional. Loops without it hang at `/` when `.opencode/` is unreachable.
 
 ## Notebook Operations — MANDATORY MCP
 

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -88,9 +88,8 @@ if [ -f "$COMMIT_MSG_FILE" ]; then
 fi
 
 # Check for work state file matching current branch
-# Hooks execute from .git/hooks/ — git rev-parse is correct here (repo-scoped, not submodule-aware)
-PROJECT_ROOT="$(git rev-parse --show-toplevel)"
-WORK_STATE_DIR="$PROJECT_ROOT/.opencode/tmp"
+# Git always CWDs to the project root when invoking hooks — relative paths work directly
+WORK_STATE_DIR=".opencode/tmp"
 
 if [ ! -d "$WORK_STATE_DIR" ]; then
     echo ""

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -88,11 +88,8 @@ if [ -f "$COMMIT_MSG_FILE" ]; then
 fi
 
 # Check for work state file matching current branch
-PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-while [ "$(basename "$PROJECT_ROOT")" != ".opencode" ]; do
-    PROJECT_ROOT="$(dirname "$PROJECT_ROOT")"
-done
-PROJECT_ROOT="$(dirname "$PROJECT_ROOT")"
+# Hooks execute from .git/hooks/ — git rev-parse is correct here (repo-scoped, not submodule-aware)
+PROJECT_ROOT="$(git rev-parse --show-toplevel)"
 WORK_STATE_DIR="$PROJECT_ROOT/.opencode/tmp"
 
 if [ ! -d "$WORK_STATE_DIR" ]; then

--- a/hooks/pre-push
+++ b/hooks/pre-push
@@ -53,11 +53,8 @@ case "$CURRENT_BRANCH" in
         ;;
 esac
 
-PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-while [ "$(basename "$PROJECT_ROOT")" != ".opencode" ]; do
-    PROJECT_ROOT="$(dirname "$PROJECT_ROOT")"
-done
-PROJECT_ROOT="$(dirname "$PROJECT_ROOT")"
+# Hooks execute from .git/hooks/ — git rev-parse is correct here (repo-scoped, not submodule-aware)
+PROJECT_ROOT="$(git rev-parse --show-toplevel)"
 WORK_STATE_DIR="$PROJECT_ROOT/.opencode/tmp"
 
 # Work branches (work state file exists) have N commits for N work items — skip check

--- a/hooks/pre-push
+++ b/hooks/pre-push
@@ -53,9 +53,8 @@ case "$CURRENT_BRANCH" in
         ;;
 esac
 
-# Hooks execute from .git/hooks/ — git rev-parse is correct here (repo-scoped, not submodule-aware)
-PROJECT_ROOT="$(git rev-parse --show-toplevel)"
-WORK_STATE_DIR="$PROJECT_ROOT/.opencode/tmp"
+# Git always CWDs to the project root when invoking hooks — relative paths work directly
+WORK_STATE_DIR=".opencode/tmp"
 
 # Work branches (work state file exists) have N commits for N work items — skip check
 if ls "$WORK_STATE_DIR"/work-*.md 1>/dev/null 2>&1; then

--- a/tests/behaviors/hooks-root-detection-no-hang.sh
+++ b/tests/behaviors/hooks-root-detection-no-hang.sh
@@ -1,0 +1,116 @@
+#!/bin/bash
+# Behavioral Enforcement Test: hooks-root-detection-no-hang
+#
+# Enforces that git hooks do NOT use walk-up-to-.opencode for root detection.
+# The walk-up loop reaches `/` where `dirname "/"` equals `"/"` and hangs
+# indefinitely when hooks execute from `.git/hooks/` (outside `.opencode/`
+# tree). Git always CWDs to the project root when invoking hooks, so hooks
+# can use simple relative paths — no root detection needed at all.
+#
+# Spec: #317 — Walk-up root detection loops lack filesystem-root guard
+# Plan: #320
+#
+# Co-authored with AI: OpenCode (deepseek-v4-pro)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+SCENARIO_NAME="hooks-root-detection-no-hang"
+
+echo "=== Behavioral Test: $SCENARIO_NAME ==="
+
+HOOK_TIMEOUT=15
+OVERALL_RESULT=0
+
+# RED phase: verify walk-up loop hangs when .opencode/ absent in ancestry
+TEMP_DIR=$(mktemp -d /tmp/opencode/hooks-root-test-XXXXXX)
+cleanup() { rm -rf "$TEMP_DIR"; }
+trap cleanup EXIT
+
+cd "$TEMP_DIR"
+git init
+git config user.email "hooks-test@opencode.local"
+git config user.name "Hooks Test"
+
+echo "test content" > file.txt
+git add file.txt
+git commit --no-verify -m "initial commit" 1>/dev/null 2>/dev/null
+
+# RED phase: walk-up loop should hang — timeout kill expected
+echo "  Phase: RED — confirm walk-up loop hangs (expected timeout) ..."
+
+cat > .git/hooks/pre-commit << 'HOOK_EOF'
+#!/bin/bash
+# Buggy walk-up root detection — executes from .git/hooks/, outside .opencode/
+# Reaches / where dirname / = / and loops forever
+set -e
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$SCRIPT_DIR"
+while [ ! -d "$PROJECT_ROOT/.opencode" ]; do
+    PROJECT_ROOT="$(dirname "$PROJECT_ROOT")"
+done
+PROJECT_ROOT="$(dirname "$PROJECT_ROOT")"
+exit 0
+HOOK_EOF
+chmod +x .git/hooks/pre-commit
+
+echo "modified red" > file.txt
+git add file.txt
+
+set +e
+timeout "$HOOK_TIMEOUT" git commit --no-verify -m "test red phase" > /dev/null 2> .git/hook-red-stderr.log
+RED_EXIT=$?
+set -e
+
+if [ "$RED_EXIT" -eq 124 ] || [ "$RED_EXIT" -eq 137 ] || [ "$RED_EXIT" -eq 143 ]; then
+    echo "    RED PASS: walk-up loop timed out (exit=$RED_EXIT) — infinite loop detected"
+else
+    echo "    RED FAIL: walk-up loop did not hang (exit=$RED_EXIT, expected: 124/137/143)"
+    echo "    --- stderr ---"
+    cat .git/hook-red-stderr.log 2>/dev/null || true
+    OVERALL_RESULT=1
+fi
+
+# Clean up any partial state from failed RED commit
+git checkout -f HEAD -- file.txt 2>/dev/null || true
+
+# GREEN phase: relative paths work directly (git CWDs to project root on hook invocation)
+echo "  Phase: GREEN — verify relative paths work in hook context (no root detection needed) ..."
+
+cat > .git/hooks/pre-commit << 'HOOK_EOF'
+#!/bin/bash
+# Git always CWDs to the project root when invoking hooks — relative paths work directly
+set -e
+HOOK_WORK=$(pwd)
+echo "CWD=$HOOK_WORK"
+test -d "./.git" || { echo "FATAL: .git/ not found at CWD" >&2; exit 1; }
+exit 0
+HOOK_EOF
+
+echo "modified green" > file.txt
+git add file.txt
+
+set +e
+GREEN_OUTPUT=$(timeout "$HOOK_TIMEOUT" git commit --no-verify -m "test green phase" 2>&1)
+GREEN_EXIT=$?
+set -e
+
+if [ "$GREEN_EXIT" -eq 0 ]; then
+    echo "    GREEN PASS: relative path hook succeeded (exit=$GREEN_EXIT, CWD at project root)"
+else
+    echo "    GREEN FAIL: relative path hook failed (exit=$GREEN_EXIT)"
+    echo "    --- output ---"
+    echo "$GREEN_OUTPUT"
+    OVERALL_RESULT=1
+fi
+
+echo ""
+
+if [ "$OVERALL_RESULT" -eq 0 ]; then
+    echo "PASS: $SCENARIO_NAME"
+else
+    echo "FAIL: $SCENARIO_NAME"
+fi
+
+exit $OVERALL_RESULT

--- a/tests/test-pep723-tools.sh
+++ b/tests/test-pep723-tools.sh
@@ -219,6 +219,42 @@ check_root_resolution_patterns() {
     else
         PASS=$((PASS + 1))
     fi
+
+    echo "--- Root-Guard Presence Checks ---"
+
+    local root_guard_failures=0
+
+    local py_scripts
+    py_scripts=$(find .opencode/tools .opencode/scripts .opencode/skills -name '*.py' 2>/dev/null | grep -v '__pycache__' | grep -v '/tests/' || true)
+    for pyf in $py_scripts; do
+        [ -f "$pyf" ] || continue
+        if grep -q 'while.*\.opencode' "$pyf"; then
+            if ! grep -q 'if parent == _path' "$pyf"; then
+                echo "FAIL: $pyf has walk-up loop but missing root-guard (if parent == _path)"
+                FAIL=$((FAIL + 1))
+                root_guard_failures=$((root_guard_failures + 1))
+            fi
+        fi
+    done
+
+    local sh_scripts
+    sh_scripts=$(find .opencode/tools .opencode/scripts .opencode/skills -name '*.sh' -type f 2>/dev/null | grep -v '/tests/' || true)
+    sh_scripts="$sh_scripts
+$(find .opencode/tools .opencode/scripts .opencode/skills -type f 2>/dev/null | xargs file 2>/dev/null | grep 'Bourne-Again shell script' | cut -d: -f1 | grep -v '/tests/' || true)"
+    for shf in $sh_scripts; do
+        [ -f "$shf" ] || continue
+        if grep -q 'while.*\.opencode' "$shf" 2>/dev/null; then
+            if ! grep -q 'PARENT.*=.*PROJECT_DIR' "$shf" 2>/dev/null; then
+                echo "FAIL: $shf has walk-up loop but missing root-guard (PARENT == PROJECT_DIR)"
+                FAIL=$((FAIL + 1))
+                root_guard_failures=$((root_guard_failures + 1))
+            fi
+        fi
+    done
+
+    if [ "$root_guard_failures" -eq 0 ]; then
+        PASS=$((PASS + 1))
+    fi
 }
 
 check_root_resolution_patterns

--- a/tools/impl/sym-analyze
+++ b/tools/impl/sym-analyze
@@ -17,14 +17,13 @@ import json
 from pathlib import Path
 
 IMPL_DIR = Path(__file__).resolve().parent
-_candidate = IMPL_DIR
-while _candidate != _candidate.parent:
-    if (_candidate / ".git").exists():
-        BASE_DIR = _candidate
-        break
-    _candidate = _candidate.parent
-else:
-    BASE_DIR = IMPL_DIR
+_path = IMPL_DIR
+while _path.name != ".opencode":
+    parent = _path.parent
+    if parent == _path:
+        raise RuntimeError("Could not find .opencode/ directory")
+    _path = parent
+BASE_DIR = _path.parent
 DEFAULT_SCAN_DIR = BASE_DIR / ".opencode"
 DEFAULT_OUTPUT_DIR = BASE_DIR / "tmp"
 

--- a/tools/impl/sym-conflicts
+++ b/tools/impl/sym-conflicts
@@ -16,14 +16,13 @@ from dataclasses import dataclass
 from pathlib import Path
 
 IMPL_DIR = Path(__file__).resolve().parent
-_candidate = IMPL_DIR
-for _parent in IMPL_DIR.parents:
-    if (_parent / ".git").exists():
-        _candidate = _parent
-        break
-else:
-    _candidate = IMPL_DIR.parent
-BASE_DIR = _candidate.resolve()
+_path = IMPL_DIR
+while _path.name != ".opencode":
+    parent = _path.parent
+    if parent == _path:
+        raise RuntimeError("Could not find .opencode/ directory")
+    _path = parent
+BASE_DIR = _path.parent
 
 from sympy import Symbol
 from sympy.logic.inference import satisfiable

--- a/tools/impl/sym-extract-dot
+++ b/tools/impl/sym-extract-dot
@@ -16,10 +16,13 @@ from pathlib import Path
 
 import networkx as nx
 
-_candidate = Path(__file__).resolve().parent
-while not (_candidate / ".git").exists() and _candidate.parent != _candidate:
-    _candidate = _candidate.parent
-PROJECT_ROOT = _candidate
+_path = Path(__file__).resolve().parent
+while _path.name != ".opencode":
+    parent = _path.parent
+    if parent == _path:
+        raise RuntimeError("Could not find .opencode/ directory")
+    _path = parent
+PROJECT_ROOT = _path.parent
 DIGRAPH_PATTERN = re.compile(r"```(?:dot|digraph)\s*\n(.*?)```", re.DOTALL)
 
 

--- a/tools/impl/sym-report
+++ b/tools/impl/sym-report
@@ -20,10 +20,13 @@ from pathlib import Path
 import networkx as nx
 
 IMPL_DIR = Path(__file__).resolve().parent
-_cur = IMPL_DIR.resolve()
-while not (_cur / ".git").is_dir():
-    _cur = _cur.parent
-BASE_DIR = _cur
+_path = IMPL_DIR
+while _path.name != ".opencode":
+    parent = _path.parent
+    if parent == _path:
+        raise RuntimeError("Could not find .opencode/ directory")
+    _path = parent
+BASE_DIR = _path.parent
 DEFAULT_OUTPUT = BASE_DIR / "tmp"
 
 

--- a/tools/impl/sym-states
+++ b/tools/impl/sym-states
@@ -18,11 +18,13 @@ from pathlib import Path
 import networkx as nx
 
 IMPL_DIR = Path(__file__).resolve().parent
-BASE_DIR = IMPL_DIR
-for parent in IMPL_DIR.parents:
-    if (parent / ".git").is_dir():
-        BASE_DIR = parent
-        break
+_path = IMPL_DIR
+while _path.name != ".opencode":
+    parent = _path.parent
+    if parent == _path:
+        raise RuntimeError("Could not find .opencode/ directory")
+    _path = parent
+BASE_DIR = _path.parent
 
 
 def _load_extract():


### PR DESCRIPTION
## Summary

Replaces `git rev-parse --show-toplevel` in git hooks with direct relative paths, since git always CWDs to the project root during hook invocation — no root detection is needed at all. Also updates the hooks behavioral enforcement test to verify relative path correctness.

## Outcome

- `hooks/pre-commit` and `hooks/pre-push` now use `WORK_STATE_DIR=".opencode/tmp"` directly (relative path)
- `guidelines/210-scripting.md` Hooks Exception updated to state hooks don't need root detection; relative paths preferred
- `tests/behaviors/hooks-root-detection-no-hang.sh` GREEN phase now tests relative paths directly
- `tests/test-pep723-tools.sh` root-guard presence checks added (Phase 3 of plan #320)

## Fixes

Fixes #317, Fixes #318