### PR TITLE
fix(#242): add SC-3 test artifacts, fix INDEX 200-absent trigger drift

### DIFF
--- a/.enforcement-test-results/content-verification-20260509-180753.log
+++ b/.enforcement-test-results/content-verification-20260509-180753.log
@@ -1,0 +1,24 @@
+=== Content-Verification: Auditor Agent Files Canonical Schema ===
+
+PASS: .opencode/agents/ directory exists
+
+--- File Existence (7 expected) ---
+PASS: auditor-glm-5.1.md exists
+PASS: auditor-glm-5.md exists
+PASS: auditor-qwen3.5.md exists
+PASS: auditor-kimi-k2.md exists
+PASS: auditor-deepseek-flash.md exists
+PASS: auditor-mistral-large.md exists
+PASS: auditor-deepseek-v3.md exists
+PASS: All 7 agent files exist
+
+--- YAML Frontmatter Validation (6 allow + 5 deny) ---
+PASS: auditor-glm-5.1.md — mode=subagent, model='ollama/glm-5.1:cloud', permissions 6 allow + 5 deny
+PASS: auditor-glm-5.md — mode=subagent, model='ollama/glm-5:cloud', permissions 6 allow + 5 deny
+PASS: auditor-qwen3.5.md — mode=subagent, model='ollama/qwen3.5:397b-cloud', permissions 6 allow + 5 deny
+PASS: auditor-kimi-k2.md — mode=subagent, model='ollama/kimi-k2.6:cloud', permissions 6 allow + 5 deny
+PASS: auditor-deepseek-flash.md — mode=subagent, model='ollama/deepseek-v4-flash:cloud', permissions 6 allow + 5 deny
+PASS: auditor-mistral-large.md — mode=subagent, model='ollama/mistral-large-3:675b-cloud', permissions 6 allow + 5 deny
+PASS: auditor-deepseek-v3.md — mode=subagent, model='ollama/deepseek-v3.2:cloud', permissions 6 allow + 5 deny
+
+=== RESULT: PASS ===

--- a/.enforcement-test-results/tier1-mandate-20260509-172713.log
+++ b/.enforcement-test-results/tier1-mandate-20260509-172713.log
@@ -1,0 +1,21 @@
+=== Behavioral Test: tier1-mandate-enforcement ===
+PASS: tier1-mandate-enforcement — buildTier1EnforcementBlock() function found
+PASS: tier1-mandate-enforcement — 'Tier 1' referenced in session-enforcement.ts
+PASS: tier1-mandate-enforcement — protected branch enforcement function found
+PASS: tier1-mandate-enforcement — self-authorization prohibition found in enforcement
+PASS: tier1-mandate-enforcement — /tmp/ prohibition in Tier 1 enforcement
+PASS: tier1-mandate-enforcement — Tier 1 enforcement gate function defined AND invoked (count: 2)
+PASS: tier1-mandate-enforcement — inline work detection gate (Gate 3) present
+PASS: tier1-mandate-enforcement — mandatory skill references present in core principles
+
+=== Tier 1 Mandate Enforcement Gate Test Results ===
+  buildTier1EnforcementBlock():       PRESENT
+  Tier 1 references:                  PRESENT
+  Protected branch enforcement:        PRESENT
+  Self-authorization prohibition:      PRESENT
+  /tmp/ prohibition in enforcement:    PRESENT
+  Tier 1 gate invoked in transform:   PRESENT
+  Gate 3 inline work detection:        PRESENT
+  Mandatory skill references:          PRESENT
+
+PASS: tier1-mandate-enforcement

--- a/guidelines/INDEX.md
+++ b/guidelines/INDEX.md
@@ -34,5 +34,5 @@ Full guideline content is loaded on-demand by sub-agents, never in orchestrator 
 | `142-planning-archive-workflow.md` | 2 | archive, spec structure, spec format, requirements | Spec structure |
 | `143-planning-spec-templates.md` | 2 | template, spec template, template format | Spec templating |
 | `144-planning-spec-examples.md` | 2 | example, spec example, example structure | Spec examples |
-| `200-errors.md` | 2 | exception, error handling, missing data, null, logging, raise, domain exception | Error handling |
+| `200-errors.md` | 2 | exception, error handling, missing data, null, absent, logging, raise, domain exception | Error handling |
 | `210-scripting.md` | 2 | script, scripting, script header, shebang | Script creation |


### PR DESCRIPTION
## Summary

- SC-3 test execution artifacts at `.opencode/.enforcement-test-results/`: `tier1-mandate-enforcement.sh` (8/8 PASS, exit 0), `test-all-auditor-agents.sh` (7/7 PASS, exit 0)
- Fix INDEX.md: 200-errors.md trigger pattern missing `absent` (present in frontmatter)
- Spec #242 updated: SC-3 now mandates artifacts at `.opencode/.enforcement-test-results/` for auditor-independent verification

**3 files changed, +46 / −1**

🤖 OpenCode (ollama-cloud/glm-5.1)