### PR TITLE
feat: specs #733-#736 + structural-evidence rejection gate (#765)

### DIFF
--- a/guidelines/020-go-prohibitions.md
+++ b/guidelines/020-go-prohibitions.md
@@ -62,6 +62,8 @@ load_when: sub-agent
   - 🚫 FORBIDDEN: "Spot-checking" as a substitute for full behavioral test execution
   - 🚫 FORBIDDEN: Any sentence containing both a cost/speed/resource noun AND a verification-skip verb
 
+**Cost is measured in defect-discovery-latency, not model roundtrips.** Running verification costs minutes of execution time — a bounded delay that surfaces defects before they reach CI. Skipping a verification step to save a tool call costs the full pipeline of rework when the defect surfaces downstream: diagnosis, fix, re-review, re-CI, re-deploy — each of which costs more roundtrips than the skipped verification would have consumed. Correctness is the only success metric — there is no score for tool-call economy.
+
 ### Authorization-Free Actions — No Deliberation Required
 
 <!-- Issue #99: Authorization-Free Actions — Signal asymmetry fix -->

--- a/guidelines/140-planning-spec-creation.md
+++ b/guidelines/140-planning-spec-creation.md
@@ -117,6 +117,7 @@ ______________________________________________________________________
 
 | Question | Why It Matters |
 | -- | -- |
+| Does the spec include an Intent and Executive Summary preamble with Problem Statement, Root Cause / Motivation, Approach Chosen, Alternatives Considered & Why Discarded, and Key Design Decisions? | Without this preamble, future readers cannot reconstruct the spec's rationale or understand why decisions were made |
 | Does the spec clearly state the problem it solves and why? | Without this, the reader doesn't know what they're solving or whether the solution addresses the right thing |
 | Does the spec provide enough context for someone with no prior knowledge? | Agents lack memory context; the spec must be self-contained |
 | Does the spec identify what constraints and assumptions apply? | Constraints shape the solution space; assumptions may be wrong and need verification |

--- a/guidelines/142-planning-archive-workflow.md
+++ b/guidelines/142-planning-archive-workflow.md
@@ -111,6 +111,18 @@ Creating a spec without completed investigation is a CRITICAL GUIDELINE VIOLATIO
 STATUS: 1.1
 CREATED: YYYY-MM-DD
 
+## Intent and Executive Summary
+
+**Problem Statement:** What problem does this spec solve? What is broken or missing?
+
+**Root Cause / Motivation:** Why is this change needed? What drove this decision?
+
+**Approach Chosen:** High-level description of the selected approach.
+
+**Alternatives Considered & Why Discarded:** What other approaches were evaluated and why were they not chosen?
+
+**Key Design Decisions:** What structural or architectural decisions were made and why?
+
 ---
 
 ## Phase 1: [Concern Name] (Gated)
@@ -165,10 +177,11 @@ ______________________________________________________________________
 
 Every spec file MUST include:
 
-1. **Title**: `# Spec: [Feature Name]`
-2. **STATUS Header**: `STATUS: phase.step` (e.g., `STATUS: 1.2`)
-3. **CREATED Date**: `CREATED: YYYY-MM-DD`
-4. **Numbered Phases**: Phase 1, Phase 2, Phase 3...
+1. **Intent and Executive Summary**: `## Intent and Executive Summary` section with all 5 fields (Problem Statement, Root Cause / Motivation, Approach Chosen, Alternatives Considered & Why Discarded, Key Design Decisions) — positioned as the first section after STATUS/CREATED header
+2. **Title**: `# Spec: [Feature Name]`
+3. **STATUS Header**: `STATUS: phase.step` (e.g., `STATUS: 1.2`)
+4. **CREATED Date**: `CREATED: YYYY-MM-DD`
+5. **Numbered Phases**: Phase 1, Phase 2, Phase 3...
 5. **Numbered Steps**: 1, 2, 3 within each phase
 6. **Status Markers**: `☐`/`↻`/`☑`/`☒` for each step
 7. **Byline Footer**: A footer line with AI attribution: `🤖 <AgentName> (<ModelId>) created`

--- a/guidelines/143-planning-spec-templates.md
+++ b/guidelines/143-planning-spec-templates.md
@@ -64,6 +64,18 @@ This minimal spec works because the change is small and self-explanatory. Separa
 
 ### Standard Feature Spec (moderate change, multiple files)
 
+> **Intent and Executive Summary**
+>
+> **Problem Statement:** Article metadata queries are slow, causing poor page load performance.
+>
+> **Root Cause / Motivation:** API calls average 150ms response time because queries hit PostgreSQL directly instead of a cache layer.
+>
+> **Approach Chosen:** Add Redis as a cache layer with 1-hour TTL and fallback to DB when Redis is unavailable.
+>
+> **Alternatives Considered & Why Discarded:** Memcached considered but Redis already deployed per infra team; in-memory cache rejected due to stateless deployment architecture.
+>
+> **Key Design Decisions:** 1-hour TTL balances freshness against cache hit rate; fallback to DB ensures availability over consistency.
+>
 > **Objective:** Add Redis caching layer for frequently accessed article metadata.
 >
 > **Problem:** Article metadata API calls average 150ms response time, causing slow page loads. 85% cache hit potential identified.
@@ -125,6 +137,18 @@ ______________________________________________________________________
 
 ### Standard Bug Fix Spec (needs investigation context)
 
+> **Intent and Executive Summary**
+>
+> **Problem Statement:** OAuth2 refresh_token expiry causes users to be unexpectedly logged out.
+>
+> **Root Cause / Motivation:** 15% of users who don't log in for more than 7 days are affected. Token expiry is not handled gracefully.
+>
+> **Approach Chosen:** Catch `TokenExpiredError` and re-authenticate with stored credentials.
+>
+> **Alternatives Considered & Why Discarded:** Extending token lifetime rejected for security reasons; forcing re-login rejected as poor UX.
+>
+> **Key Design Decisions:** Re-authenticate with stored credentials rather than prompting user; surface network/credential failures appropriately.
+>
 > **Problem:** OAuth2 refresh_token fails on expiry, causing unexpected logout for ≈15% of users who don't log in for more than 7 days.
 >
 > **Expected Behavior:** Automatically re-authenticate using stored credentials when refresh token expires.

--- a/guidelines/144-planning-spec-examples.md
+++ b/guidelines/144-planning-spec-examples.md
@@ -30,6 +30,18 @@ ______________________________________________________________________
 
 ### Standard Bug Report (needs investigation context)
 
+> **Intent and Executive Summary**
+>
+> **Problem Statement:** OAuth2 refresh_token expiry causes users to be unexpectedly logged out.
+>
+> **Root Cause / Motivation:** 15% of users who don't log in for more than 7 days are affected. Token expiry is not handled gracefully.
+>
+> **Approach Chosen:** Catch `TokenExpiredError` and re-authenticate with stored credentials.
+>
+> **Alternatives Considered & Why Discarded:** Extending token lifetime rejected for security reasons; forcing re-login rejected as poor UX.
+>
+> **Key Design Decisions:** Re-authenticate with stored credentials rather than prompting user; surface network/credential failures appropriately.
+>
 > **Problem:** OAuth2 refresh_token fails on expiry, causing unexpected logout for ≈15% of users who don't log in for more than 7 days.
 >
 > **Expected Behavior:** Automatically re-authenticate using stored credentials when refresh token expires.
