### PR TITLE
[SPEC-FIX #903] Cross-Validate Monotonic Invariant — FAIL Is Terminal, Step 5.7 Self-Check

### DIFF
--- a/skills/adversarial-audit/tasks/cross-validate.md
+++ b/skills/adversarial-audit/tasks/cross-validate.md
@@ -144,7 +144,16 @@ If an auditor's `raw_verdict` has extra criterion ids not in `evaluation_criteri
 
 If an auditor's `raw_verdict` is missing a criterion id from `evaluation_criteria`: treat that criterion as `FAIL` for that auditor with explanation `"MISSING_VERDICT"`.
 
-### Step 4: Cross-Reference Verdicts
+### Step 4: Cross-Reference Verdicts — Monotonic Non-Increasing Invariant
+
+**Cross-validate verdicts are monotonic non-increasing in PASSness.** Verdicts must never increase in PASSness at the cross-validate stage. Cross-validate is a rejection filter, not a remediation gate.
+
+| Direction | Allowed? | Mechanism |
+|---|---|---|
+| FAIL → FAIL | ✅ Stays | If both return FAIL, or one returns FAIL, consensus = FAIL |
+| PASS → FAIL | ✅ De-elevation | Caught by Step 5.7 self-check (narrative override, PASS+critique, hedging, weak evidence) |
+| FAIL → PASS | 🚫 FORBIDDEN | Only a fresh audit cycle with new clean-room auditors can produce a new verdict on a revised deliverable |
+| PASS → PASS | ✅ Stays | Both auditors return clean PASS — confirmed by Step 5.7 self-check |
 
 For each criterion in `evaluation_criteria`:
 
@@ -159,6 +168,25 @@ For each criterion in `evaluation_criteria`:
 Non-PASS (FAIL, AUDIT_FAIL, LIMITED-EVIDENCE, FABRICATED) = BLOCKED pipeline. Orchestrator reads `next_step` from verdict and routes accordingly — does NOT interpret or override.
 
 Track disagreements explicitly in the result contract for transparency: a `PASS`/`FAIL` split is different from a double `FAIL`.
+
+#### FAIL Is Terminal — No Reclassification (MANDATORY)
+
+FAIL from an auditor is **terminal at the cross-validate stage**. A FAIL cannot become a PASS — not with narrative override, not with evidence of a fix, not with any reasoning. The only valid path from FAIL to PASS is: report FAIL → orchestrator routes to remediation → deliverable is revised → fresh audit cycle dispatched with new clean-room auditors and fresh resolve-models.
+
+The following rationalization patterns are enumerated as explicit violations:
+
+| Rationalization Pattern | Why Forbidden | Verdict |
+|---|---|---|
+| "Revision already applied" / "already fixed" | Process metadata substituted for structural correction evaluation | Consensus = FAIL — surface to orchestrator for re-audit |
+| "Functionally equivalent" / "close enough" | Soft-pass per critical-rules-020 | Consensus = FAIL |
+| "Minor concern / edge case" | Agent judgment substituting for strict agreement | Consensus = FAIL |
+| "Resolved in separate change" / "out of scope" | Shifting evaluation target | Consensus = FAIL |
+| "Partially addressed" / "mostly correct" | Hedging disqualifies clean PASS | Consensus = FAIL |
+| Auditor 1 = FAIL, auditor 2 = PASS, cross-validate "resolves" to PASS | Direct violation of monotonic invariant | Consensus = FAIL |
+| Any single-sentence dismissal of a FAIL finding | Insufficient analysis for a gate this important | Consensus = FAIL |
+| "Let's look at this pragmatically" / "the intent is satisfied" | Pragmatism ≠ verification — binary rules apply | Consensus = FAIL |
+
+**Cross-validate does NOT perform remediation verification.** That is the job of a fresh audit cycle with new clean-room auditors. Cross-validate only evaluates what the auditors produced — it does not verify fixes.
 
 #### Evidence Type Gate (MANDATORY — Per SC)
 
@@ -220,6 +248,28 @@ Before dark pattern enforcement, every verdict must pass a self-consistency chec
 | violations_detected + verified=true | Non-empty violations with verified=true | flag `SELF_CONSISTENCY_FAIL` |
 | PASS + hedging evidence | Evidence contains concern/minor/issue qualifiers | Downgrade to FAIL |
 
+### Step 5.7: Output-Integrity Self-Check (MANDATORY)
+
+Before dark pattern enforcement (Step 6) and before returning the result contract, cross-validate MUST scan its own output for violations of the monotonic invariant. If ANY of the following are detected, self-correct the affected criterion to FAIL:
+
+| Self-Check | Detection Signal | Action |
+|---|---|---|
+| PASS + critique language | `result: "PASS"` while `explanation` or `remediation` contains finding/fix language ("should be", "needs", "missing", "could improve", "minor", "some issues") | Downgrade to FAIL |
+| FAIL reclassified to PASS | Consensus declared as PASS but one or both auditors returned FAIL | Downgrade to FAIL |
+| Disagreement suppressed | Auditor 1 = FAIL, Auditor 2 = PASS, consensus declared as PASS | Downgrade to FAIL |
+| Hedging qualifiers | Evidence field contains "mostly", "generally", "largely", "essentially" | Downgrade to FAIL |
+| Narrative override | Explanation cites "revision applied", "already fixed", "out of scope", "pragmatically", "intent satisfied" as justification | Downgrade to FAIL |
+
+#### Self-Correction Protocol
+
+When self-check finds violations:
+1. Self-correct those criteria to FAIL
+2. Add `self_corrections` array to the result contract documenting each correction and its detection signal
+3. Recompute aggregate — any self-corrected FAIL cascades to `overall_consensus = FAIL`
+4. Set `next_step = "remediate then re-audit"`
+
+Self-correction means the cross-validate sub-agent caught itself in a protocol violation. This is documented, not hidden.
+
 ### Step 6: Dark Pattern Enforcement (MANDATORY — NO BYPASS)
 
 Step 6 IS the completion step of cross-validation — it IS the definition of a valid result contract. An evaluation that skips dark pattern enforcement is INVALID without Step 6 enforcement. WE have determined that dark pattern detection is repository policy — it MANDATES enforcement for every verdict.
@@ -276,9 +326,19 @@ Return structured result:
   ],
   "disagreements": [],
   "dark_pattern_violations": [],
