### PR TITLE
[SPEC] Intent and Executive Summary Preamble for Specs

### DIFF
--- a/guidelines/140-planning-spec-creation.md
+++ b/guidelines/140-planning-spec-creation.md
@@ -117,6 +117,7 @@ ______________________________________________________________________
 
 | Question | Why It Matters |
 | -- | -- |
+| Does the spec include an Intent and Executive Summary preamble with Problem Statement, Root Cause / Motivation, Approach Chosen, Alternatives Considered & Why Discarded, and Key Design Decisions? | Without this preamble, future readers cannot reconstruct the spec's rationale or understand why decisions were made |
 | Does the spec clearly state the problem it solves and why? | Without this, the reader doesn't know what they're solving or whether the solution addresses the right thing |
 | Does the spec provide enough context for someone with no prior knowledge? | Agents lack memory context; the spec must be self-contained |
 | Does the spec identify what constraints and assumptions apply? | Constraints shape the solution space; assumptions may be wrong and need verification |

--- a/guidelines/142-planning-archive-workflow.md
+++ b/guidelines/142-planning-archive-workflow.md
@@ -111,6 +111,18 @@ Creating a spec without completed investigation is a CRITICAL GUIDELINE VIOLATIO
 STATUS: 1.1
 CREATED: YYYY-MM-DD
 
+## Intent and Executive Summary
+
+**Problem Statement:** What problem does this spec solve? What is broken or missing?
+
+**Root Cause / Motivation:** Why is this change needed? What drove this decision?
+
+**Approach Chosen:** High-level description of the selected approach.
+
+**Alternatives Considered & Why Discarded:** What other approaches were evaluated and why were they not chosen?
+
+**Key Design Decisions:** What structural or architectural decisions were made and why?
+
 ---
 
 ## Phase 1: [Concern Name] (Gated)
@@ -165,10 +177,11 @@ ______________________________________________________________________
 
 Every spec file MUST include:
 
-1. **Title**: `# Spec: [Feature Name]`
-2. **STATUS Header**: `STATUS: phase.step` (e.g., `STATUS: 1.2`)
-3. **CREATED Date**: `CREATED: YYYY-MM-DD`
-4. **Numbered Phases**: Phase 1, Phase 2, Phase 3...
+1. **Intent and Executive Summary**: `## Intent and Executive Summary` section with all 5 fields (Problem Statement, Root Cause / Motivation, Approach Chosen, Alternatives Considered & Why Discarded, Key Design Decisions) — positioned as the first section after STATUS/CREATED header
+2. **Title**: `# Spec: [Feature Name]`
+3. **STATUS Header**: `STATUS: phase.step` (e.g., `STATUS: 1.2`)
+4. **CREATED Date**: `CREATED: YYYY-MM-DD`
+5. **Numbered Phases**: Phase 1, Phase 2, Phase 3...
 5. **Numbered Steps**: 1, 2, 3 within each phase
 6. **Status Markers**: `☐`/`↻`/`☑`/`☒` for each step
 7. **Byline Footer**: A footer line with AI attribution: `🤖 <AgentName> (<ModelId>) created`

--- a/guidelines/143-planning-spec-templates.md
+++ b/guidelines/143-planning-spec-templates.md
@@ -64,6 +64,18 @@ This minimal spec works because the change is small and self-explanatory. Separa
 
 ### Standard Feature Spec (moderate change, multiple files)
 
+> **Intent and Executive Summary**
+>
+> **Problem Statement:** Article metadata queries are slow, causing poor page load performance.
+>
+> **Root Cause / Motivation:** API calls average 150ms response time because queries hit PostgreSQL directly instead of a cache layer.
+>
+> **Approach Chosen:** Add Redis as a cache layer with 1-hour TTL and fallback to DB when Redis is unavailable.
+>
+> **Alternatives Considered & Why Discarded:** Memcached considered but Redis already deployed per infra team; in-memory cache rejected due to stateless deployment architecture.
+>
+> **Key Design Decisions:** 1-hour TTL balances freshness against cache hit rate; fallback to DB ensures availability over consistency.
+>
 > **Objective:** Add Redis caching layer for frequently accessed article metadata.
 >
 > **Problem:** Article metadata API calls average 150ms response time, causing slow page loads. 85% cache hit potential identified.
@@ -125,6 +137,18 @@ ______________________________________________________________________
 
 ### Standard Bug Fix Spec (needs investigation context)
 
+> **Intent and Executive Summary**
+>
+> **Problem Statement:** OAuth2 refresh_token expiry causes users to be unexpectedly logged out.
+>
+> **Root Cause / Motivation:** 15% of users who don't log in for more than 7 days are affected. Token expiry is not handled gracefully.
+>
+> **Approach Chosen:** Catch `TokenExpiredError` and re-authenticate with stored credentials.
+>
+> **Alternatives Considered & Why Discarded:** Extending token lifetime rejected for security reasons; forcing re-login rejected as poor UX.
+>
+> **Key Design Decisions:** Re-authenticate with stored credentials rather than prompting user; surface network/credential failures appropriately.
+>
 > **Problem:** OAuth2 refresh_token fails on expiry, causing unexpected logout for ≈15% of users who don't log in for more than 7 days.
 >
 > **Expected Behavior:** Automatically re-authenticate using stored credentials when refresh token expires.

--- a/guidelines/144-planning-spec-examples.md
+++ b/guidelines/144-planning-spec-examples.md
@@ -30,6 +30,18 @@ ______________________________________________________________________
 
 ### Standard Bug Report (needs investigation context)
 