@@ -77,6 +89,18 @@ ______________________________________________________________________
 
 ### Standard Feature Spec (multi-file change with dependencies)
 
+> **Intent and Executive Summary**
+>
+> **Problem Statement:** Article metadata queries are slow, causing poor page load performance.
+>
+> **Root Cause / Motivation:** API calls average 150ms response time because queries hit PostgreSQL directly instead of a cache layer.
+>
+> **Approach Chosen:** Add Redis as a cache layer with 1-hour TTL and fallback to DB when Redis is unavailable.
+>
+> **Alternatives Considered & Why Discarded:** Memcached considered but Redis already deployed per infra team; in-memory cache rejected due to stateless deployment architecture.
+>
+> **Key Design Decisions:** 1-hour TTL balances freshness against cache hit rate; fallback to DB ensures availability over consistency.
+>
 > **Objective:** Add Redis caching layer for frequently accessed article metadata.
 >
 > **Problem:** Article metadata API calls average 150ms response time, causing slow page loads. 85% cache hit potential identified.

--- a/guidelines/250-dark-prose-reference.md
+++ b/guidelines/250-dark-prose-reference.md
@@ -47,6 +47,7 @@ Examples of PASSING (treats agent as professional):
 | `dark-prose-004` | Authority frame (Tier 1) | #624 | Tier 1 only |
 | `dark-prose-005` | Social proof / quality signal | #624 | Tier 3 only |
 | `dark-prose-006` | Agency-respecting identity frame | All | All tiers (meta-pattern) |
+| `dark-prose-007` | Cost-Frame Reformation | #734 | Tier 1+ |
 
 ### Anti-Patterns: What Dark Prose Is NOT
 
@@ -109,6 +110,7 @@ Multiple dark prose patterns addressing the same behavior with different formula
 | Correspondence (stakeholder communications) | Social proof / quality signal | Light | 005 |
 | CHANGELOG entries | Social proof / quality signal | Light | 005 |
 | Spec body / task definition (instruction layer) | Agency-respecting identity frame | Strong | 006 |
+| Cost-blind verification guidelines (`020-go-prohibitions.md`) | Cost-Frame Reformation | Strong | 007 |
 
 ## Section 3: Pattern Formulas (Canonical)
 
@@ -159,6 +161,16 @@ This pattern is used in spec bodies and task definitions where one agent instruc
 
 Example: "The Purpose section must carry identity-framing prose using the confirmshaming pattern (dark-prose-001). The implementing agent reads #627 Section 3 to derive the exact formulation — the specific consequence assertion must match the skill's domain. The compliance gate (#641) verifies correctness; the spec does not prescribe exact text."
 
+**dark-prose-007 — Cost-Frame Reformation (identity-frame):**
+```
+[Cost computation frame]: [metric labeled 'cost'] is measured in [correct unit], not [wrong unit].
+[Action cost]: [action] costs [magnitude] [unit] — [consequence if cost computed correctly].
+[Skipping-cost]: [skipped action] costs [magnitude] [unit] — [consequence if skip rationalized].
+[Identity anchor]: Correctness is the only success metric — there is no score for [wrong metric].
+```
+
+This pattern reframes the agent's internal cost model from tool-call-accounting to defect-discovery-latency. It replaces a procedural "don't compute cost that way" prohibition with an identity-grounded "cost IS latency-to-discovery" redefinition. The implementing agent reads the formula and derives location-specific prose autonomously — the specific consequences, magnitudes, and units must match the domain where the pattern is applied.
+
 ## Section 4: Non-Compliance Handling
 
 **DEFERRED**
@@ -180,6 +192,7 @@ When dark prose patterns overlap or conflict, the following rules apply:
 | Version | Date | SHA | Changes |
 |---------|------|-----|---------|
 | 1.0 | 2026-05-17 | `0000000000000000000000000000000000000000` | Initial catalog — all 6 patterns documented, 13-row matrix, version tracking established |
+| 1.1 | 2026-05-20 | `6ded65200bfe9b96fb448ab89ffa67a2c4284de8` | Added dark-prose-007 (Cost-Frame Reformation), 14-row matrix, cost-blind row in selection matrix, full formula in Section 3 |
 
 SHA format: 40-character lowercase hex SHA of the commit that introduced this version of the reference card. When a new version is committed, the SHA in this row is updated to match the commit hash.
 

--- a/skills/adversarial-audit/tasks/drift-detection.md
+++ b/skills/adversarial-audit/tasks/drift-detection.md
@@ -60,6 +60,7 @@ target_files = extract_file_paths_from_spec(spec["body"])
 | DD-3 | No extra implementation | No untracked files |
 | DD-4 | Function signatures match | Spec API matches code API |
 | DD-5 | Edge cases covered | All edge cases implemented |
+| DD-STRUCTURAL-FAIL | Structural evidence rejected for behavioral SC drift | If drift evidence reports SC as PASS using structural-only evidence (grep/read/file-exists) when the SC describes behavior, return FAIL with `STRUCTURAL_EVIDENCE` classification. Structural checks do NOT verify behavioral correctness — they only verify existence. |
 
 ### Step 4: Scan Implementation
 

--- a/skills/adversarial-audit/tasks/plan-fidelity.md
+++ b/skills/adversarial-audit/tasks/plan-fidelity.md
@@ -53,6 +53,8 @@ Otherwise, link from spec body.
 | PF-4 | No missing critical steps | Edge cases, error recovery included |
 | PF-5 | Approach consistent | Clean-room and existing use same strategy |
 | PF-6 | TDD checkpoints present | RED GREEN REFACTOR structure |
+| PF-7 | Cost-frame prose + runtime execution in instructions | Each phase's implementation instructions carry cost-frame reformation prose and require real test execution with saved artifacts |
+| PF-STRUCTURAL-FAIL | Structural evidence rejected for behavioral SCs in plan instructions | If a plan phase's verification instructions accept structural evidence (grep/read/file-exists) for a behavioral SC, return FAIL with `STRUCTURAL_EVIDENCE` classification. Verification instructions MUST require behavioral test execution — structural checks do not verify behavior. |
 
 ### Step 4: Cross-Validate with Pre-Resolved Verdicts
 

--- a/skills/adversarial-audit/tasks/spec-audit.md
+++ b/skills/adversarial-audit/tasks/spec-audit.md
@@ -49,6 +49,9 @@ Define audit criteria based on spec-auditor task structure:
 | SC-9 | Determinism achieved | Repeatable execution path |
 | SC-10 | Prose structure valid | Headers, lists, tables properly formatted |
 | SC-11 | Documentation Sources present and populated | Non-empty Documentation Sources section with live-source verification evidence |
