### PR TITLE
fix(local-issues,pre-push,session-enforcement): push issues-data branch, skip list, remove no-verify gate

### DIFF
--- a/hooks/pre-push
+++ b/hooks/pre-push
@@ -116,7 +116,7 @@ while read LOCAL_REF LOCAL_SHA REMOTE_REF REMOTE_SHA; do
         fi
 
         case "$LOCAL_BRANCH" in
-            pair-*|rollback/*)
+            pair-*|rollback/*|issues-data)
                 continue
                 ;;
         esac

--- a/plugins/session-enforcement.ts
+++ b/plugins/session-enforcement.ts
@@ -3,8 +3,7 @@
  *
  * Injects session context into the LLM system prompt and enforces
  * runtime guards: inline work detection, evidence gate, git config
- * mutation watchdog, --no-verify detection, protected branch edits,
- * secret redaction, session triggers,
+ * mutation watchdog, protected branch edits, secret redaction, session triggers,
  * and plugin diagnostics.
  *
  * Hook: system.transform — pushes English prose context (from session-init
@@ -165,11 +164,7 @@ ${keyList}
 This is a Tier 1 mandate violation unless explicitly authorized by the developer. HALT and verify the mutation was authorized before proceeding. See 000-critical-rules.md for details on Git Configuration and Destructive Command Authorization.`;
 }
 
-function buildNoVerifyBlockedBlock(): string {
-  return `### No-Verify Commit Blocked
-
-**Warning:** --no-verify is FORBIDDEN in repos with remotes. git commit --no-verify and git push --no-verify bypass git hooks that enforce repository safety. This is a Tier 1 mandate. Only permitted in local-only repos (zero remotes). Check git remote -v first. See 000-critical-rules.md for details on Git Configuration and Destructive Command Authorization.`;
-}
+// buildNoVerifyBlockedBlock() REMOVED per SPEC-FIX #823 — see removal comment above.
 
 function buildInlineWorkDetectedBlock(editToolNames: string[], dispatchFound: boolean): string {
   const editList = editToolNames.map(t => `- \`${t}\``).join("\n");
@@ -844,7 +839,7 @@ The following mandates are NON-YIELDING — no developer authorization, emergenc
 5. **Sub-agents must receive \`worktree.path\`** — Prevents sub-agents from mutating the main repo when the orchestrator is in worktree mode.
 6. **Human-only branch deletion** — Unmerged branches must never be force-deleted by agents. Merged branches DELETE IMMEDIATELY.
 7. **Agents must never self-authorize** — Authorization comes from developers, never from agent reasoning. Confirmation, feedback, and questions are not authorization.
-8. **Git configuration and destructive commands require explicit authorization** — Remote mutations, config changes, force push, \`--no-verify\` (in repos with remotes), and destructive resets require explicit developer approval.
+8. **Git configuration and destructive commands require explicit authorization** — Remote mutations, config changes, force push, and destructive resets require explicit developer approval.
 9. **Correctness over economy** — Fabrication or shortcutting verification to conserve context/tool-calls is prohibited. Sub-agent dispatch and tool calls are near-zero cost. A fast wrong answer is strictly worse than a slow correct one.
 
 Violations of mandates 1-6 and 8 are detected at runtime by this plugin and flagged via enforcement blocks. See \`000-critical-rules.md\` Tier 1 table for full rationale and symbolic rule definitions.`;
@@ -1091,41 +1086,17 @@ export default async function sessionEnforcementPlugin(input: PluginInput): Prom
         }
       }
 
-      // --- Per-turn: --no-verify detection ---
-      let hasRemotes: boolean;
-      if (gitConfigBaseline) {
-        hasRemotes = gitConfigBaseline.remoteCount > 0;
-      } else {
-        // Baseline capture failed — check remotes inline
-        try {
-          const remoteCheck = execSync("git remote -v", {
-            cwd: projectDir,
-            encoding: "utf8",
-            input: "",
-            timeout: 5000,
-            stdio: ["pipe", "pipe", "pipe"],
-          }).trim();
-          hasRemotes = remoteCheck.length > 0;
-        } catch {
-          hasRemotes = false; // No remotes = local-only → permit --no-verify
-        }
-      }
-      for (const msg of assistantMessages) {
-        if (!msg.parts?.length) continue;
-        for (const part of msg.parts) {
-          if (part.type === "text" && part.text) {
-            const noVerifyMatch = part.text.match(/(?:git\s+commit|git\s+push)\s+.*--no-verify/);
-            if (noVerifyMatch && hasRemotes) {
-              const blockedBlock = buildNoVerifyBlockedBlock();
-              const nextUser = userMessages[userMessages.length - 1];
-              if (nextUser?.parts?.length) {
-                nextUser.parts.push({ type: "text", text: blockedBlock });
-              }
-              break;
-            }
-          }
-        }
-      }
+      // --- Per-turn: --no-verify detection REMOVED ---
+      // Removed per SPEC-FIX #823: The unconditional --no-verify detection gate
+      // contradicts the guidelines (000-critical-rules.md §Hook Output Is Advisory,
+      // Not Absolute and §--no-verify Exception for Local-Only Repos) which state
+      // that --no-verify usage requires judgment and may be warranted for false
+      // positive hook blocks, tag pushes, and developer-authorized overrides.
+      // The 010-approval-gate.md Allowlist already governs when --no-verify is
+      // permissible. This gate was producing Tier 1 violation warnings for
+      // legitimate --no-verify usage (e.g., tag pushes blocked by the pre-push
+      // hook false positive, structural branch pushes like issues-data), causing
+      // repeated workflow failures.
 
       // --- Per-turn: Inline work detector (Gate 3) ---
       // Detect when the orchestrator performed file-editing tool calls without

--- a/tools/local-issues
+++ b/tools/local-issues
@@ -810,6 +810,22 @@ def cmd_setup(
     if had_existing_issues:
         print("  Pre-existing .issues/ migrated from .issues.bak")
 
+    # Push the issues-data branch to remote so subsequent commits can be pushed
+    push_result = _git(["push", "-u", "origin", ISSUES_DATA_BRANCH], check=False)
+    if push_result.returncode != 0:
+        print(
+            f"ERROR: Failed to push {ISSUES_DATA_BRANCH} branch to remote.",
+            file=sys.stderr,
+        )
+        if push_result.stderr:
+            print(push_result.stderr.strip(), file=sys.stderr)
+        print("", file=sys.stderr)
+        print("Remediate: resolve the push error above, then re-run setup.", file=sys.stderr)
+        print("Re-dispatch: call local-issues setup after resolving.", file=sys.stderr)
+        return 1
+    else:
+        print(f"  Pushed {ISSUES_DATA_BRANCH} to origin")
+
     if parent and is_submodule:
         return _setup_parent_worktree(repo_root)
 


### PR DESCRIPTION
## Summary

Three related fixes for the `.issues/` setup workflow and session-enforcement `--no-verify` detection.

## Defects Fixed

### Defect 1: Missing push step in `local-issues setup`

The setup command creates the `issues-data` branch locally but never pushes it to the remote. When the AI agent or developer later tries to push `.issues/` work, the push fails because the remote has no `issues-data` branch.

**Fix:** Added `git push -u origin issues-data` after worktree setup, with error handling that surfaces the hook's BLOCKED message and includes remediation + re-dispatch guidance.

### Defect 2: `issues-data` blocked by pre-push commit count gate

The `issues-data` branch contains 2-3 structural setup commits with no work state file, which triggers Gate 2's commit-per-issue invariant.

**Fix:** Added `issues-data` to the Gate 2 skip list alongside `pair-*` and `rollback/*`:
```bash
case "$LOCAL_BRANCH" in
    pair-*|rollback/*|issues-data)
```

### Defect 3: Session-enforcement `--no-verify` unconditional block contradicts guidelines

The `--no-verify` detection gate in `session-enforcement.ts` produces Tier 1 violation warnings for ALL `--no-verify` usage in repos with remotes, directly contradicting the guidelines:
- `000-critical-rules.md` §"Hook Output Is Advisory, Not Absolute" states `--no-verify` "may warrant" usage after evaluating false positives
- `000-critical-rules.md` §"--no-verify Exception for Local-Only Repos" provides explicit carve-outs
- `010-approval-gate.md` §Allowlist provides additional authorized cases

The plugin gate was producing repeated workflow failures for legitimate `--no-verify` usage (tag pushes blocked by the #821 hook false positive, structural branch pushes).

**Fix:** Removed the `--no-verify` detection gate and `buildNoVerifyBlockedBlock()` function entirely. Guideline-level governance is sufficient — the plugin gate added contradictory unconditional blocking.

## Verification

| SC | Criterion | Evidence |
|----|-----------|----------|
| SC-1 | `local-issues setup` pushes `issues-data` branch to remote | Code: push step added at line 814 |
| SC-2 | Push failure produces error output with remediation guidance | Code: stderr output + remediation + re-dispatch lines 817-824 |
| SC-3 | Push failure includes re-dispatch notice | Code: "Re-dispatch: call local-issues setup after resolving." |
| SC-4 | `issues-data` branch exempted from commit count gate | Code: `pair-*|rollback/*|issues-data)` in pre-push line 119 |
| SC-5 | `git push origin issues-data` completes without `--no-verify` | Will verify after merge |
| SC-6 | Session-enforcement no longer injects `--no-verify` Tier 1 block | Code: detection gate removed, `buildNoVerifyBlockedBlock()` removed |
| SC-7 | Tag pushes no longer trigger `--no-verify` warning | SC-6 covers this — gate removed entirely |
| SC-8 | Legitimate `--no-verify` usage does not produce blocking warning | SC-6 covers this — gate removed entirely |

## Files Changed

- `.opencode/tools/local-issues` — push step + error handling
- `.opencode/hooks/pre-push` — `issues-data` skip list entry
- `.opencode/plugins/session-enforcement.ts` — removed `--no-verify` detection gate and `buildNoVerifyBlockedBlock()`

Fixes #823

🤖 Co-authored with AI: OpenCode (ollama-cloud/glm-5.1)