### PR TITLE
feat: adopt majiayu000 TDD Reference Deck + add Documentation Sources to spec template

### DIFF
--- a/.issues/work-state-310-479.yaml
+++ b/.issues/work-state-310-479.yaml
@@ -1,0 +1,6 @@
+authorization_scope: for_pr
+halt_at: pr_created
+pr_strategy: stacked
+gap_fill_actions: [auto-create-spec, auto-create-plan, auto-approve, auto-PR]
+approved_by: michael-conrad (human)
+approved_at: "2026-05-11"

--- a/guidelines/143-planning-spec-templates.md
+++ b/guidelines/143-planning-spec-templates.md
@@ -27,6 +27,7 @@ Before creating any spec, bug report, or issue, verify these intent questions ar
 | Does the spec reference related issues with context? | Related issues — links with summaries and relevance (not bare links) |
 | Does the spec identify affected files with anchors? | Affected files — file paths with function names or section headers, not line numbers |
 | Does the spec provide enough context for a fresh agent? | Self-containment — no "as discussed above" or "see previous comment" |
+| Does the spec document what sources were consulted? | Documentation Sources — local docs, direct source search, documentation URLs, MCP search, live verification |
 
 **Simple specs may address several questions in a single paragraph. Complex specs may need separate sections for each. The format adapts to complexity.**
 
@@ -91,6 +92,18 @@ This minimal spec works because the change is small and self-explanatory. Separa
 > **Risk Assessment:** Redis memory limit (Low prob, High impact → monitor). Cache invalidation bugs (Med prob, Med impact → test update flows).
 
 This standard spec adds context, affected files, constraints, and risk because the change touches multiple files and has infrastructure dependencies.
