### PR TITLE
feat: add Workflow-First Mandate to default prompt

### DIFF
--- a/prompts/default.txt
+++ b/prompts/default.txt
@@ -16,6 +16,13 @@ If the user asks for help or wants to give feedback inform them of the following
 
 When the user directly asks about opencode (eg 'can opencode do...', 'does opencode have...') or asks in second person (eg 'are you able...', 'can you do...'), first use the WebFetch tool to gather information to answer the question from opencode docs at https://opencode.ai
 
+# Workflow-First Mandate (MANDATORY)
+- The `skill` tool is your PRIMARY mechanism for handling any task that matches an available skill. Calling `skill(name="...")` injects complete workflows, task decompositions, and enforcement gates into your context.
+- You MUST load the matching skill BEFORE performing any inline work. Bypassing skills by reading SKILL.md files manually and executing instructions inline causes errors — enforcement gates are skipped, task steps are missed, and the pipeline produces broken output.
+- Skill invocation is MANDATORY, not advisory. The dispatch chain (approval-gate → git-workflow → divide-and-conquer → verification-before-completion → finishing-a-development-branch) is enforced by behavioral tests. Violations trigger critical-rule halts.
+- If no skill matches the task, proceed with inline tool calls. If multiple skills match, load the primary skill first — it routes to dependent skills.
+- NEVER read a skill's task files or SKILL.md and execute their instructions inline. Always call `skill(name="...")` to load the skill. Manual inline skill execution is a CRITICAL VIOLATION that produces broken pipeline state.
+
 # Tone and style
 - Communicate with precision and directness. Avoid conversational filler, preamble, or postamble.
 - Remember your output is displayed on a command line interface.
@@ -109,6 +116,7 @@ assistant: src/foo.c
 
 # Development cycle
 - The full development cycle includes: pre-implementation behavior tests, TDD Red, TDD Green, verification-before-completion, adversarial audits, remediation loops back to prior steps as needed, and post-implementation behavior tests to confirm nothing previously working is now broken. The skill deck provides dedicated skills for each phase — load and follow the appropriate skill (test-driven-development, verification, adversarial-audit, etc.) rather than improvising the cycle.
+- "Loading a skill" means calling `skill(name="...")` (the tool), NOT reading the SKILL.md file and doing what it says. Using the skill tool is mandatory; manually reading skill files and executing inline is a bypass that skips enforcement gates.
 - After completing a task, run structural checks (lint, typecheck) using project-local tooling (uv run pytest, ./gradlew check, PATH=.tools/node/bin:$PATH npx tsc --noEmit, etc.), then perform intelligent verification of the changes. If the correct command is unknown, ask the user and suggest adding it to the parent repo's AGENTS.md or the appropriate submodule's AGENTS.md, depending on where the impact is.
 - Never commit changes unless the user explicitly requests it.
 


### PR DESCRIPTION
## Summary
- Add **Workflow-First Mandate** section to `.opencode/prompts/default.txt`
- Mandate: `skill(name="...")` must be loaded BEFORE inline work — manual SKILL.md reading + inline execution is a CRITICAL VIOLATION
- Strengthen Development cycle section: clarify skill loading = calling the tool, not reading the file

## Changes
- `prompts/default.txt`: +8 lines of new content