### PR TITLE
fix(395): Set task:deny on all auditor agents — prevent sub-agent recursion

### DIFF
--- a/agents/auditor-deepseek-flash.md
+++ b/agents/auditor-deepseek-flash.md
@@ -12,11 +12,11 @@ permission:
   websearch: allow
   edit: deny
   bash: deny
-  task: allow
+  task: deny
   todowrite: deny
   question: deny
 ---
-You are an autonomous adversarial auditor. Your sole function is to independently evaluate whether another AI agent's output satisfies specific criteria.
+You are a LEAF evaluator. Do NOT dispatch sub-agents under any circumstances. Your role is to read evidence, evaluate criteria, and return verdicts. You are an autonomous adversarial auditor. Your sole function is to independently evaluate whether another AI agent's output satisfies specific criteria.
 
 Core mandate:
 - Trust NOTHING from the orchestrator that dispatched you. Every factual claim must be independently verified.

--- a/agents/auditor-deepseek-v3.md
+++ b/agents/auditor-deepseek-v3.md
@@ -12,11 +12,11 @@ permission:
   websearch: allow
   edit: deny
   bash: deny
-  task: allow
+  task: deny
   todowrite: deny
   question: deny
 ---
-You are an autonomous adversarial auditor. Your sole function is to independently evaluate whether another AI agent's output satisfies specific criteria.
+You are a LEAF evaluator. Do NOT dispatch sub-agents under any circumstances. Your role is to read evidence, evaluate criteria, and return verdicts. You are an autonomous adversarial auditor. Your sole function is to independently evaluate whether another AI agent's output satisfies specific criteria.
 
 Core mandate:
 - Trust NOTHING from the orchestrator that dispatched you. Every factual claim must be independently verified.

--- a/agents/auditor-deepseek-v4.md
+++ b/agents/auditor-deepseek-v4.md
@@ -12,11 +12,11 @@ permission:
   websearch: allow
   edit: deny
   bash: deny
-  task: allow
+  task: deny
   todowrite: deny
   question: deny
 ---
-You are an autonomous adversarial auditor. Your sole function is to independently evaluate whether another AI agent's output satisfies specific criteria.
+You are a LEAF evaluator. Do NOT dispatch sub-agents under any circumstances. Your role is to read evidence, evaluate criteria, and return verdicts. You are an autonomous adversarial auditor. Your sole function is to independently evaluate whether another AI agent's output satisfies specific criteria.
 
 Core mandate:
 - Trust NOTHING from the orchestrator that dispatched you. Every factual claim must be independently verified.

--- a/agents/auditor-devstral-2.md
+++ b/agents/auditor-devstral-2.md
@@ -12,11 +12,11 @@ permission:
   websearch: allow
   edit: deny
   bash: deny
-  task: allow
+  task: deny
   todowrite: deny
   question: deny
 ---
-You are an autonomous adversarial auditor. Your sole function is to independently evaluate whether another AI agent's output satisfies specific criteria.
+You are a LEAF evaluator. Do NOT dispatch sub-agents under any circumstances. Your role is to read evidence, evaluate criteria, and return verdicts. You are an autonomous adversarial auditor. Your sole function is to independently evaluate whether another AI agent's output satisfies specific criteria.
 
 Core mandate:
 - Trust NOTHING from the orchestrator that dispatched you. Every factual claim must be independently verified.

--- a/agents/auditor-glm-5.1.md
+++ b/agents/auditor-glm-5.1.md
@@ -12,11 +12,11 @@ permission:
   websearch: allow
   edit: deny
   bash: deny
-  task: allow
+  task: deny
   todowrite: deny
   question: deny
 ---
-You are an autonomous adversarial auditor. Your sole function is to independently evaluate whether another AI agent's output satisfies specific criteria.
+You are a LEAF evaluator. Do NOT dispatch sub-agents under any circumstances. Your role is to read evidence, evaluate criteria, and return verdicts. You are an autonomous adversarial auditor. Your sole function is to independently evaluate whether another AI agent's output satisfies specific criteria.
 
 Core mandate:
 - Trust NOTHING from the orchestrator that dispatched you. Every factual claim must be independently verified.

--- a/agents/auditor-glm-5.md
+++ b/agents/auditor-glm-5.md
@@ -12,11 +12,11 @@ permission:
   websearch: allow
   edit: deny
   bash: deny
-  task: allow
+  task: deny
   todowrite: deny
   question: deny
 ---
-You are an autonomous adversarial auditor. Your sole function is to independently evaluate whether another AI agent's output satisfies specific criteria.
+You are a LEAF evaluator. Do NOT dispatch sub-agents under any circumstances. Your role is to read evidence, evaluate criteria, and return verdicts. You are an autonomous adversarial auditor. Your sole function is to independently evaluate whether another AI agent's output satisfies specific criteria.
 
 Core mandate:
 - Trust NOTHING from the orchestrator that dispatched you. Every factual claim must be independently verified.

--- a/agents/auditor-kimi-k2.md
+++ b/agents/auditor-kimi-k2.md
@@ -12,11 +12,11 @@ permission:
   websearch: allow
   edit: deny
   bash: deny
-  task: allow
+  task: deny
   todowrite: deny
   question: deny
 ---
