### PR TITLE
feat: implement dark-prose-007 (Cost-Frame Reformation) across 9 enforcement layers (#734)

### DIFF
--- a/guidelines/020-go-prohibitions.md
+++ b/guidelines/020-go-prohibitions.md
@@ -62,6 +62,8 @@ load_when: sub-agent
   - 🚫 FORBIDDEN: "Spot-checking" as a substitute for full behavioral test execution
   - 🚫 FORBIDDEN: Any sentence containing both a cost/speed/resource noun AND a verification-skip verb
 
+**Cost is measured in defect-discovery-latency, not model roundtrips.** Running verification costs minutes of execution time — a bounded delay that surfaces defects before they reach CI. Skipping a verification step to save a tool call costs the full pipeline of rework when the defect surfaces downstream: diagnosis, fix, re-review, re-CI, re-deploy — each of which costs more roundtrips than the skipped verification would have consumed. Correctness is the only success metric — there is no score for tool-call economy.
+
 ### Authorization-Free Actions — No Deliberation Required
 
 <!-- Issue #99: Authorization-Free Actions — Signal asymmetry fix -->

--- a/guidelines/250-dark-prose-reference.md
+++ b/guidelines/250-dark-prose-reference.md
@@ -47,6 +47,7 @@ Examples of PASSING (treats agent as professional):
 | `dark-prose-004` | Authority frame (Tier 1) | #624 | Tier 1 only |
 | `dark-prose-005` | Social proof / quality signal | #624 | Tier 3 only |
 | `dark-prose-006` | Agency-respecting identity frame | All | All tiers (meta-pattern) |
+| `dark-prose-007` | Cost-Frame Reformation | #734 | Tier 1+ |
 
 ### Anti-Patterns: What Dark Prose Is NOT
 
@@ -109,6 +110,7 @@ Multiple dark prose patterns addressing the same behavior with different formula
 | Correspondence (stakeholder communications) | Social proof / quality signal | Light | 005 |
 | CHANGELOG entries | Social proof / quality signal | Light | 005 |
 | Spec body / task definition (instruction layer) | Agency-respecting identity frame | Strong | 006 |
+| Cost-blind verification guidelines (`020-go-prohibitions.md`) | Cost-Frame Reformation | Strong | 007 |
 
 ## Section 3: Pattern Formulas (Canonical)
 
@@ -159,6 +161,16 @@ This pattern is used in spec bodies and task definitions where one agent instruc
 
 Example: "The Purpose section must carry identity-framing prose using the confirmshaming pattern (dark-prose-001). The implementing agent reads #627 Section 3 to derive the exact formulation — the specific consequence assertion must match the skill's domain. The compliance gate (#641) verifies correctness; the spec does not prescribe exact text."
 
+**dark-prose-007 — Cost-Frame Reformation (identity-frame):**
+```
+[Cost computation frame]: [metric labeled 'cost'] is measured in [correct unit], not [wrong unit].
+[Action cost]: [action] costs [magnitude] [unit] — [consequence if cost computed correctly].
+[Skipping-cost]: [skipped action] costs [magnitude] [unit] — [consequence if skip rationalized].
+[Identity anchor]: Correctness is the only success metric — there is no score for [wrong metric].
+```
+
+This pattern reframes the agent's internal cost model from tool-call-accounting to defect-discovery-latency. It replaces a procedural "don't compute cost that way" prohibition with an identity-grounded "cost IS latency-to-discovery" redefinition. The implementing agent reads the formula and derives location-specific prose autonomously — the specific consequences, magnitudes, and units must match the domain where the pattern is applied.
+
 ## Section 4: Non-Compliance Handling
 
 **DEFERRED**
@@ -180,6 +192,7 @@ When dark prose patterns overlap or conflict, the following rules apply:
 | Version | Date | SHA | Changes |
 |---------|------|-----|---------|
 | 1.0 | 2026-05-17 | `0000000000000000000000000000000000000000` | Initial catalog — all 6 patterns documented, 13-row matrix, version tracking established |
+| 1.1 | 2026-05-20 | `6ded65200bfe9b96fb448ab89ffa67a2c4284de8` | Added dark-prose-007 (Cost-Frame Reformation), 14-row matrix, cost-blind row in selection matrix, full formula in Section 3 |
 
 SHA format: 40-character lowercase hex SHA of the commit that introduced this version of the reference card. When a new version is committed, the SHA in this row is updated to match the commit hash.
 

--- a/skills/adversarial-audit/tasks/plan-fidelity.md
+++ b/skills/adversarial-audit/tasks/plan-fidelity.md
@@ -53,6 +53,7 @@ Otherwise, link from spec body.
 | PF-4 | No missing critical steps | Edge cases, error recovery included |
 | PF-5 | Approach consistent | Clean-room and existing use same strategy |
 | PF-6 | TDD checkpoints present | RED GREEN REFACTOR structure |
+| PF-7 | Cost-frame prose + runtime execution in instructions | Each phase's implementation instructions carry cost-frame reformation prose and require real test execution with saved artifacts |
 
 ### Step 4: Cross-Validate with Pre-Resolved Verdicts
 

--- a/skills/adversarial-audit/tasks/spec-audit.md
+++ b/skills/adversarial-audit/tasks/spec-audit.md
@@ -49,6 +49,7 @@ Define audit criteria based on spec-auditor task structure:
 | SC-9 | Determinism achieved | Repeatable execution path |
 | SC-10 | Prose structure valid | Headers, lists, tables properly formatted |
 | SC-11 | Documentation Sources present and populated | Non-empty Documentation Sources section with live-source verification evidence |
+| SC-12 | Cost-frame prose + runtime execution in SCs | Each SC carries cost-frame reformation language and requires a real test execution command, not a structural check |
 | SC-DET | SC Determinism | Each SC produces the same PASS/FAIL from any reasonable auditor |
 
 ### Step 3: Cross-Validate with Pre-Resolved Verdicts

--- a/skills/engineering-approach/tasks/verify-before-complete.md
+++ b/skills/engineering-approach/tasks/verify-before-complete.md
@@ -13,6 +13,16 @@ Enforce the verify-before-declaring-complete discipline per engineering-approach
 
 ## Procedure
 
+### Step 1a: Produce Saved Test Run Artifact
+
+Before declaring completion, produce a saved test run artifact file:
+```bash
+mkdir -p ./tmp/artifacts/
+uv run pytest test/ --junitxml=./tmp/artifacts/test-results.xml
+```
+
+The artifact file is the permanent record that runtime verification occurred. Without it, completion claims are unverifiable post-hoc — a skipped artifact equals an unverifiable completion.
+
 ### Step 1: Run Tests Manually
 
 Execute the test suite against the implementation. Do not assume tests pass based on code inspection alone.

--- a/skills/spec-creation/tasks/write.md
+++ b/skills/spec-creation/tasks/write.md
@@ -33,6 +33,8 @@ Before assembling the spec, invoke `verification-enforcement --task verify`. Thi
 
 **Cross-reference:** See `091-incremental-build.md` → Per-Item TDD Cycle → RED phase, `080-code-standards.md` → SC-to-Test Traceability and RED-Phase Ordering, and `080-code-standards.md` → Behavioral Enforcement Tests (PRIMARY) for the behavioral RED/GREEN gate.
 
+**Cost-frame mandate in SCs:** Each success criterion MUST carry a short cost-frame reformation statement that reframes what "expensive" means for that SC's domain. The statement uses the dark-prose-007 formula from `250-dark-prose-reference.md` §Section 3 — the implementing agent derives the exact prose autonomously based on the SC's verification method. Each SC's verification method MUST require a real test execution command — not a structural check (file exists, grep match). Structural verification is NEVER a valid substitute for behavioral execution: a skipped runtime equals a defect undiscovered.
+
 ### Step 0.5a: Behavioral Test Definition — Stderr-Based Evidence (MANDATORY)
 
 Valid behavioral enforcement tests use **stderr-based assertion helpers** (`assert_stderr_pattern_present`/`assert_stderr_pattern_absent_all_models`) to verify agent actions (skill dispatches, file reads, tool invocations). **Prose-recall prompts** (e.g., "Describe how you would resolve models") produce stdout prose, not behavioral evidence, and are NOT accepted as valid behavioral tests.

--- a/skills/verification-before-completion/tasks/collect.md
+++ b/skills/verification-before-completion/tasks/collect.md
@@ -11,6 +11,7 @@ For each missing criterion:
 | Need | Collection Method |
 |------|-------------------|
 | Test output? | Run test, capture output |
+| Test artifact output? | Run test with `--junitxml` or equivalent, save to `./tmp/artifacts/` | `./tmp/artifacts/test-results.xml` |
 | File creation? | Show file path and content hash |
 | Code change? | Show `git diff` output |
 | API response? | Show status code and body |

--- a/skills/verification-before-completion/tasks/verify.md
+++ b/skills/verification-before-completion/tasks/verify.md
@@ -142,6 +142,9 @@ Behavioral evidence confirms that implementation components **behave correctly**
 | API response | Status code and body | Issue comment + curl output | Behavioral SCs |
 | Screenshot | Visual verification | Issue comment + attachment | Behavioral SCs |
 | Behavioral test run | `opencode-cli run` output | Issue comment + log excerpt | Behavioral SCs |
+| Test artifact file | Saved test output in `./tmp/artifacts/` | `./tmp/artifacts/` file + issue comment | Behavioral SCs |
+
+Every behavioral SC's verification MUST produce a saved artifact file in `./tmp/artifacts/`. Chat-only output is INSUFFICIENT — structural evidence (file exists, grep match) is NEVER a valid substitute for skipped runtime execution. Ensure the directory exists: `mkdir -p ./tmp/artifacts/`.
 
 ### Invalid Evidence
 

--- a/skills/writing-plans/tasks/create.md
+++ b/skills/writing-plans/tasks/create.md
@@ -57,7 +57,7 @@ Writes plan header, stores as combined section or separate issue, creates sub-is
 Each phase MUST include (prose-driven, not rigid headers):
 - **Why this phase exists** — concern it addresses and place in overall design
 - **What it must accomplish** — tasks, deliverables, behavioral requirements
-- **How to verify completion** — success criteria and testable outcomes
+- **How to verify completion** — success criteria and testable outcomes. Each phase's verification guidance MUST carry cost-frame identity prose that reframes verification cost using the dark-prose-007 formula from `250-dark-prose-reference.md` §Section 3. Verification MUST require real test execution commands that produce saved artifact files in `./tmp/artifacts/`. Structural checks (file exists, grep match) are NEVER acceptable substitutes for behavioral runtime evidence — a skipped execution is a defect accepted at the point of verification.
 - **What could go wrong** — edge cases, known risks, failure modes
 - **What must be done first** — dependencies on prior phases or external prerequisites
 


### PR DESCRIPTION
## Summary

Defines **dark-prose-007 (Cost-Frame Reformation)** per spec #734: reframes "cost" from tool-call-count to defect-discovery-latency, then injects the mandate across all 9 enforcement layers of the verification pipeline.

## Changes

| Phase | File | Change |
|-------|------|--------|
| 1 | `250-dark-prose-reference.md` | Define dark-prose-007 (Section 1 row, Section 2 matrix row, Section 3 formula) |
| 2 | `020-go-prohibitions.md` | Insert cost-frame identity anchor block after cost-blind FORBIDDEN items |
| 3 | `spec-creation/tasks/write.md` | Step 0.5 — SC must carry cost-frame prose + real test execution |
| 4 | `writing-plans/tasks/create.md` | Plan Phase Structure — cost-frame prose + saved artifacts |
| 5 | `adversarial-audit/tasks/spec-audit.md` | SC-12 — cost-frame prose + runtime execution |
| 6 | `adversarial-audit/tasks/plan-fidelity.md` | PF-7 — cost-frame prose + runtime execution |
| 7 | `verification-before-completion/tasks/verify.md` | Test artifact file row + mandate paragraph |
| 8 | `verification-before-completion/tasks/collect.md` | Test artifact collection via `--junitxml` |
| 9 | `engineering-approach/tasks/verify-before-complete.md` | Step 1a — produce saved test run artifact |

## Commits

- 21b98cb8 — `feat: implement dark-prose-007 (Cost-Frame Reformation) across 9 enforcement layers (#734)`

Fixes #734
🤖 OpenCode (deepseek-v4-flash-free) ✅ completed