### PR TITLE
Fix worktree mandates, preserve bylines, remove pre-push Gate 2, auto-discover linked repos

### DIFF
--- a/guidelines/080-code-standards.md
+++ b/guidelines/080-code-standards.md
@@ -207,6 +207,66 @@ When a byline is missing from AI-authored posted content:
 
 The byline must be **part of the content body**, never a separate message.
 
+### Preserve Existing Bylines
+
+When an AI agent edits a file or posted content that already contains a `Co-authored with AI:` byline from a prior AI agent, the editing agent MUST preserve the existing byline. Overwriting a prior agent's identity erases audit trail, falsifies content origin history, and breaks traceability.
+
+#### Rules
+
+1. **Never overwrite a prior agent's byline.** When editing a file with an existing `Co-authored with AI:` line, the agent MUST NOT modify, replace, or remove that line.
+
+2. **Append, don't replace.** If the editing agent contributed substantive new AI-generated content, it appends its own byline on a new line following existing byline(s). Minor edits (typo fix, formatting, refactoring without new creative content) do not need an additional byline.
+
+3. **Format consistency.** The editing agent uses the same format as existing byline(s) — do not change `*italic*` to emoji or vice versa. New files use the format specified per file type.
+
+4. **Multi-agent bylines.** When a file has bylines from multiple AI agents, chronological order is preserved — each new byline appended at the end.
+
+#### Examples
+
+**Source file editing — CORRECT (preserve + append):**
+
+```python
+# Before edit (byline from prior agent Alpha):
+"""Process user data.
+
+Co-authored with AI: Alpha (alpha-model-v1)
+"""
+
+# After edit by agent Beta — CORRECT:
+"""Process user data and validate input.
+
+Co-authored with AI: Alpha (alpha-model-v1)
+Co-authored with AI: Beta (beta-model-v2)
+"""
+```
+
+**Source file editing — WRONG (identity overwrite):**
+
+```python
+# Before edit (byline from prior agent Alpha):
+"""Process user data.
+
+Co-authored with AI: Alpha (alpha-model-v1)
+"""
+
+# After edit by agent Beta — WRONG:
+"""Process user data and validate input.
+
+Co-authored with AI: Beta (beta-model-v2)  # ← prior agent identity erased
+"""
+```
+
+**Posted content editing — CORRECT (preserve + append):**
+
+When editing an existing issue or PR comment that already has a byline, preserve the existing byline and append the new one:
+
+```
+Original content here.
+
+🤖 Co-authored with AI: Alpha (alpha-model-v1)
+🤖 Co-authored with AI: Beta (beta-model-v2)
+```
+
 ### Files NOT Requiring Attribution
 
 | File Type | Reason |
@@ -624,6 +684,21 @@ rules:
     requires: []
     triggers: [issue-operations]
     source: "080-code-standards.md §AI Co-Authored Attribution"
+
+  - id: code-standards-002a
+    tier: 3
+    title: "Preserve existing AI bylines — never overwrite prior agent identity"
+    conditions:
+      all:
+        - "editing_file_with_existing_byline == true"
+        - "byline_overwrite_attempted == true"
+    actions:
+      - FLAG
+      - PRESERVE_AND_APPEND
+    conflicts_with: []
+    requires: []
+    triggers: [issue-operations]
+    source: "080-code-standards.md §Preserve Existing Bylines"
 
   - id: code-standards-003
     tier: 3

--- a/hooks/pre-push
+++ b/hooks/pre-push
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Pre-push hook: Branch topology + commit count enforcement
+# Pre-push hook: Branch topology enforcement
 # Gates inspect push refspecs from stdin, not the local checkout branch.
 # stdin format per git pre-push protocol:
 #   <local-ref> SP <local-sha> SP <remote-ref> SP <remote-sha> LF
@@ -7,7 +7,6 @@
 set -e
 
 SKIP_BRANCH_PROTECTION="${SKIP_BRANCH_PROTECTION:-}"