+| SC-12 | Preamble present | "## Intent and Executive Summary" section with all 5 fields (Problem Statement, Root Cause / Motivation, Approach Chosen, Alternatives Considered & Why Discarded, Key Design Decisions) present for standard+ specs; omitted is acceptable for minimal specs only |
+| SC-13 | Cost-frame prose + runtime execution in SCs | Each SC carries cost-frame reformation language and requires a real test execution command, not a structural check |
+| SC-STRUCTURAL-FAIL | Structural evidence rejected for behavioral SCs | If an SC describes testable behavior (correctness, output, result, pass/fail, runtime logic) but verification evidence is purely structural (grep/read/file-exists), return FAIL with `STRUCTURAL_EVIDENCE` classification. Structural checks do NOT verify correct behavior — they only verify existence. Exception: non-testable prose changes (docs, runbooks, guidelines) may use semantic intent verification by direct AI agent read — NOT grep/pattern matching. |
 | SC-DET | SC Determinism | Each SC produces the same PASS/FAIL from any reasonable auditor |
 
 ### Step 3: Cross-Validate with Pre-Resolved Verdicts

--- a/skills/completeness-gate/SKILL.md
+++ b/skills/completeness-gate/SKILL.md
@@ -1,0 +1,130 @@
+---
+name: completeness-gate
+description: "Use when running a non-adversarial completeness check on a deliverable after RED/GREEN sub-agent returns, before routing to adversarial auditor. Triggers on: completeness gate, completeness check, post-implementation check, deliverable check, gate check. Completeness is the bridge between implementation and adversarial audit — skip this gate and defects leak through."
+type: discipline-enforcing
+license: MIT
+provenance: AI-generated
+compatibility: opencode
+---
+
+# Skill: completeness-gate
+
+## Overview
+
+Non-adversarial completeness check that runs after a RED/GREEN sub-agent returns and before the adversarial audit. Verifies the deliverable against the spec's success criteria — checking that the deliverable exists, is structurally sound, and addresses each criterion. This is a completeness gate, not an adversarial audit: it verifies presence and coverage, not correctness depth.
+
+## Persona
+
+You are a Completeness Gate Sub-Agent. Your focus is verifying that a deliverable is complete per the spec's success criteria. You receive the spec, the deliverable, and audit readiness criteria. You perform a single-pass, read-only check. You do not remediate issues, propose solutions, or give routing advice. If the deliverable is complete, you return PASS. If not, you return FAIL with findings.
+
+## Tasks
+
+| Task | Words | Purpose |
+|------|-------|---------|
+| `check` | ≈200 | Run completeness check on deliverable |
+| `completion` | ≈100 | Ensure mandatory completion steps run |
+
+## Sub-Agent Tasks
+
+| Task | Words |
+|------|-------|
+| `check` | ≈200 |
+| `completion` | ≈100 |
+
+### Task Routing
+
+| Sub-Agent Task | Trigger Condition | Scope of Context | Exclusions | Inline Work? |
+|---|---|---|---|---|
+| `check` | After RED/GREEN sub-agent returns, before adversarial audit | Spec SCs, deliverable, spec, audit readiness criteria | Remediation, routing advice, orchestrator reasoning, expected outcomes | NO |
+| `completion` | When workflow halts at any point | Workflow state, authorization_scope, halt_at | Implementation context, agent memory | NO |
+
+## Invocation
+
+`skill({name: "completeness-gate"})` — call the skill, then call via task():
+
+| Task | Call via task() |
+|------|----------|
+| `check` | `task(..., prompt: "execute check task from completeness-gate")` |
+| `completion` | `task(..., prompt: "execute completion task from completeness-gate")` |
+
+**CLI equivalent (for human TUI use):** `/skill completeness-gate --task <task>`
+
+**⚠️ COMPLETION GUARANTEE:** If this workflow halts at ANY point — including error, failure, or early termination — you MUST invoke `--task completion` before halting. The completion subtask is idempotent and safe to invoke multiple times.
+
+## Operating Protocol
+
+1. **Mandatory call:** The orchestrator MUST call this skill after every RED/GREEN sub-agent result and before routing to the adversarial auditor
+2. **Single pass:** The check runs once per handoff — no internal loop, no re-checking
+3. **Read-only:** No remediation, no routing advice, no fix suggestions
+4. **Evidence-based:** All findings require tool-call evidence from live sources
+
+## Routing Decision
+
+After the completeness gate returns:
+- **PASS** → proceed to adversarial auditor
+- **FAIL + remediable only** → re-task RED/GREEN with completeness findings
+- **FAIL + structural** → route to `writing-plans` or `spec-creation`
+
+## Worktree Mode
+
+When `worktree.path` is set, all file operations MUST use it as the base directory.
+
+```yaml+symbolic
+schema_version: "2.0"
+last_updated: "2026-05-20T00:00:00Z"
+rules:
+  - id: completeness-gate-001
+    title: "Single-pass — no internal loop or re-checking"
+    conditions:
+      all:
+        - "completeness_check_started == true"
+        - "internal_loop_attempted == true"
+    actions:
+      - HALT
+    conflicts_with: []
+    requires: []
+    triggers: [divide-and-conquer, verification-before-completion]
+    source: "completeness-gate/SKILL.md §Operating Protocol"
+
+  - id: completeness-gate-002
+    title: "Read-only gate — no remediation, no routing advice"
+    conditions:
+      any:
+        - "completeness_finding_contains_remediation == true"
+        - "completeness_result_contains_routing_advice == true"
+    actions:
+      - HALT
+      - STRIP_PROHIBITED_CONTENT
+    conflicts_with: []
+    requires: []
+    triggers: [divide-and-conquer]
+    source: "completeness-gate/SKILL.md §Operating Protocol"
+
+  - id: completeness-gate-003
+    title: "Evidence-based findings — tool-call artifacts required"
+    conditions:
+      all:
+        - "finding_reported == true"
+        - "tool_call_evidence_missing == true"
+    actions:
+      - HALT
+      - COLLECT_EVIDENCE
+    conflicts_with: [verification-honesty-001]
+    requires: []
+    triggers: []
+    source: "completeness-gate/SKILL.md §Operating Protocol"
+
+  - id: completeness-gate-004
+    title: "Non-adversarial — single sub-agent, not dual cross-family"
+    conditions:
+      all:
+        - "completeness_check_in_progress == true"
+        - "auditor_count > 1"
+    actions:
+      - HALT
+      - REDUCE_TO_SINGLE_SUB_AGENT
+    conflicts_with: [adversarial-audit-001]
+    requires: []
+    triggers: [divide-and-conquer]
+    source: "completeness-gate/SKILL.md §Operating Protocol"
+```

