### PR TITLE
fix(#242): add critical-rules-050 Correctness Over Shrinkage mandate

### DIFF
--- a/.enforcement-test-results/content-verification-20260509-205256.log
+++ b/.enforcement-test-results/content-verification-20260509-205256.log
@@ -1,0 +1,24 @@
+=== Content-Verification: Auditor Agent Files Canonical Schema ===
+
+PASS: .opencode/agents/ directory exists
+
+--- File Existence (7 expected) ---
+PASS: auditor-glm-5.1.md exists
+PASS: auditor-glm-5.md exists
+PASS: auditor-qwen3.5.md exists
+PASS: auditor-kimi-k2.md exists
+PASS: auditor-deepseek-flash.md exists
+PASS: auditor-mistral-large.md exists
+PASS: auditor-deepseek-v3.md exists
+PASS: All 7 agent files exist
+
+--- YAML Frontmatter Validation (6 allow + 5 deny) ---
+PASS: auditor-glm-5.1.md — mode=subagent, model='ollama/glm-5.1:cloud', permissions 6 allow + 5 deny
+PASS: auditor-glm-5.md — mode=subagent, model='ollama/glm-5:cloud', permissions 6 allow + 5 deny
+PASS: auditor-qwen3.5.md — mode=subagent, model='ollama/qwen3.5:397b-cloud', permissions 6 allow + 5 deny
+PASS: auditor-kimi-k2.md — mode=subagent, model='ollama/kimi-k2.6:cloud', permissions 6 allow + 5 deny
+PASS: auditor-deepseek-flash.md — mode=subagent, model='ollama/deepseek-v4-flash:cloud', permissions 6 allow + 5 deny
+PASS: auditor-mistral-large.md — mode=subagent, model='ollama/mistral-large-3:675b-cloud', permissions 6 allow + 5 deny
+PASS: auditor-deepseek-v3.md — mode=subagent, model='ollama/deepseek-v3.2:cloud', permissions 6 allow + 5 deny
+
+=== RESULT: PASS ===

--- a/.enforcement-test-results/tier1-mandate-20260509-205224.log
+++ b/.enforcement-test-results/tier1-mandate-20260509-205224.log
@@ -1,0 +1,21 @@
+=== Behavioral Test: tier1-mandate-enforcement ===
+PASS: tier1-mandate-enforcement — buildTier1EnforcementBlock() function found
+PASS: tier1-mandate-enforcement — 'Tier 1' referenced in session-enforcement.ts
+PASS: tier1-mandate-enforcement — protected branch enforcement function found
+PASS: tier1-mandate-enforcement — self-authorization prohibition found in enforcement
+PASS: tier1-mandate-enforcement — /tmp/ prohibition in Tier 1 enforcement
+PASS: tier1-mandate-enforcement — Tier 1 enforcement gate function defined AND invoked (count: 2)
+PASS: tier1-mandate-enforcement — inline work detection gate (Gate 3) present
+PASS: tier1-mandate-enforcement — mandatory skill references present in core principles
+
+=== Tier 1 Mandate Enforcement Gate Test Results ===
+  buildTier1EnforcementBlock():       PRESENT
+  Tier 1 references:                  PRESENT
+  Protected branch enforcement:        PRESENT
+  Self-authorization prohibition:      PRESENT
+  /tmp/ prohibition in enforcement:    PRESENT
+  Tier 1 gate invoked in transform:   PRESENT
+  Gate 3 inline work detection:        PRESENT
+  Mandatory skill references:          PRESENT
+
+PASS: tier1-mandate-enforcement

--- a/guidelines/000-critical-rules.md
+++ b/guidelines/000-critical-rules.md
@@ -553,6 +553,9 @@ See Spec #274. Gate every execution behind pre-analysis sub-agent.
 ### [critical-rules-043] Universal Re-Dispatch Mandate — no inline fallback on sub-agent failure
 ALL pipeline stages. Re-dispatch clean-room with same context. See Spec #106.
 
+### [critical-rules-048] Correctness Over Shrinkage — compression must never remove mandatory content
+No mandatory content, behavioral mandate, workflow step, or process rule may be removed during compression — even if it means missing line/word targets. Compression passes require adversarial-audit guideline-audit before merge. See Spec #242 SC-7.
+
 ---
 
 ```yaml+symbolic
@@ -1221,6 +1224,20 @@ rules:
     requires: [verification-honesty-001, verification-honesty-004]
     triggers: [verification-before-completion]
     source: "000-critical-rules.md §VbC Fabricated PASS"
+
+  - id: critical-rules-050
+    title: "Compression must never remove mandatory content"
+    conditions:
+      all:
+        - "compression_proposed == true"
+        - "mandatory_content_removed == true"
+    actions:
+      - HALT
+      - REQUIRE_BEHAVIORAL_EVIDENCE
+    conflicts_with: []
+    requires: []
+    triggers: [skill-creator, guideline-audit]
+    source: "000-critical-rules.md §Correctness Over Shrinkage"
 
   - id: git-workflow-branch-deletion-001
     title: "Branch deletion requires content verification against target branch"


### PR DESCRIPTION
## Summary

- Add critical-rules-050 to 000-critical-rules.md: "Compression must never remove mandatory content" with HALT action and REQUIRE_BEHAVIORAL_EVIDENCE — encodes Correctness Over Shrinkage as a prescriptive gate
- Add SC-3 test artifacts at `.opencode/.enforcement-test-results/` per spec mandate

**3 files, +62 lines**

🤖 OpenCode (ollama-cloud/glm-5.1)