### PR TITLE
fix(pre-push): skip all gates for tag pushes

### DIFF
--- a/hooks/pre-push
+++ b/hooks/pre-push
@@ -17,6 +17,12 @@ ALLOWED=true
 while read LOCAL_REF LOCAL_SHA REMOTE_REF REMOTE_SHA; do
     [ -z "$LOCAL_REF" ] && continue
 
+    # Skip all gates for tag pushes — tags are immutable pointers to existing
+    # commits and do not introduce new code. All gates below are branch-only.
+    if [[ "$LOCAL_REF" == refs/tags/* ]]; then
+        continue
+    fi
+
     # Extract branch basename (strip refs/heads/)
     LOCAL_BRANCH="${LOCAL_REF#refs/heads/}"
     REMOTE_BRANCH="${REMOTE_REF#refs/heads/}"


### PR DESCRIPTION
## Summary

The `pre-push` hook applies branch-protective gates (topology check, commit count check) to tag push refspecs, causing false positive blocks when pushing annotated tags like `git push origin v0.1.1`.

## Root Cause

The hook does not distinguish `refs/tags/*` from `refs/heads/*`. All three gates assume branch refspecs. When a tag is pushed:
- `LOCAL_REF` = `refs/tags/v0.1.1` instead of `refs/heads/feature/X`
- The `refs/heads/` prefix stripping produces malformed values
- Gate 2 computes `git rev-list --count origin/dev..$TAG_SHA` producing "3 commits but no work state file"

## Fix

Add a tag detection early return at the top of the `while read` loop, before any gates execute:

```bash
if [[ "$LOCAL_REF" == refs/tags/* ]]; then
    continue
fi
```

Tags are immutable pointers to existing commits — they introduce no new code and bypassing all gates for tag refspecs is correct because:
- Gate 0 (branch protection): tags can't target `main`/`dev`
- Gate 1 (merged branch topology): tags aren't branches
- Gate 2 (commit count): tags reference existing commits, not new work

## Verification

| SC | Criterion | Evidence |
|----|-----------|----------|
| SC-1 | Tag push completes without `--no-verify` | PASS — exit code 0 |
| SC-2 | Branch gates still fire for feature branches | PASS — all 3 gates executed |
| SC-3 | Branch gates still fire for protected branches | PASS — Gate 0 triggers on `main`/`dev` |
| SC-4 | Hook source contains tag detection early return | PASS — verified by diff |
| SC-5 | Both installed copies match source | PASS — zero diff |

## Outcome

Tag pushes (`git push origin v0.1.1`) now complete without requiring `--no-verify`. Branch gates continue to function normally.

Fixes #821

🤖 Co-authored with AI: OpenCode (ollama-cloud/glm-5.1)