--- a/skills/completeness-gate/tasks/check.md
+++ b/skills/completeness-gate/tasks/check.md
@@ -1,0 +1,136 @@
+# Task: check
+
+## Purpose
+
+Non-adversarial completeness check after RED/GREEN sub-agent returns. Verifies the deliverable against the spec's success criteria — checking existence, structural soundness, and criterion coverage. Runs once per handoff with no internal loop. Read-only: no remediation, no routing advice.
+
+## Entry Criteria
+
+- Spec success criteria received in task context
+- Deliverable path(s) received in task context
+- Spec body received for criterion reference
+- Audit readiness criteria received (if applicable)
+
+## Authorization Context
+
+```
+authorization_scope: <for_analysis|for_spec|for_plan|for_implementation|for_review_prep|for_pr|for_pr_only|for_review_only>
+halt_at: <analysis_complete|spec_created|plan_created|implementation_complete|review_prep|pr_created>
+pr_strategy: <none|individual|stacked>
+pipeline_phase: <current_phase_name>
+authorization_source: "User approved #N on YYYY-MM-DD"
+```
+
+### Routing Rules
+- Missing `authorization_scope` in task context → return `status: BLOCKED`
+- Instructed to exceed `halt_at` → return `status: BLOCKED`
+
+## Exit Criteria
+
+- Completeness result returned (PASS/FAIL)
+- Findings include evidence from live source inspection
+
+## Input Contract
+
+```yaml
+spec_success_criteria:
+  - id: "SC-1"
+    description: "<success criterion description>"
+  - id: "SC-2"
+    description: "<success criterion description>"
+deliverable:
+  paths: ["path/to/deliverable1", "path/to/deliverable2"]
+  type: "file|PR|branch"
+spec: "<full spec body text>"
+audit_readiness_criteria:
+  - "deliverable exists and is non-empty"
+  - "all spec SCs addressed"
+  - "structure matches spec requirements"
+```
+
+## Output Contract
+
+```yaml
+status: DONE|BLOCKED
+completeness_result: PASS|FAIL
+findings:
+  - id: "F-1"
+    criterion: "SC-1"
+    severity: "missing|partial|incorrect|present"
+    evidence: "<tool-call artifact showing inspection result>"
+    description: "<what was found>"
+```
+
+## Procedure
+
+### Step 1: Verify Deliverable Existence
+
+For each deliverable path in the input contract:
+
+1. Use `glob` or `read` to verify the file/directory exists
+2. If the deliverable is a PR or branch, verify via GitHub API
+3. Record evidence of existence (file listing, API response)
+
+### Step 2: Verify Spec SC Coverage
+
+For each success criterion in the input:
+
+1. Read the deliverable content relevant to the criterion
+2. Inspect whether the criterion is addressed:
+   - **present**: Deliverable includes content addressing this SC
+   - **partial**: Some aspects covered, some missing
+   - **missing**: No content found addressing this SC
+   - **incorrect**: Content exists but does not match the SC requirement
+3. Record evidence for each finding (code snippet, file path, line range)
+
+### Step 3: Classify Completeness
+
+Based on findings from Step 2:
+
+- **PASS**: All SCs classified as `present`
+- **FAIL**: Any SC classified as `missing`, `partial`, or `incorrect`
+
+
+### Step 4: Return Result Contract
+
+Return the structured output contract with completeness result and findings.
+
+**Do NOT** include remediation suggestions, routing advice, or fix proposals. The gate is read-only.
+
+## Single-Pass Enforcement
+
+This is a single-pass gate. Do NOT loop back to re-check after findings. Each handoff from orchestrator to gate produces exactly one check run. If the orchestrator re-tasks the gate after remediation, that is a new handoff — not a loop within the gate.
+
+## Non-Adversarial Boundary
+
+This gate does NOT replace the adversarial auditor. It checks completeness — presence and coverage against SCs. Correctness depth, cross-validation, and model-family independence remain the adversarial auditor's domain.
+
+```yaml+symbolic
+  - id: completeness-gate-check-001
+    title: "Single pass — no internal loop"
+    conditions:
+      all:
+        - "completeness_check_completed == true"
+        - "gate_invoked_again_within_same_handoff == true"
+    actions:
+      - HALT
+      - RETURN(status=BLOCKED, reason="single-pass enforcement")
+    conflicts_with: [completeness-gate-001]
+    requires: []
+    triggers: [divide-and-conquer]
+    source: "completeness-gate/tasks/check.md §Single-Pass Enforcement"
+
+  - id: completeness-gate-check-002
+    title: "Read-only gate — no remediation or routing advice in findings"
+    conditions:
+      any:
+        - "finding_contains == 'remediation_code'"
+        - "finding_contains == 'routing_direction'"
+    actions:
+      - HALT
+      - RETURN(status=BLOCKED, reason="prohibited content in completeness findings")
+    conflicts_with: [completeness-gate-002]
+    requires: []
+    triggers: [divide-and-conquer]
+    source: "completeness-gate/tasks/check.md §Non-Adversarial Boundary"
+```

--- a/skills/completeness-gate/tasks/completion.md
+++ b/skills/completeness-gate/tasks/completion.md
@@ -1,0 +1,27 @@
+# Task: completion
+
+## Purpose
+
+Ensure mandatory completion steps run regardless of workflow outcome. Idempotent — safe to invoke multiple times.
+
+## Procedure
+
+1. Verify task marker still exists: `ls tmp/task-*.marker`
+2. Record completeness gate result in work state file if not already recorded
+3. Return compact completion result
+
+## Result Contract
+
+```yaml
+status: COMPLETED
+completeness_gate_complete: true
+marker_present: true
+```
+
+## Pipeline Signal
+
+```
+HALT
+```
+
+Co-authored with AI: <AgentName> (<ModelId>)

--- a/skills/divide-and-conquer/SKILL.md
+++ b/skills/divide-and-conquer/SKILL.md
@@ -166,4 +166,11 @@ rules:
       all: ["routing_or_verification_skipped_for_economy == true"]
     actions: [HALT]
     source: "divide-and-conquer/SKILL.md §B9"
