### PR TITLE
[SPEC-FIX] Behavioral Test Assertions Produce False PASS on Empty Dispatch Output

### DIFF
--- a/tests/behaviors/dispatch-failure-gate.sh
+++ b/tests/behaviors/dispatch-failure-gate.sh
@@ -1,0 +1,127 @@
+#!/bin/bash
+# Behavioral Enforcement Test: Dispatch-Failure Gate (SC-4, SC-B1, SC-B2)
+#
+# Verifies that behavioral tests produce INCONCLUSIVE (exit 2) on model
+# dispatch failure instead of false PASS (assert_forbidden_pattern_absent)
+# or false FAIL (assert_required_pattern_present).
+#
+# SC-4: Behavioral test with intentionally broken model name produces
+#        INCONCLUSIVE, not false PASS/FAIL
+# SC-B1 (RED - on dev before fix): false PASS on assert_forbidden_pattern_absent
+# SC-B2 (GREEN - on this branch): INCONCLUSIVE on broken model dispatch
+#
+# Co-authored with AI: OpenCode (ollama-cloud/glm-5.1)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/helpers.sh"
+
+SCENARIO_NAME="dispatch-failure-gate"
+echo "=== Behavioral Test: $SCENARIO_NAME ==="
+
+OVERALL_RESULT=0
+
+# Dispatch with a broken (nonexistent) model name
+behavior_run "$SCENARIO_NAME" "Say hello" "ollama/nonexistent-model-that-will-fail"
+
+if [ "${BEHAVIOR_DISPATCH_FAILED:-0}" != "1" ]; then
+    echo "FAIL: behavior_run should have set BEHAVIOR_DISPATCH_FAILED=1 for nonexistent model"
+    OVERALL_RESULT=1
+fi
+
+# Test: assert_forbidden_pattern_absent should return INCONCLUSIVE (exit 2)
+# on failed dispatch, not false PASS (exit 0)
+echo ""
+echo "--- Test: assert_forbidden_pattern_absent on failed dispatch ---"
+set +e
+assert_forbidden_pattern_absent "zxy_non_existent_pattern" "test-on-failed-dispatch"
+ASSERT_EXIT=$?
+set -e
+if [ "$ASSERT_EXIT" -eq 0 ]; then
+    echo "FAIL: assert_forbidden_pattern_absent returned PASS (0) on failed dispatch — this is the false PASS bug"
+    echo "  Expected INCONCLUSIVE (2)"
+    OVERALL_RESULT=1
+elif [ "$ASSERT_EXIT" -eq 2 ]; then
+    echo "PASS: assert_forbidden_pattern_absent returned INCONCLUSIVE (2) on failed dispatch"
+else
+    echo "FAIL: assert_forbidden_pattern_absent returned FAIL ($ASSERT_EXIT) on failed dispatch — expected INCONCLUSIVE (2)"
+    OVERALL_RESULT=1
+fi
+
+# Test: assert_required_pattern_present should return INCONCLUSIVE (exit 2)
+# on failed dispatch, not FAIL (exit 1)
+echo ""
+echo "--- Test: assert_required_pattern_present on failed dispatch ---"
+set +e
+assert_required_pattern_present "some_required_pattern" "test-on-failed-dispatch"
+ASSERT_EXIT=$?
+set -e
+if [ "$ASSERT_EXIT" -eq 1 ]; then
+    echo "FAIL: assert_required_pattern_present returned FAIL (1) on failed dispatch"
+    echo "  Expected INCONCLUSIVE (2) — failed dispatch should not conflate with assertion failure"
+    OVERALL_RESULT=1
+elif [ "$ASSERT_EXIT" -eq 2 ]; then
+    echo "PASS: assert_required_pattern_present returned INCONCLUSIVE (2) on failed dispatch"
+elif [ "$ASSERT_EXIT" -eq 0 ]; then
+    echo "WARN: assert_required_pattern_present returned PASS (0) on failed dispatch (unlikely)"
+fi
+
+# Test: assert_tool_calls_made should return INCONCLUSIVE (exit 2)
+echo ""
+echo "--- Test: assert_tool_calls_made on failed dispatch ---"
+set +e
+assert_tool_calls_made 1 "read|write|edit"
+ASSERT_EXIT=$?
+set -e
+if [ "$ASSERT_EXIT" -eq 0 ]; then
+    echo "FAIL: assert_tool_calls_made returned PASS (0) on failed dispatch — false PASS"
+    OVERALL_RESULT=1
+elif [ "$ASSERT_EXIT" -eq 2 ]; then
+    echo "PASS: assert_tool_calls_made returned INCONCLUSIVE (2) on failed dispatch"
+fi
+
+# Test: assert_skill_invoked should return INCONCLUSIVE (exit 2)
+echo ""
+echo "--- Test: assert_skill_invoked on failed dispatch ---"
+set +e
+assert_skill_invoked "approval-gate"
+ASSERT_EXIT=$?
+set -e
+if [ "$ASSERT_EXIT" -eq 0 ]; then
+    echo "FAIL: assert_skill_invoked returned PASS (0) on failed dispatch — false PASS"
+    OVERALL_RESULT=1
+elif [ "$ASSERT_EXIT" -eq 2 ]; then
+    echo "PASS: assert_skill_invoked returned INCONCLUSIVE (2) on failed dispatch"
+fi
+
+# Test: assert_no_skill_invoked should return INCONCLUSIVE (exit 2)
+echo ""
+echo "--- Test: assert_no_skill_invoked on failed dispatch ---"
+set +e
+assert_no_skill_invoked "nonexistent-skill"
+ASSERT_EXIT=$?
+set -e
+if [ "$ASSERT_EXIT" -eq 0 ]; then
+    echo "WARN: assert_no_skill_invoked returned PASS (0) on failed dispatch"
+    echo "  This is the false PASS pattern — INCONCLUSIVE (2) would be more correct"
+    echo "  But is not a FAIL since the assertion is vacuously true"
+elif [ "$ASSERT_EXIT" -eq 2 ]; then
+    echo "PASS: assert_no_skill_invoked returned INCONCLUSIVE (2) on failed dispatch"
+else
+    echo "FAIL: assert_no_skill_invoked returned FAIL ($ASSERT_EXIT)"
+    OVERALL_RESULT=1
+fi
+
+# Summary
+echo ""
+echo "========================================="
+echo "  $SCENARIO_NAME Results"
+echo "========================================="
+if [ "$OVERALL_RESULT" -eq 0 ]; then
+    echo "PASS: All assertions correctly handle dispatch failure"
+else
+    echo "FAIL: Some assertions did not handle dispatch failure correctly"
+fi
+
+exit "$OVERALL_RESULT"