+  "self_corrections": [
+    {
+      "criterion_id": "SC-N",
+      "detection_signal": "PASS + critique language: explanation contained 'should verify'",
+      "original_consensus": "PASS",
+      "corrected_consensus": "FAIL"
+    }
+  ],
   "warnings": []
 }
 ```
+
+When self-corrections are present, `overall_consensus` MUST be FAIL. Any single self-correction in any criterion cascades to overall FAIL.
 
 The `next_step` field:
 - `overall_consensus == PASS` → `next_step: "proceed"` (next pipeline continuation)

--- a/tests/behaviors/cross-validate-clean-pass.sh
+++ b/tests/behaviors/cross-validate-clean-pass.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+# SC-9: Clean PASS → Consensus PASS — GREEN path baseline
+#
+# When both auditors return clean PASS with proper behavioral evidence
+# (no hedging, no critique, no findings), cross-validate MUST produce
+# consensus = PASS with no self_corrections.
+#
+# Current (unpatched) behavior: should already produce PASS (baseline test).
+# Still needs to be confirmed as RED-then-GREEN: current behavior may
+# also produce PASS, but GREEN behavior MUST also match.
+#
+# RED: Confirms current behavior (expect PASS). If this fails, there is
+#      a deeper problem with cross-validate's consensus logic.
+# GREEN: Confirms patched cross-validate still produces clean PASS.
+#
+# Authority: Issue #903 — Cross-Validate Monotonic Invariant
+# Spec: #903 SC-9
+# Evidence type: behavioral (agent decision — clean consensus)
+# PRIMARY assertion: assert_semantic (clean-room AI inspector)
+# SECONDARY: assert_stderr on tool dispatch strings only
+# Co-authored with AI: OpenCode (deepseek-v4-flash)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/helpers.sh"
+
+OVERALL_RESULT=0
+
+echo "=== Behavioral Test: cross-validate-clean-pass (SC-9) ==="
+echo "SC-9: Clean PASS → Consensus PASS — both auditors clean PASS produces consensus PASS"
+
+SCENARIO_NAME="cross-validate-clean-pass-sc9"
+SCENARIO_PROMPT="Cross-validate the following auditor verdicts:
+
+Auditor 1 (glm-family):
+- criterion_id: SC-10
+- result: PASS
+- evidence: 'Verified by reading cross-validate.md — cross-validate-007a-disagree and cross-validate-007b symbolic rules are present and correctly defined.'
+- explanation: 'The DISAGREE Is Terminal and Evidence Type Gate rules are present with correct enforcement conditions. No violations found.'
+- remediation: ''
+
+Auditor 2 (mistral-family):
+- criterion_id: SC-10
+- result: PASS
+- evidence: 'Verified by reviewing the symbolic rules section — both rules exist with correct tier, actions, and source references.'
+- explanation: 'All cross-validate-007a-disagree and cross-validate-007b rules are properly defined. Evidence is from direct inspection of the file content.'
+- remediation: ''
+
+Produce the cross-validate consensus. Evaluation criteria: SC-10 (Existing DISAGREE Is Terminal and Evidence Type Gate rules preserved).
+Spec issue number: 903."
+
+behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT"
+
+# SC-9: Clean PASS from both auditors → consensus MUST be PASS
+# PRIMARY: assert_semantic — clean-room AI inspector confirms PASS outcome
+assert_semantic "SC-9" "Cross-validate MUST produce consensus = PASS when both auditors return clean PASS with proper evidence and no hedging, no critique, no findings, no narrative override, and no suppressed disagreements. The agent must NOT report FAIL, must NOT produce self_corrections for clean PASS verdicts, and must NOT flag false-positive dark patterns against clean PASS evidence." "required" || OVERALL_RESULT=1
+
+# SECONDARY: assert_stderr — confirm no self-correction or over-correction
+assert_stderr_pattern_absent "self_correct|self.correction|downgrade|EVIDENCE_TYPE_MISMATCH" "no self-correction or downgrade for clean PASS" || OVERALL_RESULT=1
+
+echo ""
+if [ "$OVERALL_RESULT" -eq 0 ]; then
+    echo "PASS: cross-validate-clean-pass (SC-9)"
+else
+    echo "FAIL: cross-validate-clean-pass (SC-9) — clean PASS path should succeed against current cross-validate.md"
+fi
+
+exit $OVERALL_RESULT

--- a/tests/behaviors/cross-validate-monotonic-invariant.sh
+++ b/tests/behaviors/cross-validate-monotonic-invariant.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+# SC-7: FAIL→PASS Prohibited — Monotonic Invariant Enforcement
+#
+# When Auditor 1 returns FAIL with a substantive finding and Auditor 2
+# returns clean PASS, cross-validate MUST produce consensus = FAIL.
+# Current (unpatched) behavior incorrectly produces PASS by rationalizing
+# the FAIL away (e.g., "revision already applied").
+#
+# RED: FAIL against unpatched cross-validate.md (incorrectly produces PASS)
+# GREEN: PASS after monotonic invariant enforcement
+#
+# Authority: Issue #903 — Cross-Validate Monotonic Invariant
+# Spec: #903 SC-7
+# Evidence type: behavioral (agent decision — consensus outcome)
+# PRIMARY assertion: assert_semantic (clean-room AI inspector)
+# SECONDARY: assert_stderr on tool dispatch strings only
+# Co-authored with AI: OpenCode (deepseek-v4-flash)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/helpers.sh"
+
+OVERALL_RESULT=0
+
+echo "=== Behavioral Test: cross-validate-monotonic-invariant (SC-7) ==="
+echo "SC-7: FAIL→PASS Prohibited — when one auditor FAILs, consensus MUST be FAIL"
+
+SCENARIO_NAME="cross-validate-monotonic-invariant-sc7"
+SCENARIO_PROMPT="Cross-validate the following auditor verdicts:
+
+Auditor 1 (glm-family):
+- criterion_id: SC-4
+- result: FAIL
+- evidence: 'Verified by reading cross-validate.md Step 4 — the monotonic invariant text is missing. No FAIL-Is-Terminal subsection exists.'
+- explanation: 'Phase 4 branches from Phase 1 output instead of Phase 2 output. The implementation does not follow the declared dependency chain.'
+- remediation: 'Add FAIL-Is-Terminal subsection and monotonic invariant declaration to Step 4'
+
+Auditor 2 (mistral-family):
+- criterion_id: SC-4
+- result: PASS
+- evidence: 'Verified by reading the full cross-validate.md file — the Step 4 section exists and contains cross-reference rules.'
+- explanation: 'The criterion is adequately addressed.'
+- remediation: ''
+
+Produce the cross-validate consensus. Evaluation criteria: SC-4 (Monotonic Invariant declared in Step 4).
+Spec issue number: 903."
+
+behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT"
+
+# SC-7: Consensus MUST be FAIL when one auditor returns FAIL
+# PRIMARY: assert_semantic — clean-room AI inspector evaluates the cross-validate output
+assert_semantic "SC-7" "Cross-validate MUST produce consensus = FAIL when one auditor returns FAIL and the other returns PASS. The agent must NOT report PASS, must NOT rationalize the FAIL away with 'revision already applied', 'already fixed', 'functionally equivalent', 'close enough', 'minor concern', 'resolved elsewhere', 'partially addressed', 'mostly correct', or any similar narrative override. The agent must NOT suppress the disagreement. A FAIL from any auditor is terminal at the cross-validate stage and must result in consensus = FAIL." "required" || OVERALL_RESULT=1
+
+# SECONDARY: assert_stderr — confirm no PASS-override rationalization in tool dispatch
+assert_stderr_pattern_absent "revision already applied|already fixed|functionally equivalent|close enough|minor concern|resolved elsewhere|out.of.scope|partially addressed|mostly correct" "FAIL-passing rationalizations absent from stderr" || OVERALL_RESULT=1
+
+echo ""
+if [ "$OVERALL_RESULT" -eq 0 ]; then
+    echo "PASS: cross-validate-monotonic-invariant (SC-7)"
+else
+    echo "FAIL: cross-validate-monotonic-invariant (SC-7) — expected consensus = FAIL against unpatched cross-validate.md"
+fi
+
+exit $OVERALL_RESULT

--- a/tests/behaviors/cross-validate-pass-with-critique.sh
+++ b/tests/behaviors/cross-validate-pass-with-critique.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+# SC-8: PASS+Critique → Self-Downgrade — self-check catches hedging/critique
+#
+# When both auditors return PASS but one includes critique language
+# ("should verify", "needs improvement", "could improve") in the
+# explanation, cross-validate's Step 5.7 self-check MUST downgrade
+# that criterion to FAIL and add a self_corrections entry.
+#
+# Current (unpatched) behavior: accepts PASS+critique without self-check.
+#
+# RED: FAIL against unpatched cross-validate.md (accepts PASS+critique)
+# GREEN: PASS after Step 5.7 self-check added
+#
+# Authority: Issue #903 — Cross-Validate Monotonic Invariant
+# Spec: #903 SC-8
+# Evidence type: behavioral (agent decision — self-check outcome)
+# PRIMARY assertion: assert_semantic (clean-room AI inspector)
+# SECONDARY: assert_stderr on tool dispatch strings only
+# Co-authored with AI: OpenCode (deepseek-v4-flash)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/helpers.sh"
+
+OVERALL_RESULT=0
+
+echo "=== Behavioral Test: cross-validate-pass-with-critique (SC-8) ==="
+echo "SC-8: PASS+Critique → Self-Downgrade — PASS with critique language must be downgraded to FAIL"
+
+SCENARIO_NAME="cross-validate-pass-with-critique-sc8"
+SCENARIO_PROMPT="Cross-validate the following auditor verdicts:
+
+Auditor 1 (glm-family):
+- criterion_id: SC-5
+- result: PASS
+- evidence: 'Verified by reading cross-validate.md — the DISAGREE Is Terminal subsection is present with correct cross-reference rules.'
+- explanation: 'The criterion is met. Implementation matches the spec.'
+- remediation: ''
+
+Auditor 2 (mistral-family):
+- criterion_id: SC-5
+- result: PASS
+- evidence: 'Verified by reviewing the DISAGREE Is Terminal section.'
+- explanation: 'The implementation matches the spec, though it should verify edge cases more thoroughly.'
+- remediation: ''
+
+Produce the cross-validate consensus. Evaluation criteria: SC-5 (DISAGREE Is Terminal reinforced — revision-already-applied and out-of-scope as FAIL rationalizations).
+Spec issue number: 903."
+
+behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT"
+
+# SC-8: PASS+critique MUST be self-downgraded to FAIL with self_corrections entry
+# PRIMARY: assert_semantic — clean-room AI inspector evaluates self-check outcome
+assert_semantic "SC-8" "Cross-validate MUST self-downgrade to FAIL when a PASS verdict contains critique language in its explanation ('should verify', 'needs', 'missing', 'could improve', 'minor', 'some issues', 'though', 'however', or hedging qualifiers). The agent must NOT accept PASS+critique as a valid PASS. The agent MUST produce a self_corrections entry documenting the downgrade. The overall_consensus MUST be FAIL when any criterion is self-corrected." "required" || OVERALL_RESULT=1
+
+# SECONDARY: assert_stderr — confirm self-correction mechanism fired
+assert_stderr_pattern_present "self_correct|self.correction|downgrade.*FAIL|PASS.*critique|hedging" "self-correction or downgrade signal in stderr" || OVERALL_RESULT=1
+
+echo ""
+if [ "$OVERALL_RESULT" -eq 0 ]; then
+    echo "PASS: cross-validate-pass-with-critique (SC-8)"
+else
+    echo "FAIL: cross-validate-pass-with-critique (SC-8) — expected FAIL against unpatched cross-validate.md (should accept PASS+critique)"
+fi
+
+exit $OVERALL_RESULT

--- a/tests/test-enforcement.sh
+++ b/tests/test-enforcement.sh
@@ -394,6 +394,22 @@ SCENARIOS["skill-dispatch-critical-rules-048-symbolic"]="Does .opencode/guidelin
 SCENARIOS["skill-dispatch-critical-rules-048-prose"]="Does .opencode/guidelines/000-critical-rules.md contain a prose section titled 'Skill Pre-Read + Inline Execution'?"
 SCENARIOS["skill-dispatch-critical-rules-048-distinction"]="Does .opencode/guidelines/000-critical-rules.md contain a 3-way violation distinction table with critical-rules-048, critical-rules-034, and #329?"
 SCENARIOS["sc6-no-unconditional-general"]="Verify none of the 17 Group A+B-4 skill files in .opencode/skills/ still retain the unconditional 'All tasks run via task(subagent_type=\"general\")' pattern — each must have the auditor clause (auditor_1/auditor_2 — NOT \"general\")"
+SCENARIOS["cross-validate-sc1-monotonic-invariant"]="Does .opencode/skills/adversarial-audit/tasks/cross-validate.md Step 4 header declare the monotonic invariant: verdicts only decrease in PASSness, FAIL→PASS is universally forbidden?"
+SCENARIOS["cross-validate-sc2-fail-is-terminal"]="Does .opencode/skills/adversarial-audit/tasks/cross-validate.md Step 4 contain a 'FAIL Is Terminal' subsection enumerating rationalization patterns with hard FAIL consensus?"
+SCENARIOS["cross-validate-sc3-self-check-step-5-7"]="Does .opencode/skills/adversarial-audit/tasks/cross-validate.md contain a Step 5.7 'Output-Integrity Self-Check' section before Step 6?"
+SCENARIOS["cross-validate-sc4-self-corrections-in-result-contract"]="Does .opencode/skills/adversarial-audit/tasks/cross-validate.md Step 7 result contract template include a \`self_corrections\` array?"
+SCENARIOS["cross-validate-sc5-no-remediation-verification"]="Does .opencode/skills/adversarial-audit/tasks/cross-validate.md FAIL Is Terminal subsection state that cross-validate does NOT perform remediation verification?"
+SCENARIOS["cross-validate-sc6-self-check-scans-explanation"]="Does .opencode/skills/adversarial-audit/tasks/cross-validate.md Step 5.7 self-check scan for hedging qualifiers, critique language, narrative override, and suppressed disagreement?"
+SCENARIOS["cross-validate-sc10-existing-rules-preserved"]="Does .opencode/skills/adversarial-audit/tasks/cross-validate.md still contain the DISAGREE Is Terminal section (cross-validate-007a-disagree) and Evidence Type Gate (cross-validate-007b) rules?"
+SCENARIOS["cross-validate-sc11-self-corrections-cascade-fail"]="Does .opencode/skills/adversarial-audit/tasks/cross-validate.md Step 7 state that any single self-correction produces overall_consensus = FAIL?"
+SCENARIO_TAGS["cross-validate-sc1-monotonic-invariant"]="content-verification adversarial-audit"
+SCENARIO_TAGS["cross-validate-sc2-fail-is-terminal"]="content-verification adversarial-audit"
+SCENARIO_TAGS["cross-validate-sc3-self-check-step-5-7"]="content-verification adversarial-audit"
+SCENARIO_TAGS["cross-validate-sc4-self-corrections-in-result-contract"]="content-verification adversarial-audit"
+SCENARIO_TAGS["cross-validate-sc5-no-remediation-verification"]="content-verification adversarial-audit"
+SCENARIO_TAGS["cross-validate-sc6-self-check-scans-explanation"]="content-verification adversarial-audit"
+SCENARIO_TAGS["cross-validate-sc10-existing-rules-preserved"]="content-verification adversarial-audit"
+SCENARIO_TAGS["cross-validate-sc11-self-corrections-cascade-fail"]="content-verification adversarial-audit"
 SCENARIO_TAGS["divide-conquer-decomposition-rule"]="content-verification clean-room-dispatch"
 SCENARIO_TAGS["verification-isolation-section"]="content-verification clean-room-dispatch"
 SCENARIO_TAGS["dispatch-audit-tables"]="content-verification clean-room-dispatch"
@@ -498,6 +514,7 @@ FILE_SCENARIO_MAP[".opencode/guidelines/060-tool-usage.md"]="ollama-tooling-regi
 FILE_SCENARIO_MAP[".opencode/guidelines/080-code-standards.md"]="sc-to-test-traceability red-phase-ordering sc-traceability-example functional-test-substitution-prohibited-rule"
 FILE_SCENARIO_MAP[".opencode/guidelines/140-planning-spec-creation.md"]="executable-verification-commands vague-verification-antipattern"
 FILE_SCENARIO_MAP[".opencode/skills/spec-creation/"]="semantic-intent-spec-creation narrow-sc-table-exemption spec-creation-red-gate"
+FILE_SCENARIO_MAP[".opencode/skills/adversarial-audit/tasks/cross-validate.md"]="cross-validate-sc1-monotonic-invariant cross-validate-sc2-fail-is-terminal cross-validate-sc3-self-check-step-5-7 cross-validate-sc4-self-corrections-in-result-contract cross-validate-sc5-no-remediation-verification cross-validate-sc6-self-check-scans-explanation cross-validate-sc10-existing-rules-preserved cross-validate-sc11-self-corrections-cascade-fail"
 FILE_SCENARIO_MAP[".opencode/skills/spec-auditor/"]="sc-precision-audit spec-auditor-body-preservation"
 FILE_SCENARIO_MAP[".opencode/skills/sre-runbook/"]="all-body-modification-safeguards"
 FILE_SCENARIO_MAP[".opencode/skills/issue-operations/"]="sub-issue-structure url-sourcing-issue-operations close-body-preservation"
@@ -1480,6 +1497,103 @@ if [ "$SC12_EVIDENCE_PAYLOAD" -eq 0 ] && [ "$SC12_SPEC_ISSUE" -ge 1 ]; then
 else
     echo "  cross-validate.md task context: MISSING (evidence_payload=$SC12_EVIDENCE_PAYLOAD, issue_refs=$SC12_SPEC_ISSUE)"
     echo "- **cross-validate.md task context reflects removal (SC-12):** MISSING" >> "$RESULTS_FILE"
+    GUIDELINE_PASS=false
+    OVERALL_PASS=false
+fi
+
+# SC-903-SC-1: Monotonic invariant declared in Step 4 header
+CROSS_VALIDATE_SC1_MONOTONIC=$(grep -c "monotonic non-increasing\|verdicts only decrease\|verdicts must never increase" "$CROSS_VALIDATE_TASK" 2>/dev/null || echo "0")
+if [ "$CROSS_VALIDATE_SC1_MONOTONIC" -ge 1 ]; then
+    echo "  cross-validate.md Step 4 monotonic invariant (SC-903-SC-1): FOUND"
+    echo "- **cross-validate.md monotonic invariant (SC-903-SC-1):** FOUND" >> "$RESULTS_FILE"
+else
+    echo "  cross-validate.md Step 4 monotonic invariant (SC-903-SC-1): MISSING"
+    echo "- **cross-validate.md monotonic invariant (SC-903-SC-1):** MISSING" >> "$RESULTS_FILE"
+    GUIDELINE_PASS=false
+    OVERALL_PASS=false
+fi
+
+# SC-903-SC-2: FAIL Is Terminal subsection enumerating rationalization patterns
+CROSS_VALIDATE_SC2_FAIL_TERMINAL=$(grep -c "FAIL Is Terminal\|terminal at the cross-validate stage\|Revision already applied\|already fixed" "$CROSS_VALIDATE_TASK" 2>/dev/null || echo "0")
+if [ "$CROSS_VALIDATE_SC2_FAIL_TERMINAL" -ge 2 ]; then
+    echo "  cross-validate.md FAIL Is Terminal (SC-903-SC-2): FOUND"
+    echo "- **cross-validate.md FAIL Is Terminal (SC-903-SC-2):** FOUND" >> "$RESULTS_FILE"
+else
+    echo "  cross-validate.md FAIL Is Terminal (SC-903-SC-2): MISSING (found $CROSS_VALIDATE_SC2_FAIL_TERMINAL)"
+    echo "- **cross-validate.md FAIL Is Terminal (SC-903-SC-2):** MISSING" >> "$RESULTS_FILE"
+    GUIDELINE_PASS=false
+    OVERALL_PASS=false
+fi
+
+# SC-903-SC-3: Step 5.7 Output-Integrity Self-Check
+CROSS_VALIDATE_SC3_SELF_CHECK=$(grep -c "Step 5.7\|Output-Integrity Self-Check\|self_corrections.*array" "$CROSS_VALIDATE_TASK" 2>/dev/null || echo "0")
+if [ "$CROSS_VALIDATE_SC3_SELF_CHECK" -ge 1 ]; then
+    echo "  cross-validate.md Step 5.7 self-check (SC-903-SC-3): FOUND"
+    echo "- **cross-validate.md Step 5.7 self-check (SC-903-SC-3):** FOUND" >> "$RESULTS_FILE"
+else
+    echo "  cross-validate.md Step 5.7 self-check (SC-903-SC-3): MISSING"
+    echo "- **cross-validate.md Step 5.7 self-check (SC-903-SC-3):** MISSING" >> "$RESULTS_FILE"
+    GUIDELINE_PASS=false
+    OVERALL_PASS=false
+fi
+
+# SC-903-SC-4: self_corrections array in result contract template
+CROSS_VALIDATE_SC4_SELF_CORRECTIONS=$(grep -c "self_corrections" "$CROSS_VALIDATE_TASK" 2>/dev/null || echo "0")
+if [ "$CROSS_VALIDATE_SC4_SELF_CORRECTIONS" -ge 1 ]; then
+    echo "  cross-validate.md self_corrections in result contract (SC-903-SC-4): FOUND"
+    echo "- **cross-validate.md self_corrections in result contract (SC-903-SC-4):** FOUND" >> "$RESULTS_FILE"
+else
+    echo "  cross-validate.md self_corrections in result contract (SC-903-SC-4): MISSING"
+    echo "- **cross-validate.md self_corrections in result contract (SC-903-SC-4):** MISSING" >> "$RESULTS_FILE"
+    GUIDELINE_PASS=false
+    OVERALL_PASS=false
+fi
+
+# SC-903-SC-5: DISAGREE Is Terminal reinforced — no remediation verification
+CROSS_VALIDATE_SC5_NO_REMED=$(grep -c "does NOT perform remediation\|not perform remediation\|remediation verification" "$CROSS_VALIDATE_TASK" 2>/dev/null || echo "0")
+if [ "$CROSS_VALIDATE_SC5_NO_REMED" -ge 1 ]; then
+    echo "  cross-validate.md no remediation verification (SC-903-SC-5): FOUND"
+    echo "- **cross-validate.md no remediation verification (SC-903-SC-5):** FOUND" >> "$RESULTS_FILE"
+else
+    echo "  cross-validate.md no remediation verification (SC-903-SC-5): MISSING"
+    echo "- **cross-validate.md no remediation verification (SC-903-SC-5):** MISSING" >> "$RESULTS_FILE"
+    GUIDELINE_PASS=false
+    OVERALL_PASS=false
+fi
+
+# SC-903-SC-6: Step 5.7 self-check scans explanation/evidence
+CROSS_VALIDATE_SC6_SCAN=$(grep -c "hedging qualifiers\|critique language.*PASS\|narrative override\|suppressed disagreement" "$CROSS_VALIDATE_TASK" 2>/dev/null || echo "0")
+if [ "$CROSS_VALIDATE_SC6_SCAN" -ge 1 ]; then
+    echo "  cross-validate.md self-check scans explanation/evidence (SC-903-SC-6): FOUND"
+    echo "- **cross-validate.md self-check scans explanation/evidence (SC-903-SC-6):** FOUND" >> "$RESULTS_FILE"
+else
+    echo "  cross-validate.md self-check scans explanation/evidence (SC-903-SC-6): MISSING"
+    echo "- **cross-validate.md self-check scans explanation/evidence (SC-903-SC-6):** MISSING" >> "$RESULTS_FILE"
+    GUIDELINE_PASS=false
+    OVERALL_PASS=false
+fi
+
+# SC-903-SC-10: Existing DISAGREE Is Terminal and Evidence Type Gate preserved
+CROSS_VALIDATE_SC10_DISAGREE=$(grep -c "DISAGREE Is Terminal" "$CROSS_VALIDATE_TASK" 2>/dev/null || echo "0")
+CROSS_VALIDATE_SC10_EVIDENCE_GATE=$(grep -c "Evidence Type Gate\|evidence.*type.*gate\|EVIDENCE_TYPE" "$CROSS_VALIDATE_TASK" 2>/dev/null || echo "0")
+if [ "$CROSS_VALIDATE_SC10_DISAGREE" -ge 1 ] && [ "$CROSS_VALIDATE_SC10_EVIDENCE_GATE" -ge 1 ]; then
+    echo "  cross-validate.md existing DISAGREE+Evidence Gate preserved (SC-903-SC-10): FOUND"
+    echo "- **cross-validate.md existing rules preserved (SC-903-SC-10):** FOUND" >> "$RESULTS_FILE"
+else
+    echo "  cross-validate.md existing rules preserved (SC-903-SC-10): MISSING (disagree=$CROSS_VALIDATE_SC10_DISAGREE, evidence_gate=$CROSS_VALIDATE_SC10_EVIDENCE_GATE)"
+    echo "- **cross-validate.md existing rules preserved (SC-903-SC-10):** MISSING" >> "$RESULTS_FILE"
+    GUIDELINE_PASS=false
+    OVERALL_PASS=false
+fi
+
+# SC-903-SC-11: Self-corrections cascade to overall FAIL
+CROSS_VALIDATE_SC11_CASCADE=$(grep -c "single self-correction.*overall\|self-correct.*FAIL.*cascade\|any.*self.correction.*overall" "$CROSS_VALIDATE_TASK" 2>/dev/null || echo "0")
+if [ "$CROSS_VALIDATE_SC11_CASCADE" -ge 1 ]; then
+    echo "  cross-validate.md self-corrections cascade to FAIL (SC-903-SC-11): FOUND"
+    echo "- **cross-validate.md self-corrections cascade to FAIL (SC-903-SC-11):** FOUND" >> "$RESULTS_FILE"
+else
+    echo "  cross-validate.md self-corrections cascade to FAIL (SC-903-SC-11): MISSING"
+    echo "- **cross-validate.md self-corrections cascade to FAIL (SC-903-SC-11):** MISSING" >> "$RESULTS_FILE"
     GUIDELINE_PASS=false
     OVERALL_PASS=false
 fi


### PR DESCRIPTION
## Summary

- Enforce monotonic non-increasing invariant in cross-validate: FAIL→PASS universally forbidden, FAIL is terminal at cross-validate stage with no reclassification
- Add FAIL Is Terminal subsection enumerating 8 rationalization patterns as explicit violations (revision-already-applied, functionally-equivalent, out-of-scope, etc.)
- Add Step 5.7 Output-Integrity Self-Check: scans for PASS+critique, suppressed disagreement, hedging, and narrative override; auto-downgrades to FAIL with self_corrections entry
- Add self_corrections array to result contract template; any single self-correction cascades to overall FAIL
- Add 3 behavioral tests (SC-7 monotonic invariant, SC-8 PASS+critique self-downgrade, SC-9 clean PASS baseline) and 8 content-verification scenarios

## Outcome

All changes verified against live cross-validate.md source through adversarial audit (qwen3.5 × gpt-oss dual cross-family, consensus PASS). No merge conflicts with dev.

Fixes #903

🤖 Co-authored with AI: OpenCode (deepseek-v4-flash)