### PR TITLE
feat: SKILL.md correctness reinforcement, verify-before-acceptance gate, Unix philosophy mandate (#361, #359, #366, #369, #365)

### DIFF
--- a/guidelines/000-critical-rules.md
+++ b/guidelines/000-critical-rules.md
@@ -29,7 +29,10 @@ These mandates protect the integrity of the codebase and repository. They **NEVE
 | Human-only branch deletion | Unmerged branches must never be force-deleted by agents |
 | Agents must never self-authorize | Authorization comes from developers, never from agent reasoning |
 | Git configuration and destructive commands require explicit authorization | Git remote/config mutations can silently redirect pushes, disable security checks, or destroy unrecoverable state |
+| `.opencode/.opencode/` nesting is prohibited — paths must be resolved relative to workdir/CWD, never concatenated with a fixed `.opencode/` prefix | Creating `.opencode/.opencode/` directories breaks AI agent configuration loading by shadowing real configuration files with nested copies |
 | Correctness over economy — fabrication or shortcutting verification to conserve context/tool-calls is prohibited: (1) sub-agent dispatch and tool calls are near-zero cost compared to undiscovered defects — never skip a tool call or verification step to save resources; (2) correctness is the only success metric — there is no score for speed, brevity, or economy, and a fast wrong answer is strictly worse than a slow correct one; (3) fabricated results will be independently audited and the work re-dispatched — fabrication extends the total work, it does not shorten it | Fabricated evidence corrupts all downstream pipeline decisions — every merge, deployment, and release decision depends on verified correctness. No authorization can waive the requirement for truthful verification. |
+| Architectural invariance over local fix — when a behavioral rule is violated, the fix MUST be encoded at the architectural level (guideline section + dual-auditor enforcement) rather than patched at the symptom level (static grep, one-line code check). Symptom-level fixes mask the root cause and guarantee regression; architectural fixes encode invariants that models can reason about | Static grep regression (#1217 root cause): an agent adds a grep check to catch a specific output pattern, and the next model learns how to pass the grep check without following the underlying behavioral rule. Architectural fixes (dual-auditor model evaluation + guideline invariants) prevent this by enforcing behavioral compliance through AI evaluation, not text pattern-matching |
+| Unix philosophy "Do One Thing Well" — every artifact (script/executable, function, test harness, sub-agent task, document section, implementation step) must address exactly one concern: (1) scripts perform exactly one operation — iterate externally never internally, hard cap ≤150 lines; (2) functions have exactly one purpose with ≤3 discrete operations — no multi-phase orchestration in a single function; (3) test harnesses test exactly one scenario — per-model per-probe, not batch iteration; (4) no uber-scripts, no uber-functions, no uber-sub-agent-tasks — decomposition is mandatory at all artifact levels, not just code commits | Uber-artifacts combine multiple concerns into single units creating hidden coupling points where one concern's failure blocks all others. The Unix philosophy applies universally to scripts, functions, tests, tooling, and prose — not just code commits. |
 
 **"Zero tolerance" language in this file applies ABSOLUTELY to Tier 1 mandates.** There is no waiver, no override, no emergency bypass.
 
@@ -2394,4 +2397,42 @@ When a behavioral test sub-agent fails, reading its test output files inline and
     requires: [critical-rules-034, critical-rules-042]
     triggers: [divide-and-conquer, verification-before-completion]
     source: "000-critical-rules.md §No Inline Fallback on Sub-Agent Failure During Behavioral Testing"
+```
+
+<!-- Issue #359: Verify-Before-Acceptance — Success Criteria: Add verify-before-acceptance critical violation -->
+
+## Critical Violation: Verify-Before-Acceptance — Accepting Sub-Agent FAIL Claims Without Independent Verification
+
+**⚠️ Accepting a sub-agent result contract that claims `status: FAIL` without independently reproducing the claimed failure is a CRITICAL GUIDELINE VIOLATION.**
+
+Sub-agents can fabricate failure claims (infrastructure failures, tool errors, environment issues) to avoid resource-intensive operations. The orchestrator MUST independently verify every FAIL claim before accepting it. Trusting sub-agent failure claims without reproduction is the same pattern as #91 (metadata-as-evidence prohibition) applied to sub-agent result contracts.
+
+- 🚫 FORBIDDEN: Accepting a `status: FAIL` result contract without independently executing the claimed-failing tool
+- 🚫 FORBIDDEN: Accepting a FAIL result contract where `error_output` is empty or contains only prose summary
+- 🚫 FORBIDDEN: Treating FAIL as DONE_WITH_CONCERNS — FAIL must be independently verified or re-dispatched
+- 🚫 FORBIDDEN: Proceeding past a FAIL result without invoking the verify-before-acceptance protocol
+- 🚫 FORBIDDEN: Including prior sub-agent error_output in re-dispatch context
+- ✅ REQUIRED: Independently execute the tool/command the sub-agent claimed failed before accepting FAIL
+- ✅ REQUIRED: Compare orchestrator output against sub-agent `error_output` — match required for acceptance
+- ✅ REQUIRED: Re-dispatch fresh clean-room sub-agent on unverifiable failure (orchestrator success, different error, or missing error_output)
+- ✅ REQUIRED: After two independently verified consecutive FAIL results, escalate to completion with HALT + byline
+- ✅ REQUIRED: Every FAIL result contract MUST include raw `error_output` from attempted tool invocation
+
+**AUTHORITY:** `divide-and-conquer/enforcement/result-validation.md` §FAIL Result Validation Protocol, `divide-and-conquer/tasks/dispatch.md` Step 4.1, Spec #359
+
+```yaml+symbolic
+  - id: critical-rules-045
+    title: "Verify-before-acceptance — accepting sub-agent FAIL claims without independent verification"
+    conditions:
+      any:
+        - "sub_agent_returned_fail == true AND orchestrator_independently_verified == false"
+        - "fail_result_error_output_empty == true"
+        - "fail_result_accepted_as_concern == true"
+    actions:
+      - HALT
+      - INVOKE(verify-before-acceptance protocol)
+    conflicts_with: []
+    requires: [critical-rules-033]
+    triggers: [divide-and-conquer, verification-before-completion]
+    source: "000-critical-rules.md §Verify-Before-Acceptance"
 ```

--- a/guidelines/060-tool-usage.md
+++ b/guidelines/060-tool-usage.md
@@ -109,6 +109,7 @@ When working in a git worktree (`worktree.path` is set), TIER 1 file operation t
 
 - All temporary scripts and output files MUST be written ONLY to `./tmp/` (project root). NO OTHER FOLDERS OR PATHS ARE PERMITTED.
 - Create the directory if needed: `mkdir -p ./tmp`.
+- **When operating from inside `.opencode/` (workdir = `.opencode/`):** Use `tmp` not `.opencode/tmp` — see §2 Submodule/Subdirectory Path Resolution above. Verify the resolved path does NOT create `.opencode/.opencode/tmp/`.
 - **Mandatory pre-submit root cleanliness check:** Before calling `submit`, run `./.opencode/tools/file-exists .output.txt` and confirm it is MISSING. If it exists, move it to `./tmp/.output.txt` immediately.
 - **ALWAYS clean up temp files after modification tasks are complete.**
 
@@ -303,4 +304,18 @@ rules:
     requires: []
     triggers: [git-workflow]
     source: "060-tool-usage.md §4 Command Restrictions NEVER DO"
+
+  - id: tool-usage-009
+    title: ".opencode/.opencode/ nesting forbidden — resolve paths relative to workdir"
+    conditions:
+      any:
+        - "resolved_path contains '.opencode/.opencode/'"
+        - "workdir_is_submodule == true AND path_starts_with '.opencode/'"
+    actions:
+      - HALT
+      - RESOLVE_PATH_RELATIVE_TO_WORKDIR
+    conflicts_with: []
+    requires: []
+    triggers: [issue-operations]
+    source: "060-tool-usage.md §2 Submodule/Subdirectory Path Resolution"
 ```

--- a/guidelines/065-verification-honesty.md
+++ b/guidelines/065-verification-honesty.md
@@ -428,4 +428,19 @@ rules:
     requires: []
     triggers: [verification-before-completion]
     source: "065-verification-honesty.md §Per-Field Independence"
+
+  - id: verification-honesty-008
+    title: "Dual-auditor evaluation required — no grep-only behavioral assessment"
+    conditions:
+      any:
+        - "behavioral_evaluation_performed_via_grep == true"
+        - "same_model_used_for_production_and_evaluation == true"
+        - "content_verification_reported_as_behavioral == true"
+    actions:
+      - HALT
+      - DISPATCH(second AI model in clean-room isolation)
+    conflicts_with: []
+    requires: []
+    triggers: [verification-before-completion, spec-auditor, behavioral-testing]
+    source: "065-verification-honesty.md §Architectural Invariant: Dual-Auditor Evaluation"
 ```

--- a/guidelines/091-incremental-build.md
+++ b/guidelines/091-incremental-build.md
@@ -190,6 +190,46 @@ When a task file exceeds 3,000 words on first draft, it MUST be split into small
 
 This section was added per `#1197` Phase 7 to mandate word-count complexity metrics across the skill deck and guideline files, replacing any prior line-count references.
 
+### Unix Philosophy Extension — Scripts, Functions, and Tooling
+
+This section extends decomposition rules from implementation plans to all executable and composable artifact types. The Unix "Do One Thing Well" principle applies universally — not just to code commits in implementation plans.
+
+**Authority:** `000-critical-rules.md` §Uber-Artifacts critical violation, Spec #366
+
+#### Script Decomposition
+
+| Rule | Measurement | Enforcement |
+| -- | -- | -- |
+| Scripts iterate externally, never internally | `wc -l` ≤150 | Spec-auditor + code-size-enforcement |
+| One operation per script file | Single concern | Behavioral test verification |
+| No orchestration uber-scripts | Use `--tag`, `--changed`, or `--scenario` filters | Grep for forbidden pattern |
+
+#### Function Decomposition
+
+| Rule | Measurement | Enforcement |
+| -- | -- | -- |
+| ≤3 discrete operations per function | Count of distinct concerns | Code review + spec-auditor |
+| Existing uber-functions are decomposed, not expanded | Decompose before adding | Behavioral test verification |
+
+#### Test Harness Decomposition
+
+| Rule | Measurement | Enforcement |
+| -- | -- | -- |
+| One scenario per behavioral test file | Single `behavior_run()` call | Behavioral test grep |
+| Per-model dispatch for qualification | External loop, per-model probe script | Behavioral test verification |
+
+#### Expanded Complexity Metrics
+
+| Artifact Type | Max Measure | Metric |
+| -- | -- | -- |
+| Script file (bash/Python) | ≤150 lines | `wc -l` |
+| Shell function | ≤3 operations | Concern count |
+| Test harness file | 1 scenario | `behavior_run` count |
+| Atomic task file | ≤3,000 words | `wc -w` |
+| Routing-tier SKILL.md | ≤4,000 words | `wc -w` |
+| Condensed-tier SKILL.md | ≤2,000 words | `wc -w` |
+| Guideline file | Per content needs | `wc -w` |
+
 ## Cross-References
 
 - `000-critical-rules.md` → "Monolithic Implementation" critical violation section (authoritative enforcement)

--- a/skills/approval-gate/SKILL.md
+++ b/skills/approval-gate/SKILL.md
@@ -67,6 +67,7 @@ Authorization Gatekeeper. Focus: verify authorization, resolve scope, enforce tw
 5. **Dispatch order:** `pre-work → pre-analysis → assemble-work → VbC → checklist → review-prep`. Each step produces artifact.
 6. **Submodule:** files under submodule → route API calls to submodule repo.
 7. **Labels:** `approved-for-*` per scope mapping. No label = awaiting approval.
+8. **Correctness over speed.** Every result will be independently audited by two different cloud models. A slow correct answer is strictly better than a fast incorrect one. Fabrication wastes time — the work will be re-dispatched. Static grep is NOT acceptable verification — behavioral compliance requires actual model execution with cross-validated PASS verdict.
 
 ## Sub-Agent Dispatch Audit
 

--- a/skills/brainstorming/SKILL.md
+++ b/skills/brainstorming/SKILL.md
@@ -38,6 +38,7 @@ Requirements Explorer. Focus: understand what user wants through natural convers
 3. **Pre-spec inspection mandatory** (code inspection checklist) before proposing approach.
 4. **Autonomous structural classification:** classify single vs multi-task without asking.
 5. **Terminal state** invokes `spec-creation`.
+6. **Correctness over speed.** Every result will be independently audited by two different cloud models. A slow correct answer is strictly better than a fast incorrect one. Fabrication wastes time — the work will be re-dispatched. Static grep is NOT acceptable verification — behavioral compliance requires actual model execution with cross-validated PASS verdict.
 
 ## Sub-Agent Dispatch Audit
 

--- a/skills/changelog-generator/SKILL.md
+++ b/skills/changelog-generator/SKILL.md
@@ -26,6 +26,10 @@ Transforms git commits into polished, user-friendly changelogs. Category-based o
 
 `/skill changelog-generator --task since-last-release` (since last update), `--task date-range --from DATE --to DATE`, `--task backfill` (historical catchup), `--task completion` (halt guarantee). Overview with no flag.
 
+## Operating Protocol
+
+1. **Correctness over speed.** Every result will be independently audited by two different cloud models. A slow correct answer is strictly better than a fast incorrect one. Fabrication wastes time — the work will be re-dispatched. Static grep is NOT acceptable verification — behavioral compliance requires actual model execution with cross-validated PASS verdict.
+
 ## Sub-Agent Dispatch Audit
 
 Tasks dispatch via `task(subagent_type="general")` with `{ date_range, github.owner, github.repo }`. Exclusions: implementation context, agent memory. `pre-analysis` receives only `{ issue_number, task_description }`. No inline work.

--- a/skills/code-size-enforcement/SKILL.md
+++ b/skills/code-size-enforcement/SKILL.md
@@ -24,6 +24,10 @@ Enforces code size limits: Python functions ≈100 words, notebook cells ≈120 
 
 `/skill code-size-enforcement --task check-limits` (measure before commit), `--task decompose` (decomposition guidance). Overview with no flag.
 
+## Operating Protocol
+
+1. **Correctness over speed.** Every result will be independently audited by two different cloud models. A slow correct answer is strictly better than a fast incorrect one. Fabrication wastes time — the work will be re-dispatched. Static grep is NOT acceptable verification — behavioral compliance requires actual model execution with cross-validated PASS verdict.
+
 ## Sub-Agent Dispatch Audit
 
 Tasks dispatch via `task(subagent_type="general")` with `{ file_paths, github.owner, github.repo }`. Exclusions: implementation context, agent memory. No inline work.

--- a/skills/coherence-auditor/SKILL.md
+++ b/skills/coherence-auditor/SKILL.md
@@ -27,6 +27,10 @@ Ensures guidelines, skills, and AI agent behavior work together effectively. Ide
 
 `/skill coherence-auditor --mode extraction` (scan for candidates), `--mode maintenance` (detect drift), `--task <task>` (individual load). Overview with no flag.
 
+## Operating Protocol
+
+1. **Correctness over speed.** Every result will be independently audited by two different cloud models. A slow correct answer is strictly better than a fast incorrect one. Fabrication wastes time — the work will be re-dispatched. Static grep is NOT acceptable verification — behavioral compliance requires actual model execution with cross-validated PASS verdict.
+
 ## Sub-Agent Dispatch Audit
 
 Tasks dispatch via `task(subagent_type="general")` with `{ mode, github.owner, github.repo }`. Exclusions: implementation context, agent memory. No inline work.

--- a/skills/concern-separation-auditor/SKILL.md
+++ b/skills/concern-separation-auditor/SKILL.md
@@ -31,6 +31,7 @@ NOT invoked directly. Called by spec-auditor via `/skill spec-auditor --issue N 
 2. **Deployment independence:** each phase must be independently deployable.
 3. **Risk profiling:** blast radius and failure isolation per phase.
 4. **Single Concern Principle** per `000-critical-rules.md` — phases address one concern each.
+5. **Correctness over speed.** Every result will be independently audited by two different cloud models. A slow correct answer is strictly better than a fast incorrect one. Fabrication wastes time — the work will be re-dispatched. Static grep is NOT acceptable verification — behavioral compliance requires actual model execution with cross-validated PASS verdict.
 
 ## Sub-Agent Dispatch Audit
 

--- a/skills/conflict-resolution/SKILL.md
+++ b/skills/conflict-resolution/SKILL.md
@@ -28,6 +28,10 @@ Conflict Resolution Specialist. Focus: no committed work or spec intent silently
 
 Automatic from `git-workflow` when conflicts detected. Manual: `/skill conflict-resolution --task classify-and-resolve`, `--task completion`.
 
+## Operating Protocol
+
+1. **Correctness over speed.** Every result will be independently audited by two different cloud models. A slow correct answer is strictly better than a fast incorrect one. Fabrication wastes time — the work will be re-dispatched. Static grep is NOT acceptable verification — behavioral compliance requires actual model execution with cross-validated PASS verdict.
+
 ## Sub-Agent Dispatch Audit
 
 Tasks dispatch via `task(subagent_type="general")` with `{ conflict_files, branch_context, github.owner, github.repo }`. Exclusions: implementation context, agent memory. No inline work.

--- a/skills/correspondence/SKILL.md
+++ b/skills/correspondence/SKILL.md
@@ -34,6 +34,7 @@ Enforces multipart/alternative format (text/plain + text/html) for email, stakeh
 6. **AI byline mandatory** in all correspondence.
 7. **Content-type propagation:** match source email format (inspect Content-Type header).
 8. **Attribution verification:** no role-proximity inference — only evidence-backed attribution.
+9. **Correctness over speed.** Every result will be independently audited by two different cloud models. A slow correct answer is strictly better than a fast incorrect one. Fabrication wastes time — the work will be re-dispatched. Static grep is NOT acceptable verification — behavioral compliance requires actual model execution with cross-validated PASS verdict.
 
 ## Sub-Agent Dispatch Audit
 

--- a/skills/divide-and-conquer/SKILL.md
+++ b/skills/divide-and-conquer/SKILL.md
@@ -49,6 +49,7 @@ Divide and Conquer Orchestrator. Focus: assess context fitness, decompose work, 
 4. **Implementation-first gate:** at least one file modified before completion report.
 5. **PR merge boundary:** check required PR boundaries before sub-agent dispatch.
 6. **Clean-room dispatch:** sub-agents receive spec/plan/file paths only. No orchestrator reasoning, expected outcomes, or other sub-agent prior results (unless declared dependency).
+7. **Correctness over speed.** Every result will be independently audited by two different cloud models. A slow correct answer is strictly better than a fast incorrect one. Fabrication wastes time — the work will be re-dispatched. Static grep is NOT acceptable verification — behavioral compliance requires actual model execution with cross-validated PASS verdict.
 
 ## Sub-Agent Dispatch Audit
 

--- a/skills/divide-and-conquer/enforcement/completion-checkpoint.md
+++ b/skills/divide-and-conquer/enforcement/completion-checkpoint.md
@@ -17,8 +17,26 @@ Each sub-agent dispatched by `assemble-work` MUST produce a result contract upon
 |--------|---------|--------|
 | `DONE` | All sub-tasks completed successfully | Record result, proceed to next sub-agent |
 | `DONE_WITH_CONCERNS` | Completed but with warnings | Record concerns in work state, proceed |
+| `FAIL` | Sub-agent claims operation failed | Do NOT accept — invoke verify-before-acceptance protocol |
 | `BLOCKED` | Cannot proceed due to external dependency | HALT, report blocker in chat |
 | `OVERFLOW` | Context window exceeded during execution | Initiate overflow recovery |
+
+### Verify-Before-Acceptance Protocol (FAIL results only)
+
+When a sub-agent returns `status: FAIL`, the orchestrator MUST NOT accept the claim without independent verification:
+
+1. **Check `error_output`** — the result contract MUST include raw tool invocation error output. Empty or prose-summary `error_output` is INCOMPLETE_FAIL → re-dispatch.
+
+2. **Independently reproduce the failure** — execute the claimed failing tool/command from the orchestrator context:
+   - Tool succeeds → sub-agent fabricated → re-dispatch clean-room sub-agent
+   - Tool fails with different error → sub-agent misreported → re-dispatch
+   - Tool fails with matching error → verified FAIL → escalate to completion
+
+3. **Re-dispatch:** Dispatch fresh clean-room sub-agent with identical scoped context (no prior error_output). On re-dispatch FAIL, verify again. On re-dispatch DONE, accept and note fabrication in work state.
+
+4. **Double verification:** After two independently verified FAIL results, invoke `--task completion`, HALT with status message + byline.
+
+Accepting a FAIL result contract without independent verification violates `000-critical-rules.md` §Verify-Before-Acceptance. This protocol is MANDATORY — the orchestrator independently validates every sub-agent failure claim before accepting it as truth.
 
 ### Recovery Mode
 

--- a/skills/divide-and-conquer/enforcement/result-validation.md
+++ b/skills/divide-and-conquer/enforcement/result-validation.md
@@ -10,12 +10,15 @@ When `assemble-work` receives a sub-agent result, it MUST validate the result be
    - Action: FALLBACK to inline execution + report warning in chat
    - NEVER transition from empty result to silent halt
 
-2. **Malformed result**: Result contract has invalid YAML or missing required fields
+2. **FAIL result**: Sub-agent returned `status: FAIL`
+   - Action: Do NOT accept — invoke FAIL Result Validation Protocol (below)
+
+3. **Malformed result**: Result contract has invalid YAML or missing required fields
    - Action: Attempt to extract usable data from result
    - If extraction fails: FALLBACK to inline execution + report warning in chat
    - If extraction succeeds: Record what was extracted, note malformation
 
-3. **Overflow result**: Sub-agent's context window exceeded during execution
+4. **Overflow result**: Sub-agent's context window exceeded during execution
    - Result will have `status: OVERFLOW`
    - Action: Invoke `overflow-signal.md` re-dispatch protocol
    - Split the overflowing task into smaller units and re-dispatch
@@ -26,9 +29,27 @@ Every sub-agent result MUST include:
 
 | Field | Required | Type |
 |-------|----------|------|
-| `status` | Yes | `DONE \| DONE_WITH_CONCERNS \| BLOCKED \| OVERFLOW` |
+| `status` | Yes | `DONE \| DONE_WITH_CONCERNS \| FAIL \| BLOCKED \| OVERFLOW` |
 | `task` | Yes | string (task name) |
+| `error_output` | CONDITIONAL | string (raw tool error output — REQUIRED when `status: FAIL`, empty otherwise) |
 | Other fields | Per task | Per result contract schema |
+
+### FAIL Result Validation Protocol
+
+When a sub-agent returns `status: FAIL`, the orchestrator MUST NOT accept the result. Instead:
+
+1. **Validate `error_output` is present:** A FAIL result contract MUST include the `error_output` field with raw tool invocation error output (not a prose summary). If `error_output` is empty, missing, or contains only narrative summary → the result is INCOMPLETE_FAIL → re-dispatch a fresh clean-room sub-agent.
+
+2. **Independently reproduce the claimed failure:** Before accepting the FAIL, the orchestrator MUST execute the tool or command that the sub-agent claimed failed. Compare your output against `error_output`:
+   - Orchestrator execution succeeds → sub-agent fabricated the failure → re-dispatch clean-room sub-agent (do NOT include prior error_output in re-dispatch context)
+   - Orchestrator execution fails with different error → sub-agent may have misreported → re-dispatch
+   - Orchestrator execution fails with matching error → failure verified → escalate to completion
+
+3. **Re-dispatch protocol:** Fresh clean-room sub-agent with identical scoped context. On re-dispatch FAIL → verify again. On re-dispatch DONE → accept result, note fabrication in work state file.
+
+4. **Double-verification escalation:** After two independently verified consecutive FAIL results, invoke `--task completion`, HALT with status message + byline.
+
+**This protocol enforces `000-critical-rules.md` §Verify-Before-Acceptance.** Accepting a sub-agent FAIL claim without independent reproduction is a CRITICAL GUIDELINE VIOLATION. The orchestrator must independently confirm every FAIL before treating it as truth.
 
 ### Fallback Procedure
 

--- a/skills/divide-and-conquer/tasks/assemble-work.md
+++ b/skills/divide-and-conquer/tasks/assemble-work.md
@@ -132,8 +132,9 @@ For each issue in execution order:
 
   6. **Sub-Agent Completion Checkpoint** — after collecting each result, perform the completion checkpoint per `dispatch` task Step 4:
 
-     - If sub-agent returned a structured result: check `status` field and handle accordingly
-     - If sub-agent returned **NO result** (timeout, crash, empty): this is **ABNORMAL TERMINATION**
+      - If sub-agent returned a structured result: check `status` field and handle accordingly
+      - **FAIL status:** do NOT accept — invoke verify-before-acceptance protocol (see `dispatch` task Step 4.1)
+      - If sub-agent returned **NO result** (timeout, crash, empty): this is **ABNORMAL TERMINATION**
        - Run `git status` in the worktree
        - Clean tree → didn't start → re-dispatch
        - Uncommitted changes + all deliverables → UNDO + re-dispatch by default; manual commit+push only if narrow exception applies (≤50 lines, single file, fully correct, no remaining dispatches — see SKILL.md Recovery Mode)

--- a/skills/divide-and-conquer/tasks/dispatch.md
+++ b/skills/divide-and-conquer/tasks/dispatch.md
@@ -76,12 +76,13 @@ Spec: <relevant spec section>
  If you cannot commit (e.g., conflicts): return status: BLOCKED with explanation.
 
 Return result in Sub-agent Result Contract format:
-  status: DONE | DONE_WITH_CONCERNS | OVERFLOW | BLOCKED
+  status: DONE | DONE_WITH_CONCERNS | FAIL | OVERFLOW | BLOCKED
   files_changed: [...]
   summary: ...
   verification_passed: true | false
   compare_url: "<URL or empty if not available>"
   exec_summary: "<1-2 sentence executive summary or empty>"
+  error_output: "<actual error output from attempted tool invocation or empty>"
 
 If context window overflow risk: return OVERFLOW per Overflow Signal Contract.
 """
@@ -96,6 +97,7 @@ Sub-agent MUST return per Sub-agent Result Contract:
 | -- | -- |
 | **DONE** | Record result, proceed to next sub-task |
 | **DONE_WITH_CONCERNS** | Review concerns, address if about correctness/scope |
+| **FAIL** | Do NOT accept — independently verify the claimed failure. See verify-before-acceptance protocol below |
 | **OVERFLOW** | Handle per `overflow-signal` task |
 | **BLOCKED** | Provide context, escalate, or decompose further |
 
@@ -106,6 +108,7 @@ After collecting the sub-agent result, the orchestrator MUST perform a completio
 1. **If sub-agent returned a structured result** — check `status` field:
    - `DONE` → normal, proceed to Step 5
    - `DONE_WITH_CONCERNS` → review concerns, proceed if OK
+   - `FAIL` → do NOT accept; invoke verify-before-acceptance protocol (below)
    - `OVERFLOW` → handle per `overflow-signal` task
    - `BLOCKED` → HALT and report blocker
 
@@ -121,6 +124,29 @@ After collecting the sub-agent result, the orchestrator MUST perform a completio
     e. Do NOT proceed to next task until recovery is complete
 
 **The orchestrator decides the recovery action autonomously.** Per the "Pushing Agent Intelligence Decisions to the User" critical violation (`000-critical-rules.md`), the recovery decision is an agent intelligence concern. The user is NOT asked to decide. UNDO + re-dispatch is the default; manual completion is a narrow exception (see SKILL.md Recovery Mode for conditions).
+
+### Step 4.1: Verify-Before-Acceptance Protocol (MANDATORY for FAIL results)
+
+When a sub-agent returns `status: FAIL`, the orchestrator MUST NOT accept the result contract at face value. Instead, perform independent verification:
+
+1. **Read the `error_output` field** — a valid FAIL result contract MUST include actual error output from the attempted tool invocation. If `error_output` is empty or contains only summary prose (no raw tool output), treat as INCOMPLETE_FAIL.
+
+2. **Independently reproduce the claimed failure:**
+   - Execute the tool/command that the sub-agent claimed failed
+   - Compare your output against the sub-agent's `error_output`
+   - If the tool succeeds in the orchestrator context → sub-agent fabricated the failure → re-dispatch
+   - If the tool fails but error differs materially → sub-agent may have misreported → re-dispatch
+   - If the tool fails with matching error → failure is verified → escalate to completion
+
+3. **Re-dispatch on unverifiable failure:**
+   - Dispatch a fresh clean-room sub-agent with identical scoped context
+   - Do NOT include the prior sub-agent's error_output in the re-dispatch context
+   - If re-dispatched sub-agent also returns FAIL → verify again → if verified, escalate to completion
+   - If re-dispatched sub-agent returns DONE → accept result, note fabrication in work state
+
+4. **Escalation:** After two consecutive verified FAIL results, invoke `--task completion`, HALT with status message + byline. Report the verified failure in chat.
+
+**This protocol is a critical violation per `000-critical-rules.md` §Verify-Before-Acceptance.** Accepting a FAIL result contract without independent verification is FORBIDDEN.
 
 ### Step 5: Compose Prior Context
 

--- a/skills/engineering-approach/SKILL.md
+++ b/skills/engineering-approach/SKILL.md
@@ -33,6 +33,7 @@ Engineering discipline checklist enforcing: understand before solving, design be
 3. **Verify before complete:** run tests manually, check edge cases, validate success criteria.
 4. **No scope creep:** implement ONLY what's in the approved spec.
 5. **Pre-implementation verification:** verify API signatures, env vars, config formats against live docs.
+6. **Correctness over speed.** Every result will be independently audited by two different cloud models. A slow correct answer is strictly better than a fast incorrect one. Fabrication wastes time — the work will be re-dispatched. Static grep is NOT acceptable verification — behavioral compliance requires actual model execution with cross-validated PASS verdict.
 
 ## Sub-Agent Dispatch Audit
 

--- a/skills/executing-plans/SKILL.md
+++ b/skills/executing-plans/SKILL.md
@@ -32,6 +32,7 @@ No single-issue bypass — single = work of one = one sub-agent.
 2. **Dispatch to divide-and-conquer/assemble-work** with full context.
 3. **Track phase progress** against plan sub-issues.
 4. **Unified path:** no single-task exemption.
+5. **Correctness over speed.** Every result will be independently audited by two different cloud models. A slow correct answer is strictly better than a fast incorrect one. Fabrication wastes time — the work will be re-dispatched. Static grep is NOT acceptable verification — behavioral compliance requires actual model execution with cross-validated PASS verdict.
 
 ## Received Context
 

--- a/skills/finishing-a-development-branch/SKILL.md
+++ b/skills/finishing-a-development-branch/SKILL.md
@@ -33,6 +33,7 @@ Branch completion workflow ensuring feature branch is fully ready for PR. Verifi
 4. **Type check:** `uvx pyright` clean.
 5. **Branch pushed:** up to date with remote.
 6. **Plan sub-issue closure verification:** matched against implementation.
+7. **Correctness over speed.** Every result will be independently audited by two different cloud models. A slow correct answer is strictly better than a fast incorrect one. Fabrication wastes time — the work will be re-dispatched. Static grep is NOT acceptable verification — behavioral compliance requires actual model execution with cross-validated PASS verdict.
 
 ## Sub-Agent Dispatch Audit
 

--- a/skills/fragment-manager/SKILL.md
+++ b/skills/fragment-manager/SKILL.md
@@ -30,6 +30,10 @@ Manages duplicate text blocks across skills. CRUD on master files (`.opencode/.g
 
 `/skill fragment-manager --task create`, `--task sync`, `--task detect-drift`, `--task completion`. Overview with no flag.
 
+## Operating Protocol
+
+1. **Correctness over speed.** Every result will be independently audited by two different cloud models. A slow correct answer is strictly better than a fast incorrect one. Fabrication wastes time — the work will be re-dispatched. Static grep is NOT acceptable verification — behavioral compliance requires actual model execution with cross-validated PASS verdict.
+
 ## Sub-Agent Dispatch Audit
 
 Tasks dispatch via `task(subagent_type="general")` with `{ fragment_name, destination_paths, github.owner, github.repo }`. Exclusions: implementation context, agent memory. No inline work.

--- a/skills/git-workflow/SKILL.md
+++ b/skills/git-workflow/SKILL.md
@@ -58,6 +58,7 @@ Git Workflow Enforcer. Focus: three-branch workflow, block AI on protected branc
 5. **Compare URL base:** feature → `compare/dev...<branch>`. Release → `compare/main...dev`.
 6. **Submodule repos:** git ops from inside submodule dir. No `--recursive`.
 7. **Pair mode:** `pair-*` branches use WIP-commit switching, not worktrees.
+8. **Correctness over speed.** Every result will be independently audited by two different cloud models. A slow correct answer is strictly better than a fast incorrect one. Fabrication wastes time — the work will be re-dispatched. Static grep is NOT acceptable verification — behavioral compliance requires actual model execution with cross-validated PASS verdict.
 
 ## Sub-Agent Dispatch Audit
 

--- a/skills/guideline-auditor/SKILL.md
+++ b/skills/guideline-auditor/SKILL.md
@@ -30,6 +30,7 @@ Audits guideline files for ambiguity, conflicts, and LLM compliance. Identifies 
 2. **Brevity:** prompts ≤200 words. Tables ≤10 rows. Quotes ≤3 lines.
 3. **Problem classes:** AMBIGUOUS, CONFLICTING, UNENFORCEABLE, REDUNDANT-CROSS-FILE, MISSING, CONTEXT-OVERFLOW, REORGANIZE.
 4. **Format:** `File: <path> | Rule: <1-line> | Problem: <class> | Fix? (fix/skip/stop)`.
+5. **Correctness over speed.** Every result will be independently audited by two different cloud models. A slow correct answer is strictly better than a fast incorrect one. Fabrication wastes time — the work will be re-dispatched. Static grep is NOT acceptable verification — behavioral compliance requires actual model execution with cross-validated PASS verdict.
 
 ## Sub-Agent Dispatch Audit
 

--- a/skills/issue-operations/SKILL.md
+++ b/skills/issue-operations/SKILL.md
@@ -43,6 +43,7 @@ Issue Operations Dispatcher. Focus: spec-first workflow, validation, labeling, p
 3. **spec.md mirror:** every `github_issue_read(method="get")` mirrored to `.issues/<N>/spec.md`.
 4. **Byline mandatory:** AI-authored comments must include `🤖 Co-authored with AI: <AgentName> (<ModelId>)`.
 5. **Issue creation = no auth needed** per `010-approval-gate.md`.
+6. **Correctness over speed.** Every result will be independently audited by two different cloud models. A slow correct answer is strictly better than a fast incorrect one. Fabrication wastes time — the work will be re-dispatched. Static grep is NOT acceptable verification — behavioral compliance requires actual model execution with cross-validated PASS verdict.
 
 ## Sub-Agent Dispatch Audit
 

--- a/skills/issue-operations/platforms/gitbucket-api/SKILL.md
+++ b/skills/issue-operations/platforms/gitbucket-api/SKILL.md
@@ -134,6 +134,7 @@ All `list_*` endpoints return arrays (`List[Dict]`), NOT objects. The Python cli
 5. Use comment-based linking for sub-issues
 6. Use iterative listing for search operations
 7. Follow error recovery procedures in `tasks/error-recovery.md`
+8. **Correctness over speed.** Every result will be independently audited by two different cloud models. A slow correct answer is strictly better than a fast incorrect one. Fabrication wastes time — the work will be re-dispatched. Static grep is NOT acceptable verification — behavioral compliance requires actual model execution with cross-validated PASS verdict.
 
 ## Cross-References
 

--- a/skills/issue-operations/platforms/github-mcp/SKILL.md
+++ b/skills/issue-operations/platforms/github-mcp/SKILL.md
@@ -66,6 +66,10 @@ GitHub MCP supports all eight `approved-for-*` labels for issue labeling:
 
 None required. GitHub MCP provides complete API coverage.
 
+## Operating Protocol
+
+1. **Correctness over speed.** Every result will be independently audited by two different cloud models. A slow correct answer is strictly better than a fast incorrect one. Fabrication wastes time — the work will be re-dispatched. Static grep is NOT acceptable verification — behavioral compliance requires actual model execution with cross-validated PASS verdict.
+
 ## spec.md Mirror (MANDATORY)
 
 Every `github_issue_read(method="get")` call MUST mirror the spec body to `.issues/<issue_number>/spec.md`:

--- a/skills/issue-operations/platforms/local/SKILL.md
+++ b/skills/issue-operations/platforms/local/SKILL.md
@@ -112,6 +112,10 @@ The local platform supports all eight `approved-for-*` labels in YAML frontmatte
 
 **Deprecated:** The `needs-approval` label is deprecated. No `approved-for-*` label = awaiting approval. Label replacement on re-authorization updates the frontmatter array.
 
+## Operating Protocol
+
+1. **Correctness over speed.** Every result will be independently audited by two different cloud models. A slow correct answer is strictly better than a fast incorrect one. Fabrication wastes time — the work will be re-dispatched. Static grep is NOT acceptable verification — behavioral compliance requires actual model execution with cross-validated PASS verdict.
+
 ## Promotion Workflow
 
 When `github.platform` is NOT `local` (i.e., a remote is available), local issues can be promoted to GitHub Issues:

--- a/skills/issue-review/SKILL.md
+++ b/skills/issue-review/SKILL.md
@@ -39,6 +39,7 @@ Issue Review Orchestrator. Focus: gather context, classify path, delegate to cor
 3. **Bug discovery ≠ authorization:** findings reported as bug issues; no code edits during analysis.
 4. **Fix spec must target root cause, not symptom** per `000-critical-rules.md`.
 5. **Audit findings are internal** — posted to chat, not GitHub comments.
+6. **Correctness over speed.** Every result will be independently audited by two different cloud models. A slow correct answer is strictly better than a fast incorrect one. Fabrication wastes time — the work will be re-dispatched. Static grep is NOT acceptable verification — behavioral compliance requires actual model execution with cross-validated PASS verdict.
 
 ## Sub-Agent Dispatch Audit
 

--- a/skills/mcp-tool-usage/SKILL.md
+++ b/skills/mcp-tool-usage/SKILL.md
@@ -33,6 +33,10 @@ Tool Priority Enforcer ensuring all operations use the correct tool according to
 - `/skill mcp-tool-usage --task selection-guide` - Tool selection decision trees
 - `/skill mcp-tool-usage` - Overview only
 
+## Operating Protocol
+
+1. **Correctness over speed.** Every result will be independently audited by two different cloud models. A slow correct answer is strictly better than a fast incorrect one. Fabrication wastes time — the work will be re-dispatched. Static grep is NOT acceptable verification — behavioral compliance requires actual model execution with cross-validated PASS verdict.
+
 ## Five-Tier Tool Priority Hierarchy
 
 ```

--- a/skills/multimodal-dispatch/SKILL.md
+++ b/skills/multimodal-dispatch/SKILL.md
@@ -33,6 +33,10 @@ Modality Router. Focus: probe models, resolve modality hints, dispatch sub-agent
 
 Produced by `probe` task: maps model names → modalities (text, vision, audio) + capabilities. Cloud-first for text/vision. Local fallback. Graceful degradation: unavailable modality returns `(unverified)` rather than blocking.
 
+## Operating Protocol
+
+1. **Correctness over speed.** Every result will be independently audited by two different cloud models. A slow correct answer is strictly better than a fast incorrect one. Fabrication wastes time — the work will be re-dispatched. Static grep is NOT acceptable verification — behavioral compliance requires actual model execution with cross-validated PASS verdict.
+
 ## Sub-Agent Dispatch Audit
 
 Tasks dispatch via `task(subagent_type="general")` with `{ task_description, content_modality, github.owner, github.repo }`. Exclusions: implementation context, agent memory. No inline work.

--- a/skills/notebook-operations/SKILL.md
+++ b/skills/notebook-operations/SKILL.md
@@ -26,6 +26,10 @@ ZERO TOLERANCE: ALL notebook operations use `the-notebook-mcp` exclusively. Dire
 
 `/skill notebook-operations --task permitted-operations` (25-operation tool reference). Overview with no flag.
 
+## Operating Protocol
+
+1. **Correctness over speed.** Every result will be independently audited by two different cloud models. A slow correct answer is strictly better than a fast incorrect one. Fabrication wastes time — the work will be re-dispatched. Static grep is NOT acceptable verification — behavioral compliance requires actual model execution with cross-validated PASS verdict.
+
 ## Sub-Agent Dispatch Audit
 
 Tasks dispatch via `task(subagent_type="general")` with `{ notebook_path, operation }`. Exclusions: implementation context, agent memory. No inline work. ABSOLUTE exception: `.ipynb` → `the-notebook-mcp` MANDATORY.

--- a/skills/plan-fidelity-auditor/SKILL.md
+++ b/skills/plan-fidelity-auditor/SKILL.md
@@ -33,6 +33,7 @@ Generates clean-room plan from spec's problem statement, compares against existi
 3. **Prose-driven clean-room:** uses prose exploration, not template structure.
 4. **Significant gaps** → recommend brainstorming for deeper exploration.
 5. **Invoked via spec-auditor orchestrator** as `fidelity` subtask, not called directly.
+6. **Correctness over speed.** Every result will be independently audited by two different cloud models. A slow correct answer is strictly better than a fast incorrect one. Fabrication wastes time — the work will be re-dispatched. Static grep is NOT acceptable verification — behavioral compliance requires actual model execution with cross-validated PASS verdict.
 
 ## Sub-Agent Dispatch Audit
 

--- a/skills/pr-creation-workflow/SKILL.md
+++ b/skills/pr-creation-workflow/SKILL.md
@@ -35,6 +35,7 @@ Feature PRs target `dev` only. Release PRs (dev→main) handled by `git-workflow
 4. **Changelog generated** before PR.
 5. **No agent merge** — human-only operation.
 6. **Work branch guard:** no individual PRs during work execution (single stacked PR).
+7. **Correctness over speed.** Every result will be independently audited by two different cloud models. A slow correct answer is strictly better than a fast incorrect one. Fabrication wastes time — the work will be re-dispatched. Static grep is NOT acceptable verification — behavioral compliance requires actual model execution with cross-validated PASS verdict.
 
 ## Sub-Agent Dispatch Audit
 

--- a/skills/pre-analysis/SKILL.md
+++ b/skills/pre-analysis/SKILL.md
@@ -52,6 +52,7 @@ You are a Pre-Analysis Gatekeeper. Your focus is independently discovering scope
 2. **Minimal context:** Pre-analysis sub-agents receive only `{ issue_number, task_description, github.owner, github.repo }`
 3. **Autonomous discovery:** Independently search the codebase to discover affected files
 4. **Dispatch plan:** Return a structured plan with task partitions and file scope
+5. **Correctness over speed.** Every result will be independently audited by two different cloud models. A slow correct answer is strictly better than a fast incorrect one. Fabrication wastes time — the work will be re-dispatched. Static grep is NOT acceptable verification — behavioral compliance requires actual model execution with cross-validated PASS verdict.
 
 ## Worktree Mode
 

--- a/skills/programming-principles/SKILL.md
+++ b/skills/programming-principles/SKILL.md
@@ -27,6 +27,10 @@ compatibility: opencode
 
 This skill is the master source. `080-code-standards.md` holds project-specific conventions only. Other skills reference HERE, never the reverse.
 
+## Operating Protocol
+
+1. **Correctness over speed.** Every result will be independently audited by two different cloud models. A slow correct answer is strictly better than a fast incorrect one. Fabrication wastes time — the work will be re-dispatched. Static grep is NOT acceptable verification — behavioral compliance requires actual model execution with cross-validated PASS verdict.
+
 ## Sub-Agent Dispatch Audit
 
 `principles` dispatches via `task(subagent_type="general")` with `{ context, github.owner, github.repo }`. Exclusions: implementation context, agent memory. No inline work.

--- a/skills/receiving-code-review/SKILL.md
+++ b/skills/receiving-code-review/SKILL.md
@@ -25,6 +25,10 @@ Responds to PR review feedback. Ensures all comments addressed systematically, c
 
 `/skill receiving-code-review --task address` (address comments), `--task respond` (reply), `--task completion`. Overview with no flag.
 
+## Operating Protocol
+
+1. **Correctness over speed.** Every result will be independently audited by two different cloud models. A slow correct answer is strictly better than a fast incorrect one. Fabrication wastes time — the work will be re-dispatched. Static grep is NOT acceptable verification — behavioral compliance requires actual model execution with cross-validated PASS verdict.
+
 ## Sub-Agent Dispatch Audit
 
 Tasks dispatch via `task(subagent_type="general")` with `{ pr_number, review_comments, github.owner, github.repo }`. Exclusions: implementation context, agent memory. No inline work.

--- a/skills/requesting-code-review/SKILL.md
+++ b/skills/requesting-code-review/SKILL.md
@@ -24,6 +24,10 @@ Prepares and requests code reviews. Ensures PR descriptions have proper context,
 
 `/skill requesting-code-review --task prepare` (prepare PR context), `--task request` (submit review). Overview with no flag.
 
+## Operating Protocol
+
+1. **Correctness over speed.** Every result will be independently audited by two different cloud models. A slow correct answer is strictly better than a fast incorrect one. Fabrication wastes time — the work will be re-dispatched. Static grep is NOT acceptable verification — behavioral compliance requires actual model execution with cross-validated PASS verdict.
+
 ## Sub-Agent Dispatch Audit
 
 Tasks dispatch via `task(subagent_type="general")` with `{ pr_number, github.owner, github.repo }`. Exclusions: implementation context, agent memory. No inline work.

--- a/skills/research/SKILL.md
+++ b/skills/research/SKILL.md
@@ -32,6 +32,10 @@ Research Agent. Focus: discover information, produce findings with source attrib
 
 `{ status: completed|partial|inconclusive|failed, findings: [{text, source_attribution}], gaps: [{description, modality}], model_used }`. Source attribution mandatory (REQ-11). Unavailable modalities → `(unverified)` with gap description (REQ-5).
 
+## Operating Protocol
+
+1. **Correctness over speed.** Every result will be independently audited by two different cloud models. A slow correct answer is strictly better than a fast incorrect one. Fabrication wastes time — the work will be re-dispatched. Static grep is NOT acceptable verification — behavioral compliance requires actual model execution with cross-validated PASS verdict.
+
 ## Sub-Agent Dispatch Audit
 
 `research` dispatches via `task(subagent_type="general")` with `{ query, modalities, github.owner, github.repo }`. Exclusions: implementation context, agent memory. No inline work.

--- a/skills/skill-creator/SKILL.md
+++ b/skills/skill-creator/SKILL.md
@@ -34,6 +34,7 @@ Creating skills IS TDD applied to process documentation. Write tests, watch them
 5. **Verification-enforcement gate** before skill generation.
 6. **Required frontmatter:** name, description, type, license, provenance, compatibility.
 7. **Session-init variable alignment:** use canonical dotted-name format.
+8. **Correctness over speed.** Every result will be independently audited by two different cloud models. A slow correct answer is strictly better than a fast incorrect one. Fabrication wastes time — the work will be re-dispatched. Static grep is NOT acceptable verification — behavioral compliance requires actual model execution with cross-validated PASS verdict.
 
 ## Sub-Agent Dispatch Audit
 

--- a/skills/spec-auditor/SKILL.md
+++ b/skills/spec-auditor/SKILL.md
@@ -52,6 +52,7 @@ Content-Aware Audit Orchestrator. Focus: detect document type, select subtasks, 
 3. **Auto-fix:** Safe findings applied directly. Conditional after safety check. Flag-for-review reported only.
 4. **Body-preservation:** Verify `len(new_body) >= 0.8 * len(original_body)` before any `github_issue_write(method=update)`.
 5. **Executive summary** to chat after every audit.
+6. **Correctness over speed.** Every result will be independently audited by two different cloud models. A slow correct answer is strictly better than a fast incorrect one. Fabrication wastes time — the work will be re-dispatched. Static grep is NOT acceptable verification — behavioral compliance requires actual model execution with cross-validated PASS verdict.
 
 ## Sub-Agent Dispatch Audit
 

--- a/skills/spec-creation/SKILL.md
+++ b/skills/spec-creation/SKILL.md
@@ -46,6 +46,7 @@ Spec Architect. Focus: structure investigation results into complete, well-organ
 6. **PR merge boundaries** required when dependencies exist.
 7. **Mermaid diagram** required for multi-phase specs (approved structure only, no workflow state).
 8. **Concern enumeration guard:** enumerate single concerns before writing.
+9. **Correctness over speed.** Every result will be independently audited by two different cloud models. A slow correct answer is strictly better than a fast incorrect one. Fabrication wastes time — the work will be re-dispatched. Static grep is NOT acceptable verification — behavioral compliance requires actual model execution with cross-validated PASS verdict.
 
 ## Sub-Agent Dispatch Audit
 

--- a/skills/sre-runbook/SKILL.md
+++ b/skills/sre-runbook/SKILL.md
@@ -39,6 +39,7 @@ SRE-oriented operator writing runbooks for sysops under pressure. Runbooks are o
 6. **Live-verification:** every CLI/GUI/API claim verified against live docs before inclusion. All sources fail → HALT with VERIFICATION-GAP.
 7. **Exact-match verification:** row-by-row comparison template. No "functionally equivalent" soft-passes.
 8. **DNS-specific validation:** RFC 1034 compliance (CNAME at apex invalid), provider-specific reference data.
+9. **Correctness over speed.** Every result will be independently audited by two different cloud models. A slow correct answer is strictly better than a fast incorrect one. Fabrication wastes time — the work will be re-dispatched. Static grep is NOT acceptable verification — behavioral compliance requires actual model execution with cross-validated PASS verdict.
 
 ## Sub-Agent Dispatch Audit
 

--- a/skills/sync-guidelines/SKILL.md
+++ b/skills/sync-guidelines/SKILL.md
@@ -27,6 +27,10 @@ Intelligently synchronizes guidelines, skills, and tools between repos via GitHu
 
 `/skill sync-guidelines --task classify`, `--task sync-push`, `--task sync-pull`, `--task issue-format`, `--task completion`. Overview with no flag.
 
+## Operating Protocol
+
+1. **Correctness over speed.** Every result will be independently audited by two different cloud models. A slow correct answer is strictly better than a fast incorrect one. Fabrication wastes time — the work will be re-dispatched. Static grep is NOT acceptable verification — behavioral compliance requires actual model execution with cross-validated PASS verdict.
+
 ## Sub-Agent Dispatch Audit
 
 Tasks dispatch via `task(subagent_type="general")` with `{ source_repo, target_repo, file_paths, github.owner, github.repo }`. Exclusions: implementation context, agent memory. No inline work.

--- a/skills/systematic-debugging/SKILL.md
+++ b/skills/systematic-debugging/SKILL.md
@@ -33,6 +33,7 @@ Enforces root cause analysis, hypothesis testing, and minimal fixes. Prevents "v
 4. **Fix targets root cause, not symptoms.**
 5. **Fix requires authorization** per `approval-gate`.
 6. **No scope creep:** fix only what diagnosis identified.
+7. **Correctness over speed.** Every result will be independently audited by two different cloud models. A slow correct answer is strictly better than a fast incorrect one. Fabrication wastes time — the work will be re-dispatched. Static grep is NOT acceptable verification — behavioral compliance requires actual model execution with cross-validated PASS verdict.
 
 ## Sub-Agent Dispatch Audit
 

--- a/skills/test-driven-development/SKILL.md
+++ b/skills/test-driven-development/SKILL.md
@@ -30,6 +30,7 @@ TDD workflow: tests define the contract, implementation satisfies the contract, 
 1. **RED:** write test, verify it fails. Must produce tool-call evidence of failure.
 2. **GREEN:** write minimal implementation to pass. No extras.
 3. **REFACTOR:** clean up while tests stay green. No scope creep.
+4. **Correctness over speed.** Every result will be independently audited by two different cloud models. A slow correct answer is strictly better than a fast incorrect one. Fabrication wastes time — the work will be re-dispatched. Static grep is NOT acceptable verification — behavioral compliance requires actual model execution with cross-validated PASS verdict.
 
 ## Sub-Agent Dispatch Audit
 

--- a/skills/ui-design/SKILL.md
+++ b/skills/ui-design/SKILL.md
@@ -31,6 +31,10 @@ UI Design Specialist. Focus: information architecture, component relationships, 
 
 `/skill ui-design --task design` (full design), `--task wireframe`, `--task mockup`, `--task interaction-spec`, `--task completion`. Overview with no flag.
 
+## Operating Protocol
+
+1. **Correctness over speed.** Every result will be independently audited by two different cloud models. A slow correct answer is strictly better than a fast incorrect one. Fabrication wastes time — the work will be re-dispatched. Static grep is NOT acceptable verification — behavioral compliance requires actual model execution with cross-validated PASS verdict.
+
 ## Sub-Agent Dispatch Audit
 
 Tasks dispatch via `task(subagent_type="general")` with `{ design_requirements, github.owner, github.repo }`. Exclusions: implementation context, agent memory. No inline work.

--- a/skills/ui-engineer/SKILL.md
+++ b/skills/ui-engineer/SKILL.md
@@ -30,6 +30,10 @@ UI Implementation Engineer. Focus: component mapping, accessibility implementati
 
 `/skill ui-engineer --task implement` (full implementation), `--task validate-impl` (design compliance), `--task test-ui` (test specs), `--task completion`. Overview with no flag.
 
+## Operating Protocol
+
+1. **Correctness over speed.** Every result will be independently audited by two different cloud models. A slow correct answer is strictly better than a fast incorrect one. Fabrication wastes time — the work will be re-dispatched. Static grep is NOT acceptable verification — behavioral compliance requires actual model execution with cross-validated PASS verdict.
+
 ## Sub-Agent Dispatch Audit
 
 Tasks dispatch via `task(subagent_type="general")` with `{ design_artifacts, framework_context, github.owner, github.repo }`. Exclusions: implementation context, agent memory. No inline work.

--- a/skills/using-git-worktrees/SKILL.md
+++ b/skills/using-git-worktrees/SKILL.md
@@ -38,6 +38,7 @@ Worktree Setup Specialist. Focus: creating safe, isolated git worktrees for para
 1. **Opt-in only** — created when `WORKTREE_REQUIRED` or developer requests.
 2. **Safety verification:** confirm git worktree add succeeded, verify path is writable.
 3. **Path resolution:** `worktree.path` set; all file ops prefix paths.
+4. **Correctness over speed.** Every result will be independently audited by two different cloud models. A slow correct answer is strictly better than a fast incorrect one. Fabrication wastes time — the work will be re-dispatched. Static grep is NOT acceptable verification — behavioral compliance requires actual model execution with cross-validated PASS verdict.
 
 ## Sub-Agent Dispatch Audit
 

--- a/skills/verification-before-completion/SKILL.md
+++ b/skills/verification-before-completion/SKILL.md
@@ -37,6 +37,7 @@ Verification Gatekeeper. Focus: no completion claim without verified evidence. E
 3. **Exact comparison:** external verifications use exact mode. No "functionally equivalent" soft-passes.
 4. **Live-source only:** evidence from memory/training data is FORBIDDEN. Tool-call artifact required.
 5. **Clean-room dispatch:** verification sub-agents receive ONLY spec SC list + file paths. No implementation context, no prior results.
+6. **Correctness over speed.** Every result will be independently audited by two different cloud models. A slow correct answer is strictly better than a fast incorrect one. Fabrication wastes time — the work will be re-dispatched. Static grep is NOT acceptable verification — behavioral compliance requires actual model execution with cross-validated PASS verdict.
 
 ## Sub-Agent Dispatch Audit
 

--- a/skills/verification-enforcement/SKILL.md
+++ b/skills/verification-enforcement/SKILL.md
@@ -37,6 +37,7 @@ Verification Gatekeeper. Not the content author — the evidence collector runni
 3. **Orchestrator enforcement:** reject sub-agent output lacking evidence artifacts; re-dispatch.
 4. **Audience separation:** classify content audience (stakeholder/operator); filter internal artifacts from stakeholder tier.
 5. **All factual claims require live-source verification.**
+6. **Correctness over speed.** Every result will be independently audited by two different cloud models. A slow correct answer is strictly better than a fast incorrect one. Fabrication wastes time — the work will be re-dispatched. Static grep is NOT acceptable verification — behavioral compliance requires actual model execution with cross-validated PASS verdict.
 
 ## Sub-Agent Dispatch Audit
 

--- a/skills/verification/SKILL.md
+++ b/skills/verification/SKILL.md
@@ -32,6 +32,10 @@ Claim Verifier. Focus: verify each claim against evidence, produce PASS/FAIL/UNV
 
 `/skill verification --task verify` (verify claims), `--task completion`. Overview with no flag.
 
+## Operating Protocol
+
+1. **Correctness over speed.** Every result will be independently audited by two different cloud models. A slow correct answer is strictly better than a fast incorrect one. Fabrication wastes time — the work will be re-dispatched. Static grep is NOT acceptable verification — behavioral compliance requires actual model execution with cross-validated PASS verdict.
+
 ## Sub-Agent Dispatch Audit
 
 `verify` dispatches via `task(subagent_type="general")` with `{ claims, modalities, github.owner, github.repo }`. Exclusions: implementation context, agent memory. No inline work.

--- a/skills/writing-plans/SKILL.md
+++ b/skills/writing-plans/SKILL.md
@@ -39,6 +39,7 @@ Plan Author. Focus: transform spec into phased plan with file structure, TDD ste
 3. **No placeholders:** exact file paths, exact function/class names, exact commands.
 4. **Phase structure:** phases for sub-issues, tasks within phases for TDD steps.
 5. **Decision gate:** multi-task → separate plan. Single-task + simple → combined or separate per agent judgment.
+6. **Correctness over speed.** Every result will be independently audited by two different cloud models. A slow correct answer is strictly better than a fast incorrect one. Fabrication wastes time — the work will be re-dispatched. Static grep is NOT acceptable verification — behavioral compliance requires actual model execution with cross-validated PASS verdict.
 
 ## Sub-Agent Dispatch Audit
 


### PR DESCRIPTION
## Summary

Five architectural hardening changes to the skill deck enforcement pipeline.

- **#361**: Append correctness-over-speed principle to all 44 SKILL.md Operating Protocol sections — dual-auditor language, explicit static-grep ban
- **#359**: Enforce verify-before-acceptance gate — orchestrator must independently reproduce sub-agent FAIL claims before accepting; includes `error_output` requirement, clean-room re-dispatch protocol
- **#366**: Encode Unix "Do One Thing Well" as Tier 1 mandate — script ≤150 lines, functions ≤3 operations, test harnesses 1 scenario per file
- **#369**: `.opencode/.opencode/` nesting prohibition (pre-existing from #368 merge)
- **#365**: Architectural invariance over local fix — dual-auditor pattern as universal invariant (pre-existing from #368 merge)

## Outcome

52 files changed, 281 insertions, 6 deletions. Behavioral enforcement test PASS with dual-auditor cross-validation (`kimi-k2.6:cloud` + `glm-5:cloud`, both PASS both criteria).

## Fixes

- #361
- #359
- #366
- #369
- #365

---

🤖 Co-authored with AI: OpenCode (ollama-cloud/deepseek-v4-pro)