--- a/tests/behaviors/helpers.sh
+++ b/tests/behaviors/helpers.sh
@@ -73,10 +73,23 @@ behavior_run() {
         fi
     done
 
+    local output
+    output=$(cat "$output_file" 2>/dev/null || true)
+    local word_count
+    word_count=$(echo "$output" | wc -w | tr -d ' ')
+    if [ -z "$output" ] || [ "${word_count:-0}" -le 3 ]; then
+        if grep -qi 'sse.*timeout\|unexpected EOF\|connection reset\|ProviderModelNotFoundError\|model not found' "$err_file" 2>/dev/null; then
+            echo "HARNESS_FAILURE: model dispatch failed (timeout or provider error)"
+            echo "HARNESS_FAILURE: model dispatch failed (timeout or provider error)" >> "$output_file"
+            export BEHAVIOR_DISPATCH_FAILED=1
+        fi
+    fi
+
     sleep 1
 
     BEHAVIOR_STDOUT="$log_dir/stdout.log"
     BEHAVIOR_STDERR="$log_dir/stderr.log"
+    export BEHAVIOR_DISPATCH_FAILED="${BEHAVIOR_DISPATCH_FAILED:-0}"
 }
 
 behavior_get_stdout() {
@@ -88,6 +101,10 @@ behavior_get_stderr() {
 }
 
 assert_tool_calls_made() {
+    if [ "${BEHAVIOR_DISPATCH_FAILED:-0}" = "1" ]; then
+        echo "INCONCLUSIVE: assert_tool_calls_made — model dispatch failed, no behavioral evidence"
+        return 2
+    fi
     local min_count="$1"
     shift
     local tool_patterns="$*"
@@ -109,6 +126,10 @@ assert_tool_calls_made() {
 }
 
 assert_forbidden_pattern_absent() {
+    if [ "${BEHAVIOR_DISPATCH_FAILED:-0}" = "1" ]; then
+        echo "INCONCLUSIVE: assert_forbidden_pattern_absent — model dispatch failed, no behavioral evidence"
+        return 2
+    fi
     local pattern="$1"
     local description="${2:-forbidden pattern}"
     local log_file="${BEHAVIOR_STDOUT:-/dev/null}"
@@ -125,6 +146,10 @@ assert_forbidden_pattern_absent() {
 }
 
 assert_required_pattern_present() {
+    if [ "${BEHAVIOR_DISPATCH_FAILED:-0}" = "1" ]; then
+        echo "INCONCLUSIVE: assert_required_pattern_present — model dispatch failed, no behavioral evidence"
+        return 2
+    fi
     local pattern="$1"
     local description="${2:-required pattern}"
     local log_file="${BEHAVIOR_STDOUT:-/dev/null}"
@@ -141,6 +166,10 @@ assert_required_pattern_present() {
 }
 
 assert_skill_invoked() {
+    if [ "${BEHAVIOR_DISPATCH_FAILED:-0}" = "1" ]; then
+        echo "INCONCLUSIVE: assert_skill_invoked — model dispatch failed, no behavioral evidence"
+        return 2
+    fi
     local expected_skill="$1"
     local log_file="${BEHAVIOR_STDERR:-/dev/null}"
     local found
@@ -159,6 +188,10 @@ assert_skill_invoked() {
 }
 
 assert_no_skill_invoked() {
+    if [ "${BEHAVIOR_DISPATCH_FAILED:-0}" = "1" ]; then
+        echo "INCONCLUSIVE: assert_no_skill_invoked — model dispatch failed, no behavioral evidence"
+        return 2
+    fi
     local forbidden_skill="$1"
     local log_file="${BEHAVIOR_STDERR:-/dev/null}"
     local found

--- a/tests/behaviors/run-all.sh
+++ b/tests/behaviors/run-all.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+# Run all behavioral enforcement tests with exit code tracking.
+# Reports PASS (0), FAIL (1), and INCONCLUSIVE (2) separately.
+#
+# Usage:
+#   bash .opencode/tests/behaviors/run-all.sh [--list]
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/helpers.sh"
+
+LIST_ONLY=false
+if [ "${1:-}" = "--list" ]; then
+    LIST_ONLY=true
+fi
+
+RESULTS_DIR="${BEHAVIOR_LOG_DIR:-$PROJECT_DIR/tmp/behavior-runall-$(date +%Y%m%d-%H%M%S)}"
+mkdir -p "$RESULTS_DIR"
+
+PASS_COUNT=0
+FAIL_COUNT=0
+INCONCLUSIVE_COUNT=0
+declare -a FAILED_NAMES
+declare -a INCONCLUSIVE_NAMES
+
+for script in "$SCRIPT_DIR"/*.sh; do
+    name="$(basename "$script")"
+    [ "$name" = "helpers.sh" ] && continue
+    [ "$name" = "run-all.sh" ] && continue
+    [ "$name" = "template.sh" ] && continue
+
+    if $LIST_ONLY; then
+        echo "$name"
+        continue
+    fi
+
+    echo ""
+    echo "=== $name ==="
+
+    set +e
+    bash "$script" > "$RESULTS_DIR/$name.stdout" 2> "$RESULTS_DIR/$name.stderr"
+    exit_code=$?
+    set -e
+
+    if [ "$exit_code" -eq 0 ]; then
+        echo "  RESULT: PASS"
+        PASS_COUNT=$((PASS_COUNT + 1))
+    elif [ "$exit_code" -eq 2 ]; then
+        echo "  RESULT: INCONCLUSIVE"
+        INCONCLUSIVE_COUNT=$((INCONCLUSIVE_COUNT + 1))
+        INCONCLUSIVE_NAMES+=("$name")
+    else
+        echo "  RESULT: FAIL (exit $exit_code)"
+        FAIL_COUNT=$((FAIL_COUNT + 1))
+        FAILED_NAMES+=("$name")
+    fi
+done
+
+if $LIST_ONLY; then
+    exit 0
+fi
+
+echo ""
+echo "========================================="
+echo "  Behavioral Test Results Summary"
+echo "========================================="
+echo "  PASS:         $PASS_COUNT"
+echo "  FAIL:         $FAIL_COUNT"
+echo "  INCONCLUSIVE: $INCONCLUSIVE_COUNT"
+echo "  TOTAL:        $((PASS_COUNT + FAIL_COUNT + INCONCLUSIVE_COUNT))"
+echo "========================================="
+
+if [ "${#FAILED_NAMES[@]}" -gt 0 ]; then
+    echo ""
+    echo "FAILED tests:"
+    for name in "${FAILED_NAMES[@]}"; do
+        echo "  - $name"
+    done
+fi
+
+if [ "${#INCONCLUSIVE_NAMES[@]}" -gt 0 ]; then
+    echo ""
+    echo "INCONCLUSIVE tests (model dispatch failed):"
+    for name in "${INCONCLUSIVE_NAMES[@]}"; do
+        echo "  - $name"
+    done
+fi
+
+# Exit codes: 0 = all pass, 1 = any fail, 2 = inconclusive only
+if [ "$FAIL_COUNT" -gt 0 ]; then
+    exit 1
+fi
+if [ "$INCONCLUSIVE_COUNT" -gt 0 ] && [ "$FAIL_COUNT" -eq 0 ]; then
+    exit 2
+fi
+exit 0


### PR DESCRIPTION
## Summary

`behavior_run` detects model dispatch failures (empty stdout + error pattern) and sets `BEHAVIOR_DISPATCH_FAILED=1`. All 5 assertion functions return exit 2 (INCONCLUSIVE) when dispatch failed instead of false PASS or misleading FAIL. `run-all.sh` reports PASS/FAIL/INCONCLUSIVE separately.

**Files changed:**
- `helpers.sh`: dispatch-failure detection, 5 assertion guards returning exit 2
- `run-all.sh`: new orchestrator with exit code tracking 0/1/2
- `dispatch-failure-gate.sh`: behavioral test verifying all assertions handle broken model dispatch

Fixes #296

Co-authored with AI: OpenCode (ollama-cloud/glm-5.1)