-SKIP_COMMIT_COUNT_CHECK="${SKIP_COMMIT_COUNT_CHECK:-}"
 
 # Read stdin refspecs. For each line, evaluate all gates.
 # If any line triggers a block, the hook exits 1.
@@ -103,62 +102,6 @@ while read LOCAL_REF LOCAL_SHA REMOTE_REF REMOTE_SHA; do
                 echo "  git checkout dev && git pull origin dev"
                 echo "  git branch -d $LOCAL_BRANCH"
                 echo "  git push origin --delete $LOCAL_BRANCH"
-                echo ""
-                ALLOWED=false
-            fi
-        fi
-    fi
-
-    # --- Gate 2: Commit count check (commit-per-issue invariant) ---
-    if [ "$IS_DELETE" = false ] && [ -n "$LOCAL_BRANCH" ] && [ "$LOCAL_BRANCH" = "$REMOTE_BRANCH" ]; then
-        if [ "$SKIP_COMMIT_COUNT_CHECK" = "1" ]; then
-            continue
-        fi
-
-        case "$LOCAL_BRANCH" in
-            pair-*|rollback/*|issues-data)
-                continue
-                ;;
-        esac
-
-        # Work state files live at the repo root's tmp/ directory.
-        # git rev-parse --show-toplevel resolves to the correct root
-        # whether running in parent repo or submodule context.
-        WORK_STATE_DIR="tmp"
-
-        # Work branches have N commits for N work items — skip check
-        WORK_BRANCH=false
-        if ls "$WORK_STATE_DIR"/work-*.md 1>/dev/null 2>&1; then
-            for f in "$WORK_STATE_DIR"/work-*.md; do
-                if grep -q "$LOCAL_BRANCH" "$f" 2>/dev/null; then
-                    WORK_BRANCH=true
-                    break
-                fi
-            done
-        fi
-
-        if [ "$WORK_BRANCH" = false ]; then
-            COMMIT_COUNT=0
-            if git rev-parse --verify origin/dev >/dev/null 2>&1; then
-                COMMIT_COUNT=$(git rev-list --count origin/dev.."$LOCAL_SHA" 2>/dev/null || echo "0")
-            elif git rev-parse --verify dev >/dev/null 2>&1; then
-                COMMIT_COUNT=$(git rev-list --count dev.."$LOCAL_SHA" 2>/dev/null || echo "0")
-            fi
-
-            if [ "$COMMIT_COUNT" -gt 1 ]; then
-                echo ""
-                echo "BLOCKED: Commit-per-issue invariant violated."
-                echo ""
-                echo "Branch '$LOCAL_BRANCH' has $COMMIT_COUNT commits but no work state file."
-                echo "Single-issue branches must have exactly 1 commit."
-                echo ""
-                echo "To fix:"
-                echo "  1. Squash: git reset --soft origin/dev && git commit -m '<message>'"
-                echo ""
-                echo "BLOCKED: Pushing without work state — unattributed commits entering the integration branch."
-                echo "No traceability means defects untraceable to spec. Every unpipelined push is orphaned changes."
-                echo ""
-                echo "Remediate: call skill({name: \"divide-and-conquer\"}) --task assemble-work"
                 echo ""
                 ALLOWED=false
             fi

--- a/skills/approval-gate/tasks/verify-authorization/auto-dispatch.md
+++ b/skills/approval-gate/tasks/verify-authorization/auto-dispatch.md
@@ -19,17 +19,17 @@ authorization_source: "User approved #N on YYYY-MM-DD"
 - Instructed to exceed `halt_at` → return `status: BLOCKED`
 - The `pipeline_phase` field is NEW — it tracks which phase of a multi-phase plan is currently executing
 
-## 6.1 Pre-Implementation Worktree Setup (MANDATORY)
+## 6.1 Pre-Implementation Branch Setup (MANDATORY)
 
 **Before any sub-agent task() or file modification, the agent MUST task `git-workflow --task pre-work` to:**
 
-1. Create the feature branch in a worktree (`.worktrees/`)
-2. Set the `worktree.path` environment variable
+1. Create the feature branch (direct-branch or worktree depending on `WORKTREE_REQUIRED`)
+2. If `WORKTREE_REQUIRED` is set: set the `worktree.path` environment variable
 3. Verify branch state and working tree cleanliness
 
-**This step is MANDATORY and CANNOT be skipped.** If the worktree already exists from a previous session, verify it and proceed. If worktree creation fails, HALT — do not proceed without a valid worktree.
+**This step is MANDATORY and CANNOT be skipped.** Pre-work.md handles the worktree vs direct-branch decision — the agent does NOT decide worktree mode here. If pre-work fails, HALT — do not proceed without a valid branch.
 
-**Evidence requirement:** `git worktree list` must show the feature branch worktree, and `worktree.path` must be set before any `divide-and-conquer` task().
+**Evidence requirement:** `git branch --show-current` must show the feature branch. If `WORKTREE_REQUIRED` is set, `git worktree list` must also show the feature branch worktree and `worktree.path` must be set before any `divide-and-conquer` task().
 
 ## Auto-Dispatch Situation Differentiation
 

--- a/skills/git-workflow/tasks/pr-creation/squash-push.md
+++ b/skills/git-workflow/tasks/pr-creation/squash-push.md
@@ -67,15 +67,23 @@ git rebase origin/dev
 git push --force-with-lease origin <branch>
 ```
 
-## Worktree Mode (MANDATORY — NO EXCEPTIONS)
+## Branch Mode (Conditional — Based on WORKTREE_REQUIRED)
 
-All feature branches operate in worktrees. If `worktree.path` is not set: **FATAL ERROR → HALT.**
+**Direct-branch mode (default — when `WORKTREE_REQUIRED` is NOT set):**
+
+- Operate normally from the main repo directory
+- Relative paths work directly
+- No worktree path prefixing needed
+
+**Worktree mode (opt-in — when `WORKTREE_REQUIRED` is set):**
+
+If `worktree.path` is not set or empty: **FATAL ERROR → FLAG DEV → HALT.** Do not proceed without a valid worktree path.
 
 1. All `bash` tool calls MUST use `workdir="{{worktree.path}}"`
 2. All `read`/`edit`/`write`/`glob`/`grep` tool calls MUST prefix with `{{worktree.path}}/`
 3. Before any push/squash/rebase: verify `git branch --show-current` matches expected branch
 4. `git rev-parse --show-toplevel` MUST return the worktree path
-5. NEVER operate in the main working directory during implementation
+5. NEVER operate in the main working directory during worktree mode
 
 ## Live Verification (MANDATORY)
 

--- a/skills/git-workflow/tasks/review-prep/push-and-cleanup.md
+++ b/skills/git-workflow/tasks/review-prep/push-and-cleanup.md
@@ -105,14 +105,24 @@ git branch -vv
 git push -u origin <branch-name>
 ```
 
-## Worktree Mode (MANDATORY — NO EXCEPTIONS)
+## Branch Mode (Conditional — Based on WORKTREE_REQUIRED)
 
-All feature branches operate in worktrees. If `worktree.path` is not set: **FATAL ERROR → HALT.**
+**Direct-branch mode (default — when `WORKTREE_REQUIRED` is NOT set):**
+
+- Operate normally from the main repo directory
+- Relative paths work directly
+- No worktree path prefixing needed
+- `git fetch`/`git rebase` run directly
+
+**Worktree mode (opt-in — when `WORKTREE_REQUIRED` is set):**
+
+If `worktree.path` is not set or empty: **FATAL ERROR → FLAG DEV → HALT.** Do not proceed without a valid worktree path.
 
 1. All `bash` calls use `workdir="{{worktree.path}}"`
 2. All `read`/`edit`/`write`/`glob`/`grep` prefix with `{{worktree.path}}/`
 3. Verify branch before push: `git branch --show-current`
-4. `origin/dev` is shared across worktrees — `git fetch`/`git rebase` work from any worktree
+4. `git rev-parse --show-toplevel` MUST return the worktree path
+5. NEVER operate in the main working directory during worktree mode
 
 ### Step 2.5: Worktree Handoff (CONDITIONAL)
 

--- a/tools/session-init
+++ b/tools/session-init
@@ -1,5 +1,5 @@
 #!/usr/bin/env -S uv run --script
-"exec" "uv" "run" "--script" "$0" "$@" # MUST GO BEFORE PEP 723 HEADER
+"exec" "uv" "run" "--script" "$0" "$@"  # MUST GO BEFORE PEP 723 HEADER
 
 # PEP 723 HEADER MUST BE AFTER BASH GUARD
 # /// script
@@ -71,6 +71,7 @@ while _path.name != ".opencode":
     _path = _path.parent
 PROJECT_ROOT = _path.parent
 
+
 def run_git_command(args: list[str]) -> str | None:
     """Run a git command and return output, or None if failed."""
     try:
@@ -90,12 +91,14 @@ def run_git_command(args: list[str]) -> str | None:
         pass
     return None
 
+
 def get_user_name() -> str:
     """Get git user name or fallback to $USER."""
     name = run_git_command(["config", "user.name"])
     if name:
         return name
     return os.environ.get("USER", "unknown")
+
 
 def get_user_email() -> str:
     """Get git user email or fallback to $USER@$HOSTNAME."""
@@ -106,35 +109,58 @@ def get_user_email() -> str:
     hostname = os.environ.get("HOSTNAME", "localhost")
     return f"{user}@{hostname}"
 
-def parse_git_remote_url(url: str) -> tuple[str, str] | tuple[None, None]:
-    """Parse owner and repo from GitHub remote URL.
+
+def parse_repo_url(url: str) -> tuple[str, str, str] | tuple[None, None, None]:
+    """Parse owner, repo, and platform (bare hostname) from any git remote URL.
 
     Supports:
-    - SSH: git@github.com:owner/repo.git
-    - HTTPS: https://github.com/owner/repo.git
+    - SSH: git@HOSTNAME:OWNER/REPO.git
+    - HTTPS: https://HOSTNAME/OWNER/REPO.git
+    - SSH with port: ssh://git@HOSTNAME:PORT/OWNER/REPO.git
 
     Returns:
-        (owner, repo) on success, (None, None) on failure
+        (owner, repo, platform) on success, (None, None, None) on failure.
+        platform is the bare hostname from the URL.
     """
-    ssh_pattern = r"^git@github\.com:([^/]+)/([^/]+?)(?:\.git)?$"
-    match = re.match(ssh_pattern, url)
+    ssh_port_pattern = r"^ssh://git@([^:/]+):(\d+)/([^/]+)/([^/]+?)(?:\.git)?$"
+    match = re.match(ssh_port_pattern, url)
     if match:
-        return match.group(1), match.group(2)
+        return match.group(3), match.group(4), match.group(1)
 
-    https_pattern = r"^https://github\.com/([^/]+)/([^/]+?)(?:\.git)?$"
+    ssh_short_pattern = r"^git@([^:]+):([^/]+)/([^/]+?)(?:\.git)?$"
+    match = re.match(ssh_short_pattern, url)
+    if match:
+        return match.group(2), match.group(3), match.group(1)
+
+    https_pattern = r"^https://([^/]+)/([^/]+)/([^/]+?)(?:\.git)?$"
     match = re.match(https_pattern, url)
     if match:
-        return match.group(1), match.group(2)
+        return match.group(2), match.group(3), match.group(1)
 
+    return None, None, None
+
+
+def parse_git_remote_url(url: str) -> tuple[str, str] | tuple[None, None]:
+    """Parse owner and repo from GitHub remote URL (backward compat).
+
+    Delegates to parse_repo_url and returns (owner, repo) for github.com URLs.
+    """
+    owner, repo, platform = parse_repo_url(url)
+    if owner and repo and platform == "github.com":
+        return owner, repo
     return None, None
+
 
 def is_github_remote(url: str) -> bool:
     """Check if remote URL is a GitHub remote."""
-    return "github.com" in url
+    owner, repo, platform = parse_repo_url(url)
+    return platform == "github.com" if platform else "github.com" in url
+
 
 def is_gitbucket_remote(url: str) -> bool:
     """Check if remote URL is a GitBucket remote (non-github.com)."""
     return not is_github_remote(url)
+
 
 def parse_gitbucket_url(
     url: str,
@@ -182,6 +208,7 @@ def parse_gitbucket_url(
 
     return base_url, owner, repo
 
+
 def _read_gitbucket_url_from_env() -> str | None:
     """Read GITBUCKET_HTML_URL (preferred) or GITBUCKET_URL (legacy) from .env file."""
     try:
@@ -201,6 +228,7 @@ def _read_gitbucket_url_from_env() -> str | None:
         pass
     return None
 
+
 def extract_ssh_url(url: str) -> str | None:
     """Extract SSH base URL (host + port, no path) from a GitBucket SSH remote.
 
@@ -213,13 +241,16 @@ def extract_ssh_url(url: str) -> str | None:
         return match.group(1)
     return None
 
+
 def get_remote_url() -> str | None:
     """Get origin remote URL or None if not configured."""
     return run_git_command(["remote", "get-url", "origin"])
 
+
 def get_current_branch() -> str | None:
     """Get current git branch name or None if HEAD is detached."""
     return run_git_command(["branch", "--show-current"])
+
 
 def check_srclight() -> str:
     """Check srclight index health. Returns 'indexed', 'empty', or 'not_indexed'."""
@@ -241,48 +272,77 @@ def check_srclight() -> str:
         )
         return "not_indexed"
 
-def get_submodule_dirs() -> list[str]:
-    """Get list of submodule directory paths using git config."""
-    result = run_git_command(
-        ["config", "--file", ".gitmodules", "--get-regexp", "path"]
-    )
-    if not result:
+
+def get_linked_repo_dirs() -> list[str]:
+    """Get immediate subdirectories containing .git entries (file or directory).
+
+    Depth-1 only: scans os.listdir(cwd), no recursion.
+    Returns directories that have a .git entry, an 'origin' remote,
+    and whose origin resolves to a DIFFERENT owner/repo than the parent.
+    Worktrees of the parent repo (same owner/repo) are excluded.
+    """
+    cwd = os.getcwd()
+    parent_url = get_remote_url()
+    parent_owner = None
+    parent_repo = None
+    if parent_url:
+        parent_owner, parent_repo, _ = parse_repo_url(parent_url)
+
+    try:
+        entries = os.listdir(cwd)
+    except OSError:
         return []
 
-    paths: list[str] = []
-    for line in result.splitlines():
-        parts = line.strip().split()
-        if len(parts) >= 2:
-            paths.append(parts[-1])
-    return paths
+    dirs: list[str] = []
+    for entry in sorted(entries):
+        entry_path = os.path.join(cwd, entry)
+        if not os.path.isdir(entry_path):
+            continue
+        git_path = os.path.join(entry_path, ".git")
+        if not os.path.exists(git_path):
+            continue
+        url = run_git_command(["-C", entry_path, "remote", "get-url", "origin"])
+        if not url:
+            continue
+        owner, repo, _ = parse_repo_url(url)
+        if not owner or not repo:
+            continue
+        if (
+            parent_owner
+            and parent_repo
+            and owner == parent_owner
+            and repo == parent_repo
+        ):
+            continue
+        dirs.append(entry)
+    return dirs
+
 
 def emit_subfolder_mappings() -> None:
-    """Emit sub-folder repo mappings in YAML format."""
-    submodules = get_submodule_dirs()
-    if not submodules:
+    """Emit linked repo mappings in YAML format.
+
+    Uses get_linked_repo_dirs() for auto-discovery instead of .gitmodules.
+    Output includes owner, repo, platform (bare hostname), and url fields.
+    """
+    linked_dirs = get_linked_repo_dirs()
+    if not linked_dirs:
         return
 
     lines: list[str] = []
-    for sm_path in submodules:
-        url = run_git_command(["-C", sm_path, "remote", "get-url", "origin"])
+    for dir_name in linked_dirs:
+        url = run_git_command(["-C", dir_name, "remote", "get-url", "origin"])
         if not url:
             continue
 
-        if is_github_remote(url):
-            owner, repo = parse_git_remote_url(url)
-            if not owner or not repo:
-                continue
-            platform = "github"
-        else:
-            _base_url, owner, repo = parse_gitbucket_url(url)
-            if not owner or not repo:
-                continue
-            platform = "gitbucket"
+        owner, repo, platform = parse_repo_url(url)
+        if not owner or not repo:
+            continue
 
-        lines.append(f"  - path: {sm_path}")
+        lines.append(f"  - path: {dir_name}")
         lines.append(f"    owner: {owner}")
         lines.append(f"    repo: {repo}")
-        lines.append(f"    platform: {platform}")
+        lines.append(f"    platform: {platform or ''}")
+        lines.append(f"    url: {url}")
 
     if not lines:
         return
@@ -292,6 +352,7 @@ def emit_subfolder_mappings() -> None:
     for line in lines:
         print(line)
 
+
 def get_source_hooks_dir() -> str | None:
     """Find the .opencode/hooks/ directory or None if missing."""
     hooks_dir = os.path.join(os.getcwd(), ".opencode", "hooks")
@@ -299,10 +360,12 @@ def get_source_hooks_dir() -> str | None:
         return hooks_dir
     return None
 
+
 def get_hooks_path() -> str:
     """Get git hooks path or empty string if not configured."""
     hooks = run_git_command(["config", "core.hooksPath"])
     return hooks or ""
+
 
 def _hooks_match(src: str, dst: str) -> bool:
     """Check if two hook files have the same content."""
@@ -310,6 +373,7 @@ def _hooks_match(src: str, dst: str) -> bool:
         return os.path.isfile(dst) and open(src).read() == open(dst).read()
     except OSError:
         return False
+
 
 def _copy_hook(src: str, dst: str) -> bool:
     """Copy a hook file, making it executable."""
@@ -320,6 +384,7 @@ def _copy_hook(src: str, dst: str) -> bool:
     except OSError:
         return False
 
+
 def _resolve_git_dir() -> str | None:
     """Resolve the actual .git directory using git rev-parse --git-dir."""
     result = run_git_command(["rev-parse", "--git-dir"])
@@ -329,6 +394,7 @@ def _resolve_git_dir() -> str | None:
     if os.path.isabs(result):
         return result
     return os.path.normpath(os.path.join(cwd, result))
+
 
 def install_hooks() -> None:
     """Install git hooks from .opencode/hooks/. Reports failures to stderr."""
@@ -383,32 +449,34 @@ def install_hooks() -> None:
                 )
                 failed_count += 1
 
-    submodules = get_submodule_dirs()
-    for submod_path in submodules:
-        if not os.path.isdir(submod_path):
+    linked_dirs = get_linked_repo_dirs()
+    for dir_name in linked_dirs:
+        if not os.path.isdir(dir_name):
             continue
 
-        hooks_target = os.path.join(
-            os.getcwd(), ".git", "modules", submod_path, "hooks"
-        )
+        dir_git_path = os.path.join(os.getcwd(), dir_name, ".git")
 
-        if not os.path.isdir(hooks_target):
-            submod_git_file = os.path.join(os.getcwd(), submod_path, ".git")
-            if os.path.isfile(submod_git_file):
-                try:
-                    with open(submod_git_file) as f:
-                        gitdir_ref = f.read().strip()
-                    if gitdir_ref.startswith("gitdir: "):
-                        resolved = gitdir_ref[8:]
-                        if not os.path.isabs(resolved):
-                            resolved = os.path.join(os.getcwd(), submod_path, resolved)
-                        hooks_target = os.path.join(resolved, "hooks")
-                except OSError:
-                    pass
+        if os.path.isfile(dir_git_path):
+            try:
+                with open(dir_git_path) as f:
+                    gitdir_ref = f.read().strip()
+                if gitdir_ref.startswith("gitdir: "):
+                    resolved = gitdir_ref[8:]
+                    if not os.path.isabs(resolved):
+                        resolved = os.path.join(os.getcwd(), dir_name, resolved)
+                    hooks_target = os.path.join(resolved, "hooks")
+                else:
+                    continue
+            except OSError:
+                continue
+        elif os.path.isdir(dir_git_path):
+            hooks_target = os.path.join(dir_git_path, "hooks")
+        else:
+            continue
 
         if not os.path.isdir(hooks_target):
             print(
-                f"Could not resolve hooks dir for submodule: {submod_path}",
+                f"Could not resolve hooks dir for linked repo: {dir_name}",
                 file=sys.stderr,
             )
             failed_count += 1
@@ -424,7 +492,7 @@ def install_hooks() -> None:
                 installed_count += 1
             else:
                 print(
-                    f"Failed to install hook {hook_name} into {submod_path}",
+                    f"Failed to install hook {hook_name} into {dir_name}",
                     file=sys.stderr,
                 )
                 failed_count += 1
@@ -441,6 +509,7 @@ def install_hooks() -> None:
             file=sys.stderr,
         )
 
+
 def _extract_version_from_pyproject() -> str:
     """Extract version string from pyproject.toml, or return '0.1.0' as fallback."""
     pyproject_path = os.path.join(os.getcwd(), "pyproject.toml")
@@ -456,6 +525,7 @@ def _extract_version_from_pyproject() -> str:
         except OSError:
             pass
     return "0.1.0"
+
 
 def _ensure_dev_branch() -> str:
     """Ensure dev branch exists. Returns 'exists', 'created from main', 'created from master', or 'failed'."""
@@ -475,10 +545,12 @@ def _ensure_dev_branch() -> str:
     )
     return "failed"
 
+
 def is_worktree_setup() -> bool:
     main_wt = os.path.join(os.getcwd(), ".worktrees", "main")
     git_entry = os.path.join(main_wt, ".git")
     return os.path.isdir(main_wt) and os.path.exists(git_entry)
+
 
 def detect_worktree() -> tuple[bool, str | None, str | None]:
     toplevel = run_git_command(["rev-parse", "--show-toplevel"])
@@ -507,6 +579,7 @@ def detect_worktree() -> tuple[bool, str | None, str | None]:
 
     return False, None, None
 
+
 def is_submodule_context() -> bool:
     toplevel = run_git_command(["rev-parse", "--show-toplevel"])
     if not toplevel:
@@ -529,6 +602,7 @@ def is_submodule_context() -> bool:
             pass
     return False
 
+
 def _add_to_gitignore(entry: str) -> bool:
     """Add an entry to .gitignore if not already present."""
     gitignore_path = os.path.join(os.getcwd(), ".gitignore")
@@ -547,6 +621,7 @@ def _add_to_gitignore(entry: str) -> bool:
     except OSError:
         return False
 
+
 def get_worktree_display() -> str:
     in_wt, wt_path, _ = detect_worktree()
     if in_wt:
@@ -554,6 +629,7 @@ def get_worktree_display() -> str:
     if is_worktree_setup():
         return "Worktrees: .worktrees/main/"
     return ""
+
 
 def bootstrap_worktree_layout() -> bool:
     in_wt, _, _ = detect_worktree()
@@ -604,16 +680,15 @@ def bootstrap_worktree_layout() -> bool:
 
     _add_to_gitignore(".worktrees/")
 
-    submod_dirs = get_submodule_dirs()
-    if submod_dirs:
-        init_result = run_git_command(["submodule", "update", "--init"])
-        if init_result is not None:
-            for submod in submod_dirs:
-                submod_path = os.path.join(main_wt_path, submod)
-                if os.path.isdir(submod_path):
-                    run_git_command(
-                        ["-C", main_wt_path, "submodule", "update", "--init", submod]
-                    )
+    linked_dirs = get_linked_repo_dirs()
+    for dir_name in linked_dirs:
+        dir_git_path = os.path.join(os.getcwd(), dir_name, ".git")
+        if os.path.isfile(dir_git_path):
+            run_git_command(
+                ["-C", main_wt_path, "submodule", "update", "--init", dir_name]
+            )
+        elif os.path.isdir(dir_git_path):
+            pass
 
     if current and current != "dev":
         run_git_command(["checkout", current])
@@ -622,11 +697,13 @@ def bootstrap_worktree_layout() -> bool:
 
     return True
 
+
 CREDENTIAL_FILE_PATTERNS = [
     (".env", "Environment variables file"),
     (".streamlit/secrets.toml", "Streamlit secrets file"),
     (".streamlit/secrets.toml.production", "Streamlit production secrets file"),
 ]
+
 
 def _check_credential_files_gitignored() -> list[str]:
     """Check credential files for gitignore coverage.
@@ -660,6 +737,7 @@ def _check_credential_files_gitignored() -> list[str]:
             )
     return unprotected
 
+
 def run_guard_checks() -> list[str]:
     """Run guard checks silently. Returns list of problem descriptions."""
     problems: list[str] = []
@@ -669,6 +747,7 @@ def run_guard_checks() -> list[str]:
     unprotected = _check_credential_files_gitignored()
     problems.extend(unprotected)
     return problems
+
 
 def resolve_identity(remote_url: str) -> tuple[str, str, str] | tuple[None, None, None]:
     """Resolve git platform, owner, and repo from the remote URL.
@@ -687,6 +766,7 @@ def resolve_identity(remote_url: str) -> tuple[str, str, str] | tuple[None, None
     if owner and repo:
         return "gitbucket", owner, repo
     return None, None, None
+
 
 def main() -> int:
     remote_url = get_remote_url()
@@ -806,6 +886,7 @@ def main() -> int:
 
     emit_subfolder_mappings()
     return 0
+
 
 if __name__ == "__main__":
     sys.exit(main())


### PR DESCRIPTION
## Summary

Stacked PR addressing 4 spec/spec-fix issues with one commit per spec:

| Commit | Issue | Description |
|--------|-------|-------------|
| `f5291d30` | #814 | Preserve existing AI co-authored bylines — prevent identity overwrite on edit |
| `3750cdb2` | #815 | Fix worktree opt-in contradiction — condition mandates on WORKTREE_REQUIRED |
| `2775d5ba` | #818 | Remove Gate 2 (commit count) from pre-push hook — defer to PR-time enforcement |
| `1b2c8579` | #819 | Auto-discover linked repos in session-init — replace .gitmodules-only discovery |

## Outcome

All 12 success criteria verified PASS:
- **#814**: Preserve Existing Bylines subsection added with 4 rules (SC-1 ✓, SC-2 ✓, SC-4 ✓)
- **#815**: Unconditional worktree mandates conditioned on WORKTREE_REQUIRED (SC-1 ✓, SC-2 ✓, SC-3 ✓, SC-4 ✓)
- **#818**: Gate 2 removed from pre-push hook; PR-time enforcement intact (SC-1 ✓, SC-4 ✓)
- **#819**: session-init auto-discovers linked repos via depth-1 `.git` scan (SC-1 ✓, SC-5 ✓, SC-7 ✓)

## Fixes

- Fixes #814 — byline identity overwrite on edit
- Fixes #815 — worktree opt-in contradiction in push/squash/auto-dispatch
- Fixes #818 — pre-push commit count enforcement blocking multi-issue branches
- Fixes #819 — linked repo mapping lost when `.gitmodules` absent

🤖 Co-authored with AI: OpenCode (ollama-cloud/glm-5.1)