### PR TITLE
fix(#460): Gap-fill cascade path selection fix

### DIFF
--- a/skills/approval-gate/tasks/verify-authorization.md
+++ b/skills/approval-gate/tasks/verify-authorization.md
@@ -51,6 +51,7 @@ Before dispatching behavioral test sub-agents (Phase 4 of any plan), resolve the
 | Condition | Path |
 |-----------|------|
 | 1 issue + `standard` scope + 0 sub-issues + explicit auth | fast-path (skip 2, 4.5, 4.6, 5, 5b, 5b.5+5c) |
+| 1 issue + scope ∈ {for_pr, for_implementation, for_plan, for_code_review} + 0 sub-issues | gap-fill-path (0.5, 1, 5b.5+5c, then 6) |
 | 1 issue + sub-issues OR plan with phases | medium-path (0.5, 1, 4.5, 4.6, 5, then 6) |
 | Multi-issue authorization set | full-path (all steps) |
 


### PR DESCRIPTION
## Summary

- Add gap-fill-path for `for_pr`, `for_implementation`, `for_plan`, `for_code_review` scopes
- Fixes cascade bypass bug where gap-fill scopes matched fast-path instead of triggering gap-fill-cascade
- Ensures `verify-authorization/gap-fill-cascade` executes for all gap-fill scopes

## Verification Criteria

- [x] Path table updated with gap-fill-path row
- [x] Gap-fill scope set defined: `{for_pr, for_implementation, for_plan, for_code_review}`
- [x] Gap-fill-path skips sub-issue verification (steps 4.5, 4.6, 5) since 0 sub-issues
- [x] Fast-path still applies only to `standard` scope

## References

- Spec: #460
- Plan: #461

## Change Impact

**Before:** `for_pr` authorization with 0 sub-issues matched fast-path → gap-fill-cascade skipped → agent blocked on missing implementation details

**After:** `for_pr` authorization with 0 sub-issues matches gap-fill-path → gap-fill-cascade executes → auto-create spec/plan → proceed to PR