### PR TITLE
Gate 4: Submodule-pointer-only commit blocker (content-based, no exemptions)

### DIFF
--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -81,8 +81,64 @@ GATE_EXIT_CODES+=($?)
 )
 GATE_EXIT_CODES+=($?)
 
+# --- Gate 4: Submodule-pointer-only commit blocker (content-based, no exemptions) ---
+(
+  if [ ! -f ".gitmodules" ]; then
+    exit 0
+  fi
+
+  SUBMODULE_PATHS=$(git submodule status 2>/dev/null | awk '{print $2}')
+  if [ -z "$SUBMODULE_PATHS" ]; then
+    exit 0
+  fi
+
+  STAGED_FILES_G4=$(git diff --cached --name-only 2>/dev/null)
+  if [ -z "$STAGED_FILES_G4" ]; then
+    exit 0
+  fi
+
+  ALL_SUBMODULE_POINTERS=1
+  while IFS= read -r f; do
+    MATCHED=0
+    for sp in $SUBMODULE_PATHS; do
+      if [ "$f" = "$sp" ]; then
+        MATCHED=1
+        break
+      fi
+    done
+    if [ "$MATCHED" -eq 0 ]; then
+      ALL_SUBMODULE_POINTERS=0
+      break
+    fi
+  done <<< "$STAGED_FILES_G4"
+
+  if [ "$ALL_SUBMODULE_POINTERS" = "1" ]; then
+    echo ""
+    echo "ERROR: Submodule-pointer-only commit blocked."
+    echo ""
+    echo "ALL staged changes are submodule pointer updates."
+    echo "No branch-name exemptions — this gate applies universally."
+    echo ""
+    echo "Submodule pointer updates belong in the submodule repo itself,"
+    echo "not as standalone commits in the parent repo."
+    echo ""
+    echo "BLOCKED: Submodule-only commit — every submodule pointer update"
+    echo "must be accompanied by a meaningful parent-repo change."
+    echo ""
+    echo "To fix: Commit changes inside the submodule directly,"
+    echo "or include a non-submodule change in this commit."
+    echo ""
+    echo "Remediate: commit inside submodule first, then commit the"
+    echo "pointer update alongside a real parent-repo change."
+    echo ""
+    exit 1
+  fi
+  exit 0
+)
+GATE_EXIT_CODES+=($?)
+
 # Report per-gate status
-GATE_NAMES=("Gate 1 (branch protection)" "Gate 3 (submodule bump)")
+GATE_NAMES=("Gate 1 (branch protection)" "Gate 3 (submodule bump)" "Gate 4 (submodule pointer)")
 ANY_FAILED=0
 for i in "${!GATE_EXIT_CODES[@]}"; do
   if [ "${GATE_EXIT_CODES[$i]}" -ne 0 ]; then

