### PR TITLE
feat(#555): sub-agent role identity rule + skill+task pipeline mandate

### DIFF
--- a/plugins/session-enforcement.ts
+++ b/plugins/session-enforcement.ts
@@ -816,7 +816,7 @@ function buildCorePrinciplesBlock(): string {
 3. **Mandatory skills** — \`/skill git-workflow\`, \`/skill divide-and-conquer\`, \`/skill verification-before-completion\`, \`/skill adversarial-audit\`. Not optional.
 4. **TDD Red/Green** — Approval→pre-work→audit spec/plan→RED(test+audit; fail→fix, pass→commit)→GREEN(impl+audit; fail→fix+restart, pass→commit)→final spec/plan audit.
 5. **Feedback ≠ Auth** — Feedback/clarification/technical input → update understanding, discuss, HALT. Never proceed to implementation.
-6. **Orchestrator = pure router** — Zero inline file work. Sub-agents do ALL ops, clean-room discipline.
+6. **Dispatch via \`skill()\` + \`task()\` is the PRIMARY execution model** — Load every skill with \`skill()\`, dispatch execution with \`task()\`. The orchestrator routes and dispatches only; it never executes. A dispatcher that reads SKILL.md files and executes steps inline is not a dispatcher — it is an agent working without enforcement gates. Professional orchestrators dispatch; amateurs inline.
 7. **Sub-agents are INTELLIGENT** — No bot-splaining, no tool-recipe dispatch. They read specs and use skills autonomously.
 8. **Verify LIVE** — Never trust training data, memory, or metadata. Always verify via live docs, direct inspection, and verified test results.`;
 }
@@ -828,7 +828,8 @@ function buildSubAgentPrinciplesBlock(): string {
 2. **TDD discipline** — RED phase tests before GREEN phase implementation.
 3. **Clean-room** — No inline fallback. If task context is contaminated (pre-determined findings, expected outcomes, orchestrator reasoning, tool recipes, line numbers), HALT and notify parent.
 4. **Independent intelligence** — You are an autonomous agent. If the task contains excessive bot-splaining, rote instructions, or leading questions where your own analysis should apply, HALT and notify parent.
-5. **Verify LIVE** — Never trust training data, memory, or metadata. Verify against live docs, direct inspection of source code/configs, and verified test results.`;
+5. **Verify LIVE** — Never trust training data, memory, or metadata. Verify against live docs, direct inspection of source code/configs, and verified test results.
+6. **Sub-agent role** — You are a sub-agent, not the orchestrator. Sub-agents execute single-step work units; orchestrators dispatch. A sub-agent that dispatches sub-agents is producing cascaded delegation instead of focused execution. If your assigned task requires sub-agent dispatch, return a \`NEEDS_ORCHESTRATOR\` status — the orchestrator will re-dispatch with the correct decomposition. Professional sub-agents execute their unit with focus; they do not become orchestrators.`;
 }
 
 function buildTier1EnforcementBlock(): string {


### PR DESCRIPTION
## Summary

Implements `.opencode#555` — two changes to the runtime guard principles blocks in `session-enforcement.ts`:

### Change A: Sub-Agent Principles — Rule 6 (Role Identity)

Adds a 6th rule to `buildSubAgentPrinciplesBlock()` that tells sub-agents what they are (not just how to behave). Uses confirmshaming-aligned prose per #622 — identity statement ("You are a sub-agent, not the orchestrator") rather than authority-frame prohibitions.

### Change B: Primary Principles — Rule 6 (Skill+Task Pipeline Mandate)

Replaces the existing Rule 6 ("Orchestrator = pure router") with a positive mandate: "Dispatch via `skill()` + `task()` is the PRIMARY execution model." Uses identity-reflection ("A dispatcher that reads SKILL.md files... is not a dispatcher") and closes with the confirmshaming signature phrase. No "NEVER" language.

## Outcome

- `approved-for-pr` label applied
- 1 commit (squashed)
- Branch: `feature/555-sub-agent-role-identity`
- Behavioral tests SC-11 and SC-12 run and pass via `opencode-cli run`
- Frame consistency scan (SC-14) — zero authority-frame language in either new rule

## Verification

| SC | Criterion | Status |
|----|-----------|--------|
| SC-1 | Sub-agent block returns 6 rules | ✅ Verified via read |
| SC-2 | Identity claim, no MUST NOT | ✅ Verified via read |
| SC-3 | NEEDS_ORCHESTRATOR return protocol | ✅ Verified via read |
| SC-4 | Identity-contrast closing | ✅ Verified via read |
| SC-5 | Primary block returns 8 rules (new Rule 6) | ✅ Verified via read |
| SC-6 | `skill()` + `task()` PRIMARY statement | ✅ Verified via read |
| SC-7 | Identity-reflection, no NEVER | ✅ Verified via read |
| SC-8 | Orchestrator routes/dispatches only | ✅ Verified via read |
| SC-9 | "Professional orchestrators dispatch; amateurs inline" | ✅ Verified via read |
| SC-10 | Rules 1-5, 7, 8 preserved unchanged | ✅ Verified via read |
| SC-11 | Behavioral: sub-agent output contains role identity | ✅ Verified via `opencode-cli run` |
| SC-12 | Behavioral: primary output references `skill()`/`task()` | ✅ Verified via `opencode-cli run` |
| SC-13 | Content verification: correct rule count and content | ✅ Verified via read |
| SC-14 | Frame consistency: no forbidden authority prose | ✅ Verified via grep scan |

## Evidence

Content verification: `plugins/session-enforcement.ts:819` (new primary Rule 6), `plugins/session-enforcement.ts:832` (new sub-agent Rule 6).

Behavioral evidence: SC-11 run produced sub-agent output with role identity; SC-12 run produced skill dispatch description with zero "NEVER"/"MUST NOT" occurrences.

---

🤖 Co-authored with AI: OpenCode (deepseek-v4-flash)