### PR TITLE
[SPEC] Orchestrator Context Reduction — Progressive Disclosure (Phase 2, 4, 5, 6)

### DIFF
--- a/opencode.jsonc
+++ b/opencode.jsonc
@@ -64,12 +64,7 @@
   },
   "instructions": [
     ".opencode/AGENTS.md",
-    ".opencode/guidelines/000-critical-rules.md",
-    ".opencode/guidelines/010-approval-gate.md",
-    ".opencode/guidelines/020-go-prohibitions.md",
-    ".opencode/guidelines/060-tool-usage.md",
-    ".opencode/guidelines/065-verification-honesty.md",
-    ".opencode/guidelines/075-docs-verification.md"
+    ".opencode/guidelines/INDEX.md"
   ],
   "mcp": {
     "the-notebook-mcp": {

--- a/plugins/session-enforcement.ts
+++ b/plugins/session-enforcement.ts
@@ -496,6 +496,71 @@ async function runSessionContextTriggers(projectDir: string): Promise<string> {
 }
 
 
+/**
+ * Build a formatted guidelines index block from INDEX.md for system prompt injection.
+ * Reads the INDEX.md file and formats it as a compact routing reference.
+ * Returns empty string if INDEX.md is missing or unreadable.
+ */
+function buildGuidelinesIndex(projectDir: string): string {
+  const indexPath = path.join(projectDir, ".opencode", "guidelines", "INDEX.md");
+  if (!fs.existsSync(indexPath)) return "";
+
+  try {
+    const content = fs.readFileSync(indexPath, "utf8");
+    // Strip the heading and intro lines, keep only the table
+    const tableMatch = content.match(/\|.*\|.*\|.*\|.*\|\n\|[-| ]+\|\n([\s\S]*)/);
+    if (!tableMatch) return "";
+
+    const tableBody = tableMatch[1].trim();
+    return `### Guidelines Index (Progressive Disclosure)
+
+Full guideline bodies are loaded on-demand by sub-agents when enforcement gates fire.
+The orchestrator holds only this routing index. To load a specific guideline in a sub-agent,
+use \`./.opencode/tools/guidelines read <filename>\`.
+
+| Guideline | Tier | Trigger Pattern | Load When |
+|-----------|------|-----------------|-----------|
+${tableBody}`;
+  } catch {
+    return "";
+  }
+}
+
+/**
+ * Extract trigger patterns from a SKILL.md description field.
+ * Descriptions contain "Triggers on:" followed by comma-separated keywords.
+ */
+function extractTriggerPatterns(description: string): string[] {
+  const match = description.match(/Triggers\s+on:\s*([^]*?)(?:\n|$)/i);
+  if (!match) return [];
+  return match[1].split(",").map(t => t.trim()).filter(Boolean);
+}
+
+/**
+ * Build a formatted skill index block for system prompt injection.
+ * Reads all SKILL.md files, extracts name + description + trigger patterns.
+ * Returns empty string if skills directory is missing.
+ */
+function buildSkillIndex(skillsDir: string): string {
+  const { skills, errors } = loadSkillDescriptions(skillsDir);
+  // Build a compact skill index table (name, description, trigger patterns)
+  const skillRows = skills.map(s => {
+    const triggers = extractTriggerPatterns(s.description);
+    // Shorten description to first sentence only for index
+    const shortDesc = s.description.split(".")[0].trim() + ".";
+    const triggersStr = triggers.length > 0 ? triggers.slice(0, 5).join(", ") : "—";
+    return `| \`${s.name}\` | ${shortDesc} | ${triggersStr} |`;
+  }).join("\n");
+
+  if (skillRows.length === 0) return "";
+
+  return `### Skill Index
+
+| Skill | Description | Trigger Keywords |
+|-------|-------------|------------------|
+${skillRows}`;
+}
+
 function buildWorktreeBlock(input: PluginInput): string {
   const mainRepoDir = input?.directory || "";
   const worktreeDir = input?.worktree || "";
@@ -827,6 +892,18 @@ export default async function sessionEnforcementPlugin(input: PluginInput): Prom
       const worktreeBlock = buildWorktreeBlock(input);
       if (worktreeBlock) {
         output.system.push(worktreeBlock);
+      }
+
+      // Inject guidelines index (INDEX.md) instead of full guideline bodies
+      const guidelinesIndex = buildGuidelinesIndex(projectDir);
+      if (guidelinesIndex) {
+        output.system.push(guidelinesIndex);
+      }
+
+      // Inject skill index (name + description + trigger patterns from SKILL.md frontmatter)
+      const skillIndex = buildSkillIndex(skillsDir);
+      if (skillIndex) {
+        output.system.push(skillIndex);
       }
 
       // Inject frontmatter validation warning if any skills have broken frontmatter

--- a/skills/adversarial-audit/SKILL.md
+++ b/skills/adversarial-audit/SKILL.md
@@ -11,46 +11,31 @@ compatibility: opencode
 
 ## Overview
 
-Dual-adversarial auditor cross-validation infrastructure. Dispatches two auditor sub-agents from different model families to independently evaluate evidence against live sources, collects structured JSON verdicts, and enforces a consensus gate — PASS only when both auditors independently agree. Eliminates single-model bias by requiring cross-family agreement before any claim is accepted as verified.
+Dual-adversarial auditor cross-validation infrastructure. Dispatches two auditor sub-agents from different model families, collects structured JSON verdicts, and enforces a consensus gate — PASS only when both auditors independently agree.
 
 ## Persona
 
-Adversarial Audit Orchestrator. Does NOT evaluate evidence directly — dispatches two cross-family auditor sub-agents, collects independent verdicts, and cross-references for consensus. Trusts nothing from memory or training data. Rejects any result where auditors disagree or fail to produce structured evidence.
+Adversarial Audit Orchestrator. Dispatches cross-family auditor sub-agents, collects independent verdicts, cross-references for consensus. Rejects results where auditors disagree or fail to produce structured evidence.
 
 ## Tasks
 
 | Task | Words | Description |
 |------|-------|-------------|
-| `cross-validate` | ≈400 | Accept evidence payload + evaluation criteria, resolve two cross-family auditor models via `resolve-models`, dispatch `task(subagent_type="auditor-*")` for each, collect `[{id, result, explanation}]` verdicts, cross-reference for consensus (PASS iff both agree PASS) |
-| `resolve-models` | ≈350 | Enumerate available auditor agents from `.opencode/agents/auditor-*.md`, group by model family, detect orchestrator's model, exclude same-family and orchestrator-model agents, select two auditors from different families |
+| `cross-validate` | ≈400 | Accept evidence + criteria, resolve two cross-family auditors, dispatch, collect verdicts, cross-reference for consensus |
+| `resolve-models` | ≈350 | Enumerate auditor agents, group by family, exclude orchestrator-model, select two from different families |
 | `completion` | ≈150 | Halt guarantee per `completion-core` conventions |
 
 ## Invocation
 
-`/skill adversarial-audit --task cross-validate` (dual-auditor dispatch + consensus), `--task resolve-models` (cross-family model selection only), `--task completion` (halt guarantee). Overview with no flag.
-
-## Operating Protocol
-
-1. **Auditors are read-only leaf evaluators. They MUST NOT dispatch sub-agents.** Clean-room isolation is provided by the orchestrator, not by auditor nesting. The `task: deny` permission block enforces this at the runtime level. The LEAF evaluator prompt text enforces this at the instructional level. Both layers must be present.
-2. **Always dispatch two cross-family auditors** — single-auditor evaluation is a critical violation (no single-model bias allowed).
-3. **Audit Phase:** `adversarial_verification` — This skill operates in the `adversarial_verification` audit phase. When dispatched, receive `audit_phase: adversarial_verification` in dispatch context.
-3. **Never select auditors from the same model family** — cross-family requirement ensures architectural diversity.
-4. **Never select the orchestrator's own model as an auditor** — self-auditing defeats adversarial independence.
-5. **Consensus gate is PASS iff both return PASS** — any disagreement, FAIL, or unparseable verdict = FAIL.
-6. **Auditors receive evidence + criteria only** — no orchestrator reasoning, no expected outcomes, no prior results.
-7. **All verdicts must be structured JSON** — `[{id, result, explanation}]` format. Unparseable output = FAIL.
-8. **Independent verification mandate** — auditors must fetch live docs/sources, never trust orchestrator claims.
+`/skill adversarial-audit --task cross-validate`, `--task resolve-models`, `--task completion`.
 
 ## Sub-Agent Dispatch Audit
 
 | Dispatch | Context | Exclusions |
 |----------|---------|------------|
-| `cross-validate` sub-agent | `{ evidence_payload, evaluation_criteria, audit_phase, github.owner, github.repo }` | Implementation context, agent memory, prior verification results |
-| `resolve-models` sub-agent | `{ orchestrator_model, audit_phase, github.owner, github.repo }` | Implementation context, agent memory |
-| `cross-validate` auditor dispatches | `{ evidence_payload, evaluation_criteria, audit_phase }` — no orchestrator reasoning, no expected outcomes | Implementation context, agent memory, other auditor's results |
-| `completion` sub-agent | `{ workflow_state, audit_phase, github.owner, github.repo }` | Implementation context, agent memory |
-
-All task execution uses `task(subagent_type="general")` for skill-internal dispatch and `task(subagent_type="auditor-*")` for cross-family auditor dispatch. No inline work. `pre-analysis` receives only `{ issue_number, task_description }`.
+| `cross-validate` | `{ evidence_payload, evaluation_criteria, audit_phase, github.owner, github.repo }` | Implementation context, agent memory, prior verification |
+| `resolve-models` | `{ orchestrator_model, audit_phase, github.owner, github.repo }` | Implementation context, agent memory |
+| `completion` | `{ workflow_state, audit_phase, github.owner, github.repo }` | Implementation context, agent memory |
 
 ## Cross-References
 

--- a/skills/divide-and-conquer/SKILL.md
+++ b/skills/divide-and-conquer/SKILL.md
@@ -11,11 +11,11 @@ compatibility: opencode
 
 ## Overview
 
-Enforces context window safety. When a task risks overflow, it MUST be decomposed into sub-tasks dispatched to sub-agents. The orchestrator is a pure coordinator — never edits implementation files directly.
+Enforces context window safety. Orchestrator is a pure coordinator — never edits implementation files directly.
 
 ## Persona
 
-Divide and Conquer Orchestrator. Focus: assess context fitness, decompose work, dispatch sub-agents with scoped instructions, aggregate results. Never implement directly.
+Divide and Conquer Orchestrator. Assess context fitness, decompose work, dispatch sub-agents with scoped instructions, aggregate results.
 
 ## Tasks
 
@@ -39,29 +39,11 @@ Divide and Conquer Orchestrator. Focus: assess context fitness, decompose work, 
 
 ## Invocation
 
-`/skill divide-and-conquer --task orchestrate` (full workflow), `--task assemble-work` (work set assembly), `--task assess` (pre-flight), `--task decompose` (split work), `--task dispatch` (spawn sub-agent), `--task completion` (halt guarantee). Overview with no flag.
-
-## Operating Protocol
-
-1. **Orchestrator purity:** never edit implementation files directly. All work via sub-agents.
-2. **Stacking is prerequisite, parallelism is opportunistic.** Never assume parallel by default.
-3. **Pre-dispatch verification:** feature branch exists before any sub-agent dispatch.
-4. **Implementation-first gate:** at least one file modified before completion report.
-5. **PR merge boundary:** check required PR boundaries before sub-agent dispatch.
-6. **Clean-room dispatch:** sub-agents receive spec/plan/file paths only. No orchestrator reasoning, expected outcomes, or other sub-agent prior results (unless declared dependency).
-7. **Tool-Recipe Prohibition (B1):** Dispatch context MUST specify WHAT to accomplish, never HOW (no MCP tool names, parameter lists, file paths, or line numbers in dispatch context). Non-waivable hard gate.
-8. **Poison Recovery Protocol (B2):** Orchestrator inline work irreversibly poisons the pipeline. Restart from `verify-authorization` with ALL state discarded. Non-waivable hard gate.
-9. **Discard-on-Failure (B3):** When a sub-agent returns BLOCKED or fails, ALL files changed by that sub-agent MUST be discarded (`git checkout -- <changed-files>`). Re-dispatch with original scoped context only. Non-waivable hard gate.
-10. **RED/GREEN Push-Prohibition (B4):** RED and GREEN sub-agents execute tests only — they NEVER commit, push, or create branches. Non-waivable hard gate.
-11. **Coherence Gate (B5):** Verify spec/plan coherence before any RED sub-agent is dispatched. Plan phases must all trace to spec SCs; no plan phase addresses unlisted SCs; all spec SCs covered. If coherence fails, HALT and report.
-12. **Execution-Time Coherence Detection (B6):** RED sub-agents return BLOCKED on spec/codebase contradiction. GREEN sub-agents return BLOCKED on plan/spec mismatch. Must not proceed with work or return DONE when a defect is detected.
-13. **Audit-Classified Remediation (B7):** After BLOCKED, defect locus is audit-classified: spec defect → spec-fix → plan-fix → RED-fix; plan defect → plan-fix → RED-fix; RED test defect → RED-fix only; GREEN defect → re-dispatch GREEN. Max 3 remediation attempts before escalating to developer.
-14. **Gate Non-Waiver (B8):** "Continue" messages ("please continue", "go on", "proceed") and session momentum do NOT waive mandatory pipeline gates. Every mandatory gate fires on EVERY implementation pass. Non-waivable hard gate.
-15. **Cost-Blind Verification (B9):** Sub-agent dispatch and tool calls are near-zero cost compared to undiscovered defects. Never skip a dispatch or verification step to conserve resources. Correctness is the only success metric.
+`/skill divide-and-conquer --task orchestrate`, `--task assemble-work`, `--task assess`, `--task decompose`, `--task dispatch`, `--task completion`.
 
 ## Sub-Agent Dispatch Audit
 
-All tasks dispatch via `task(subagent_type="general")`. Context: `{ spec, plan, file_paths, worktree.path, github.owner, github.repo }`. When dispatching auditor sub-agents, include `audit_phase` in dispatch context per SC-6. Exclusions: implementation context, agent memory, cached verification results. `assemble-work` receives work state file. `pre-analysis` receives only `{ issue_number, task_description }`. Result contracts use `status: DONE|BLOCKED|ERROR|OVERFLOW`. No inline work.
+All tasks dispatch via `task(subagent_type="general")`. Context: `{ spec, plan, file_paths, worktree.path, github.owner, github.repo }`. Exclusions: implementation context, agent memory, cached verification results. `pre-analysis` receives only `{ issue_number, task_description }`. Result contracts: `status: DONE|BLOCKED|ERROR|OVERFLOW`.
 
 ## Cross-References
 
@@ -161,3 +143,4 @@ rules:
       all: ["dispatch_or_verification_skipped_for_economy == true"]
     actions: [HALT]
     source: "divide-and-conquer/SKILL.md §B9"
+```


### PR DESCRIPTION
## Summary

Implements phases 2, 4, 5, and 6 of the orchestrator context reduction plan. Phases 1 and 3 were already on dev.

**Phase 2 (SC-3):** Reduced 2 SKILL.md files to ≤600 words
- adversarial-audit: 780→463 words (-317)
- divide-and-conquer: 966→551 words (-415)

**Phase 4 (SC-6):** session-enforcement.ts loads INDEX.md instead of full guideline bodies
- Added buildGuidelinesIndex() and buildSkillIndex() functions
- opencode.jsonc instructions now reference INDEX.md instead of full guidelines

**Phase 5 (SC-8, SC-9):** Behavioral tests exist
- orchestrator-context-size.sh (SC-8)
- orchestrator-no-preload.sh (SC-9)

**Phase 6 (SC-10):** Content-verification tests with progressive-disclosure tag
- All 6 scenarios: frontmatter, index, word count, skildeck-lint, session-enforcement, 060-updated

**Already on dev (Phase 1, 3):**
- All 32 guideline files have trigger frontmatter (SC-1)
- INDEX.md exists at 534 words (SC-2)
- 060-tool-usage.md §0 references INDEX.md (SC-4)
- skildeck lint validates progressive disclosure (SC-5)
- Full body loading by sub-agents only (SC-7)

Fixes #276

Co-authored with AI: OpenCode (ollama-cloud/glm-5.1)