--- a/tests/test-gate4-red.sh
+++ b/tests/test-gate4-red.sh
@@ -1,0 +1,131 @@
+#!/bin/bash
+# RED phase: Pre-commit Gate 4 — Submodule-pointer-only commit blocker
+#
+# RED: This test FAILS because Gate 4 does not exist yet.
+#      After GREEN (adding Gate 4 to hooks/pre-commit), this test PASSES.
+#
+# TDD: Exit 0 = GREEN (Gate 4 exists and blocks submodule-pointer-only commits)
+#      Exit 1 = RED  (Gate 4 missing — commits sail through unblocked)
+#
+# Co-authored with AI: OpenCode (deepseek-v4-flash-free)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$SCRIPT_DIR"
+while [ "$(basename "$PROJECT_DIR")" != ".opencode" ]; do
+    PROJECT_DIR="$(dirname "$PROJECT_DIR")"
+done
+PROJECT_DIR="$(dirname "$PROJECT_DIR")"
+
+OVERALL_RESULT=0
+TEST_TMPDIR=$(mktemp -d "$PROJECT_DIR/tmp/gate4-red-XXXXXX")
+GATE4_FOUND=0
+cleanup() { rm -rf "$TEST_TMPDIR"; }
+trap cleanup EXIT
+
+echo "=== RED: Pre-commit Gate 4 TDD Test ==="
+echo ""
+
+# --- Check pre-condition: Gate 4 does not exist yet ---
+if grep -q 'Gate 4\|GATE 4\|Gate4\|GATE4\|# Gate 4' "$PROJECT_DIR/.opencode/hooks/pre-commit" 2>/dev/null; then
+    echo "WARNING: Gate 4 already exists in hooks/pre-commit!"
+    echo "This test expects RED (no Gate 4). If Gate 4 was already added,"
+    echo "delete it or revert the change before running this test in RED."
+    GATE4_FOUND=1
+fi
+
+# --- Setup: Create test parent repo with submodule ---
+echo "--- Creating test environment ---"
+PARENT_DIR="$TEST_TMPDIR/parent"
+SUBMODULE_DIR="$TEST_TMPDIR/submodule"
+
+# Submodule repo
+mkdir -p "$SUBMODULE_DIR"
+git init -q "$SUBMODULE_DIR"
+git -C "$SUBMODULE_DIR" config user.email "test@test.dev"
+git -C "$SUBMODULE_DIR" config user.name "Test"
+echo "submodule-file" > "$SUBMODULE_DIR/file.txt"
+git -C "$SUBMODULE_DIR" add -A
+git -C "$SUBMODULE_DIR" commit -q -m "submodule init"
+
+# Parent repo with submodule
+mkdir -p "$PARENT_DIR"
+git init -q "$PARENT_DIR"
+git -C "$PARENT_DIR" config user.email "test@test.dev"
+git -C "$PARENT_DIR" config user.name "Test"
+git -C "$PARENT_DIR" submodule add "$SUBMODULE_DIR" mysubmodule
+git -C "$PARENT_DIR" add -A
+git -C "$PARENT_DIR" commit -q -m "parent init"
+git -C "$PARENT_DIR" checkout -q -b feature/test-gate4
+
+# Install the pre-commit hook
+cp "$PROJECT_DIR/.opencode/hooks/pre-commit" "$PARENT_DIR/.git/hooks/pre-commit"
+chmod +x "$PARENT_DIR/.git/hooks/pre-commit"
+echo "  Hook installed from hooks/pre-commit"
+echo ""
+
+# === Test 1: Submodule-pointer-only commit (feature branch) ===
+echo "--- Test 1: Submodule-pointer-only commit on feature branch ---"
+echo "updated" > "$PARENT_DIR/mysubmodule/file.txt"
+git -C "$PARENT_DIR/mysubmodule" add -A
+git -C "$PARENT_DIR/mysubmodule" commit -q -m "update"
+git -C "$PARENT_DIR" add mysubmodule
+
+set +e
+git -C "$PARENT_DIR" commit -m "test: submodule pointer only" > /dev/null 2>&1
+EXIT_1=$?
+set -e
+
+if [ "$EXIT_1" -eq 0 ]; then
+    echo "  ✗ FAIL (RED): Submodule-pointer-only commit was ALLOWED (exit 0)"
+    echo "    Gate 4 should block this but does not exist yet."
+    echo "    Expected: commit blocked (exit 1)"
+    OVERALL_RESULT=1
+else
+    echo "  ✓ PASS (GREEN): Submodule-pointer-only commit was BLOCKED (exit $EXIT_1)"
+fi
+
+# === Test 2: Submodule-pointer-only commit (pair-* branch) ===
+echo ""
+echo "--- Test 2: Submodule-pointer-only commit on pair-* branch ---"
+git -C "$PARENT_DIR" reset --hard HEAD~1 > /dev/null 2>&1 || true
+git -C "$PARENT_DIR" checkout -q -b pair-test/gate4-check
+
+echo "updated2" > "$PARENT_DIR/mysubmodule/file.txt"
+git -C "$PARENT_DIR/mysubmodule" add -A
+git -C "$PARENT_DIR/mysubmodule" commit -q -m "update2"
+git -C "$PARENT_DIR" add mysubmodule
+
+set +e
+git -C "$PARENT_DIR" commit -m "test: pair branch submodule pointer" > /dev/null 2>&1
+EXIT_2=$?
+set -e
+
+if [ "$EXIT_2" -eq 0 ]; then
+    echo "  ✗ FAIL (RED): Submodule-pointer-only commit was ALLOWED on pair-* branch (exit 0)"
+    echo "    Gate 4 should block ALL branches, including pair-*."
+    echo "    Expected: commit blocked (exit 1)"
+    OVERALL_RESULT=1
+else
+    echo "  ✓ PASS (GREEN): Submodule-pointer-only commit was BLOCKED on pair-* (exit $EXIT_2)"
+fi
+
+# === Result ===
+echo ""
+echo "=== TDD Result ==="
+if [ "$GATE4_FOUND" -eq 1 ]; then
+    echo "Gate 4 already exists — this test is moot."
+    echo "Revert hooks/pre-commit to run RED phase."
+    exit 0
+fi
+
+if [ "$OVERALL_RESULT" -ne 0 ]; then
+    echo "  RED (exit $OVERALL_RESULT): Gate 4 not implemented"
+    echo "  Proceed to GREEN: add Gate 4 to hooks/pre-commit"
+    exit $OVERALL_RESULT
+else
+    echo "  UNEXPECTED PASS: All commits were blocked — Gate 4 is already working"
+    echo "  (Test may have reached GREEN state without GREEN implementation)"
+    exit 0
+fi


### PR DESCRIPTION
## Summary

Adds pre-commit Gate 4 to `hooks/pre-commit` — a content-based submodule-pointer-only commit blocker with no branch-name exemptions.

## Success Criteria

| ID | Criterion | Evidence Type | Result |
|----|-----------|--------------|--------|
| SC-1 | Submodule-pointer-only commit on feature branch → blocked | `behavioral` | ✅ PASS |
| SC-2 | Mixed commit (submodule pointer + regular file) → allowed | `behavioral` | ✅ PASS |
| SC-5 | Submodule-pointer-only commit on `pair-*` branch → blocked | `behavioral` | ✅ PASS |
| SC-6 | Repo without `.gitmodules` → unaffected | `behavioral` | ✅ PASS |

## Implementation

Gate 4 reads submodule paths dynamically from `git submodule status | awk '{print $2}'`, compares against `git diff --cached --name-only`. If ALL staged files match submodule paths, the commit is blocked. No branch-name matching, no hardcoded paths, no exemptions.

Gate 3 (existing) exempts `pair-*`, `rollback/*`, `hotfix/*`, `main`, `dev` branches via branch-name matching. Gate 4 closes the gap: content-based, universal.

## Regression

SC-2 and SC-6 verified as PASS — Gate 4 does not affect mixed commits or repos without `.gitmodules`.

## File Changes

- `.opencode/hooks/pre-commit`: Gate 4 added after Gate 3 (lines 84–124), GATE_NAMES updated

Fixes #892

🤖 Co-authored with AI: OpenCode (deepseek-v4-flash-free)