### PR TITLE
chore(git-workflow): strengthen submodule pointer commit prohibition in cleanup task (#519)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,3 +66,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - **Batch PR enforcement** (#904) - Add mandatory rule #07 to `assemble-batch.md` and update `pr-creation-workflow/SKILL.md` to enforce single PR per batch. No per-issue PRs in batch orchestration.
 - **Submodule provenance tracking** (#783) - Add `provenance.md` task to `git-workflow` skill for submodule commit provenance tracking. Update `release-promotion.md` and `review-prep.md` with submodule-aware checkout verification. Ensure release promotion preserves submodule commit provenance.
 - **Default Base Prompt Override** (#494) - Added `.opencode/prompts/default.txt` with skill-deck-optimized replacement base system prompt. Added `agent.build.prompt` and `agent.plan.prompt` config keys in `opencode.jsonc` for prompt customization.
+
+### Added
+
+- **Tier 1 Guidelines Restoration** (#497) - Restored all 12 Tier 1 guideline files to `opencode.jsonc` instructions array, fixing regression where only `INDEX.md` was loaded at session start. Added WARNING comment to prevent future removal.
+- **TDD Reference Deck** (#310, #479) - Adopted majiayu000 TDD Reference Deck with Phase 0 pre-regression baseline and Phase 4 post-regression verification. Added `patterns.md`, `anti-patterns.md`, and `checklist.md` task files. Added mandatory Documentation Sources section to spec templates.
+- **Skill Dispatch Mandate** (#516) - Replaced Workflow-First Mandate with zero-tolerance CRITICAL VIOLATION rule for skill pre-read + inline execution. Added `critical-rules-048` with 3-way violation distinction table, behavioral test, and content-verification scenarios.
+
+### Changed
+
+- **Submodule Pointer PR Block** (#519) - Strengthened cleanup task prohibition against standalone submodule-only PR creation. Explicitly forbids committing `.opencode/` during cleanup; submodule pointer updates must occur on feature branches during pre-work, never on `dev` during cleanup.

--- a/skills/git-workflow/tasks/cleanup/branch-cleanup.md
+++ b/skills/git-workflow/tasks/cleanup/branch-cleanup.md
@@ -126,8 +126,11 @@ fi
 **⚠️ CRITICAL: Dirty submodule pointer exemption:**
 - 🚫 FORBIDDEN: Attempting to commit, stash, or resolve the dirty submodule pointer
 - 🚫 FORBIDDEN: Treating a dirty submodule pointer as a cleanup failure or error condition
+- 🚫 FORBIDDEN: Creating a PR whose sole purpose is to update a submodule pointer (submodule-only PR)
+- 🚫 FORBIDDEN: Running `git add .opencode`, `git commit`, or any git operation that commits the submodule pointer during cleanup
 - ✅ REQUIRED: Acknowledge the dirty state as expected and continue
 - ✅ REQUIRED: The parent repo `git status` after this step will show `.opencode (modified)` — this is correct and expected
+- ✅ REQUIRED: Submodule pointer updates happen on feature branches during pre-work (Step 3.5), never on `dev` during cleanup
 
 **Evidence artifact (MANDATORY):** Tool-call output showing `git -C "$PARENT_REPO_PATH" branch --show-current` returns `dev` MUST be present before proceeding. If no parent repo exists (not a submodule), evidence that the step was evaluated and skipped is sufficient.
 


### PR DESCRIPTION
## Summary

The `git-workflow --task cleanup` execution created a standalone submodule-pointer PR (#73 in `opencode-config`) instead of leaving the submodule pointer dirty on `dev`. The cleanup task file (`branch-cleanup.md` Step 1.7) explicitly prohibits this, but a **critical-rules-048 violation** caused the regression: the orchestrator bypassed the mandatory `skill()` invocation, read the task file into context, and dispatched a generic sub-agent with custom instructions that overrode the task file.

## Changes

- **Submodule Pointer PR Block** — Strengthened `cleanup/branch-cleanup.md` Step 1.7 to explicitly prohibit standalone submodule-only PR creation during cleanup. Added CRITICAL language forbidding `git add .opencode`, `git commit`, and any git operation that commits the submodule pointer during cleanup. Clarified that submodule pointer updates happen on feature branches during pre-work (Step 3.5), never on `dev` during cleanup.
- **Changelog Updated** — Incremental CHANGELOG.md entries for #497, #310/#479, #516, and #519.

## Verification

- [x] Single commit verified (1 commit on branch vs `origin/dev`)
- [x] Changelog generated and committed
- [x] Working tree clean
- [x] Parent repo gate `pr-workflow-003` applied — submodule-only bump PR BLOCKED, no parent PR created
- [x] Base branch: `dev` (feature PR)

Fixes #519