### PR TITLE
fix(#242): fix broken incremental-build-enforcement.sh ref in 091

### DIFF
--- a/guidelines/091-incremental-build.md
+++ b/guidelines/091-incremental-build.md
@@ -6,7 +6,7 @@ load_when: sub-agent
 
 # Incremental Build Discipline
 
-**Enforced by behavioral test `tests/behaviors/incremental-build-enforcement.sh`.** See `000-critical-rules.md` §Monolithic Implementation for the critical violation.
+**Enforced by yaml+symbolic rules below and `000-critical-rules.md` §Monolithic Implementation. Also covered by `tests/behaviors/tier1-mandate-enforcement.sh` for the overarching incremental build discipline.** See `000-critical-rules.md` §Monolithic Implementation for the critical violation.
 
 ## Mandate
 


### PR DESCRIPTION
## Summary

091-incremental-build.md line 9 referenced `tests/behaviors/incremental-build-enforcement.sh` which was never created — the file does not exist. Replaced with correct reference to symbolic rules + tier1-mandate-enforcement.sh which does exist.

**1 file, +1 / −1**

🤖 OpenCode (ollama-cloud/glm-5.1)