### PR TITLE
fix: add verify-understanding to engineering-approach Invocation dispatch table (audit follow-up for #547)

### DIFF
--- a/skills/engineering-approach/SKILL.md
+++ b/skills/engineering-approach/SKILL.md
@@ -28,6 +28,7 @@ Engineering discipline checklist enforcing: understand before solving, design be
 
 | Task | Dispatch |
 |------|----------|
+| `verify-understanding` | `task(..., prompt: "execute verify-understanding task from engineering-approach")` |
 | `design-before-code` | `task(..., prompt: "execute design-before-code task from engineering-approach")` |
 | `verify-before-complete` | `task(..., prompt: "execute verify-before-complete task from engineering-approach")` |
 | `completion` | `task(..., prompt: "execute completion task from engineering-approach")` |


### PR DESCRIPTION
## Summary

Adversarial audit found that `engineering-approach/SKILL.md` Invocation dispatch table was missing the `verify-understanding` task entry (task exists in Tasks section, documented in Sub-Agent Dispatch Audit, but absent from the Invocation dispatch table).

### Change
- Added `verify-understanding` dispatch entry to the Invocation table

### Verification
- Dual cross-family adversarial audit: GLM-5 (PASS) + Kimi-K2 (PASS) — both independently verified the fix is correct
- All 4 tasks (verify-understanding, design-before-code, verify-before-complete, completion) present in both Tasks and Invocation sections
- CLI equivalent secondary notation preserved

Fixes audit finding from #548 review cycle

🤖 Co-authored with AI: OpenCode (ollama-cloud/deepseek-v4-flash)