+
+#### Documentation Sources Table
+
+A Documentation Sources section may be included to document where the spec author looked for information. This is particularly important for specs making factual claims about code behavior, config schemas, or API signatures:
+
+| Source Category | What Was Consulted | Purpose |
+|----------------|-------------------|---------|
+| Local docs | `README.md`, `docs/architecture.md` | Understand existing caching architecture |
+| Direct source search | `srclight_search_symbols("cache")`, `grep -r "redis" src/` | Identify existing cache patterns |
+| Documentation URLs | [redis-py docs](https://redis-py.readthedocs.io/) | Verify Redis client API signatures |
+| MCP search | `srclight_get_signature("get_article_metadata")` | Verify function signature for cache integration |
+| Live verification | `uv run pytest test/test_articles.py -k "metadata"` | Confirm test coverage before making changes |
 
 ### Comprehensive Feature Spec (large change, cross-cutting)
 

--- a/guidelines/144-planning-spec-examples.md
+++ b/guidelines/144-planning-spec-examples.md
@@ -106,6 +106,17 @@ ______________________________________________________________________
 
 **Why this works:** The change touches multiple files and has infrastructure dependencies. The standard format provides affected files, constraints, and risk assessment. Without these, an implementer might miss the Redis unavailable edge case or the memory constraint.
 
+A Documentation Sources section could be added to document where the spec author verified factual claims:
+
+> **Documentation Sources:**
+> | Source Category | What Was Consulted | Purpose |
+> |----------------|-------------------|---------|
+> | Local docs | `README.md`, `docs/architecture.md` | Understand existing caching architecture |
+> | Direct source search | `srclight_search_symbols("cache")`, `grep -r "redis" src/` | Identify existing cache patterns |
+> | Documentation URLs | [redis-py docs](https://redis-py.readthedocs.io/) | Verify Redis client API signatures |
+> | MCP search | `srclight_get_signature("get_article_metadata")` | Verify function signature for cache integration |
+> | Live verification | `uv run pytest test/test_articles.py -k "metadata"` | Confirm test coverage before making changes |
+
 ### Comprehensive Feature Spec (large, cross-cutting change)
 
 For features that span multiple systems, require phased deployment, or have significant risk, use the full structure with phased implementation, extended risk assessment with blast radius analysis, detailed decision rationale with alternatives, and dependencies table. The comprehensive format serves the complexity.

--- a/guidelines/144-planning-spec-examples.md
+++ b/guidelines/144-planning-spec-examples.md
@@ -106,7 +106,7 @@ ______________________________________________________________________
 
 **Why this works:** The change touches multiple files and has infrastructure dependencies. The standard format provides affected files, constraints, and risk assessment. Without these, an implementer might miss the Redis unavailable edge case or the memory constraint.
 
-A Documentation Sources section could be added to document where the spec author verified factual claims:
+Documentation Sources section: standard and complex specs MUST include a table documenting where the spec author verified each factual claim. Minimal specs and simple bug reports may omit it:
 
 > **Documentation Sources:**
 > | Source Category | What Was Consulted | Purpose |

--- a/skills/adversarial-audit/tasks/spec-audit.md
+++ b/skills/adversarial-audit/tasks/spec-audit.md
@@ -43,6 +43,7 @@ Define audit criteria based on spec-auditor task structure:
 | SC-8 | Operational clarity | Edge cases and error recovery defined |
 | SC-9 | Determinism achieved | Repeatable execution path |
 | SC-10 | Prose structure valid | Headers, lists, tables properly formatted |
+| SC-11 | Documentation Sources present and populated | Non-empty Documentation Sources section with live-source verification evidence |
 
 ### Step 3: Dispatch Cross-Validate
 
@@ -152,4 +153,11 @@ rules:
       all: ["auditor_1_result != auditor_2_result", "bidirectional_finding == null"]
     actions: [APPEND_BIDIRECTIONAL_FINDING]
     source: "spec-audit.md §Step 5"
+
+  - id: spec-audit-004
+    title: "Documentation Sources section required and populated"
+    conditions:
+      all: ["doc_sources_missing_or_empty == true"]
+    actions: [FAIL_CRITERION(SC-11)]
+    source: "spec-audit.md §Step 2"
 ```

--- a/skills/spec-creation/tasks/write.md
+++ b/skills/spec-creation/tasks/write.md
@@ -45,6 +45,33 @@ Combine outputs from prerequisite tasks into a coherent spec. The spec should ad
 
 Skip areas that don't apply to simple specs; add areas that do. The spec should be self-contained and clear, regardless of structure.
 
+A **Documentation Sources** section documents where the spec author verified factual claims. This is especially important for specs making claims about code behavior, config schemas, or API signatures. Place it before the AI byline section.
+
+**Source Categories:**
+
+| Category | Description | Examples |
+|----------|-------------|----------|
+| Local docs | Project documentation, README, design docs | `docs/architecture.md`, `README.md` |
+| Direct source search | Codebase search via grep, srclight, or glob | `srclight_search_symbols("cache")`, `grep -r "redis" src/` |
+| Documentation URLs | External documentation or API references | Language docs, library docs, framework guides |
+| MCP search | Tool-based code analysis | `srclight_get_signature()`, `srclight_get_symbol()` |
+| Live verification | Test execution or runtime checks | `uv run pytest test/test_*.py`, config validation |
+
+**Format:**
+
+```markdown
+**Documentation Sources:**
+| Source Category | What Was Consulted | Purpose |
+|----------------|-------------------|---------|
+| Local docs | `README.md`, `docs/architecture.md` | Understand existing architecture |
+| Direct source search | `srclight_search_symbols("cache")` | Identify existing cache patterns |
+| Documentation URLs | [redis-py docs](https://redis-py.readthedocs.io/) | Verify API signatures |
+| MCP search | `srclight_get_signature("get_data")` | Verify function signature |
+| Live verification | `uv run pytest test/test_data.py` | Confirm test coverage |
+```
+
+Simple specs may skip this section. Standard and complex specs SHOULD include it when making factual claims that require verification.
+
 ### Step 2: Eliminate Ambiguity (Principle #4)
 
 Review every requirement statement:

--- a/skills/test-driven-development/SKILL.md
+++ b/skills/test-driven-development/SKILL.md
@@ -3,45 +3,113 @@ name: test-driven-development
 description: Use when writing tests before implementation, or when adopting a test-first development approach. Triggers on: TDD, test first, red green refactor, write test, test-driven, unit test, regression.
 type: discipline-enforcing
 license: MIT
-provenance: AI-generated
+provenance: Derived from majiayu000/claude-skill-registry (MIT)
 compatibility: opencode
 ---
 
 # Skill: test-driven-development
 
-## Overview
+## Five Core Principles
 
-TDD workflow: tests define the contract, implementation satisfies the contract, refactoring maintains quality. Optional quality gate invoked contextually.
+1. **FAIL=FAIL** — No soft-passing. Verify against live sources. Report PASS/FAIL truthfully.
+2. **TDD discipline** — RED phase tests before GREEN phase implementation. REFACTOR is mandatory, not optional.
+3. **Clean-room** — No inline fallback. Sub-agents receive only scoped context. No pre-determined findings.
+4. **Independent intelligence** — Autonomous analysis. If the task contains excessive instruction where your own analysis should apply, HALT and notify parent.
+5. **Verify LIVE** — Never trust training data, memory, or metadata. Verify against live docs, source code, and test results.
+
+## ASCII Cycle Diagram
+
+```
+┌─────────────────────────────────────────────────────────┐
+│                    TDD CYCLE (per item)                  │
+│                                                         │
+│   PHASE 0 ──► RED ──► GREEN ──► REFACTOR ──► PHASE 4    │
+│   (baseline)   │        │          │         (verify)    │
+│       ▲        │  fails │ passes   │            │        │
+│       │        ▼        ▼          ▼            ▼        │
+│       │     BLOCKED  BLOCKED    REVERT       BLOCKED      │
+│       │     (fix or  (fix or    (bad        (2x fail     │
+│       │      halt)    halt)     refactor)    = halt)      │
+│       │                                                  │
+│       └──────────── CYCLE RESET ──────────────────────────┘
+│                                                          │
+│   Next item ──► back to Phase 0                         │
+└──────────────────────────────────────────────────────────┘
+```
 
 ## Tasks
 
-| Task | Words |
-|------|-------|
-| `red` | ≈200 |
-| `green` | ≈150 |
-| `refactor` | ≈200 |
+| Task | Words | Purpose |
+|------|-------|---------|
+| `red` | ≈80 | Execution-only: write failing test |
+| `green` | ≈80 | Execution-only: minimal impl |
+| `refactor` | ≈120 | Execution-only: clean while green |
+| `patterns` | ≈400 | 4-pattern decision matrix |
+| `anti-patterns` | ≈500 | 5 anti-patterns with alternatives |
+| `checklist` | ≈350 | Quality checklists, timing, step-size |
+| `phase-0` | ≈400 | Pre-regression baseline gate |
+| `phase-4` | ≈400 | Post-regression verification gate |
 
 ## Invocation
 
-`/skill test-driven-development --task red` (failing test), `--task green` (minimal impl), `--task refactor` (cleanup). Overview with no flag.
+`/skill test-driven-development --task <name>`. No flag = overview.
 
-## Operating Protocol
+## Gate Descriptions
 
-1. **RED:** write test, verify it fails. Must produce tool-call evidence of failure.
-2. **GREEN:** write minimal implementation to pass. No extras.
-3. **REFACTOR:** clean up while tests stay green. No scope creep.
+### Phase 0 — Pre-Regression Baseline
 
-## Sub-Agent Dispatch Audit
+Invoked before the first RED phase. AI-driven dependency analysis (`srclight_get_dependents`), full test suite execution. BLOCKED on test failure — cycle cannot start until existing failures are resolved. Empty blast radius = silent proceed.
 
-Tasks dispatch via `task(subagent_type="general")` with `{ spec_context, test_path, worktree.path, github.owner, github.repo }`. Exclusions: implementation context, agent memory, prior test results. `pre-analysis` receives only `{ issue_number, task_description, audit_phase, github.owner, github.repo }`. No inline work.
+### Phase 4 — Post-Regression Verification
+
+Invoked after REFACTOR completes. Re-computes blast radius, runs full suite. Remediation loop: first failure returns to GREEN, second consecutive failure = BLOCKED with halt.
+
+## Cycle-Reset Discipline
+
+### Normal Completion
+
+After Phase 4 PASSES:
+1. Commit the cycle (test + implementation + refactor as one working slice)
+2. Reset to Phase 0 for the next item
+3. Never carry state across cycles
+
+### Mid-Cycle Restart
+
+If at ANY point within RED/GREEN/REFACTOR a step exceeds its timing target (30s RED / 2-5min GREEN / 1-3min REFACTOR) or produces unexpected test failures, the agent MUST restart the full RED→GREEN→REFACTOR cycle from the beginning — not limp forward on a broken foundation:
+
+1. Discard all uncommitted changes from the current cycle
+2. Restart from RED with zero state carryover
+3. If Phase 0 elapsed > 1 full cycle since last baseline, re-execute Phase 0
+
+## Clean-Room Dispatch Audit
+
+Tasks dispatch via `task(subagent_type="general")` with `{ spec_context, test_path, phase_0_contract, cycle_id, worktree.path, github.owner, github.repo }`. Exclusions: implementation context, agent memory, prior test results, pre-determined file paths, expected outcomes. `pre-analysis` receives only `{ issue_number, task_description, audit_phase, github.owner, github.repo }`. No inline work.
+
+## Provenance
+
+Derived from [majiayu000/claude-skill-registry](https://github.com/majiayu000/claude-skill-registry) (MIT).
 
 ```yaml+symbolic
 schema_version: "2.0"
-last_updated: "2026-05-01T00:00:00Z"
+last_updated: "2026-05-11T00:00:00Z"
 rules:
   - id: tdd-001
     title: "RED phase must produce evidence of test failure"
     conditions:
       all: ["red_phase_started == true", "test_failure_evidence_missing == true"]
     actions: [HALT, COLLECT_EVIDENCE]
+    source: "test-driven-development/SKILL.md"
+
+  - id: tdd-002
+    title: "Phase 0 must complete before RED phase"
+    conditions:
+      all: ["tdd_cycle_started == true", "phase_0_completed == false"]
+    actions: [HALT, INVOKE(phase-0)]
+    source: "test-driven-development/SKILL.md"
+
+  - id: tdd-003
+    title: "Phase 4 must complete before cycle reset"
+    conditions:
+      all: ["refactor_phase_completed == true", "phase_4_completed == false"]
+    actions: [HALT, INVOKE(phase-4)]
     source: "test-driven-development/SKILL.md"

--- a/skills/test-driven-development/tasks/anti-patterns.md
+++ b/skills/test-driven-development/tasks/anti-patterns.md
@@ -1,0 +1,149 @@
+<!-- SPDX-FileCopyrightText: 2026 michael-conrad -->
+<!-- SPDX-License-Identifier: MIT -->
+<!-- Provenance: Derived from majiayu000/claude-skill-registry (MIT) -->
+
+# Task: anti-patterns
+
+## Purpose
+
+Five common TDD anti-patterns with correct alternatives. Language-agnostic — applies to Python, Java, Go, Rust, JS, etc.
+
+## Anti-Patterns
+
+| # | Anti-Pattern | Symptom | Root Cause | Alternative |
+|---|-------------|---------|------------|-------------|
+| 1 | **Too-Big Step** | RED→GREEN cycle takes >5 min, multiple asserts in one test | Writing too much implementation at once | Smaller test, one assertion per concept |
+| 2 | **Forgotten Red** | Test passes on first run | Test was written after implementation (or tests greenfield code) | Write test first, confirm FAIL before GREEN |
+| 3 | **Over-Mocking** | Tests pass but production breaks | Mocked interface doesn't match real behavior | Use real objects or contract tests; mock only external I/O |
+| 4 | **Green-Worship** | Code never refactored, accumulating technical debt | Fear of breaking passing tests | REFACTOR is mandatory, not optional. Tests protect you. |
+| 5 | **Test-Once** | Single test covers one happy-path only | Edge cases unaddressed, regressions slip through | Add edge-case tests in RED phase; triangulate |
+
+## Pattern Details
+
+### 1. Too-Big Step
+
+**Symptom:** RED→GREEN takes >5 minutes or test has >1 assertion.
+
+**Root cause:** Writing a test that requires implementing multiple behaviors at once.
+
+**Fix:** Decompose the test. Each test covers one behavior. Each RED→GREEN cycle takes 30 seconds to 3 minutes.
+
+```python
+# WRONG — Too-Big Step (2 behaviors, complex implementation)
+def test_user_registration():
+    user = register_user("alice@example.com", "pw")
+    assert user.email == "alice@example.com"
+    assert user.welcome_email_sent is True
+
+# RIGHT — one behavior per test
+def test_user_creation_sets_email():
+    user = register_user("alice@example.com", "pw")
+    assert user.email == "alice@example.com"
+
+# (Separate RED→GREEN for welcome email)
+def test_user_creation_sends_welcome_email():
+    user = register_user("alice@example.com", "pw")
+    assert user.welcome_email_sent is True
+```
+
+### 2. Forgotten Red
+
+**Symptom:** First run of new test PASSES without any implementation code.
+
+**Root cause:** The test was written after the implementation (post-hoc), or the test itself is vacuously true (e.g., testing a constant against itself).
+
+**Fix:** Before writing any implementation, run the test and watch it FAIL. If it passes, the test is wrong.
+
+```python
+# WRONG — test written after implementation, always passes
+# Implementation already exists
+def test_existing_feature():
+    assert existing_function() is not None
+
+# RIGHT — test before implementation
+# No implementation exists yet
+def test_new_feature():
+    result = new_function()
+    assert result == expected
+# First run: FAIL (function doesn't exist)
+```
+
+### 3. Over-Mocking
+
+**Symptom:** All tests pass but production crashes.
+
+**Root cause:** Mocks assume an interface contract that doesn't match reality. Common with deep mock chains.
+
+**Fix:** Mock only at system boundaries (external APIs, databases, filesystem). Use real objects for in-process dependencies. Verify mocks match real API signatures.
+
+```python
+# WRONG — mocking internal logic
+mock_validator = MagicMock()
+mock_validator.validate.return_value = True
+result = processor.process(mock_validator)
+assert result.success
+
+# RIGHT — real object for internal logic
+validator = EmailValidator(config)
+result = processor.process(validator)
+# Mock only external HTTP call
+mock_post.assert_called_once()
+```
+
+### 4. Green-Worship
+
+**Symptom:** Code smells accumulate. No one refactors because "tests pass."
+
+**Root cause:** Treating GREEN as the terminal state.
+
+**Fix:** REFACTOR is part of every TDD cycle. Small, safe refactors keep code clean. Run tests after each refactor step. If test breaks, revert — the refactor introduced a bug.
+
+```python
+# Before REFACTOR — works but smells
+def calc(a, b, op):
+    if op == "+": return a + b
+    if op == "-": return a - b
+    if op == "*": return a * b
+    if op == "/": return a / b
+
+# After REFACTOR — same behavior, cleaner structure
+OPERATIONS = {
+    "+": operator.add,
+    "-": operator.sub,
+    "*": operator.mul,
+    "/": operator.truediv,
+}
+
+def calc(a, b, op):
+    return OPERATIONS[op](a, b)
+```
+
+### 5. Test-Once
+
+**Symptom:** Single happy-path test. Regressions appear in edge cases that "were never tested."
+
+**Root cause:** One test per function. No boundary/edge/error cases.
+
+**Fix:** Each TDD cycle adds edge cases. Use triangulation to generalize. Empty/zero/null/overflow/exception cases are mandatory.
+
+```python
+# WRONG — Test-Once (happy path only)
+def test_divide():
+    assert divide(6, 3) == 2
+
+# RIGHT — happy + edge cases
+def test_divide_normal():
+    assert divide(6, 3) == 2
+
+def test_divide_by_zero_raises():
+    with pytest.raises(ZeroDivisionError):
+        divide(6, 0)
+
+def test_divide_negative():
+    assert divide(-6, 3) == -2
+```
+
+## Context Required
+
+- Related skills: `test-driven-development` (parent skill)
+- Related tasks: `patterns`, `checklist`

--- a/skills/test-driven-development/tasks/checklist.md
+++ b/skills/test-driven-development/tasks/checklist.md
@@ -1,0 +1,70 @@
+<!-- SPDX-FileCopyrightText: 2026 michael-conrad -->
+<!-- SPDX-License-Identifier: MIT -->
+<!-- Provenance: Derived from majiayu000/claude-skill-registry (MIT) -->
+
+# Task: checklist
+
+## Purpose
+
+Quality gates for each TDD cycle phase. Pre-cycle readiness, RED correctness, GREEN minimality, REFACTOR safety. Timing and step-size guides prevent Too-Big Step and Forgotten Red.
+
+## Pre-Cycle Checklist
+
+Before starting a TDD cycle:
+
+- [ ] Spec/requirement is clear and unambiguous
+- [ ] One specific behavior identified (not a feature bundle)
+- [ ] Success criterion is testable (binary PASS/FAIL)
+- [ ] Correct TDD pattern selected (Straight-Red, Triangulation, Obvious Implementation, One-to-Many)
+- [ ] Test file exists or creation path is known
+- [ ] Test runner configured and working (`uv run pytest` or equivalent)
+
+## RED Checklist
+
+- [ ] Test name follows convention: `test_<function>_<behavior>_<condition>`
+- [ ] One assertion per test concept
+- [ ] Test makes no assumptions about implementation
+- [ ] Test correctly expresses the spec (not the implementation)
+- [ ] **RUN THE TEST — confirm FAIL or ERROR**
+- [ ] Evidence of failure captured (tool call output)
+
+## GREEN Checklist
+
+- [ ] Minimal implementation — only what's needed to pass
+- [ ] No speculative code (no "we might need this later")
+- [ ] No premature optimization
+- [ ] No new features beyond what the test requires
+- [ ] **RUN THE TEST — confirm PASS**
+- [ ] All previously passing tests still pass (`uv run pytest test/ -v`)
+
+## REFACTOR Checklist
+
+- [ ] Tests stay GREEN throughout (run after each refactor step)
+- [ ] One refactor at a time — don't batch changes
+- [ ] No behavior changes (structure only)
+- [ ] If test breaks: REVERT and try different approach
+- [ ] Code smells addressed (duplication, long methods, unclear names)
+- [ ] **Final run: all tests PASS**
+
+## Timing Guide
+
+| Phase | Target Duration | Max | Alarm |
+|-------|----------------|-----|-------|
+| RED | 30s - 2min | 5min | If >5min, test is too big → decompose |
+| GREEN | 30s - 3min | 5min | If >5min, step is too big → smaller test |
+| REFACTOR | 1 - 3min | 5min | If >5min, too many changes → one at a time |
+| Full cycle | 2 - 8min | 15min | If >15min, cycle is too big → split |
+
+## Step-Size Guide
+
+| Step Size | RED Duration | GREEN Duration | Pattern | When Appropriate |
+|-----------|-------------|----------------|---------|-----------------|
+| Micro | 30s | 30s | Obvious Impl | Trivial one-liners |
+| Small | 1-2min | 1-3min | Straight-Red | Most cases |
+| Medium | 2-5min | 2-5min | Triangulation | Complex but decomposable |
+| Large | >5min | >5min | 🚫 | **Decompose first** |
+
+## Context Required
+
+- Related skills: `test-driven-development` (parent skill)
+- Related tasks: `red`, `green`, `refactor`, `patterns`

--- a/skills/test-driven-development/tasks/green.md
+++ b/skills/test-driven-development/tasks/green.md
@@ -1,46 +1,36 @@
+<!-- SPDX-FileCopyrightText: 2026 michael-conrad -->
+<!-- SPDX-License-Identifier: MIT -->
+<!-- Provenance: Derived from majiayu000/claude-skill-registry (MIT) -->
+
 # Task: green
 
-## Purpose
+## Invocation
 
-Write minimal implementation code to make the failing test pass. No more, no less.
+`/skill test-driven-development --task green`
 
-## Operating Protocol
+## Exit Criteria
 
-1. Invoked by: `/skill test-driven-development --task green`
-2. When to use: After `--task red` has confirmed a failing test
-3. Exit criteria: Implementation written, test PASSES
+Implementation written, test PASSES.
 
-## Principles
-
-1. **Write minimal code:** Only enough to make the test pass
-2. **No premature optimization:** Get it working first
-3. **No scope creep:** Don't add features not tested
-4. **Don't predict future tests:** Today's test only
-
-## Workflow
-
-```python
-# src/module.py
-
-from datetime import date
-
-def parse_date(date_string: str) -> date:
-    """Parse ISO format date string to date object."""
-    try:
-        return date.fromisoformat(date_string)
-    except ValueError:
-        raise ValueError(f"Invalid date format: {date_string}")
-```
-
-## Verification
+## Verification Command
 
 ```bash
-# Test must PASS after implementation
-uv run pytest test/test_module.py::test_parse_date_iso_format -v
+uv run pytest test/test_module.py::test_<name> -v
 # Expected: PASSED
+
+# Confirm no regressions
+uv run pytest test/ -v
+# Expected: all PASSED
 ```
 
-## Context Required
+## Dispatch Context Schema
 
-- Related skills: `test-driven-development` (parent skill)
-- Related tasks: `red`, `refactor`
+```json
+{
+  "spec_context": "<scope of behavior to implement>",
+  "test_path": "<path to test file>",
+  "worktree.path": "<if set>",
+  "github.owner": "<from session>",
+  "github.repo": "<from session>"
+}
+```

--- a/skills/test-driven-development/tasks/patterns.md
+++ b/skills/test-driven-development/tasks/patterns.md
@@ -1,0 +1,110 @@
+<!-- SPDX-FileCopyrightText: 2026 michael-conrad -->
+<!-- SPDX-License-Identifier: MIT -->
+<!-- Provenance: Derived from majiayu000/claude-skill-registry (MIT) -->
+
+# Task: patterns
+
+## Purpose
+
+Decision matrix for selecting the correct TDD pattern. Each pattern corresponds to a different level of certainty about the desired implementation.
+
+## Four-Pattern Decision Matrix
+
+| Pattern | When to Use | Certainty | Steps |
+|---------|------------|-----------|-------|
+| **Straight-Red** | Clear contract, algorithm known | High | RED → GREEN → REFACTOR |
+| **Triangulation** | Boundary/edge cases uncertain | Medium | RED (edge 1) → GREEN → RED (edge 2) → GENERALIZE → REFACTOR |
+| **Obvious Implementation** | Trivial solution, no design needed | Very High | GREEN only (skip RED) |
+| **One-to-Many** | Same behavior across multiple inputs | High | RED (parameterized) → GREEN (loop/table) → REFACTOR |
+
+## Pattern Details
+
+### Straight-Red
+
+Default pattern. Write one failing test, implement to pass, refactor. No ambiguity about what the function should do.
+
+```
+RED (write test → confirm FAIL)
+  ↓
+GREEN (minimal impl → confirm PASS)
+  ↓
+REFACTOR (clean → confirm still PASS)
+```
+
+```bash
+# RED
+uv run pytest test/test_module.py::test_feature_x -v
+# Expected: FAILED
+
+# GREEN
+uv run pytest test/test_module.py::test_feature_x -v
+# Expected: PASSED
+
+# REFACTOR
+uv run pytest test/ -v
+# Expected: all PASSED
+```
+
+### Triangulation
+
+Use when a single test doesn't force the right generalization. Add a second, third example until the implementation naturally generalizes.
+
+```
+RED (test case 1 → FAIL)
+  ↓
+GREEN (passes case 1)
+  ↓
+RED (test case 2 → FAIL)
+  ↓
+GREEN (passes case 1+2)
+  ↓
+... repeat until generalized
+  ↓
+REFACTOR
+```
+
+```python
+# RED — case 1
+def test_parse_date_iso():
+    assert parse_date("2026-04-07") == date(2026, 4, 7)
+# GREEN — return date(2026, 4, 7)
+
+# RED — case 2
+def test_parse_date_iso_alt():
+    assert parse_date("2025-12-25") == date(2025, 12, 25)
+# GREEN — use date.fromisoformat()
+```
+
+### Obvious Implementation
+
+Skip RED when the solution is trivially correct and the test would pass on first write. Only applies when:
+- One-liner implementation
+- No design decisions needed
+- Zero ambiguity about correctness
+
+```python
+# No RED needed — trivial
+def is_positive(n: int) -> bool:
+    return n > 0
+```
+
+### One-to-Many
+
+Same assertion structure repeated across inputs. Use parameterized tests to collapse N tests into one.
+
+```python
+import pytest
+
+@pytest.mark.parametrize("input,expected", [
+    ("", 0),
+    ("hello", 5),
+    ("hello world", 11),
+])
+def test_string_length(input, expected):
+    assert string_length(input) == expected
+```
+
+## Context Required
+
+- Related skills: `test-driven-development` (parent skill)
+- Related tasks: `red`, `green`, `refactor`, `checklist`

--- a/skills/test-driven-development/tasks/phase-0.md
+++ b/skills/test-driven-development/tasks/phase-0.md
@@ -1,0 +1,77 @@
+<!-- SPDX-FileCopyrightText: 2026 michael-conrad -->
+<!-- SPDX-License-Identifier: MIT -->
+<!-- Provenance: Derived from majiayu000/claude-skill-registry (MIT) -->
+
+# Task: phase-0
+
+## Purpose
+
+Pre-Regression Baseline — establish the current state of the codebase before any TDD cycle begins. Ensures the agent knows what depends on what and that all existing tests pass before touching any code.
+
+## Phase 0 Gate: Pre-Regression Baseline
+
+Invoked before the first RED phase of any new TDD cycle. One-time gate per cycle.
+
+## Exit Criteria
+
+Blast radius computed, existing tests verified GREEN. If tests fail, cycle is BLOCKED.
+
+## Workflow
+
+### Step 1: AI-Driven Dependency Analysis
+
+Use `srclight_get_dependents` (or equivalent) to identify the blast radius of the code area being touched:
+
+```bash
+# Identify dependents of the area under change
+srclight_get_dependents(symbol_name="<function/class under test>", transitive=True)
+```
+
+Document the blast radius in the dispatch context:
+- Direct dependents (functions that call this symbol)
+- Transitive dependents (functions that call the callers)
+- Test files that cover this area
+
+### Step 2: Functional Test Execution
+
+Run the full test suite for the affected area:
+
+```bash
+uv run pytest test/ -v
+# Expected: all PASSED
+```
+
+### Step 3: BLOCKED-on-Failure Protocol
+
+If any existing tests fail during Phase 0:
+
+1. **HALT** — do not proceed to RED
+2. **Report** the failing tests with their error output
+3. **BLOCKED status** — the cycle cannot start until existing failures are resolved
+4. **Do NOT fix the failures** — report only. Bug fixes follow their own spec→plan→implementation pipeline.
+5. Return contract: `{ status: "BLOCKED", reason: "<test failures>", failures: [...] }`
+
+### Step 4: Empty Blast Radius = Silent Proceed
+
+If dependency analysis shows zero dependents and all tests pass:
+
+- Return contract: `{ status: "PASS", blast_radius: "empty", evidence: "all tests GREEN" }`
+- The orchestrator proceeds to RED immediately — no user notification needed
+- Empty blast radius means the change cannot cause regressions, so no gate output is required
+
+## Dispatch Context Schema
+
+```json
+{
+  "spec_context": "<scope of behavior to test>",
+  "target_symbol": "<primary function/class under change>",
+  "worktree.path": "<if set>",
+  "github.owner": "<from session>",
+  "github.repo": "<from session>"
+}
+```
+
+## Context Required
+
+- Related skills: `test-driven-development` (parent skill)
+- Related tasks: `red`, `checklist`

--- a/skills/test-driven-development/tasks/phase-4.md
+++ b/skills/test-driven-development/tasks/phase-4.md
@@ -1,0 +1,84 @@
+<!-- SPDX-FileCopyrightText: 2026 michael-conrad -->
+<!-- SPDX-License-Identifier: MIT -->
+<!-- Provenance: Derived from majiayu000/claude-skill-registry (MIT) -->
+
+# Task: phase-4
+
+## Purpose
+
+Post-Regression Verification — after the TDD cycle completes (RED→GREEN→REFACTOR), re-compute the blast radius and verify no regressions were introduced. Provides a remediation loop back to GREEN if defects are found.
+
+## Phase 4 Gate: Post-Regression Verification
+
+Invoked after REFACTOR completes. One-time gate per cycle.
+
+## Exit Criteria
+
+Blast radius re-verified GREEN, or entered remediation loop. If BLOCKED after 2 consecutive failures, cycle is HALTED.
+
+## Workflow
+
+### Step 1: Re-Computed Blast Radius
+
+Re-run dependency analysis on the changed area:
+
+```bash
+srclight_get_dependents(symbol_name="<function/class under change>", transitive=True)
+```
+
+Compare against the Phase 0 blast radius. If new dependents appeared (code was added), verify they are tested.
+
+### Step 2: Remediation Loop
+
+If any Phase 4 verification fails (tests broken, blast radius regressions, uncovered dependents):
+
+1. **First failure:** Return to GREEN phase — fix the defect. Then re-run Phase 4.
+2. **Second consecutive failure:** HALT and report BLOCKED status.
+3. **Report:** `{ status: "BLOCKED", reason: "2 consecutive Phase 4 failures", cycle: "<cycle-id>" }`
+4. The orchestrator must NOT re-dispatch — this is a genuine blockage requiring human intervention.
+5. Return contract: `{ status: "BLOCKED", reason: "<failure details>", cycle: "<cycle-id>" }`
+
+### Step 3: Full Suite Verification
+
+```bash
+uv run pytest test/ -v
+# Expected: all PASSED
+```
+
+### Step 4: PASS Contract
+
+```json
+{
+  "status": "PASS",
+  "blast_radius": "<re-computed blast radius list or 'empty'>",
+  "cycle": "<cycle-id>",
+  "evidence": "full suite GREEN after Phase 4"
+}
+```
+
+## Dispatch Context Schema
+
+```json
+{
+  "spec_context": "<scope of behavior tested>",
+  "target_symbol": "<primary function/class under change>",
+  "cycle_id": "<unique cycle identifier>",
+  "phase_0_contract": "<Phase 0 result contract for comparison>",
+  "worktree.path": "<if set>",
+  "github.owner": "<from session>",
+  "github.repo": "<from session>"
+}
+```
+
+## Cycle-Reset Discipline
+
+After Phase 4 PASSES, the cycle is complete. The agent MUST:
+
+1. Commit the cycle (test + implementation + refactor as one working slice)
+2. Reset to Phase 0 for the next item
+3. Never carry state across cycles
+
+## Context Required
+
+- Related skills: `test-driven-development` (parent skill)
+- Related tasks: `refactor`, `green`

--- a/skills/test-driven-development/tasks/red.md
+++ b/skills/test-driven-development/tasks/red.md
@@ -1,58 +1,32 @@
+<!-- SPDX-FileCopyrightText: 2026 michael-conrad -->
+<!-- SPDX-License-Identifier: MIT -->
+<!-- Provenance: Derived from majiayu000/claude-skill-registry (MIT) -->
+
 # Task: red
 
-## Purpose
+## Invocation
 
-Write a failing test that defines the expected behavior before any implementation code exists.
+`/skill test-driven-development --task red`
 
-## Operating Protocol
+## Exit Criteria
 
-1. Invoked by: `/skill test-driven-development --task red`
-2. When to use: When starting TDD cycle — writing the first test for new behavior
-3. Exit criteria: Test written and confirmed FAILING (or ERROR if function doesn't exist yet)
+Test written and confirmed FAILING (or ERROR if function doesn't exist yet).
 
-## Principles
-
-1. **Test defines the contract:** What should the function/class do?
-2. **Test must fail:** If test passes without implementation, test is wrong
-3. **One assertion per test concept:** Test one behavior per test method
-4. **Use meaningful test names:** `test_functionName_expectedBehavior_whenCondition`
-
-## Workflow
-
-```python
-# test/test_module.py
-
-def test_parse_date_iso_format():
-    """parse_date should return date object for ISO format strings."""
-    result = parse_date("2026-04-07")
-    assert result == date(2026, 4, 7)
-
-def test_parse_date_invalid_input_raises():
-    """parse_date should raise ValueError for invalid date strings."""
-    with pytest.raises(ValueError, match="Invalid date format"):
-        parse_date("not-a-date")
-```
-
-## Test Location
-
-Tests go in `test/` directory following project convention:
-
-```
-test/
-├── test_module.py          # Unit tests for src/module.py
-├── test_integration.py     # Integration tests
-└── conftest.py             # Shared fixtures
-```
-
-## Verification
+## Verification Command
 
 ```bash
-# Test must FAIL before implementation
-uv run pytest test/test_module.py::test_parse_date_iso_format -v
-# Expected: FAILED (or ERROR if function doesn't exist yet)
+uv run pytest test/test_module.py::test_<name> -v
+# Expected: FAILED (or ERROR)
 ```
 
-## Context Required
+## Dispatch Context Schema
 
-- Related skills: `test-driven-development` (parent skill)
-- Related tasks: `green`, `refactor`
+```json
+{
+  "spec_context": "<scope of behavior to test>",
+  "test_path": "<path to test file>",
+  "worktree.path": "<if set>",
+  "github.owner": "<from session>",
+  "github.repo": "<from session>"
+}
+```

--- a/skills/test-driven-development/tasks/refactor.md
+++ b/skills/test-driven-development/tasks/refactor.md
@@ -1,35 +1,34 @@
+<!-- SPDX-FileCopyrightText: 2026 michael-conrad -->
+<!-- SPDX-License-Identifier: MIT -->
+<!-- Provenance: Derived from majiayu000/claude-skill-registry (MIT) -->
+
 # Task: refactor
 
-## Purpose
+## Invocation
 
-Clean up implementation code while keeping all tests passing. Refactoring changes structure, not behavior.
+`/skill test-driven-development --task refactor`
 
-## Operating Protocol
+## Exit Criteria
 
-1. Invoked by: `/skill test-driven-development --task refactor`
-2. When to use: After `--task green` has confirmed passing tests
-3. Exit criteria: Code refactored, all tests still pass, no behavior changes
+Code refactored, all tests still pass, no behavior changes.
 
-## Principles
-
-1. **Tests stay green:** All tests pass during refactoring
-2. **Small steps:** One refactoring at a time
-3. **Run tests after each step:** Ensure nothing breaks
-4. **No behavior changes:** Refactoring changes structure, not behavior
-
-## Workflow
-
-1. Identify code smells (duplication, long methods, unclear names)
-2. Make one small refactoring
-3. Run tests
-4. If tests pass → commit refactoring
-5. If tests fail → revert and try different approach
-
-## Verification
+## Verification Command
 
 ```bash
-# All tests must pass after refactoring
 uv run pytest test/ -v
+# Expected: all PASSED
+```
+
+## Dispatch Context Schema
+
+```json
+{
+  "spec_context": "<scope of behavior to refactor>",
+  "test_path": "<path to test file>",
+  "worktree.path": "<if set>",
+  "github.owner": "<from session>",
+  "github.repo": "<from session>"
+}
 ```
 
 ## When to Use TDD
@@ -42,8 +41,3 @@ uv run pytest test/ -v
 | Exploration/prototyping | ❌ No | Behavior not yet defined |
 | UI layout changes | ❌ No | Hard to test visually |
 | Config/data changes | ❌ No | No code logic to test |
-
-## Context Required
-
-- Related skills: `test-driven-development` (parent skill)
-- Related tasks: `red`, `green`

--- a/skills/verification-enforcement/SKILL.md
+++ b/skills/verification-enforcement/SKILL.md
@@ -13,6 +13,8 @@ compatibility: opencode
 
 Shared verification gate for ALL content-generating skills. Pre-generation: dispatch section-based sub-agents to collect evidence artifacts for every claim. Post-generation: scan for unverified markers, attempt resolution, escalate unresolvable claims. Orchestrator level: reject sub-agent output without evidence artifacts.
 
+Spec content that makes factual claims must include a **Documentation Sources** section documenting live-source verification used for each claim. This section is mandatory for standard and complex specs and is enforced by `adversarial-audit --task spec-audit` criterion SC-11. Simple specs may omit it.
+
 ## Persona
 
 Verification Gatekeeper. Not the content author — the evidence collector running before and after generation. Treats memory/training data as insufficient; tool calls and live documentation as sufficient. Marks what cannot be verified, escalates what cannot be resolved.


### PR DESCRIPTION
## Summary

Two related changes in `.opencode/skills/` and `.opencode/guidelines/`:

**TDD Reference Deck (#310):**
- Replace SKILL.md body with adapted majiayu000/claude-skill-registry (MIT) methodology  
- Add Phase 0 (pre-regression baseline) and Phase 4 (post-regression verification)  
- Add patterns.md, anti-patterns.md, checklist.md task files  
- Slim red.md, green.md, refactor.md to execution-only  
- Add cycle-reset discipline for timing/test failures  

**Documentation Sources (#479):**
- Add Documentation Sources section to spec templates (143, 144)  
- Update spec-creation write task with Documentation Sources guidance  
- Add SC-11 enforcement to adversarial-audit spec-audit (FAIL if missing/empty)  
- Add Documentation Sources reference to verification-enforcement  

## Files Changed

15 files (708 insertions, 125 deletions):
- `skills/test-driven-development/SKILL.md` — full rewrite with majiayu000 content  
- 5 new task files (patterns, anti-patterns, checklist, phase-0, phase-4)  
- 3 slimmed task files (red, green, refactor)  
- `guidelines/143-planning-spec-templates.md` — Documentation Sources  
- `guidelines/144-planning-spec-examples.md` — Documentation Sources example  
- `skills/spec-creation/tasks/write.md` — Documentation Sources section  
- `skills/adversarial-audit/tasks/spec-audit.md` — SC-11 enforcement  
- `skills/verification-enforcement/SKILL.md` — Sources reference  

## Fixes

Closes #310, #479

🤖 Co-authored with AI: OpenCode (deepseek-v4-flash)