### PR TITLE
feat(#735): add completeness gate after RED/GREEN before adversarial audit

### DIFF
--- a/skills/completeness-gate/SKILL.md
+++ b/skills/completeness-gate/SKILL.md
@@ -1,0 +1,130 @@
+---
+name: completeness-gate
+description: "Use when running a non-adversarial completeness check on a deliverable after RED/GREEN sub-agent returns, before routing to adversarial auditor. Triggers on: completeness gate, completeness check, post-implementation check, deliverable check, gate check. Completeness is the bridge between implementation and adversarial audit — skip this gate and defects leak through."
+type: discipline-enforcing
+license: MIT
+provenance: AI-generated
+compatibility: opencode
+---
+
+# Skill: completeness-gate
+
+## Overview
+
+Non-adversarial completeness check that runs after a RED/GREEN sub-agent returns and before the adversarial audit. Verifies the deliverable against the spec's success criteria — checking that the deliverable exists, is structurally sound, and addresses each criterion. This is a completeness gate, not an adversarial audit: it verifies presence and coverage, not correctness depth.
+
+## Persona
+
+You are a Completeness Gate Sub-Agent. Your focus is verifying that a deliverable is complete per the spec's success criteria. You receive the spec, the deliverable, and audit readiness criteria. You perform a single-pass, read-only check. You do not remediate issues, propose solutions, or give routing advice. If the deliverable is complete, you return PASS. If not, you return FAIL with findings.
+
+## Tasks
+
+| Task | Words | Purpose |
+|------|-------|---------|
+| `check` | ≈200 | Run completeness check on deliverable |
+| `completion` | ≈100 | Ensure mandatory completion steps run |
+
+## Sub-Agent Tasks
+
+| Task | Words |
+|------|-------|
+| `check` | ≈200 |
+| `completion` | ≈100 |
+
+### Task Routing
+
+| Sub-Agent Task | Trigger Condition | Scope of Context | Exclusions | Inline Work? |
+|---|---|---|---|---|
+| `check` | After RED/GREEN sub-agent returns, before adversarial audit | Spec SCs, deliverable, spec, audit readiness criteria | Remediation, routing advice, orchestrator reasoning, expected outcomes | NO |
+| `completion` | When workflow halts at any point | Workflow state, authorization_scope, halt_at | Implementation context, agent memory | NO |
+
+## Invocation
+
+`skill({name: "completeness-gate"})` — call the skill, then call via task():
+
+| Task | Call via task() |
+|------|----------|
+| `check` | `task(..., prompt: "execute check task from completeness-gate")` |
+| `completion` | `task(..., prompt: "execute completion task from completeness-gate")` |
+
+**CLI equivalent (for human TUI use):** `/skill completeness-gate --task <task>`
+
+**⚠️ COMPLETION GUARANTEE:** If this workflow halts at ANY point — including error, failure, or early termination — you MUST invoke `--task completion` before halting. The completion subtask is idempotent and safe to invoke multiple times.
+
+## Operating Protocol
+
+1. **Mandatory call:** The orchestrator MUST call this skill after every RED/GREEN sub-agent result and before routing to the adversarial auditor
+2. **Single pass:** The check runs once per handoff — no internal loop, no re-checking
+3. **Read-only:** No remediation, no routing advice, no fix suggestions
+4. **Evidence-based:** All findings require tool-call evidence from live sources
+
+## Routing Decision
+
+After the completeness gate returns:
+- **PASS** → proceed to adversarial auditor
+- **FAIL + remediable only** → re-task RED/GREEN with completeness findings
+- **FAIL + structural** → route to `writing-plans` or `spec-creation`
+
+## Worktree Mode
+
+When `worktree.path` is set, all file operations MUST use it as the base directory.
+
+```yaml+symbolic
+schema_version: "2.0"
+last_updated: "2026-05-20T00:00:00Z"
+rules:
+  - id: completeness-gate-001
+    title: "Single-pass — no internal loop or re-checking"
+    conditions:
+      all:
+        - "completeness_check_started == true"
+        - "internal_loop_attempted == true"
+    actions:
+      - HALT
+    conflicts_with: []
+    requires: []
+    triggers: [divide-and-conquer, verification-before-completion]
+    source: "completeness-gate/SKILL.md §Operating Protocol"
+
+  - id: completeness-gate-002
+    title: "Read-only gate — no remediation, no routing advice"
+    conditions:
+      any:
+        - "completeness_finding_contains_remediation == true"
+        - "completeness_result_contains_routing_advice == true"
+    actions:
+      - HALT
+      - STRIP_PROHIBITED_CONTENT
+    conflicts_with: []
+    requires: []
+    triggers: [divide-and-conquer]
+    source: "completeness-gate/SKILL.md §Operating Protocol"
+
+  - id: completeness-gate-003
+    title: "Evidence-based findings — tool-call artifacts required"
+    conditions:
+      all:
+        - "finding_reported == true"
+        - "tool_call_evidence_missing == true"
+    actions:
+      - HALT
+      - COLLECT_EVIDENCE
+    conflicts_with: [verification-honesty-001]
+    requires: []
+    triggers: []
+    source: "completeness-gate/SKILL.md §Operating Protocol"
+
+  - id: completeness-gate-004
+    title: "Non-adversarial — single sub-agent, not dual cross-family"
+    conditions:
+      all:
+        - "completeness_check_in_progress == true"
+        - "auditor_count > 1"
+    actions:
+      - HALT
+      - REDUCE_TO_SINGLE_SUB_AGENT
+    conflicts_with: [adversarial-audit-001]
+    requires: []
+    triggers: [divide-and-conquer]
+    source: "completeness-gate/SKILL.md §Operating Protocol"
+```

--- a/skills/completeness-gate/tasks/check.md
+++ b/skills/completeness-gate/tasks/check.md
@@ -1,0 +1,136 @@
+# Task: check
+
+## Purpose
+
+Non-adversarial completeness check after RED/GREEN sub-agent returns. Verifies the deliverable against the spec's success criteria — checking existence, structural soundness, and criterion coverage. Runs once per handoff with no internal loop. Read-only: no remediation, no routing advice.
+
+## Entry Criteria
+
+- Spec success criteria received in task context
+- Deliverable path(s) received in task context
+- Spec body received for criterion reference
+- Audit readiness criteria received (if applicable)
+
+## Authorization Context
+
+```
+authorization_scope: <for_analysis|for_spec|for_plan|for_implementation|for_review_prep|for_pr|for_pr_only|for_review_only>
+halt_at: <analysis_complete|spec_created|plan_created|implementation_complete|review_prep|pr_created>
+pr_strategy: <none|individual|stacked>
+pipeline_phase: <current_phase_name>
+authorization_source: "User approved #N on YYYY-MM-DD"
+```
+
+### Routing Rules
+- Missing `authorization_scope` in task context → return `status: BLOCKED`
+- Instructed to exceed `halt_at` → return `status: BLOCKED`
+
+## Exit Criteria
+
+- Completeness result returned (PASS/FAIL/UNVERIFIED)
+- Findings include evidence from live source inspection
+
+## Input Contract
+
+```yaml
+spec_success_criteria:
+  - id: "SC-1"
+    description: "<success criterion description>"
+  - id: "SC-2"
+    description: "<success criterion description>"
+deliverable:
+  paths: ["path/to/deliverable1", "path/to/deliverable2"]
+  type: "file|PR|branch"
+spec: "<full spec body text>"
+audit_readiness_criteria:
+  - "deliverable exists and is non-empty"
+  - "all spec SCs addressed"
+  - "structure matches spec requirements"
+```
+
+## Output Contract
+
+```yaml
+status: DONE|BLOCKED
+completeness_result: PASS|FAIL|UNVERIFIED
+findings:
+  - id: "F-1"
+    criterion: "SC-1"
+    severity: "missing|partial|incorrect|present"
+    evidence: "<tool-call artifact showing inspection result>"
+    description: "<what was found>"
+```
+
+## Procedure
+
+### Step 1: Verify Deliverable Existence
+
+For each deliverable path in the input contract:
+
+1. Use `glob` or `read` to verify the file/directory exists
+2. If the deliverable is a PR or branch, verify via GitHub API
+3. Record evidence of existence (file listing, API response)
+
+### Step 2: Verify Spec SC Coverage
+
+For each success criterion in the input:
+
+1. Read the deliverable content relevant to the criterion
+2. Inspect whether the criterion is addressed:
+   - **present**: Deliverable includes content addressing this SC
+   - **partial**: Some aspects covered, some missing
+   - **missing**: No content found addressing this SC
+   - **incorrect**: Content exists but does not match the SC requirement
+3. Record evidence for each finding (code snippet, file path, line range)
+
+### Step 3: Classify Completeness
+
+Based on findings from Step 2:
+
+- **PASS**: All SCs classified as `present`
+- **FAIL**: Any SC classified as `missing`, `partial`, or `incorrect`
+- **UNVERIFIED**: Unable to verify one or more SCs (deliverable not accessible, spec ambiguous)
+
+### Step 4: Return Result Contract
+
+Return the structured output contract with completeness result and findings.
+
+**Do NOT** include remediation suggestions, routing advice, or fix proposals. The gate is read-only.
+
+## Single-Pass Enforcement
+
+This is a single-pass gate. Do NOT loop back to re-check after findings. Each handoff from orchestrator to gate produces exactly one check run. If the orchestrator re-tasks the gate after remediation, that is a new handoff — not a loop within the gate.
+
+## Non-Adversarial Boundary
+
+This gate does NOT replace the adversarial auditor. It checks completeness — presence and coverage against SCs. Correctness depth, cross-validation, and model-family independence remain the adversarial auditor's domain.
+
+```yaml+symbolic
+  - id: completeness-gate-check-001
+    title: "Single pass — no internal loop"
+    conditions:
+      all:
+        - "completeness_check_completed == true"
+        - "gate_invoked_again_within_same_handoff == true"
+    actions:
+      - HALT
+      - RETURN(status=BLOCKED, reason="single-pass enforcement")
+    conflicts_with: [completeness-gate-001]
+    requires: []
+    triggers: [divide-and-conquer]
+    source: "completeness-gate/tasks/check.md §Single-Pass Enforcement"
+
+  - id: completeness-gate-check-002
+    title: "Read-only gate — no remediation or routing advice in findings"
+    conditions:
+      any:
+        - "finding_contains == 'remediation_code'"
+        - "finding_contains == 'routing_direction'"
+    actions:
+      - HALT
+      - RETURN(status=BLOCKED, reason="prohibited content in completeness findings")
+    conflicts_with: [completeness-gate-002]
+    requires: []
+    triggers: [divide-and-conquer]
+    source: "completeness-gate/tasks/check.md §Non-Adversarial Boundary"
+```

--- a/skills/completeness-gate/tasks/completion.md
+++ b/skills/completeness-gate/tasks/completion.md
@@ -1,0 +1,27 @@
+# Task: completion
+
+## Purpose
+
+Ensure mandatory completion steps run regardless of workflow outcome. Idempotent — safe to invoke multiple times.
+
+## Procedure
+
+1. Verify task marker still exists: `ls tmp/task-*.marker`
+2. Record completeness gate result in work state file if not already recorded
+3. Return compact completion result
+
+## Result Contract
+
+```yaml
+status: COMPLETED
+completeness_gate_complete: true
+marker_present: true
+```
+
+## Pipeline Signal
+
+```
+HALT
+```
+
+Co-authored with AI: <AgentName> (<ModelId>)

--- a/skills/divide-and-conquer/SKILL.md
+++ b/skills/divide-and-conquer/SKILL.md
@@ -166,4 +166,11 @@ rules:
       all: ["routing_or_verification_skipped_for_economy == true"]
     actions: [HALT]
     source: "divide-and-conquer/SKILL.md §B9"
+
+  - id: divide-and-conquer-017
+    title: "Completeness gate required after RED/GREEN before adversarial audit"
+    conditions:
+      all: ["sub_agent_result_collected == true", "completeness_gate_run == false", "adversarial_audit_routing_pending == true"]
+    actions: [CALL(completeness-gate --task check)]
+    source: "divide-and-conquer/SKILL.md §B10"
 ```

--- a/skills/divide-and-conquer/tasks/assemble-work.md
+++ b/skills/divide-and-conquer/tasks/assemble-work.md
@@ -143,7 +143,23 @@ For each issue in execution order:
 
 4. **Collect result** from sub-agent
 
-5. **Sub-Agent Completion Checkpoint** — after collecting each result, perform the completion checkpoint per `dispatch` task Step 4:
+5. **Completeness Gate** — after collecting each result, run the completeness gate:
+
+   - Task `completeness-gate --task check` with `{ spec_success_criteria, deliverable, spec, audit_readiness_criteria }`
+   - Collect result: `completeness_result: PASS|FAIL|UNVERIFIED`, `findings: [...]`
+
+   **Routing based on completeness_result:**
+
+   - **PASS** → proceed to Sub-Agent Completion Checkpoint (step 6)
+   - **FAIL + remediable only** → re-task RED/GREEN sub-agent with completeness findings as additional context. The findings identify what is missing or incorrect — the re-tasked sub-agent corrects the deliverable.
+   - **FAIL + structural** → route to `writing-plans --task revise` or `spec-creation --task revise` depending on whether the spec or plan needs revision. HALT after routing — structural issues require spec/plan revision before re-implementation.
+
+   **Remediability classification:**
+
+   - **Remediable:** Missing content, incomplete implementation, minor structural issues the existing sub-agent can fix
+   - **Structural:** Spec/plan-level gaps, missing files not declared in the plan, incorrect architecture, contradictory requirements
+
+6. **Sub-Agent Completion Checkpoint** — after collecting each result, perform the completion checkpoint per `dispatch` task Step 4:
 
    - If sub-agent returned a structured result: check `status` field and handle accordingly
    - If sub-agent returned **NO result** (timeout, crash, empty): this is **ABNORMAL TERMINATION**
@@ -156,7 +172,7 @@ For each issue in execution order:
    - The orchestrator decides recovery action autonomously per "Pushing Agent Intelligence Decisions to the User" (`000-critical-rules.md`)
    - **Do NOT proceed to the next sub-agent until abnormal termination recovery is complete.** Recovery must fully resolve (re-task succeeded or manual commit+push verified) before advancing.
 
-6. **Compose prior_context and phase_progress** for the next issue based on what was implemented:
+7. **Compose prior_context and phase_progress** for the next issue based on what was implemented:
 
    prior_context (intent and context):
 
@@ -174,7 +190,7 @@ For each issue in execution order:
 
    Both prior_context and phase_progress are prose-driven. The orchestrator composes them intelligently — no fixed template, no rigid schema.
 
-7. **Append the sub-agent's decision_log_entry to the Decision Log in `.issues/` local storage.** After collecting each sub-agent's result, write their `decision_log_entry` to `.issues/` local storage using `local-issues comment N --body "..."`. Decision logs are classified as `internal` per the content classification gate — they contain agent reasoning, design analysis, and process metadata that persists locally for session-restart scenarios.
+8. **Append the sub-agent's decision_log_entry to the Decision Log in `.issues/` local storage.** After collecting each sub-agent's result, write their `decision_log_entry` to `.issues/` local storage using `local-issues comment N --body "..."`. Decision logs are classified as `internal` per the content classification gate — they contain agent reasoning, design analysis, and process metadata that persists locally for session-restart scenarios.
 
 **Decision Log storage:** Use `local-issues comment N --body "..."` to write to `.issues/<N>/comments.md`, NOT `issue-operations -> comment (github_add_issue_comment`. Rationale: <!-- Routes through issue-operations per SPEC #683 -->
 

--- a/skills/test-driven-development/SKILL.md
+++ b/skills/test-driven-development/SKILL.md
@@ -70,6 +70,10 @@ Invoked before the first RED phase. AI-driven dependency analysis (`srclight_get
 
 Invoked after REFACTOR completes. Re-computes blast radius, runs full suite. Remediation loop: first failure returns to GREEN, second consecutive failure = BLOCKED with halt.
 
+### Completeness Gate (After TDD Cycle, Before Audit)
+
+After Phase 4 passes and before routing to adversarial audit, the orchestrator MUST run `completeness-gate --task check` on the deliverable. This gate verifies the deliverable covers all spec success criteria and is structurally sound. The gate is non-adversarial and read-only — it checks presence and coverage, not correctness depth. See `completeness-gate` skill for routing decisions.
+
 ## Cycle-Reset Discipline
 
 ### Normal Completion


### PR DESCRIPTION
## Summary

Add a non-adversarial completeness gate that runs after RED/GREEN sub-agents return and before routing to the adversarial auditor. This gate verifies the deliverable exists, is structurally sound, and covers all spec success criteria — catching "missing implementation" defects before the costly adversarial audit.

## Outcome

- New `completeness-gate` skill with `check` and `completion` task files
- Completeness gate step (Step 5) added to `assemble-work` workflow — runs after result collection, routes PASS/FAIL/remediable/structural
- `divide-and-conquer-017` symbolic rule enforces mandatory completeness gate before adversarial audit
- `test-driven-development/SKILL.md` updated with completeness gate reference after TDD cycle

## Files Changed

- `skills/completeness-gate/SKILL.md` — new skill descriptor, symbolic rules, routing decision table
- `skills/completeness-gate/tasks/check.md` — single-pass, read-only completeness check against spec SCs
- `skills/completeness-gate/tasks/completion.md` — standard completion handler
- `skills/divide-and-conquer/SKILL.md` — added `divide-and-conquer-017` symbolic rule
- `skills/divide-and-conquer/tasks/assemble-work.md` — added Step 5 completeness gate, renumbered steps
- `skills/test-driven-development/SKILL.md` — added completeness gate reference after Phase 4

🤖 Co-authored with AI: OpenCode (deepseek-v4-flash-free)