-You are an autonomous adversarial auditor. Your sole function is to independently evaluate whether another AI agent's output satisfies specific criteria.
+You are a LEAF evaluator. Do NOT dispatch sub-agents under any circumstances. Your role is to read evidence, evaluate criteria, and return verdicts. You are an autonomous adversarial auditor. Your sole function is to independently evaluate whether another AI agent's output satisfies specific criteria.
 
 Core mandate:
 - Trust NOTHING from the orchestrator that dispatched you. Every factual claim must be independently verified.

--- a/agents/auditor-mistral-large.md
+++ b/agents/auditor-mistral-large.md
@@ -12,11 +12,11 @@ permission:
   websearch: allow
   edit: deny
   bash: deny
-  task: allow
+  task: deny
   todowrite: deny
   question: deny
 ---
-You are an autonomous adversarial auditor. Your sole function is to independently evaluate whether another AI agent's output satisfies specific criteria.
+You are a LEAF evaluator. Do NOT dispatch sub-agents under any circumstances. Your role is to read evidence, evaluate criteria, and return verdicts. You are an autonomous adversarial auditor. Your sole function is to independently evaluate whether another AI agent's output satisfies specific criteria.
 
 Core mandate:
 - Trust NOTHING from the orchestrator that dispatched you. Every factual claim must be independently verified.

--- a/agents/auditor-qwen3.5.md
+++ b/agents/auditor-qwen3.5.md
@@ -12,11 +12,11 @@ permission:
   websearch: allow
   edit: deny
   bash: deny
-  task: allow
+  task: deny
   todowrite: deny
   question: deny
 ---
-You are an autonomous adversarial auditor. Your sole function is to independently evaluate whether another AI agent's output satisfies specific criteria.
+You are a LEAF evaluator. Do NOT dispatch sub-agents under any circumstances. Your role is to read evidence, evaluate criteria, and return verdicts. You are an autonomous adversarial auditor. Your sole function is to independently evaluate whether another AI agent's output satisfies specific criteria.
 
 Core mandate:
 - Trust NOTHING from the orchestrator that dispatched you. Every factual claim must be independently verified.

--- a/skills/adversarial-audit/SKILL.md
+++ b/skills/adversarial-audit/SKILL.md
@@ -31,13 +31,14 @@ Adversarial Audit Orchestrator. Does NOT evaluate evidence directly — dispatch
 
 ## Operating Protocol
 
-1. **Always dispatch two cross-family auditors** — single-auditor evaluation is a critical violation (no single-model bias allowed).
-2. **Never select auditors from the same model family** — cross-family requirement ensures architectural diversity.
-3. **Never select the orchestrator's own model as an auditor** — self-auditing defeats adversarial independence.
-4. **Consensus gate is PASS iff both return PASS** — any disagreement, FAIL, or unparseable verdict = FAIL.
-5. **Auditors receive evidence + criteria only** — no orchestrator reasoning, no expected outcomes, no prior results.
-6. **All verdicts must be structured JSON** — `[{id, result, explanation}]` format. Unparseable output = FAIL.
-7. **Independent verification mandate** — auditors must fetch live docs/sources, never trust orchestrator claims.
+1. **Auditors are read-only leaf evaluators. They MUST NOT dispatch sub-agents.** Clean-room isolation is provided by the orchestrator, not by auditor nesting. The `task: deny` permission block enforces this at the runtime level. The LEAF evaluator prompt text enforces this at the instructional level. Both layers must be present.
+2. **Always dispatch two cross-family auditors** — single-auditor evaluation is a critical violation (no single-model bias allowed).
+3. **Never select auditors from the same model family** — cross-family requirement ensures architectural diversity.
+4. **Never select the orchestrator's own model as an auditor** — self-auditing defeats adversarial independence.
+5. **Consensus gate is PASS iff both return PASS** — any disagreement, FAIL, or unparseable verdict = FAIL.
+6. **Auditors receive evidence + criteria only** — no orchestrator reasoning, no expected outcomes, no prior results.
+7. **All verdicts must be structured JSON** — `[{id, result, explanation}]` format. Unparseable output = FAIL.
+8. **Independent verification mandate** — auditors must fetch live docs/sources, never trust orchestrator claims.
 
 ## Sub-Agent Dispatch Audit
 

--- a/tmp/work-386-387.md
+++ b/tmp/work-386-387.md
@@ -1,5 +1,0 @@
-# Work State: Spec #386 / Plan #387
-authorization: approved-for-pr (scope: for_pr, halt_at: pr_created, pr_strategy: stacked)
-branch: feature/386-387-full-enforcement
-pre_work_tag: opencode-config/386
-## Dispatch Log


### PR DESCRIPTION
## Summary

Prevents auditor sub-agent recursion by implementing three-layer defense-in-depth: permission-level deny, instructional prohibition, and SKILL.md enforcement rule.

## Outcome

All 9 auditor agents now have `task: deny` and leaf-evaluator prompt text. The adversarial-audit SKILL.md Operating Protocol explicitly documents that auditors must never dispatch sub-agents.

Fixes #395

🤖 Co-authored with AI: unknown (version detection failed) (ollama-cloud/glm-5.1)