### PR TITLE
feat: restore Tier 1 guideline files to opencode.jsonc instructions array (#497)

### DIFF
--- a/guidelines/INDEX.md
+++ b/guidelines/INDEX.md
@@ -1,13 +1,13 @@
 # Guidelines Index
 
 Progressive disclosure routing index for all guideline files. Contains name + trigger-pattern pairs only.
-Full guideline content is loaded on-demand by sub-agents, never in orchestrator context.
+Full guideline content for Tier 2+ is loaded on-demand by sub-agents. Tier 1 files are loaded upfront via the opencode.jsonc instructions array.
 
 ## Index
 
 | Guideline | Tier | Trigger Pattern | Load When |
 |-----------|------|-----------------|-----------|
-| `000-critical-rules.md` | 1 | critical, zero tolerance, violation, mandate, Tier 1 | Always loaded (critical rules) |
+| `000-critical-rules.md` | 1 | critical, zero tolerance, violation, mandate, Tier 1 | Instructions array (all Tier 1 files) |
 | `010-approval-gate.md` | 1 | approved, go, authorization, approve, approval-gate, spec-before-code | Implementation authorization |
 | `015-pre-spec-inspection.md` | 2 | code inspection, pre-spec, investigate codebase | Pre-spec creation |
 | `016-srclight-preference.md` | 2 | srclight, code search, symbol lookup | Code analysis |

--- a/opencode.jsonc
+++ b/opencode.jsonc
@@ -68,8 +68,28 @@
       }
     }
   },
+  // WARNING — DO NOT REMOVE OR CONDENSE TO INDEX.MD ONLY
+  // All 12 Tier 1 guidelines MUST be loaded here. The orchestrator needs
+  // safety-critical rules (000: human-only merge, no self-auth, etc.) in
+  // system context at session start — BEFORE any sub-agent dispatch.
+  // Removing these files and relying on INDEX.md alone caused a critical
+  // safety regression: the agent merged a PR because 000-critical-rules.md
+  // was never loaded into orchestrator context. INDEX.md is for Tier 2+
+  // sub-agent routing only. See #497 for the full root-cause analysis.
   "instructions": [
     ".opencode/AGENTS.md",
+    ".opencode/guidelines/000-critical-rules.md",
+    ".opencode/guidelines/010-approval-gate.md",
+    ".opencode/guidelines/020-go-prohibitions.md",
+    ".opencode/guidelines/060-tool-usage.md",
+    ".opencode/guidelines/065-verification-honesty.md",
+    ".opencode/guidelines/067-context-completeness.md",
+    ".opencode/guidelines/075-docs-verification.md",
+    ".opencode/guidelines/080-code-standards.md",
+    ".opencode/guidelines/090-data-integrity.md",
+    ".opencode/guidelines/091-incremental-build.md",
+    ".opencode/guidelines/117-session-trigger-behavior.md",
+    ".opencode/guidelines/130-authority-source.md",
     ".opencode/guidelines/INDEX.md"
   ],
   "agent": {


### PR DESCRIPTION
## Summary

Fix the safety-critical regression where Tier 1 guideline files were removed from the `instructions` array in `opencode.jsonc`, causing the orchestrator to lose access to safety mandates including `critical-rules-003` (human-only merge).

### Root Cause

At commit `51c338d`, the `instructions` array was changed from loading 7 individual guideline files to loading only `INDEX.md`. The orchestrator (main agent) never received Tier 1 safety mandates at session start because they were delegated to sub-agent on-demand loading.

### Changes

- `opencode.jsonc`: Restore all 12 Tier 1 guidelines to `instructions` array
- `opencode.jsonc`: Add WARNING comment referencing the #497 regression to prevent future removal
- `guidelines/INDEX.md`: Update preamble and `000-critical-rules.md` annotation

Fixes #497