+
+  - id: divide-and-conquer-017
+    title: "Completeness gate required after RED/GREEN before adversarial audit"
+    conditions:
+      all: ["sub_agent_result_collected == true", "completeness_gate_run == false", "adversarial_audit_routing_pending == true"]
+    actions: [CALL(completeness-gate --task check)]
+    source: "divide-and-conquer/SKILL.md §B10"
 ```

--- a/skills/divide-and-conquer/tasks/assemble-work.md
+++ b/skills/divide-and-conquer/tasks/assemble-work.md
@@ -128,22 +128,53 @@ For each issue in execution order:
 
    ````
 
-2. **Spawn sub-agent** via `task(subagent_type=..., prompt=...)`
-   - For non-audit tasks: use `task(subagent_type="general")`
-   - For audit/verification tasks (keywords: `audit`, `cross-validate`, `verify`, `spec-audit`, `plan-fidelity`): use `subagent_type` from resolve-models result contract (`result.auditor_1`/`result.auditor_2`) — NOT `"general"`. See adversarial-audit SKILL.md §DISPATCH_GATE.
 
-3. **Sub-agent responsibilities:**
+2. **Spawn RED sub-agent** — writes tests only:
 
    - Load spec + session context + prior context
-   - Run `divide-and-conquer` skill for the specific issue
-   - Make WIP commits as needed
+   - Run `test-driven-development` skill for RED phase
+   - Return structured result: `{status, test_files, test_assertions, summary}`
+
+3. **Collect result** from RED sub-agent
+
+4. **Completeness Gate (RED)** — after RED sub-agent completes, run the completeness gate before routing to GREEN:
+
+   - Task `completeness-gate --task check` with `{ spec_success_criteria, deliverable: test_artifacts, spec, audit_readiness_criteria }`
+   - Collect result: `completeness_result: PASS|FAIL`, `findings: [...]`
+
+   **Routing based on completeness_result (RED):**
+
+   - **PASS** → proceed to GREEN sub-agent (step 5)
+   - **FAIL + remediable only** → re-task RED sub-agent with completeness findings as additional context — the findings identify tests missing or incorrect
+   - **FAIL + structural** → route to `spec-creation --task revise` or `writing-plans --task revise`. HALT — structural issues require spec/plan revision before re-implementation.
+
+5. **Spawn GREEN sub-agent** — implements code only:
+
+   - Load spec + session context + prior context + RED test outputs
+   - Run `test-driven-development` skill for GREEN phase
    - Run `verification-before-completion --task verify`
    - Run `finishing-a-development-branch --task checklist`
-   - Return structured result: `{status, files_changed, summary}`
+   - Return structured result: `{status, files_changed, implementation_summary}`
 
-4. **Collect result** from sub-agent
+6. **Collect result** from GREEN sub-agent
 
-5. **Sub-Agent Completion Checkpoint** — after collecting each result, perform the completion checkpoint per `dispatch` task Step 4:
+7. **Completeness Gate (GREEN)** — after GREEN sub-agent completes, run the completeness gate before routing to the adversarial auditor:
+
+   - Task `completeness-gate --task check` with `{ spec_success_criteria, deliverable: implementation_artifacts, spec, audit_readiness_criteria }`
+   - Collect result: `completeness_result: PASS|FAIL`, `findings: [...]`
+
+   **Routing based on completeness_result (GREEN):**
+
+   - **PASS** → proceed to Sub-Agent Completion Checkpoint (step 8)
+   - **FAIL + remediable only** → re-task GREEN sub-agent with completeness findings as additional context. The findings identify what is missing or incorrect — the re-tasked sub-agent corrects the deliverable.
+   - **FAIL + structural** → route to `writing-plans --task revise` or `spec-creation --task revise` depending on whether the spec or plan needs revision. HALT after routing — structural issues require spec/plan revision before re-implementation.
+
+   **Remediability classification:**
+
+   - **Remediable:** Missing content, incomplete implementation, minor structural issues the existing sub-agent can fix
+   - **Structural:** Spec/plan-level gaps, missing files not declared in the plan, incorrect architecture, contradictory requirements
+
+8. **Sub-Agent Completion Checkpoint** — after collecting each result, perform the completion checkpoint per `dispatch` task Step 4:
 
    - If sub-agent returned a structured result: check `status` field and handle accordingly
    - If sub-agent returned **NO result** (timeout, crash, empty): this is **ABNORMAL TERMINATION**
@@ -156,7 +187,7 @@ For each issue in execution order:
    - The orchestrator decides recovery action autonomously per "Pushing Agent Intelligence Decisions to the User" (`000-critical-rules.md`)
    - **Do NOT proceed to the next sub-agent until abnormal termination recovery is complete.** Recovery must fully resolve (re-task succeeded or manual commit+push verified) before advancing.
 
-6. **Compose prior_context and phase_progress** for the next issue based on what was implemented:
+9. **Compose prior_context and phase_progress** for the next issue based on what was implemented:
 
    prior_context (intent and context):
 
@@ -174,7 +205,7 @@ For each issue in execution order:
 
    Both prior_context and phase_progress are prose-driven. The orchestrator composes them intelligently — no fixed template, no rigid schema.
 
-7. **Append the sub-agent's decision_log_entry to the Decision Log in `.issues/` local storage.** After collecting each sub-agent's result, write their `decision_log_entry` to `.issues/` local storage using `local-issues comment N --body "..."`. Decision logs are classified as `internal` per the content classification gate — they contain agent reasoning, design analysis, and process metadata that persists locally for session-restart scenarios.
+11. **Append the sub-agent's decision_log_entry to the Decision Log in `.issues/` local storage.** After collecting each sub-agent's result, write their `decision_log_entry` to `.issues/` local storage using `local-issues comment N --body "..."`. Decision logs are classified as `internal` per the content classification gate — they contain agent reasoning, design analysis, and process metadata that persists locally for session-restart scenarios.
 
 **Decision Log storage:** Use `local-issues comment N --body "..."` to write to `.issues/<N>/comments.md`, NOT `issue-operations -> comment (github_add_issue_comment`. Rationale: <!-- Routes through issue-operations per SPEC #683 -->
 
@@ -187,9 +218,9 @@ For each issue in execution order:
 
 The orchestrator writes the decision log entry after each sub-agent returns. If writing fails, log the failure and continue — the Decision Log is a durability enhancement, not a blocking gate. The `decision_log_entry` is also returned in the sub-agent result for immediate use by subsequent task()s within the same session.
 
-09. **Mark prior issue's branch as frozen** — no rebasing, amending, or force-pushing
+12. **Mark prior issue's branch as frozen** — no rebasing, amending, or force-pushing
 
-10. **Handle failures:**
+13. **Handle failures:**
 
 - If sub-agent fails: record failure
 - For independent issues: continue to next issue

--- a/skills/engineering-approach/tasks/verify-before-complete.md
+++ b/skills/engineering-approach/tasks/verify-before-complete.md
@@ -13,6 +13,18 @@ Enforce the verify-before-declaring-complete discipline per engineering-approach
 
 ## Procedure
 
+### Step 1a: Produce Saved Test Run Artifact
+
+Before declaring completion, produce a saved test run artifact file:
+```bash
+mkdir -p ./tmp/artifacts/
+uv run pytest test/ --junitxml=./tmp/artifacts/test-results.xml
+```
+
+The artifact file is the permanent record that runtime verification occurred. Without it, completion claims are unverifiable post-hoc — a skipped artifact equals an unverifiable completion.
+
+**Cost frame:** Verification cost is measured in defect-discovery-latency, not tool-call count. A skipped artifact means a post-hoc-unverifiable completion — the defect is now discovered at review time instead of verification time, at a multiplier of the original cost. Correctness is the only success metric — there is no score for tool-call economy. Running `uv run pytest --junitxml` costs minutes of execution. A single defect reaching post-merge remediation costs the full pipeline of diagnosis, rework, re-review, re-CI, re-deploy — each roundtrip more expensive than any verification run.
+
 ### Step 1: Run Tests Manually
 
 Execute the test suite against the implementation. Do not assume tests pass based on code inspection alone.

--- a/skills/git-workflow/tasks/pr-creation/create-pr.md
+++ b/skills/git-workflow/tasks/pr-creation/create-pr.md
@@ -2,6 +2,8 @@
 
 ## Purpose
 
+PR body creation IS verification evidence publishing. Every PR body requires preceding verification PASS. No valid PR exists without verification evidence embedded in the body — a PR without evidence is a PR that carries undiscovered defects into the codebase.
+
 Create the pull request after squash/push, collect sub-issues, generate PR body, and extract PR URL from API response.
 
 ## Entry Criteria
@@ -17,6 +19,71 @@ Create the pull request after squash/push, collect sub-issues, generate PR body,
 - Agent HALTs waiting for human merge
 
 ## Procedure
+
+### Step 4.5: Read Source Artifacts
+
+The Summary section MUST be sourced from the issue ticket body that authorized the work — not from agent memory, free-form paraphrasing, or implementation details.
+
+**Summary Sourcing Rule:**
+1. Route through `issue-operations --task read-issue` on the parent issue
+2. Extract the core problem statement or intent from the issue body
+3. Rephrase into 1-2 succinct sentences describing stakeholder impact
+4. NEVER use direct `github_issue_read` calls — all issue reads MUST route through the `issue-operations` dispatcher per `000-critical-rules.md` §critical-rules-platform-routing-bypass
+
+**Forbidden:**
+- Direct `github_*` calls bypassing `issue-operations` dispatcher
+- Free-form paraphrasing from agent memory of what was implemented
+- Implementation-detail summaries ("Added a method to class X that validates Y")
+- Hallucinated intent not present in the source issue
+
+**Data Flow:**
+
+| Body Section | Source | Access Method |
+|--------------|--------|---------------|
+| **Summary** | Issue ticket body (spec/plan issue for this PR) | `issue-operations --task read-issue` on parent issue |
+| **Outcome** | Issue ticket body + implementation knowledge | Synthesized from issue body + changesets |
+| **Per-SC Evidence** | VbC verification report | `read ./tmp/artifacts/verification-*.md` |
+| **Dual-Auditor Cross-Validation** | Cross-validate result contract | `read ./tmp/artifacts/audit-cross-validate-*.json` |
+| **Tracking references** | Sub-issues from parent | `issue-operations --task read-sub-issues` on parent issue |
+
+### Step 4.75: Verification-Evidence-Check Gate
+
+The verification-evidence check is a gate, not a banner. A PR without evidence is not a PR with a warning label — it is a PR that does not exist. The create-pr sub-agent that produces an unverified PR is not creating a deliverable; it is routing a defect into the codebase under a label that no reviewer will read. Every unverified PR that reaches a reviewer is a quality failure that verification should have caught. No valid PR exists without a preceding verification PASS — the gate is the identity, not the label.
+
+**Before proceeding to Step 5, check that required verification artifacts exist:**
+
+1. Check `./tmp/artifacts/verification-*.md` exists and contains PASS for all SCs
+2. Check `./tmp/artifacts/audit-cross-validate-*.json` exists and reports consensus PASS from both auditors
+3. If any artifact is MISSING or reports FAIL: do NOT create a PR
+
+**Blocked State (Missing or Failing Verification Evidence):**
+
+If verification or audit evidence is missing or reports FAIL, return BLOCKED status with structured defect list:
+
+```
+Status: BLOCKED
+Gate: verification-evidence-check
+Blockers:
+  - [MISSING|FAIL] <path> — <description>
+    <details>
+remediation: "<action to remediate>"
+next_step: "remediate then re-audit"
+```
+
+Example:
+```
+Status: BLOCKED
+Gate: verification-evidence-check
+Blockers:
+  - [MISSING] ./tmp/artifacts/verification-*.md — VbC evidence not found
+  - [FAIL] ./tmp/artifacts/audit-cross-validate-*.json — auditor consensus reports FAIL
+    SC-1: Auditor 1 PASS, Auditor 2 FAIL
+    Remediation: Re-audit SC-1 with fresh model pair
+remediation: "Run verification-before-completion --task verify, then adversarial-audit before retrying PR creation"
+next_step: "remediate then re-audit"
+```
+
+**No PR is created in this state.** The orchestrator receives the BLOCKED contract and routes to remediation.
 
 ### Step 5: Collect Sub-Issues (Multi-Task Specs)
 
@@ -46,12 +113,27 @@ github_create_pull_request(
     title="[SPEC] <description>",
     body="""**Summary:**
 
-<1-2 sentences describing impact and stakeholder value>
+<1-2 sentences describing impact and stakeholder value, sourced from issue body via issue-operations --task read-issue>
 
 **Outcome:** <What changed for stakeholders>
 
-Fixes #<parent>
-Fixes #<child1>
+**Verification Attestation:** All success criteria verified PASS — exact-match against live evidence. Dual independent auditors from different model families returned consensus PASS on every criterion. No caveats. No qualifications. Every PASS is a binary exact match. This deliverable is ready for merge.
+
+**Detail: Per-SC Evidence**
+
+| SC ID | Success Criterion | Command | Result |
+|-------|-------------------|---------|--------|
+| SC-1 | ... | ... | PASS |
+| SC-2 | ... | ... | PASS |
+
+**Detail: Dual-Auditor Cross-Validation**
+
+| Criterion | Auditor 1 | Auditor 2 | Consensus |
+|-----------|-----------|-----------|-----------|
+| SC-1 | PASS | PASS | PASS |
+| SC-2 | PASS | PASS | PASS |
+
+Implements #<parent>
 """,
     head=branch_name,
     base="dev"
@@ -66,9 +148,14 @@ Fixes #<child1>
 
 ### PR Body Requirements
 
-- **Summary** section: 1-2 sentences describing stakeholder value (NOT implementation details)
+A Summary sourced from the issue ticket through the issue-operations dispatcher is what correct attribution looks like. A free-formed summary means the reviewer cannot verify intent against the authorizing issue — the summary is an unverifiable assertion. Professional-grade PRs derive their Summary from the authorizing issue; bodies that fabricate it introduce scope the reviewer never approved.
+
+- **Summary** section: 1-2 sentences describing stakeholder value (NOT implementation details) — sourced from issue body via `issue-operations --task read-issue`
 - **Outcome** section: What changed for stakeholders
-- `Fixes #N` annotations at bottom (informational — autoclose is inert for `dev` merges)
+- **Verification Attestation**: Binary PASS language — no caveats, no justifications, no false-fail remediation language
+- **Per-SC Evidence Table**: SC ID, Success Criterion, Command, Result columns
+- **Dual-Auditor Cross-Validation Table**: Criterion, Auditor 1, Auditor 2, Consensus columns
+- `Fixes #N` or `Implements #N` annotations at bottom (informational — autoclose is inert for `dev` merges)
 - Target branch is `dev` for feature work
 
 **Use `Implements #N` instead of `Fixes #N` when the issue has sub-issues or is part of a plan-bridge hierarchy.**
@@ -87,9 +174,11 @@ Ensures specs are audited for plan fidelity before implementation, catching miss
 **Outcome:** Developers will catch spec quality issues before code changes begin.
 
 Fixes #505
-
+```
 
 ### Step 6.5: Verify Byline in PR Body (MANDATORY)
+
+The byline is the authorship check — the verification table is the quality check. A PR body with a byline but without verification evidence is incomplete — it carries authorship attribution without quality attestation. The implementing agent reads #627 Section 3 to derive the exact confirmshaming formula; the consequence assertion must match the PR domain. The verification evidence tables in this PR body satisfy the quality check requirement.
 
 **Before calling the PR creation API, verify the PR body contains an AI co-authored byline.**
 
@@ -97,15 +186,15 @@ All AI-authored PR bodies MUST contain one of the following byline patterns:
 
 | Format | Pattern |
 |--------|---------|
-| Emoji format | `🤖 Co-authored with AI: \u003cAgentName\u003e (\u003cModelId\u003e)` |
-| Non-emoji format | `Co-authored with AI: \u003cAgentName\u003e (\u003cModelId\u003e)` |
+| Emoji format | `🤖 Co-authored with AI: <AgentName> (<ModelId>)` |
+| Non-emoji format | `Co-authored with AI: <AgentName> (<ModelId>)` |
 
 **Verification:**
 1. Scan the assembled PR `body` string for `Co-authored with AI:` before the API call
 2. If missing: append a byline footer to the body:
 
 ```
-🤖 Co-authored with AI: \u003cAgentName\u003e (\u003cModelId\u003e)
+🤖 Co-authored with AI: <AgentName> (<ModelId>)
 ```
 
 3. If present: proceed to the API call

--- a/skills/spec-creation/tasks/write.md
+++ b/skills/spec-creation/tasks/write.md
@@ -33,6 +33,8 @@ Before assembling the spec, invoke `verification-enforcement --task verify`. Thi
 
 **Cross-reference:** See `091-incremental-build.md` → Per-Item TDD Cycle → RED phase, `080-code-standards.md` → SC-to-Test Traceability and RED-Phase Ordering, and `080-code-standards.md` → Behavioral Enforcement Tests (PRIMARY) for the behavioral RED/GREEN gate.
 
+**Cost-frame mandate in SCs:** Each success criterion MUST carry a short cost-frame reformation statement that reframes what "expensive" means for that SC's domain. The statement uses the dark-prose-007 formula from `250-dark-prose-reference.md` §Section 3 — the implementing agent derives the exact prose autonomously based on the SC's verification method. Each SC's verification method MUST require a real test execution command — not a structural check (file exists, grep match). Structural verification is NEVER a valid substitute for behavioral execution: a skipped runtime equals a defect undiscovered.
+
 ### Step 0.5a: Behavioral Test Definition — Stderr-Based Evidence (MANDATORY)
 
 Valid behavioral enforcement tests use **stderr-based assertion helpers** (`assert_stderr_pattern_present`/`assert_stderr_pattern_absent_all_models`) to verify agent actions (skill dispatches, file reads, tool invocations). **Prose-recall prompts** (e.g., "Describe how you would resolve models") produce stdout prose, not behavioral evidence, and are NOT accepted as valid behavioral tests.
@@ -123,9 +125,9 @@ If the answer is "no", the SC must be rewritten.
 
 **Content coverage matters more than section structure.** The agent chooses the optimal structure for the spec's complexity:
 
-- **Simple specs** (bug fixes, one-file changes): May use a minimal format — Problem, Context, Fix, Criteria, Edge Cases — all in flowing prose without section headers
-- **Standard specs** (multi-file changes): May use typical sections — Objective, Problem, Context, Fix Approach, Success Criteria, Edge Cases
-- **Complex specs** (cross-cutting, multi-phase): May use full structure — Objective, Problem, Context, Affected Files, Fix Approach, Success Criteria, Edge Cases, Dependencies, Risk, Decision Rationale, Phases
+- **Minimal specs** (bug fixes, one-file changes): May use a minimal format — Problem, Context, Fix, Criteria, Edge Cases — all in flowing prose without section headers. Preamble is optional.
+- **Standard specs** (multi-file changes): May use typical sections — Intent and Executive Summary (mandatory), Objective, Problem, Context, Fix Approach, Success Criteria, Edge Cases. Include a `## Intent and Executive Summary` preamble with the 5 fields (Problem Statement, Root Cause / Motivation, Approach Chosen, Alternatives Considered & Why Discarded, Key Design Decisions) before the Objective section.
+- **Complex specs** (cross-cutting, multi-phase): May use full structure — Intent and Executive Summary (mandatory), Objective, Problem, Context, Affected Files, Fix Approach, Success Criteria, Edge Cases, Dependencies, Risk, Decision Rationale, Phases. Preamble is mandatory.
 
 **Any format that covers the required content areas is acceptable.** The agent decides the structure that best serves the specific spec.
 

--- a/skills/test-driven-development/SKILL.md
+++ b/skills/test-driven-development/SKILL.md
@@ -70,6 +70,10 @@ Invoked before the first RED phase. AI-driven dependency analysis (`srclight_get
 
 Invoked after REFACTOR completes. Re-computes blast radius, runs full suite. Remediation loop: first failure returns to GREEN, second consecutive failure = BLOCKED with halt.
 
+### Completeness Gate (After TDD Cycle, Before Audit)
+
+After Phase 4 passes and before routing to adversarial audit, the orchestrator MUST run `completeness-gate --task check` on the deliverable. This gate verifies the deliverable covers all spec success criteria and is structurally sound. The gate is non-adversarial and read-only — it checks presence and coverage, not correctness depth. See `completeness-gate` skill for routing decisions.
+
 ## Cycle-Reset Discipline
 
 ### Normal Completion

--- a/skills/verification-before-completion/tasks/collect.md
+++ b/skills/verification-before-completion/tasks/collect.md
@@ -4,16 +4,26 @@ Collect evidence for incomplete success criteria when verification identifies ga
 
 ## Process
 
+**EVIDENCE COLLECTION CLASSIFICATION:** All evidence collection defaults to Tier 1 (behavioral/functional test execution). Tier 2 (structural grep/read) is ONLY acceptable for explicit metadata/existence SCs.
+
+| Tier | Classification | Default | Acceptable For |
+|------|---------------|---------|----------------|
+| 1 | Behavioral/Functional Test Execution | **DEFAULT — ALL SCs** | Any SC. REQUIRED for behavioral SCs (anything describing behavior, correctness, output, result, pass/fail) |
+| 2 | Structural Existence Check | OPT-IN REQUIRED | Only metadata/existence SCs: "file X exists", "label Y present", "header Z present" |
+
+**🚫 FAIL RULE:** If evidence collection uses Tier 2 (structural grep/read) for a Tier 1 SC (behavioral/correctness/output), the collection MUST be reclassified as FAIL with `STRUCTURAL_EVIDENCE` classification. The agent MUST re-run collection using behavioral test execution.
+
 For each missing criterion:
 
 ### 1. Identify What Evidence Is Needed
 
-| Need | Collection Method |
-|------|-------------------|
-| Test output? | Run test, capture output |
-| File creation? | Show file path and content hash |
-| Code change? | Show `git diff` output |
-| API response? | Show status code and body |
+| Need | Tier | Collection Method |
+|------|------|-------------------|
+| Test output? | 1 — REQUIRED | Run test, capture output |
+| Test artifact output? | 1 — REQUIRED | Run test with `--junitxml` or equivalent, save to `./tmp/artifacts/` |
+| File creation? | 2 — OPT-IN ONLY | Show file path and content hash |
+| Code change? | 2 — OPT-IN ONLY | Show `git diff` output |
+| API response? | 1 — REQUIRED | Show status code and body |
 
 ### 2. Collect Evidence
 

--- a/skills/verification-before-completion/tasks/verify.md
+++ b/skills/verification-before-completion/tasks/verify.md
@@ -117,31 +117,30 @@ authorization_source: "User approved #N on YYYY-MM-DD"
 
 **AUTHORITY:** `000-critical-rules.md` §Model-Aware Clean-Room task(), Spec #262
 
-## Evidence Types
+## Evidence Types — STRUCTURAL EVIDENCE IS ALWAYS FAIL FOR CODE CHANGES (ZERO TOLERANCE)
 
-### Structural Evidence (Valid for Structural SCs ONLY)
+**🚫 STRUCTURAL EVIDENCE (grep/read/file-exists) IS NEVER ACCEPTABLE FOR TESTABLE CODE.**
 
-Structural evidence confirms that implementation components **exist** — files, functions, config entries, yaml blocks. It does NOT confirm that they **behave correctly**.
+If the change modifies behavior, logic, or executable code, ALL success criteria require behavioral/functional/regression test execution as evidence. grep, read, ls, file-existence, content-checking are NOT evidence of correct behavior — they are evidence that text was written. Code that exists but produces wrong output is indistinguishable from code that does not exist until you run it.
 
-| Type | Description | Storage | Valid For |
-| -- | -- | -- | -- |
-| File path | Created file exists | Issue comment + `ls -la` | Structural SCs only |
-| File content | File content hash | Issue comment + `head -20` | Structural SCs only |
-| Git diff | Code changes | Issue comment + `git diff` | Structural SCs only |
-| `yaml+symbolic` block | Rule/state_machine present | Issue comment + line range | Structural SCs only |
+### Exception: Non-Testable Content (docs, runbooks, guidelines, prose)
 
-### Behavioral Evidence (Required for Behavioral SCs)
+For changes to non-executable content (markdown documentation, runbooks, guidelines, prose-only files), structural evidence IS acceptable but MUST use **semantic intent verification by direct AI agent inspection** — NOT grep/pattern matching. The agent MUST:
 
-Behavioral evidence confirms that implementation components **behave correctly** — tests pass, lints clean, API responses match, runtime behavior matches spec. Structural evidence is INSUFFICIENT for behavioral SCs.
+1. Read the actual content of the modified file
+2. Compare it semantically against the spec's intent — does the prose actually convey the intended meaning?
+3. Report PASS only if the semantic intent is correctly expressed, not just if keywords appear
 
-| Type | Description | Storage | Valid For |
-| -- | -- | -- | -- |
-| Test output | `pytest` pass/fail | Issue comment | Behavioral SCs |
-| Lint output | `ruff check` clean | Issue comment | Behavioral SCs |
-| Type check | `pyright` clean | Issue comment | Behavioral SCs |
-| API response | Status code and body | Issue comment + curl output | Behavioral SCs |
-| Screenshot | Visual verification | Issue comment + attachment | Behavioral SCs |
-| Behavioral test run | `opencode-cli run` output | Issue comment + log excerpt | Behavioral SCs |
+Grep/pattern-match verification is FORBIDDEN even for prose content. The agent must read and understand, not search for string patterns.
+
+### Classification
+
+| Change Type | Evidence Requirement | Method |
+|-------------|---------------------|--------|
+| Testable code (logic, behavior, runtime) | Behavioral/functional/regression test execution | `pytest`, `opencode-cli run`, lint, typecheck — all with saved artifacts in `./tmp/artifacts/` |
+| Non-testable prose (docs, runbooks, guidelines) | Semantic intent verification by direct AI agent read | Read the file, understand the prose, verify semantic intent against spec — NOT grep/pattern matching |
+| | | |
+| Structural-only evidence (grep/read/file-exists) for testable code | **TOTAL FAIL** — entire verification gate returns FAIL | No exceptions. No metadata exemption. |
 
 ### Invalid Evidence
 

--- a/skills/writing-plans/tasks/create.md
+++ b/skills/writing-plans/tasks/create.md
@@ -57,7 +57,7 @@ Writes plan header, stores as combined section or separate issue, creates sub-is
 Each phase MUST include (prose-driven, not rigid headers):
 - **Why this phase exists** — concern it addresses and place in overall design
 - **What it must accomplish** — tasks, deliverables, behavioral requirements
-- **How to verify completion** — success criteria and testable outcomes
+- **How to verify completion** — success criteria and testable outcomes. Each phase's verification guidance MUST carry cost-frame identity prose that reframes verification cost using the dark-prose-007 formula from `250-dark-prose-reference.md` §Section 3. Verification MUST require real test execution commands that produce saved artifact files in `./tmp/artifacts/`. Structural checks (file exists, grep match) are NEVER acceptable substitutes for behavioral runtime evidence — a skipped execution is a defect accepted at the point of verification.
 - **What could go wrong** — edge cases, known risks, failure modes
 - **What must be done first** — dependencies on prior phases or external prerequisites
 


### PR DESCRIPTION
**Summary:**

Specs gain structured Intent/Executive Summary with decision history; cost-frame dark-prose-007 reframes verification cost as defect-discovery-latency across 9 enforcement layers; completeness gate catches surface defects before adversarial audit; PR body becomes inverted-pyramid format with verifiable evidence; VbC and auditors now reject structural-only evidence for code changes.

**Outcome:** Developers can trace design decisions in every spec, agents stop rationalizing verification skips, completeness defects caught before costly audit, PR reviewers see attested evidence, and the structural-evidence bypass is now gated by mandatory behavioral test execution for code changes.

**Verification Attestation:** FAIL — all 36 SCs have structural-only evidence.

**Verification Detail:** This PR implements changes to guidelines/skills that ARE testable (modified task files control agent behavior). However, no functional/behavioral tests were executed for the 36 original SCs from specs #733-#736. Per the new structural-evidence rule installed in this very PR, structural-only verification is a total FAIL.

The fix installed in this PR (`verify.md`, `collect.md`, `spec-audit.md`, `plan-fidelity.md`, `drift-detection.md`) ensures future PRs will:
- Require behavioral test execution for all testable code changes
- Accept semantic intent verification (direct AI read + understanding) for non-testable prose
- Auto-FAIL any SC with structural-only evidence

**Functional tests executed (behavioral evidence for the fix itself):**

| Test | Command | Result | Artifact |
|------|---------|--------|----------|
| pyunit test suite | `uv run pytest .opencode/tests/` | 27 passed, 0 failed | `./tmp/artifacts/` |

Implements #733
Implements #734
Implements #735
Implements #736
🤖 Co-authored with AI: OpenCode (deepseek-v4-flash)