### PR TITLE
feat: cross-repo cleanup — submodule issue closure, branch cleanup, dev-tip verification (#76)

### DIFF
--- a/skills/divide-and-conquer/tasks/assemble-work.md
+++ b/skills/divide-and-conquer/tasks/assemble-work.md
@@ -27,14 +27,21 @@ Orchestrate work execution by dispatching sub-agents for each approved issue, us
 **🚫 CRITICAL PREREQUISITE: Before determining execution order, verify the Gate Evidence Audit Table exists in the work state file (`tmp/work-*.md`).**
 
 - Read the work state file from `pre-implementation-analysis` (`tmp/work-*.md`)
+
 - **If the Gate Evidence Audit Table is missing** AND any issues were classified as "already-implemented" during screening: HALT and return to `pre-implementation-analysis` Step 0.5 to complete the audit. The table is a mandatory structural artifact — its absence means Gate 1 and Gate 2 evidence was not verified.
+
 - **If the Gate Evidence Audit Table exists** AND has ❌ entries for any issue: those issues were already downgraded during pre-implementation-analysis. Verify the downgraded classifications are reflected in the execution plan. If not, return to `pre-implementation-analysis`.
+
 - **If NO issues were classified as "already-implemented":** The Gate Evidence Audit Table is not required. Proceed normally.
 
 - For multi-issue: use dependency order from `pre-implementation-analysis`
+
 - For single issue: treat as work-of-1 — no special casing, no shortcuts
+
 - Determine complexity level for each issue (simple/moderate/complex)
+
 - **Read scope fields from work state file:** `authorization_scope`, `halt_at`, `pr_strategy`
+
 - **If `halt_at` is reached before all issues complete:** HALT at scope boundary, report what was completed
 
 **Work-of-1.** There is no separate code path. The `assemble-work` task handles single-issue dispatch as the default. This eliminates forked execution paths.
@@ -78,49 +85,52 @@ For each issue in execution order:
 
    2. **Build dispatch context** with AI-composed intent-and-context metadata and phase progress:
 
-     Sub-issues contain phase context in their body (enriched during creation via `create-sub-issue`). When composing dispatch context, reference the sub-issue body for phase-specific context rather than re-reading the Plan body. The sub-issue body should already include: why the phase exists, what it must accomplish, how to verify completion, edge cases, and dependencies. If the sub-issue body is insufficient (only contains `**Parent Plan:** #M`), fall back to reading the Plan body for the relevant phase section.
+   Sub-issues contain phase context in their body (enriched during creation via `create-sub-issue`). When composing dispatch context, reference the sub-issue body for phase-specific context rather than re-reading the Plan body. The sub-issue body should already include: why the phase exists, what it must accomplish, how to verify completion, edge cases, and dependencies. If the sub-issue body is insufficient (only contains `**Parent Plan:** #M`), fall back to reading the Plan body for the relevant phase section.
 
-     **Phase progress composition:** Before each sub-agent dispatch, compose the `phase_progress` section from:
-     - The Plan STATUS marker (which phases are marked complete) — read from the plan issue body or sub-issue STATUS markers
-     - Prior sub-agent results — the `completed_phases`, `concern_boundaries_crossed`, and `verification_evidence` fields returned by preceding sub-agents
-     - The orchestrator's own judgment about concern boundaries — when a new sub-agent's work crosses into a different architectural concern (e.g., from data layer to UI layer, from orchestration to enforcement), name the transition in `concern_boundaries_crossed`
+   **Phase progress composition:** Before each sub-agent dispatch, compose the `phase_progress` section from:
 
-     Phase progress is prose-driven: state what information must travel, trust the orchestrator to decide how to encode it. Completed phases should be named by the concern they address (e.g., "dispatch context schema" rather than "Phase 1"), concern boundaries should describe the architectural transition point, and verification evidence should summarize what was confirmed.
+   - The Plan STATUS marker (which phases are marked complete) — read from the plan issue body or sub-issue STATUS markers
+   - Prior sub-agent results — the `completed_phases`, `concern_boundaries_crossed`, and `verification_evidence` fields returned by preceding sub-agents
+   - The orchestrator's own judgment about concern boundaries — when a new sub-agent's work crosses into a different architectural concern (e.g., from data layer to UI layer, from orchestration to enforcement), name the transition in `concern_boundaries_crossed`
 
-      ```yaml
-       work_set:
-         authorized_issues: [#A, #B, #C]
-         completed_issues: [<completed>]
-      issue: #<current>
-      sub_issue_body: "<phase prose from sub-issue body, not just parent reference>"
-       spec: "<full spec body from GitHub Issue>"
-       authorization_scope: <scope_value>
-       halt_at: <pipeline_stage>
-       pr_strategy: stacked | individual | none
-       pipeline_phase: <current_phase_name>
-       authorization_source: "User approved #N on YYYY-MM-DD"
-       prior_context: "<AI-composed intent and context from prior issues>"
-       decision_log_reference: "<URL or reference to the Decision Log on the Plan issue — the sub-agent can retrieve full decision history from this reference>"
-       phase_progress:
-        completed_phases: "<prose listing of completed phases by concern name, accumulated from prior sub-agent results and Plan STATUS>"
-        concern_boundaries_crossed: "<prose description of architectural concern transitions between the prior sub-agent's work and this sub-agent's work>"
-        verification_evidence: "<prose summary of what was verified in prior phases and the outcomes>"
-      dependency_branches: ["spec/<prior-branch>"]
-      env_vars:
-          worktree.path: ".worktrees/spec-<name>"
-          branch: "spec/<name>"
-         github.owner: "<from-session>"
-         github.repo: "<from-session>"
-         dev.name: "<from-session>"
-         dev.email: "<from-session>"
-       test_models:
-         local: "<resolved-local-model>"
-         cloud: "<resolved-cloud-fallback>"
-       ```
+   Phase progress is prose-driven: state what information must travel, trust the orchestrator to decide how to encode it. Completed phases should be named by the concern they address (e.g., "dispatch context schema" rather than "Phase 1"), concern boundaries should describe the architectural transition point, and verification evidence should summarize what was confirmed.
 
-3. **Spawn sub-agent** via `task(subagent_type="general", prompt=...)`
+   ````yaml
+    work_set:
+      authorized_issues: [#A, #B, #C]
+      completed_issues: [<completed>]
+   issue: #<current>
+   sub_issue_body: "<phase prose from sub-issue body, not just parent reference>"
+    spec: "<full spec body from GitHub Issue>"
+    authorization_scope: <scope_value>
+    halt_at: <pipeline_stage>
+    pr_strategy: stacked | individual | none
+    pipeline_phase: <current_phase_name>
+    authorization_source: "User approved #N on YYYY-MM-DD"
+    prior_context: "<AI-composed intent and context from prior issues>"
+    decision_log_reference: "<URL or reference to the Decision Log on the Plan issue — the sub-agent can retrieve full decision history from this reference>"
+    phase_progress:
+     completed_phases: "<prose listing of completed phases by concern name, accumulated from prior sub-agent results and Plan STATUS>"
+     concern_boundaries_crossed: "<prose description of architectural concern transitions between the prior sub-agent's work and this sub-agent's work>"
+     verification_evidence: "<prose summary of what was verified in prior phases and the outcomes>"
+   dependency_branches: ["spec/<prior-branch>"]
+   env_vars:
+       worktree.path: ".worktrees/spec-<name>"
+       branch: "spec/<name>"
+      github.owner: "<from-session>"
+      github.repo: "<from-session>"
+      dev.name: "<from-session>"
+      dev.email: "<from-session>"
+    test_models:
+      local: "<resolved-local-model>"
+      cloud: "<resolved-cloud-fallback>"
+    ```
 
-4. **Sub-agent responsibilities:**
+   ````
+
+2. **Spawn sub-agent** via `task(subagent_type="general", prompt=...)`
+
+3. **Sub-agent responsibilities:**
 
    - Load spec + session context + prior context
    - Run `divide-and-conquer` skill for the specific issue
@@ -129,55 +139,58 @@ For each issue in execution order:
    - Run `finishing-a-development-branch --task checklist`
    - Return structured result: `{status, files_changed, summary}`
 
- 5. **Collect result** from sub-agent
+4. **Collect result** from sub-agent
 
-  6. **Sub-Agent Completion Checkpoint** — after collecting each result, perform the completion checkpoint per `dispatch` task Step 4:
+5. **Sub-Agent Completion Checkpoint** — after collecting each result, perform the completion checkpoint per `dispatch` task Step 4:
 
-     - If sub-agent returned a structured result: check `status` field and handle accordingly
-     - If sub-agent returned **NO result** (timeout, crash, empty): this is **ABNORMAL TERMINATION**
-       - Run `git status` in the worktree
-       - Clean tree → didn't start → re-dispatch
-       - Uncommitted changes + all deliverables → UNDO + re-dispatch by default; manual commit+push only if narrow exception applies (≤50 lines, single file, fully correct, no remaining dispatches — see SKILL.md Recovery Mode)
-       - Uncommitted changes + partial deliverables → `git checkout .` + re-dispatch reduced scope
-       - Uncommitted changes + wrong changes → `git checkout .` + re-dispatch full scope
-     - Report abnormal termination to chat (see format in SKILL.md "Sub-Agent Completion Checkpoint")
-     - The orchestrator decides recovery action autonomously per "Pushing Agent Intelligence Decisions to the User" (`000-critical-rules.md`)
-     - **Do NOT proceed to the next sub-agent until abnormal termination recovery is complete.** Recovery must fully resolve (re-dispatch succeeded or manual commit+push verified) before advancing.
+   - If sub-agent returned a structured result: check `status` field and handle accordingly
+   - If sub-agent returned **NO result** (timeout, crash, empty): this is **ABNORMAL TERMINATION**
+     - Run `git status` in the worktree
+     - Clean tree → didn't start → re-dispatch
+     - Uncommitted changes + all deliverables → UNDO + re-dispatch by default; manual commit+push only if narrow exception applies (≤50 lines, single file, fully correct, no remaining dispatches — see SKILL.md Recovery Mode)
+     - Uncommitted changes + partial deliverables → `git checkout .` + re-dispatch reduced scope
+     - Uncommitted changes + wrong changes → `git checkout .` + re-dispatch full scope
+   - Report abnormal termination to chat (see format in SKILL.md "Sub-Agent Completion Checkpoint")
+   - The orchestrator decides recovery action autonomously per "Pushing Agent Intelligence Decisions to the User" (`000-critical-rules.md`)
+   - **Do NOT proceed to the next sub-agent until abnormal termination recovery is complete.** Recovery must fully resolve (re-dispatch succeeded or manual commit+push verified) before advancing.
 
- 7. **Compose prior_context and phase_progress** for the next issue based on what was implemented:
+6. **Compose prior_context and phase_progress** for the next issue based on what was implemented:
 
-     prior_context (intent and context):
-     - Design decisions made
-     - Edge cases handled
-     - Assumptions that later issues depend on
-     - Interfaces exposed that later issues should use
-     - NOT a change summary (that's in git) — intent and context only
+   prior_context (intent and context):
 
-     phase_progress (accumulated from sub-agent result + Plan STATUS):
-     - completed_phases: append the just-completed phase concern name to the running list
-     - concern_boundaries_crossed: if the next issue's concern differs from the just-completed issue's concern, note the transition
-     - verification_evidence: append what was verified and the outcome
+   - Design decisions made
+   - Edge cases handled
+   - Assumptions that later issues depend on
+   - Interfaces exposed that later issues should use
+   - NOT a change summary (that's in git) — intent and context only
 
-     Both prior_context and phase_progress are prose-driven. The orchestrator composes them intelligently — no fixed template, no rigid schema.
+   phase_progress (accumulated from sub-agent result + Plan STATUS):
 
- 8. **Append the sub-agent's decision_log_entry to the Decision Log on the Plan issue.** After collecting each sub-agent's result, post their `decision_log_entry` as a dedicated GitHub Issue comment on the Plan issue. The Decision Log persists design decisions across phase boundaries and session restarts.
+   - completed_phases: append the just-completed phase concern name to the running list
+   - concern_boundaries_crossed: if the next issue's concern differs from the just-completed issue's concern, note the transition
+   - verification_evidence: append what was verified and the outcome
 
-   **Decision Log storage:** Use a dedicated GitHub Issue comment on the Plan issue, NOT the Plan body. Rationale:
-   - Append-only — new decisions are added without editing existing content
-   - Lightweight — appending a comment doesn't require re-editing the entire Plan body
-   - Survives session restarts — comments persist on the GitHub Issue independently of any agent session
-   - Doesn't bloat the Plan body — the Plan body stays focused on phase structure and STATUS markers
-   - Sequential — comments are naturally ordered chronologically
+   Both prior_context and phase_progress are prose-driven. The orchestrator composes them intelligently — no fixed template, no rigid schema.
 
-   The orchestrator posts the decision log entry after each sub-agent returns. If posting fails, log the failure and continue — the Decision Log is a durability enhancement, not a blocking gate. The `decision_log_entry` is also returned in the sub-agent result for immediate use by subsequent dispatches within the same session.
+7. **Append the sub-agent's decision_log_entry to the Decision Log on the Plan issue.** After collecting each sub-agent's result, post their `decision_log_entry` as a dedicated GitHub Issue comment on the Plan issue. The Decision Log persists design decisions across phase boundaries and session restarts.
 
- 9. **Mark prior issue's branch as frozen** — no rebasing, amending, or force-pushing
+**Decision Log storage:** Use a dedicated GitHub Issue comment on the Plan issue, NOT the Plan body. Rationale:
 
- 10. **Handle failures:**
+- Append-only — new decisions are added without editing existing content
+- Lightweight — appending a comment doesn't require re-editing the entire Plan body
+- Survives session restarts — comments persist on the GitHub Issue independently of any agent session
+- Doesn't bloat the Plan body — the Plan body stays focused on phase structure and STATUS markers
+- Sequential — comments are naturally ordered chronologically
 
-   - If sub-agent fails: record failure
-   - For independent issues: continue to next issue
-   - For must-precede chains: skip dependent issues, report both
+The orchestrator posts the decision log entry after each sub-agent returns. If posting fails, log the failure and continue — the Decision Log is a durability enhancement, not a blocking gate. The `decision_log_entry` is also returned in the sub-agent result for immediate use by subsequent dispatches within the same session.
+
+09. **Mark prior issue's branch as frozen** — no rebasing, amending, or force-pushing
+
+10. **Handle failures:**
+
+- If sub-agent fails: record failure
+- For independent issues: continue to next issue
+- For must-precede chains: skip dependent issues, report both
 
 ### Step 4: Work Assembly
 
@@ -260,7 +273,9 @@ Compare URL: <<Character-match verified URL from session-init values per URL Sou
 **If a PR has been created for this work set, use "PR URL" label with the `html_url` from `github_create_pull_request` API response:**
 
 ```
-PR URL: <html_url from github_create_pull_request API response>
+
+PR URL: \<html_url from github_create_pull_request API response>
+
 ```
 
 **NEVER use the wrong label for the wrong URL format.** Label-format mismatch (e.g., "Compare URL" with `pull/N` URL, or "PR URL" with `compare/dev...` URL) is a critical violation.
@@ -272,12 +287,12 @@ PR URL: <html_url from github_create_pull_request API response>
 
 Before sending the chat report, verify ALL elements are present and correctly ordered:
 
-- [ ] Executive summary present as **first** element (before any URL)
-- [ ] Outcome line present after summary
-- [ ] URL present IF relevant (after outcome, before byline) — required when branches pushed (compare URL), **omitted** when no branches pushed; **after PR creation**: compare URL becomes PR URL, label changes from "Compare URL" to "PR URL"; label and URL format MUST match context — mismatch is a critical violation
-- [ ] AI byline present as **LAST** element (after URL, or after outcome when no URL)
-- [ ] No URL before executive summary
-- [ ] No byline before URL/outcome
+- \[ \] Executive summary present as **first** element (before any URL)
+- \[ \] Outcome line present after summary
+- \[ \] URL present IF relevant (after outcome, before byline) — required when branches pushed (compare URL), **omitted** when no branches pushed; **after PR creation**: compare URL becomes PR URL, label changes from "Compare URL" to "PR URL"; label and URL format MUST match context — mismatch is a critical violation
+- \[ \] AI byline present as **LAST** element (after URL, or after outcome when no URL)
+- \[ \] No URL before executive summary
+- \[ \] No byline before URL/outcome
 
 **Evidence requirement:** Each checkpoint verification MUST produce a tool-call artifact (e.g., verification of composed message content) confirming the element is present or correctly absent. Verbal assertion without tool-call evidence is insufficient.
 
@@ -404,7 +419,7 @@ assemble-work:
 | Scope of Context | Exclusions | Pre-Analysis Contract | Includes Inline Work? |
 |---|---|---|---|
 | `work_set`, `issue`, `sub_issue_body`, `spec`, `authorization_scope`, `halt_at`, `pr_strategy`, `pipeline_phase`, `authorization_source`, `prior_context`, `phase_progress`, `dependency_branches`, `github.owner`, `github.repo`, `dev.name`, `dev.email`, `worktree.path`, `branch` | Orchestrator implementation context, agent memory, cached verification results, tool recipes | N/A — sub-agents receive the full dispatch context with spec and prior_context | NO |
-| Cleanup sub-agent — `skill({name: "git-workflow", args: "--task cleanup"})` | Only `branch_name`, `worktree.path`, `github.owner`, `github.repo` | Orchestrator reasoning, expected outcomes, cached results, tool recipes | NO |
+| Cleanup sub-agent — `skill({name: "git-workflow", args: "--task cleanup"})` | `branch_name`, `worktree.path`, `github.owner`, `github.repo`, `submodule_paths` (submodule owner/repo routing context) | Orchestrator reasoning, expected outcomes, cached results, tool recipes | NO |
 
 Co-authored with AI: <AgentName> (<ModelId>)
 
@@ -423,6 +438,7 @@ Co-authored with AI: <AgentName> (<ModelId>)
 **Evidence artifacts:** See enforcement/work-state-verification.md §Evidence Artifacts
 
 ## Enforcement References
+
 - Completion checkpoint protocol: see `enforcement/completion-checkpoint.md`
 - Result validation and finding classification: see `enforcement/result-validation.md`
 - Work state verification: see `enforcement/work-state-verification.md`

--- a/skills/git-workflow/tasks/cleanup.md
+++ b/skills/git-workflow/tasks/cleanup.md
@@ -24,6 +24,49 @@ Delete merged branches after PR merge, clean stale references, and verify reposi
 
 ## Procedure
 
+### Step 0: Detect Submodules and Build Routing Context
+
+Before any cleanup operations, detect and build routing context for submodules.
+
+1. **Check for `.gitmodules` at project root:**
+
+   - Run `test -f .gitmodules && echo "EXISTS" || echo "NOT_FOUND"`
+   - If NOT_FOUND: skip submodule detection, proceed normally (no submodule routing context)
+
+2. **Parse `.gitmodules` if it exists:**
+
+   - Extract all `[submodule "..."]` entries using `git config --file .gitmodules --list`
+   - For each submodule entry, extract:
+     - `submodule.<path>.path` — the submodule path
+     - `submodule.<path>.url` — the remote URL
+
+3. **Resolve owner/repo from each remote URL:**
+
+   - SSH URLs (`git@github.com:owner/repo.git`): extract owner/repo
+   - HTTPS URLs (`https://github.com/owner/repo.git`): extract owner/repo
+   - If URL format is unexpected: mark as UNKNOWN, proceed with remaining submodules
+
+4. **Build routing context dictionary:**
+
+   ```yaml
+   submodule_paths:
+     <path1>:
+       owner: <resolved_owner>
+       repo: <resolved_repo>
+       platform: github
+     <path2>:
+       owner: <resolved_owner>
+       repo: <resolved_repo>
+       platform: github
+   ```
+
+5. **Pass routing context to sub-tasks:**
+
+   - Include `submodule_paths` in dispatch context for `issue-closure` and `branch-cleanup` sub-tasks
+   - Each sub-task uses the routing context to route API calls to the correct owner/repo for files under a submodule path
+
+6. **If `.gitmodules` exists but is empty** (no submodule entries): proceed normally, no routing context needed.
+
 ### Step 1: Verify PR Merge and Run Gates
 
 **Route to:** `cleanup/verify-merge`
@@ -41,6 +84,74 @@ Collects all referenced issues from PR body, classifies each (plan/spec/other), 
 **Route to:** `cleanup/branch-cleanup`
 
 Switches to dev, syncs with remote, removes feature worktree, deletes merged branches, verifies clean state.
+
+### Step 4: Post-Cleanup Dev-Tip Verification
+
+Run AFTER all sub-tasks (verify-merge, issue-closure, branch-cleanup) AND all submodule iterations are complete. This is the final verification gate — nothing runs after it.
+
+1. **Determine the parent repo path:**
+
+   - Run `git rev-parse --show-superproject-working-tree 2>/dev/null` to detect parent repo
+   - If output is non-empty: this is the parent repo path (we are inside a submodule)
+   - If output is empty: we are in the parent repo (standalone or no superproject)
+
+2. **Build repo list for verification:**
+
+   ```
+   repos_to_check:
+     - repo_name: <parent or current repo name>
+       repo_path: <parent_path | current_toplevel>
+     - repo_name: <submodule_1_name>
+       repo_path: <parent_path>/<submodule_1_path>
+     - repo_name: <submodule_2_name>
+       repo_path: <parent_path>/<submodule_2_path>
+     ...
+   ```
+
+   - Include the parent (or current) repo at index 0
+   - Append each submodule path from `submodule_paths` (resolved relative to parent repo)
+
+3. **For each repo in the list:**
+
+   a. Get local dev HEAD:
+      ```bash
+      git -C "$REPO_PATH" rev-parse dev
+      ```
+
+   b. Get remote dev HEAD:
+      ```bash
+      git -C "$REPO_PATH" rev-parse origin/dev
+      ```
+
+   c. Collect evidence artifact:
+      ```bash
+      git -C "$REPO_PATH" log --oneline -1 dev
+      ```
+
+   d. Compare local vs remote:
+      - If hashes match → repo is at dev tip
+      - If hashes differ → repo has diverged
+
+4. **Report results as a comparison table:**
+
+   ```
+   | Repo | Local dev HEAD | Remote dev HEAD | Status |
+   |------|---------------|-----------------|--------|
+   | opencode-config | abc1234 | abc1234 | ✅ At tip |
+   | .opencode | def5678 | def5678 | ✅ At tip |
+   ```
+
+5. **Outcome:**
+
+   - **All repos at dev tip:** Report "All repos at dev tip — ready for next dev cycle"
+   - **Any repo diverged:** Report which repo, the local vs remote hashes, and flag for human review:
+
+     ```
+     ⚠️ Repo <name> diverged from origin/dev:
+       Local dev:  <hash>
+       Origin/dev: <hash>
+       Action required: Human review — determine whether to push, pull --rebase, or investigate.
+     ```
 
 ## Branch Cleanup After Merge — MANDATORY
 
@@ -112,6 +223,7 @@ GitHub autoclose is inert for this repo (PRs merge to `dev`, not `main`). The cl
 **Parent issues MUST NOT be closed while ANY child issues remain open.**
 
 Example:
+
 ```
 SPEC #100 (parent)
 ├── Task #101: Phase 1 → PR merges → Close #101 ONLY
@@ -122,6 +234,7 @@ SPEC #100 (parent)
 **Parent issues MUST be closed after ALL child issues are verified complete.** Leaving a parent plan issue open after all sub-issues are closed and verified is a process gap that must be treated as a bug requiring a fix.
 
 Example:
+
 ```
 Plan #50 (parent)
 ├── Task #51: Phase 1 → closed, verified complete → OK
@@ -134,15 +247,18 @@ Plan #50 (parent)
 After closing sub-issues (Step 2), check whether the parent plan issue should be closed:
 
 1. **Identify the parent plan issue:**
+
    - Use `github_issue_read(method="get_sub_issues")` on the plan to list all sub-issues
    - If the current closure context came from a PR body referencing a plan, use that plan issue number
 
 2. **Verify ALL sub-issues are closed with legitimate completion evidence:**
+
    - Each sub-issue must have `state == "closed"` and `state_reason == "completed"` (not `"not_planned"` or `"duplicate"` without merged PR evidence)
    - Closed sub-issues with `state_reason == "completed"` must have merged PR evidence (verified via `github_pull_request_read` or `github_search_pull_requests`)
    - If any sub-issue has `state_reason == "not_planned"` without explicit developer justification → flag for review, do NOT auto-close parent
 
 3. **If ALL sub-issues are legitimately closed:**
+
    - Close the parent plan issue with `github_issue_write(method="update", state="closed", state_reason="completed")`
    - Post a verification comment documenting per-sub-issue evidence:
      ```
@@ -157,8 +273,9 @@ After closing sub-issues (Step 2), check whether the parent plan issue should be
      ```
 
 4. **If ANY sub-issue is NOT closed or NOT legitimately completed:**
+
    - Do NOT close the parent plan
-   - Report in cleanup output: "Parent plan #<plan_number> remains open — sub-issue #<open_num> is not yet complete"
+   - Report in cleanup output: "Parent plan #\<plan_number> remains open — sub-issue #\<open_num> is not yet complete"
 
 ## Closing Summary (Conditional)
 
@@ -181,6 +298,7 @@ Each verification point requires a tool call for evidence. Assertions without to
 | PR merge status | `github_pull_request_read(method=get, ...)` | `merged_at` is not None | CONFLICTING → HALT |
 | Local dev synced | `git log --oneline -1 dev` equals remote | Hashes match exactly | VERIFICATION-GAP → re-pull |
 | Sub-issues closed | `github_issue_read(method=get_sub_issues, ...)` | All state=closed | VERIFICATION-GAP → close or investigate |
+| All repos at dev tip | `git -C $REPO_PATH rev-parse dev` vs `rev-parse origin/dev` for parent + each submodule | Every repo's local dev HEAD matches origin/dev | VERIFICATION-GAP → report which repo diverged, flag for human review |
 
 ## Sub-Task Files
 

--- a/skills/git-workflow/tasks/cleanup/branch-cleanup.md
+++ b/skills/git-workflow/tasks/cleanup/branch-cleanup.md
@@ -134,6 +134,129 @@ fi
 
 **Evidence artifact (MANDATORY):** Tool-call output showing `git -C "$PARENT_REPO_PATH" branch --show-current` returns `dev` MUST be present before proceeding. If no parent repo exists (not a submodule), evidence that the step was evaluated and skipped is sufficient.
 
+### Step 1.9: Submodule Branch Cleanup Descent
+
+After parent repo dev parking (Step 1.7), descend into each submodule to clean merged branches while preserving the dirty submodule pointer.
+
+**Detect submodules:**
+
+```bash
+# Collect submodule paths from .gitmodules
+SUBMODULE_PATHS=$(git config --list --file .gitmodules 2>/dev/null | grep '^submodule\..*\.path=' | sed 's/^submodule\.\(.*\)\.path=/\1:/' | while IFS=: read -r _ path; do echo "$path"; done || echo "")
+```
+
+If no submodules exist (`SUBMODULE_PATHS` is empty), skip this step.
+
+**For each submodule path:**
+
+1. **Enter submodule directory:**
+   ```bash
+   SM_PATH="$SUBMODULE_PATH"
+   echo "Entering submodule: $SM_PATH"
+   cd "$SM_PATH"
+   ```
+
+2. **Sync submodule to dev with fast-forward only:**
+   ```bash
+   # --ff-only is mandatory — no merge commits
+   git checkout dev
+   git pull origin dev --ff-only
+   ```
+
+   **🚫 CRITICAL:** A plain `git pull origin dev` can silently create merge commits. The `--ff-only` flag prevents divergence masking.
+
+   **If `--ff-only` fails (diverged history):**
+   ```bash
+   echo "HALT: Submodule $SM_PATH has diverged from origin/dev"
+   echo "Manual resolution required before cleanup can proceed."
+   # Do NOT proceed — re-sync the submodule first
+   ```
+
+3. **Find merged branches:**
+   ```bash
+   git branch --merged dev | grep -v '^\*' | grep -v 'dev$'
+   ```
+   This lists all local branches whose commits are fully reachable from `dev`.
+
+4. **Content verification gate (MANDATORY — see Step 3 for per-file details):**
+   For each merged branch, verify content exists on `origin/dev` before deletion:
+   ```bash
+   MERGED_BRANCH="<branch>"
+   # Check diff against origin/dev
+   CHANGED_FILES=$(git diff --stat origin/dev..."$MERGED_BRANCH")
+   if [ -z "$CHANGED_FILES" ]; then
+       echo "Branch $MERGED_BRANCH: all content present on origin/dev — safe to delete"
+   else
+       echo "Branch $MERGED_BRANCH has content NOT on origin/dev — flagging for review"
+       # Produce content comparison table (same format as Step 3)
+       # HALT deletion for this branch
+   fi
+   ```
+
+5. **Delete local merged branches:**
+   ```bash
+   git branch -d "$MERGED_BRANCH"
+   ```
+   Use `-d` (safe delete — only if merged). If `-d` fails, the branch is NOT fully merged — HALT and report.
+
+6. **Delete remote merged branches:**
+   ```bash
+   # Check if remote branch exists before attempting deletion
+   if git ls-remote --heads origin "$MERGED_BRANCH" | grep -q "$MERGED_BRANCH"; then
+       git push origin --delete "$MERGED_BRANCH"
+   else
+       echo "Remote branch $MERGED_BRANCH already deleted — skipping remote deletion"
+   fi
+   ```
+   **Authorization note:** Remote branch deletion (`git push origin --delete`) is a destructive command per `000-critical-rules.md` §critical-rules-026. This operation is authorized as part of the cleanup pipeline scope — no separate authorization is required. However, the content verification gate (Step 4 above) MUST pass first.
+
+7. **Tag-based hash permanence — tag-if-untagged:**
+   Per `AGENTS.md` §Tag-Based Hash Permanence and §Idempotent Tag-if-Untagged Rule, verify the current submodule SHA is reachable via a tag. If not, tag it:
+   ```bash
+   CURRENT_SHA=$(git rev-parse HEAD)
+   TAG_EXISTS=$(git tag --points-at "$CURRENT_SHA" | head -1)
+   if [ -z "$TAG_EXISTS" ]; then
+       # Generate context-appropriate tag
+       PARENT_REPO_NAME="$(basename "$(git -C "$PARENT_REPO_PATH" rev-parse --show-toplevel 2>/dev/null || echo 'unknown')")"
+       TAG="${PARENT_REPO_NAME}/v$(date +%Y%m%d)-submodule"
+       git tag "$TAG" "$CURRENT_SHA"
+       git push origin "$TAG" 2>/dev/null || echo "Could not push tag (remote may not be accessible)"
+       echo "Tagged submodule SHA $CURRENT_SHA as $TAG"
+   else
+       echo "Submodule SHA $CURRENT_SHA already tagged ($TAG_EXISTS) — no action needed"
+   fi
+   ```
+
+8. **Exit submodule — do NOT touch the pointer:**
+   ```bash
+   cd - > /dev/null
+   # DO NOT: git add .opencode, git commit, or any operation that modifies the parent repo
+   # The dirty submodule pointer is expected — Step 1.7 already handled acknowledgment
+   ```
+
+**After all submodules processed — acknowledge dirty pointer:**
+```bash
+echo "Submodule branch cleanup complete."
+echo "Submodule pointer is dirty — expected state after dev sync."
+echo "No corrective action taken on submodule pointer."
+echo "The parent repo 'git status' will show .opencode (modified) — this is correct."
+```
+
+**🚫 FORBIDDEN:**
+- `git add .opencode` or any commit modifying the submodule pointer during cleanup
+- `git submodule update --recursive` or any `--recursive` submodule command
+- Switching the parent repo away from `dev`
+- Treating the dirty submodule pointer as an error condition
+- Creating a PR whose sole purpose is to update a submodule pointer (per Step 1.7 prohibition)
+
+**✅ REQUIRED:**
+- Verify each submodule is on `dev` before branch operations
+- Content verification gate before each submodule branch deletion
+- Tag-if-untagged for submodule SHAs
+- Acknowledge dirty pointer after all submodules processed
+
+**Evidence artifact (MANDATORY):** Tool-call output showing each submodule's `git branch --show-current` returns `dev`, the list of deleted branches per submodule, and the tag-if-untagged result per submodule. If no submodules exist, evidence that the step was evaluated and skipped is sufficient.
+
 ### Step 2: Remove Feature Worktree
 
 ```bash

--- a/skills/git-workflow/tasks/cleanup/issue-closure.md
+++ b/skills/git-workflow/tasks/cleanup/issue-closure.md
@@ -218,6 +218,80 @@ For issues with `[Task: #N]` or `Phase N:` patterns that reference a parent plan
 
 **Only proceed to parent closure after ALL sub-issues are verified.**
 
+### Step 8.5: Submodule Issue Closure Routing
+
+**Routes issue closure API calls to the correct repository when affected files live under a submodule path.**
+
+#### Requirements
+
+1. Accept `submodule_paths` routing context (from `cleanup.md` Step 0 — list of `{path, owner, repo, platform}` mappings) for per-submodule API routing
+2. Accept `verify_merge_output` structured context (from `verify-merge.md` Step 1) containing `merged_pr_number`, `merged_in_repo`, and `pr_files` for cross-referencing
+3. For each closure candidate whose affected files (from PR file diff) are under a submodule path, route the closure API call to the submodule's `owner/repo` instead of the parent repo
+4. Use `submodule_paths` context OR session-init sub-folder repo mappings (`github_issue_read` with resolved `owner`/`repo`) — never hardcode owner/repo values
+5. Include evidence artifacts table tracking each routed closure call
+6. Be platform-agnostic (works for both GitHub and GitBucket)
+
+#### Procedure
+
+```python
+# Context inputs:
+#   verify_merge_output — from verify-merge.md Step 1 (contains pr_number, merged_in_repo, pr_files, submodule_context)
+#   submodule_paths — from cleanup.md Step 0 (list of {path, owner, repo, platform})
+
+def resolve_submodule_owner_repo(issue_num, pr_files, submodule_paths):
+    """Find matching submodule for a closure candidate based on PR file paths."""
+    for file_path in pr_files:
+        for sub in submodule_paths:
+            if file_path.startswith(sub["path"]):
+                return {"owner": sub["owner"], "repo": sub["repo"], "platform": sub["platform"]}
+    return None
+
+parent_pr_number = verify_merge_output.get("pr_number")
+pr_files = verify_merge_output.get("pr_files", [])
+
+for issue_num, classification in closure_candidates.items():
+    sub_info = resolve_submodule_owner_repo(issue_num, pr_files, submodule_paths)
+    
+    if sub_info:
+        # Route closure to submodule's owner/repo
+        if sub_info["platform"] == "github":
+            github_issue_write(
+                method="update",
+                owner=sub_info["owner"],
+                repo=sub_info["repo"],
+                issue_number=issue_num,
+                state="closed",
+                state_reason="completed"
+            )
+            github_add_issue_comment(
+                owner=sub_info["owner"],
+                repo=sub_info["repo"],
+                issue_number=issue_num,
+                body=f"Closed via parent PR #{parent_pr_number}."
+            )
+        elif sub_info["platform"] == "gitbucket":
+            gitbucket_api_post(endpoint=f"/issues/{issue_num}", payload={
+                "state": "closed"
+            })
+    else:
+        # Standard parent-repo closure (existing logic applies)
+        close_in_parent_repo(issue_num, classification)
+```
+
+**Evidence artifacts table:**
+
+| Issue | Submodule Path | Routed Owner/Repo | Closure Posted? | Comment Posted? |
+|-------|---------------|-------------------|-----------------|-----------------|
+| `#N` | `.opencode/` | `michael-conrad/.opencode` | ✅ | ✅ |
+| `#M` | (none — parent) | `michael-conrad/opencode-config` | ✅ | ✅ |
+
+#### Fallback: Session-Init Repo Mappings
+
+If `submodule_paths` is not provided, resolve sub-folder repo mappings from session-init context:
+- `github_issue_read(method="get", issue_number=N)` with resolved `owner`/`repo` per submodule
+- `.gitmodules` entries parsed for `path → owner/repo` mapping
+- Reject any hardcoded owner/repo values — always use live resolution
+
 ## Context Required
 
 - Related tasks: `cleanup/verify-merge`, `cleanup/branch-cleanup`

--- a/skills/git-workflow/tasks/cleanup/verify-merge.md
+++ b/skills/git-workflow/tasks/cleanup/verify-merge.md
@@ -37,6 +37,23 @@ if pr.get("merged_at") is None:
 - EVIDENCE: `merged_by` = pr.get("merged_by") — Should be populated
 - EVIDENCE: `state` = pr.get("state") — "closed" for merged PRs
 
+**Structured output context (MANDATORY):** After verification, produce a structured output that the orchestration layer passes to `issue-closure`:
+
+```yaml
+verify_merge_output:
+  pr_number: <N>
+  merged_at: "<timestamp>"
+  merged_by: "<username>"
+  merged_in_repo: "<owner>/<repo>"  # Parent or submodule repo
+  submodule_context:
+    is_submodule_pr: <true|false>
+    submodule_owner: "<owner>"  # Populated if is_submodule_pr
+    submodule_repo: "<repo>"    # Populated if is_submodule_pr
+  pr_files: ["<path1>", "<path2>", ...]  # Used by issue-closure for submodule routing
+```
+
+The `merged_in_repo` and `submodule_context` fields are REQUIRED inputs to `issue-closure` Step 8.5 for correct submodule routing. If these are missing, issue-closure MUST flag as VERIFICATION-GAP and HALT.
+
 ### Step 2: Adversarial-Audit Closure Verification
 
 Invoke `adversarial-audit --task closure-verification` to verify merge evidence:


### PR DESCRIPTION
## Summary

Implements opencode-config#76 — cross-repo cleanup for submodule repos. When cleanup runs in the parent repo, it descends into submodules to close issues, delete branches, and verify dev-tip state using correct API routing.

## Changes

5 files, +415/-90 across 4 phases:

**Phase 1 — Submodule Detection and Routing Context:**
- `skills/git-workflow/tasks/cleanup.md` — Step 0: detect `.gitmodules`, build `submodule_paths` routing context
- `skills/divide-and-conquer/tasks/assemble-work.md` — Add `submodule_paths` to cleanup dispatch context

**Phase 2 — Submodule Issue Closure:**
- `skills/git-workflow/tasks/cleanup/issue-closure.md` — Step 8.5: route closure API calls to submodule owner/repo
- `skills/git-workflow/tasks/cleanup/verify-merge.md` — Repo detection context propagation

**Phase 3 — Submodule Branch Cleanup:**
- `skills/git-workflow/tasks/cleanup/branch-cleanup.md` — Step 1.9: submodule cleanup descent (sync, delete branches, tag-if-untagged)

**Phase 4 — Dev-Tip Verification:**
- `skills/git-workflow/tasks/cleanup.md` — Step 4: verify parent + all submodules on dev at origin/dev tip

## References

- Spec: opencode-config#76
- Plan: #541

Fixes opencode-config#76