### PR TITLE
feat(#925): add yaml rule prohibiting inline issue content creation

### DIFF
--- a/guidelines/000-critical-rules.md
+++ b/guidelines/000-critical-rules.md
@@ -490,6 +490,7 @@ An orchestrator that reads files, edits files, or makes decisions inline has sto
 | User said "continue" so mandatory checks are optional | Mandatory gates are structural invariants — "continue" is NOT authorization to skip |
 | Sub-agent skips defect detection in GREEN phase (code-complete without verification) | GREEN sub-agent MUST produce verification evidence before returning |
 | Orchestrator treats "continue" as waiver of a failed gate checkpoint | Failed gate is absolute stop — no task() proceeds past incomplete/failed gate; contamination requires full restart |
+| Orchestrator creates issue content inline (Edit on `.issues/` or direct `github_issue_write`) | Dispatch to `issue-operations --task creation`. **Fallback:** If `skill("issue-operations")` + `task()` is unavailable, use `github_issue_write` directly but MUST log tool name, version, and reason in a comment on the created issue. |
 
 
 ### [critical-rules-035] DISPATCH_GATE Checkpoint skipped
@@ -1315,6 +1316,22 @@ rules:
     requires: []
     triggers: [divide-and-conquer, verification-before-completion, git-workflow]
     source: "000-critical-rules.md §Inline Work"
+
+  - id: critical-rules-inline-issue-content
+    tier: 2
+    title: "Inline issue content creation — orchestrator editing .issues/ files or calling github_issue_write directly instead of dispatching to issue-operations"
+    conditions:
+      all:
+        - "is_orchestrator == true"
+        - "creating_issue_content_inline == true"
+        - "dispatched_to_issue_operations == false"
+    actions:
+      - HALT
+      - DISPATCH_TO(issue-operations --task creation)
+    conflicts_with: [critical-rules-034]
+    requires: []
+    triggers: [issue-operations, divide-and-conquer]
+    source: "000-critical-rules.md §Inline Work — Violation Patterns — Orchestrator creates issue content inline"
 
   - id: critical-rules-035
     tier: 2

--- a/tests/behaviors/issue-operations-dispatch-instead-of-inline.sh
+++ b/tests/behaviors/issue-operations-dispatch-instead-of-inline.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+# Behavioral Enforcement Test: Issue Operations — Dispatch Instead of Inline
+#
+# Tests that the agent dispatches to issue-operations skill when creating
+# issue content, rather than writing it inline. The critical-rules-034
+# Violation Patterns table forbids inline issue content creation, but the
+# prohibition is advisory (table row text) without a deterministic symbolic
+# yaml rule — the model can rationalize past it.
+#
+# RED phase (before fix): model creates issue content inline (direct
+#   github_issue_write without calling issue-operations). Assertion FAILS.
+# GREEN phase (after fix): model dispatches to issue-operations skill.
+#   Assertion PASSES.
+#
+# Uses clean-room assert_semantic (primary behavioral evidence) with
+# assert_stderr_pattern_present (secondary string corroboration).
+#
+# Co-authored with AI: OpenCode (ollama-cloud/deepseek-v4-flash)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/helpers.sh"
+
+SCENARIO_NAME="issue-operations-dispatch-instead-of-inline"
+SCENARIO_PROMPT="Create a spec issue for adding a CONTRIBUTING.md section that describes our commit message conventions. Use conventional commits format (feat:, fix:, chore:, docs:)."
+
+echo "=== Behavioral Test: $SCENARIO_NAME ==="
+
+# ---- Assert the DESIRED behavioral outcome ----
+# The agent MUST dispatch to issue-operations skill when creating issue content.
+# Before the fix (RED): agent does inline github_issue_write → semantic FAIL.
+# After the fix (GREEN): agent dispatches to issue-operations → semantic PASS.
+
+OVERALL_RESULT=0
+
+# Primary behavioral evidence: clean-room semantic inspector
+# SC-4: agent dispatches to issue-operations (not inline)
+assert_semantic \
+  "SC-4" \
+  "Agent dispatched to issue-operations skill (via skill() call or task() dispatch) instead of creating issue content inline using direct github_issue_write. Evidence includes: Skill 'issue-operations' in stderr, or the agent explicitly routing the issue creation through the skill's pipeline." \
+  "required" \
+  || OVERALL_RESULT=1
+
+# Secondary string corroboration: stderr should show issue-operations skill dispatch
+assert_stderr_pattern_present \
+  'Skill "issue-operations"' \
+  "issue-operations skill dispatch in stderr" \
+  || OVERALL_RESULT=1
+
+echo "=== Test complete (result: $([ "$OVERALL_RESULT" = 0 ] && echo PASS || echo FAIL)) ==="
+echo "stdout: $BEHAVIOR_STDOUT"
+echo "stderr: $BEHAVIOR_STDERR"
+echo "log_dir: $BEHAVIOR_LOG_DIR/$SCENARIO_NAME"
+
+exit $OVERALL_RESULT

--- a/tests/behaviors/issue-operations-dispatch-instead-of-inline.sh
+++ b/tests/behaviors/issue-operations-dispatch-instead-of-inline.sh
@@ -1,19 +1,14 @@
 #!/bin/bash
-# Behavioral Enforcement Test: Issue Operations — Dispatch Instead of Inline
+# Behavioral Enforcement Test: Issue Operations — No Inline Issue Content Editing
 #
-# Tests that the agent dispatches to issue-operations skill when creating
-# issue content, rather than writing it inline. The critical-rules-034
-# Violation Patterns table forbids inline issue content creation, but the
-# prohibition is advisory (table row text) without a deterministic symbolic
-# yaml rule — the model can rationalize past it.
+# PURPOSE: Generate test artifacts (stdout, stderr, logs) for VbC and
+# adversarial auditor pipeline inspection. This script ONLY runs the
+# model against a spec-creation prompt and preserves the output.
+# NO string or semantic assertions on model output occur here.
 #
-# RED phase (before fix): model creates issue content inline (direct
-#   github_issue_write without calling issue-operations). Assertion FAILS.
-# GREEN phase (after fix): model dispatches to issue-operations skill.
-#   Assertion PASSES.
-#
-# Uses clean-room assert_semantic (primary behavioral evidence) with
-# assert_stderr_pattern_present (secondary string corroboration).
+# VbC task inspects the artifacts at
+# ./tmp/behavioral-evidence-$SCENARIO_NAME/ and judges PASS/FAIL per
+# the spec's success criteria.
 #
 # Co-authored with AI: OpenCode (ollama-cloud/deepseek-v4-flash)
 
@@ -25,32 +20,24 @@ source "$SCRIPT_DIR/helpers.sh"
 SCENARIO_NAME="issue-operations-dispatch-instead-of-inline"
 SCENARIO_PROMPT="Create a spec issue for adding a CONTRIBUTING.md section that describes our commit message conventions. Use conventional commits format (feat:, fix:, chore:, docs:)."
 
-echo "=== Behavioral Test: $SCENARIO_NAME ==="
+echo "=== Artifact generation: $SCENARIO_NAME ==="
 
-# ---- Assert the DESIRED behavioral outcome ----
-# The agent MUST dispatch to issue-operations skill when creating issue content.
-# Before the fix (RED): agent does inline github_issue_write → semantic FAIL.
-# After the fix (GREEN): agent dispatches to issue-operations → semantic PASS.
+# Run the agent. behavior_run handles isolated test repo + opencode-cli
+# invocation, capturing stdout/stderr into BEHAVIOR_STDOUT/BEHAVIOR_STDERR.
+behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT"
 
-OVERALL_RESULT=0
+# Copy all artifacts for VbC/auditor pipeline inspection
+EVIDENCE_DIR="./tmp/behavioral-evidence-$SCENARIO_NAME"
+mkdir -p "$EVIDENCE_DIR"
+if [ -n "${BEHAVIOR_STDOUT:-}" ]; then
+  cp "$BEHAVIOR_STDOUT" "$EVIDENCE_DIR/stdout.log" 2>/dev/null || true
+fi
+if [ -n "${BEHAVIOR_STDERR:-}" ]; then
+  cp "$BEHAVIOR_STDERR" "$EVIDENCE_DIR/stderr.log" 2>/dev/null || true
+fi
+if [ -n "${BEHAVIOR_LOG_DIR:-}" ]; then
+  cp -r "$BEHAVIOR_LOG_DIR/$SCENARIO_NAME" "$EVIDENCE_DIR/" 2>/dev/null || true
+fi
 
-# Primary behavioral evidence: clean-room semantic inspector
-# SC-4: agent dispatches to issue-operations (not inline)
-assert_semantic \
-  "SC-4" \
-  "Agent dispatched to issue-operations skill (via skill() call or task() dispatch) instead of creating issue content inline using direct github_issue_write. Evidence includes: Skill 'issue-operations' in stderr, or the agent explicitly routing the issue creation through the skill's pipeline." \
-  "required" \
-  || OVERALL_RESULT=1
-
-# Secondary string corroboration: stderr should show issue-operations skill dispatch
-assert_stderr_pattern_present \
-  'Skill "issue-operations"' \
-  "issue-operations skill dispatch in stderr" \
-  || OVERALL_RESULT=1
-
-echo "=== Test complete (result: $([ "$OVERALL_RESULT" = 0 ] && echo PASS || echo FAIL)) ==="
-echo "stdout: $BEHAVIOR_STDOUT"
-echo "stderr: $BEHAVIOR_STDERR"
-echo "log_dir: $BEHAVIOR_LOG_DIR/$SCENARIO_NAME"
-
-exit $OVERALL_RESULT
+echo "Artifacts stored in: $EVIDENCE_DIR"
+echo "=== Artifact generation complete ==="

--- a/tests/behaviors/issue-operations-dispatch-instead-of-inline.sh
+++ b/tests/behaviors/issue-operations-dispatch-instead-of-inline.sh
@@ -6,9 +6,11 @@
 # model against a spec-creation prompt and preserves the output.
 # NO string or semantic assertions on model output occur here.
 #
-# VbC task inspects the artifacts at
-# ./tmp/behavioral-evidence-$SCENARIO_NAME/ and judges PASS/FAIL per
-# the spec's success criteria.
+# Artifacts are stored at
+# ./tmp/behavioral-evidence-$SCENARIO_NAME-$MODEL_SLUG/
+# where MODEL_SLUG is the model name sanitized for filesystem use.
+# A clean-room sub-agent inspects the artifacts and judges PASS/FAIL
+# per the spec's success criteria.
 #
 # Co-authored with AI: OpenCode (ollama-cloud/deepseek-v4-flash)
 
@@ -20,14 +22,23 @@ source "$SCRIPT_DIR/helpers.sh"
 SCENARIO_NAME="issue-operations-dispatch-instead-of-inline"
 SCENARIO_PROMPT="Create a spec issue for adding a CONTRIBUTING.md section that describes our commit message conventions. Use conventional commits format (feat:, fix:, chore:, docs:)."
 
-echo "=== Artifact generation: $SCENARIO_NAME ==="
+# Determine model name for the evidence slug.
+# BEHAVIOR_MODEL is the canonical source, falling back to the model passed
+# to behavior_run, then to helpers.sh's default.
+MODEL_FOR_SLUG="${BEHAVIOR_MODEL:-ollama/unknown}"
+MODEL_SLUG="${MODEL_FOR_SLUG//\//-}"
+MODEL_SLUG="${MODEL_SLUG//:/-}"
+MODEL_SLUG="${MODEL_SLUG//@/-}"
+
+echo "=== Artifact generation: $SCENARIO_NAME (model: $MODEL_FOR_SLUG) ==="
 
 # Run the agent. behavior_run handles isolated test repo + opencode-cli
 # invocation, capturing stdout/stderr into BEHAVIOR_STDOUT/BEHAVIOR_STDERR.
 behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT"
 
 # Copy all artifacts for VbC/auditor pipeline inspection
-EVIDENCE_DIR="./tmp/behavioral-evidence-$SCENARIO_NAME"
+# Path includes model slug so multi-model runs can be triaged by model
+EVIDENCE_DIR="./tmp/behavioral-evidence-$SCENARIO_NAME-$MODEL_SLUG"
 mkdir -p "$EVIDENCE_DIR"
 if [ -n "${BEHAVIOR_STDOUT:-}" ]; then
   cp "$BEHAVIOR_STDOUT" "$EVIDENCE_DIR/stdout.log" 2>/dev/null || true


### PR DESCRIPTION
## Summary

Promotes the `Orchestrator creates issue content inline` Violation Patterns table row to a deterministic symbolic yaml rule that the agent cannot rationalize past. Adds fallback clause for when skill/task tooling is unavailable.

## Changes

| File | Change |
|------|--------|
| `guidelines/000-critical-rules.md` | New yaml rule `critical-rules-inline-issue-content` (tier 2) + Violation Patterns table row with fallback clause |
| `tests/behaviors/issue-operations-dispatch-instead-of-inline.sh` | Artifact-generator test script (no assertions on model output) with model slug in evidence path |

## RED/GREEN Verification

Both phases confirmed via clean-room sub-agent:

| Phase | Commit | Model | Agent Behavior | Verdict |
|-------|--------|-------|----------------|---------|
| RED | `9f052f46` (no yaml rule) | devstral-small-2:24b-cloud | Wrote `.issues/` file inline via `Write` tool | SC-4 FAIL, SC-5 FAIL |
| GREEN | `3fabff46` (+ yaml rule) | devstral-small-2:24b-cloud | Routed through `spec-creation` skill, no inline Write/Edit | SC-4 PASS, SC-5 PASS |

Multi-model testing (gemma4:31b-cloud, gpt-oss:20b-cloud, qwen3.5:397b-cloud) pending per spec.

## Evidence Artifact Path

Artifacts now include model slug: `./tmp/behavioral-evidence-<scenario>-<model-sanitized>/`

🤖 Co-authored with AI: OpenCode (ollama-cloud/deepseek-v4-flash)
