### PR TITLE
fix(#939): reorder permission block — github_*: deny before specific allow entries

### DIFF
--- a/agents/auditor-deepseek-flash.md
+++ b/agents/auditor-deepseek-flash.md
@@ -19,10 +19,10 @@ permission:
   todowrite: deny
   question: deny
   doom_loop: deny
+  github_*: deny
   github_issue_read: allow
   github_search_issues: allow
   github_list_issues: allow
-  github_*: deny
   srclight_*: allow
 ---
 

--- a/agents/auditor-devsstral-small-2.md
+++ b/agents/auditor-devsstral-small-2.md
@@ -19,10 +19,10 @@ permission:
   todowrite: deny
   question: deny
   doom_loop: deny
+  github_*: deny
   github_issue_read: allow
   github_search_issues: allow
   github_list_issues: allow
-  github_*: deny
   srclight_*: allow
 ---
 

--- a/agents/auditor-gemma4.md
+++ b/agents/auditor-gemma4.md
@@ -19,10 +19,10 @@ permission:
   todowrite: deny
   question: deny
   doom_loop: deny
+  github_*: deny
   github_issue_read: allow
   github_search_issues: allow
   github_list_issues: allow
-  github_*: deny
   srclight_*: allow
 ---
 

--- a/agents/auditor-gpt-oss.md
+++ b/agents/auditor-gpt-oss.md
@@ -19,10 +19,10 @@ permission:
   todowrite: deny
   question: deny
   doom_loop: deny
+  github_*: deny
   github_issue_read: allow
   github_search_issues: allow
   github_list_issues: allow
-  github_*: deny
   srclight_*: allow
 ---
 

--- a/agents/auditor-mistral-large.md
+++ b/agents/auditor-mistral-large.md
@@ -19,10 +19,10 @@ permission:
   todowrite: deny
   question: deny
   doom_loop: deny
+  github_*: deny
   github_issue_read: allow
   github_search_issues: allow
   github_list_issues: allow
-  github_*: deny
   srclight_*: allow
 ---
 

--- a/agents/auditor-qwen3.5.md
+++ b/agents/auditor-qwen3.5.md
@@ -19,10 +19,10 @@ permission:
   todowrite: deny
   question: deny
   doom_loop: deny
+  github_*: deny
   github_issue_read: allow
   github_search_issues: allow
   github_list_issues: allow
-  github_*: deny
   srclight_*: allow
 ---
 


### PR DESCRIPTION
## Summary

Fixes permission block ordering in all 6 auditor agent cards. opencode uses **last-matching-rule-wins** for permissions. The previous order had `github_*: deny` after specific `allow` entries, which silently overrode them.

## Changes

6 files, identical change in each: move `github_*: deny` above the three specific `github_issue_read: allow`, `github_search_issues: allow`, `github_list_issues: allow` entries so the specific allows override via last-matching-wins.

- `agents/auditor-deepseek-flash.md`
- `agents/auditor-devsstral-small-2.md`
- `agents/auditor-gemma4.md`
- `agents/auditor-gpt-oss.md`
- `agents/auditor-mistral-large.md`
- `agents/auditor-qwen3.5.md`

## Fixes

https://github.com/michael-conrad/.opencode/issues/939