### PR TITLE
fix: Plugin export pattern for env-loader.ts

### DIFF
--- a/plugins/env-loader.ts
+++ b/plugins/env-loader.ts
@@ -213,7 +213,7 @@ function readGitBucketUrlFromEnv(envPath: string): string | null {
   return null;
 }
 
-export async function EnvLoaderPlugin(input: PluginInput): Promise<Hooks> {
+export default async function envLoaderPlugin(input: PluginInput): Promise<Hooks> {
   const projectDir = input?.directory || process.cwd();
   const envPath = path.join(projectDir, ENV_FILE);
 
@@ -336,6 +336,6 @@ export async function EnvLoaderPlugin(input: PluginInput): Promise<Hooks> {
   };
 }
 
-export default EnvLoaderPlugin;
+
 export { parseEnvFile, isEnvGitignored, writeDiagnostic, DIAGNOSTICS_PATH };
 export type { PluginDiagnostic };


### PR DESCRIPTION
## Summary

Fixes the `env-loader.ts` plugin export pattern that caused "Plugin export is not a function" errors at startup. The plugin used a named export with separate `export default` reference, while `session-enforcement.ts` (the working reference) declares the function directly as the default export.

## Outcome

- `env-loader.ts` now uses `export default async function envLoaderPlugin(...)` matching the working `session-enforcement.ts` pattern
- Removed redundant `export default EnvLoaderPlugin;` line
- Named utility exports (`parseEnvFile`, `isEnvGitignored`, etc.) remain accessible

Fixes #424

🤖 Co-authored with AI: OpenCode (ollama-cloud/glm-5.1)