+> **Intent and Executive Summary**
+>
+> **Problem Statement:** OAuth2 refresh_token expiry causes users to be unexpectedly logged out.
+>
+> **Root Cause / Motivation:** 15% of users who don't log in for more than 7 days are affected. Token expiry is not handled gracefully.
+>
+> **Approach Chosen:** Catch `TokenExpiredError` and re-authenticate with stored credentials.
+>
+> **Alternatives Considered & Why Discarded:** Extending token lifetime rejected for security reasons; forcing re-login rejected as poor UX.
+>
+> **Key Design Decisions:** Re-authenticate with stored credentials rather than prompting user; surface network/credential failures appropriately.
+>
 > **Problem:** OAuth2 refresh_token fails on expiry, causing unexpected logout for ≈15% of users who don't log in for more than 7 days.
 >
 > **Expected Behavior:** Automatically re-authenticate using stored credentials when refresh token expires.
@@ -77,6 +89,18 @@ ______________________________________________________________________
 
 ### Standard Feature Spec (multi-file change with dependencies)
 
+> **Intent and Executive Summary**
+>
+> **Problem Statement:** Article metadata queries are slow, causing poor page load performance.
+>
+> **Root Cause / Motivation:** API calls average 150ms response time because queries hit PostgreSQL directly instead of a cache layer.
+>
+> **Approach Chosen:** Add Redis as a cache layer with 1-hour TTL and fallback to DB when Redis is unavailable.
+>
+> **Alternatives Considered & Why Discarded:** Memcached considered but Redis already deployed per infra team; in-memory cache rejected due to stateless deployment architecture.
+>
+> **Key Design Decisions:** 1-hour TTL balances freshness against cache hit rate; fallback to DB ensures availability over consistency.
+>
 > **Objective:** Add Redis caching layer for frequently accessed article metadata.
 >
 > **Problem:** Article metadata API calls average 150ms response time, causing slow page loads. 85% cache hit potential identified.

--- a/skills/adversarial-audit/tasks/spec-audit.md
+++ b/skills/adversarial-audit/tasks/spec-audit.md
@@ -49,6 +49,7 @@ Define audit criteria based on spec-auditor task structure:
 | SC-9 | Determinism achieved | Repeatable execution path |
 | SC-10 | Prose structure valid | Headers, lists, tables properly formatted |
 | SC-11 | Documentation Sources present and populated | Non-empty Documentation Sources section with live-source verification evidence |
+| SC-12 | Preamble present | "## Intent and Executive Summary" section with all 5 fields (Problem Statement, Root Cause / Motivation, Approach Chosen, Alternatives Considered & Why Discarded, Key Design Decisions) present for standard+ specs; omitted is acceptable for minimal specs only |
 | SC-DET | SC Determinism | Each SC produces the same PASS/FAIL from any reasonable auditor |
 
 ### Step 3: Cross-Validate with Pre-Resolved Verdicts

--- a/skills/spec-creation/tasks/write.md
+++ b/skills/spec-creation/tasks/write.md
@@ -123,9 +123,9 @@ If the answer is "no", the SC must be rewritten.
 
 **Content coverage matters more than section structure.** The agent chooses the optimal structure for the spec's complexity:
 
-- **Simple specs** (bug fixes, one-file changes): May use a minimal format — Problem, Context, Fix, Criteria, Edge Cases — all in flowing prose without section headers
-- **Standard specs** (multi-file changes): May use typical sections — Objective, Problem, Context, Fix Approach, Success Criteria, Edge Cases
-- **Complex specs** (cross-cutting, multi-phase): May use full structure — Objective, Problem, Context, Affected Files, Fix Approach, Success Criteria, Edge Cases, Dependencies, Risk, Decision Rationale, Phases
+- **Minimal specs** (bug fixes, one-file changes): May use a minimal format — Problem, Context, Fix, Criteria, Edge Cases — all in flowing prose without section headers. Preamble is optional.
+- **Standard specs** (multi-file changes): May use typical sections — Intent and Executive Summary (mandatory), Objective, Problem, Context, Fix Approach, Success Criteria, Edge Cases. Include a `## Intent and Executive Summary` preamble with the 5 fields (Problem Statement, Root Cause / Motivation, Approach Chosen, Alternatives Considered & Why Discarded, Key Design Decisions) before the Objective section.
+- **Complex specs** (cross-cutting, multi-phase): May use full structure — Intent and Executive Summary (mandatory), Objective, Problem, Context, Affected Files, Fix Approach, Success Criteria, Edge Cases, Dependencies, Risk, Decision Rationale, Phases. Preamble is mandatory.
 
 **Any format that covers the required content areas is acceptable.** The agent decides the structure that best serves the specific spec.
 


### PR DESCRIPTION
## Summary

Add a structured `## Intent and Executive Summary` preamble section to the beginning of every spec, containing 5 fields: Problem Statement, Root Cause / Motivation, Approach Chosen, Alternatives Considered & Why Discarded, Key Design Decisions. Preamble is mandatory for standard+ complexity specs, optional for minimal/bug-fix.

## Outcome

All spec structure guidelines now list the preamble as the first section after STATUS/CREATED header. Templates, examples, the write task, and spec-audit criteria are all updated.

## Files Modified

| File | Change |
|------|--------|
| `guidelines/142-planning-archive-workflow.md` | Added preamble to canonical template (§6) and required elements list (§7) |
| `guidelines/140-planning-spec-creation.md` | Added preamble row to Content Coverage Questions (§1.1) |
| `guidelines/143-planning-spec-templates.md` | Added preamble to Standard Feature and Standard Bug Fix examples |
| `guidelines/144-planning-spec-examples.md` | Added preamble to Standard Bug Report and Standard Feature examples |
| `skills/spec-creation/tasks/write.md` | Added preamble as required section for standard+ complexity specs (Step 5) |
| `skills/adversarial-audit/tasks/spec-audit.md` | Added SC-12 preamble presence criterion (Step 2) |

Fixes #733