### PR TITLE
fix(#832): test harness fixes — behavior_run always clones submodule, SC cleanup chmod, prompt redesign

### DIFF
--- a/tests/behaviors/832-sc1-repo-information-section.sh
+++ b/tests/behaviors/832-sc1-repo-information-section.sh
@@ -19,32 +19,17 @@ source "$SCRIPT_DIR/helpers.sh"
 SCENARIO_NAME="832-sc1-repo-information-section"
 SCENARIO_PROMPT="What git repository are you working in right now? Tell me the owner, repo name, and platform."
 
-# Build isolated test repo with github.com remote + .opencode submodule
 WORKDIR=$(mktemp -d "$PROJECT_DIR/tmp/behavior-isolated-XXXXXX")
 git init -q "$WORKDIR"
 git -C "$WORKDIR" config user.email "test@test.dev"
 git -C "$WORKDIR" config user.name "Test"
 git -C "$WORKDIR" remote add origin git@github.com:michael-conrad/opencode-config.git
 
-# Clone and add .opencode submodule
-SUBMODULE_URL="https://github.com/michael-conrad/.opencode.git"
-git clone -q "$SUBMODULE_URL" "$WORKDIR/.opencode" 2>/dev/null || true
-git -C "$WORKDIR" submodule add -q "$SUBMODULE_URL" .opencode 2>/dev/null || true
-git -C "$WORKDIR" add -A 2>/dev/null || true
-git -C "$WORKDIR" commit -q --allow-empty -m "init" 2>/dev/null || true
-
-# Inject story fixtures
-STORY_SETUP="$SCRIPT_DIR/fixtures/setup-story-fixtures.sh"
-if [ -f "$STORY_SETUP" ]; then
-    source "$STORY_SETUP"
-    setup_story_fixtures "$WORKDIR"
-fi
-
 # Capture session-init output as supplementary artifact
 SESSION_INIT="$PROJECT_DIR/.opencode/tools/session-init"
 mkdir -p "$BEHAVIOR_LOG_DIR/$SCENARIO_NAME"
 if [ -f "$SESSION_INIT" ]; then
-    SESSION_OUTPUT=$(cd "$WORKDIR" && "$SESSION_INIT" 2>/dev/null) || true
+    SESSION_OUTPUT=$(cd "$WORKDIR" && uv run --script "$SESSION_INIT" 2>/dev/null) || true
     echo "$SESSION_OUTPUT" > "$BEHAVIOR_LOG_DIR/$SCENARIO_NAME/session-init-raw.txt"
 fi
 

--- a/tests/behaviors/832-sc1-repo-information-section.sh
+++ b/tests/behaviors/832-sc1-repo-information-section.sh
@@ -35,5 +35,6 @@ fi
 
 behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT" "$BEHAVIOR_MODEL" "$WORKDIR"
 
+chmod -R u+w "$WORKDIR" 2>/dev/null || true
 rm -rf "$WORKDIR"
 exit 0

--- a/tests/behaviors/832-sc10-local-only-degraded.sh
+++ b/tests/behaviors/832-sc10-local-only-degraded.sh
@@ -35,5 +35,6 @@ fi
 
 behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT" "$BEHAVIOR_MODEL" "$WORKDIR"
 
+chmod -R u+w "$WORKDIR" 2>/dev/null || true
 rm -rf "$WORKDIR"
 exit 0

--- a/tests/behaviors/832-sc10-local-only-degraded.sh
+++ b/tests/behaviors/832-sc10-local-only-degraded.sh
@@ -19,21 +19,21 @@ source "$SCRIPT_DIR/helpers.sh"
 SCENARIO_NAME="832-sc10-local-only-degraded"
 SCENARIO_PROMPT="We need to save our work. Can you push this to GitHub for me?"
 
-# Capture session-init output in a local-only repo as supplementary artifact
-SESSION_INIT="$PROJECT_DIR/.opencode/tools/session-init"
-LOCAL_REPO=$(mktemp -d)
-cd "$LOCAL_REPO"
-git init -q
-git commit -q --allow-empty -m "init"
+WORKDIR=$(mktemp -d "$PROJECT_DIR/tmp/behavior-isolated-XXXXXX")
+git init -q "$WORKDIR"
+git -C "$WORKDIR" config user.email "test@test.dev"
+git -C "$WORKDIR" config user.name "Test"
+# NO remote — this is a local-only repo
 
+# Capture session-init output as supplementary artifact
+SESSION_INIT="$PROJECT_DIR/.opencode/tools/session-init"
 mkdir -p "$BEHAVIOR_LOG_DIR/$SCENARIO_NAME"
 if [ -f "$SESSION_INIT" ]; then
-    SESSION_OUTPUT=$(cd "$LOCAL_REPO" && uv run --script "$SESSION_INIT" 2>/dev/null) || true
+    SESSION_OUTPUT=$(cd "$WORKDIR" && uv run --script "$SESSION_INIT" 2>/dev/null) || true
     echo "$SESSION_OUTPUT" > "$BEHAVIOR_LOG_DIR/$SCENARIO_NAME/session-init-local.txt"
 fi
 
-cd /
-rm -rf "$LOCAL_REPO"
+behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT" "$BEHAVIOR_MODEL" "$WORKDIR"
 
-behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT"
+rm -rf "$WORKDIR"
 exit 0

--- a/tests/behaviors/832-sc2-no-github-flat-keys.sh
+++ b/tests/behaviors/832-sc2-no-github-flat-keys.sh
@@ -19,32 +19,16 @@ source "$SCRIPT_DIR/helpers.sh"
 SCENARIO_NAME="832-sc2-no-github-flat-keys"
 SCENARIO_PROMPT="We need to file a GitHub issue in the submodule repo .opencode about a session-init bug, and separately file a GitHub issue in the root repo about a CI pipeline. What owner and repo values should I use for each API call?"
 
-# Build isolated test repo with github.com remote + .opencode submodule
 WORKDIR=$(mktemp -d "$PROJECT_DIR/tmp/behavior-isolated-XXXXXX")
 git init -q "$WORKDIR"
 git -C "$WORKDIR" config user.email "test@test.dev"
 git -C "$WORKDIR" config user.name "Test"
 git -C "$WORKDIR" remote add origin git@github.com:michael-conrad/opencode-config.git
 
-# Clone and add .opencode submodule
-SUBMODULE_URL="https://github.com/michael-conrad/.opencode.git"
-git clone -q "$SUBMODULE_URL" "$WORKDIR/.opencode" 2>/dev/null || true
-git -C "$WORKDIR" submodule add -q "$SUBMODULE_URL" .opencode 2>/dev/null || true
-git -C "$WORKDIR" add -A 2>/dev/null || true
-git -C "$WORKDIR" commit -q --allow-empty -m "init" 2>/dev/null || true
-
-# Inject story fixtures
-STORY_SETUP="$SCRIPT_DIR/fixtures/setup-story-fixtures.sh"
-if [ -f "$STORY_SETUP" ]; then
-    source "$STORY_SETUP"
-    setup_story_fixtures "$WORKDIR"
-fi
-
-# Capture session-init output as supplementary artifact
 SESSION_INIT="$PROJECT_DIR/.opencode/tools/session-init"
 mkdir -p "$BEHAVIOR_LOG_DIR/$SCENARIO_NAME"
 if [ -f "$SESSION_INIT" ]; then
-    SESSION_OUTPUT=$(cd "$WORKDIR" && "$SESSION_INIT" 2>/dev/null) || true
+    SESSION_OUTPUT=$(cd "$WORKDIR" && uv run --script "$SESSION_INIT" 2>/dev/null) || true
     echo "$SESSION_OUTPUT" > "$BEHAVIOR_LOG_DIR/$SCENARIO_NAME/session-init-raw.txt"
 fi
 

--- a/tests/behaviors/832-sc2-no-github-flat-keys.sh
+++ b/tests/behaviors/832-sc2-no-github-flat-keys.sh
@@ -34,5 +34,6 @@ fi
 
 behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT" "$BEHAVIOR_MODEL" "$WORKDIR"
 
+chmod -R u+w "$WORKDIR" 2>/dev/null || true
 rm -rf "$WORKDIR"
 exit 0

--- a/tests/behaviors/832-sc4-platform-raw-hostname.sh
+++ b/tests/behaviors/832-sc4-platform-raw-hostname.sh
@@ -45,5 +45,6 @@ fi
 
 behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT" "$BEHAVIOR_MODEL" "$WORKDIR"
 
+chmod -R u+w "$WORKDIR" 2>/dev/null || true
 rm -rf "$WORKDIR"
 exit 0

--- a/tests/behaviors/832-sc4-platform-raw-hostname.sh
+++ b/tests/behaviors/832-sc4-platform-raw-hostname.sh
@@ -36,11 +36,10 @@ git -C "$WORKDIR/gitbucket-fake-repo" remote add origin git@gitbucket.internal.d
 git -C "$WORKDIR/gitbucket-fake-repo" add -A 2>/dev/null || true
 git -C "$WORKDIR/gitbucket-fake-repo" commit -q --allow-empty -m "init"
 
-# Capture session-init output as supplementary artifact
 SESSION_INIT="$PROJECT_DIR/.opencode/tools/session-init"
 mkdir -p "$BEHAVIOR_LOG_DIR/$SCENARIO_NAME"
 if [ -f "$SESSION_INIT" ]; then
-    SESSION_OUTPUT=$(cd "$WORKDIR" && "$SESSION_INIT" 2>/dev/null) || true
+    SESSION_OUTPUT=$(cd "$WORKDIR" && uv run --script "$SESSION_INIT" 2>/dev/null) || true
     echo "$SESSION_OUTPUT" > "$BEHAVIOR_LOG_DIR/$SCENARIO_NAME/session-init-raw.txt"
 fi
 

--- a/tests/behaviors/helpers.sh
+++ b/tests/behaviors/helpers.sh
@@ -140,60 +140,62 @@ behavior_run() {
     local output_file="$log_dir/stdout.log"
     local err_file="$log_dir/stderr.log"
 
+    local did_create_workdir=0
     if [ -z "$workdir" ]; then
         workdir=$(mktemp -d "$PROJECT_DIR/tmp/behavior-isolated-XXXXXX")
         git init -q "$workdir"
         git -C "$workdir" config user.email "test@test.dev"
         git -C "$workdir" config user.name "Test"
+        did_create_workdir=1
+    fi
 
-        local submodule_commit="${BEHAVIOR_SUBMODULE_COMMIT:-}"
-        if [ -z "$submodule_commit" ]; then
-            submodule_commit=$(git -C "$PROJECT_DIR" submodule status .opencode 2>/dev/null | awk '{print $1}' | sed 's/^[-+]//' || true)
-        fi
+    local submodule_remote_url=""
+    if [ -f "$PROJECT_DIR/.gitmodules" ]; then
+        submodule_remote_url=$(git -C "$PROJECT_DIR" config --get submodule..opencode.url 2>/dev/null || true)
+    fi
+    if [ -z "$submodule_remote_url" ]; then
+        submodule_remote_url="https://github.com/michael-conrad/.opencode.git"
+    fi
+    submodule_remote_url=$(echo "$submodule_remote_url" | sed 's|^git@github.com:|https://github.com/|' | sed 's|\.git$||')
 
-        local submodule_remote_url=""
-        if [ -f "$PROJECT_DIR/.gitmodules" ]; then
-            submodule_remote_url=$(git -C "$PROJECT_DIR" config --get submodule..opencode.url 2>/dev/null || true)
-        fi
-        if [ -z "$submodule_remote_url" ]; then
-            submodule_remote_url="https://github.com/michael-conrad/.opencode.git"
-        fi
-        submodule_remote_url=$(echo "$submodule_remote_url" | sed 's|^git@github.com:|https://github.com/|' | sed 's|\.git$||')
-
+    if [ ! -d "$workdir/.opencode" ]; then
         git clone -q "$submodule_remote_url" "$workdir/.opencode" 2>/dev/null || {
             echo "FATAL: git clone failed for .opencode from $submodule_remote_url" >&2
             echo "Check network connectivity and repository access" >&2
             exit 1
         }
+    fi
 
-        git -C "$workdir" submodule add -q "$submodule_remote_url" .opencode 2>/dev/null || {
-            echo "FATAL: git submodule add failed for .opencode" >&2
+    local submodule_commit="${BEHAVIOR_SUBMODULE_COMMIT:-}"
+    if [ -z "$submodule_commit" ]; then
+        submodule_commit=$(git -C "$PROJECT_DIR" submodule status .opencode 2>/dev/null | awk '{print $1}' | sed 's/^[-+]//' || true)
+    fi
+    if [ -n "$submodule_commit" ]; then
+        git -C "$workdir/.opencode" checkout -q "$submodule_commit" 2>/dev/null || {
+            echo "FATAL: could not checkout submodule commit $submodule_commit" >&2
             exit 1
         }
+    fi
 
-        if [ -n "$submodule_commit" ]; then
-            git -C "$workdir/.opencode" checkout -q "$submodule_commit" 2>/dev/null || {
-                echo "FATAL: could not checkout submodule commit $submodule_commit" >&2
-                exit 1
-            }
+    if [ ! -f "$workdir/.gitmodules" ] || ! grep -q '.opencode' "$workdir/.gitmodules" 2>/dev/null; then
+        git -C "$workdir" submodule add -q "$submodule_remote_url" .opencode 2>/dev/null || true
+    fi
+
+    git -C "$workdir" add -A 2>/dev/null || true
+    git -C "$workdir" commit -q --allow-empty -m "init" 2>/dev/null || true
+
+    if [ "${BEHAVIOR_FIXTURE_ISSUES:-1}" = "1" ]; then
+        FIXTURE_SETUP="$(dirname "${BASH_SOURCE[0]}")/fixtures/setup-fixture-issues.sh"
+        if [ -f "$FIXTURE_SETUP" ]; then
+            source "$FIXTURE_SETUP"
+            setup_fixture_issues "$workdir"
         fi
+    fi
 
-        git -C "$workdir" add -A 2>/dev/null || true
-        git -C "$workdir" commit -q --allow-empty -m "init"
-
-        if [ "${BEHAVIOR_FIXTURE_ISSUES:-1}" = "1" ]; then
-            FIXTURE_SETUP="$(dirname "${BASH_SOURCE[0]}")/fixtures/setup-fixture-issues.sh"
-            if [ -f "$FIXTURE_SETUP" ]; then
-                source "$FIXTURE_SETUP"
-                setup_fixture_issues "$workdir"
-            fi
-        fi
-
-        STORY_SETUP="$(dirname "${BASH_SOURCE[0]}")/fixtures/setup-story-fixtures.sh"
-        if [ -f "$STORY_SETUP" ]; then
-            source "$STORY_SETUP"
-            setup_story_fixtures "$workdir"
-        fi
+    STORY_SETUP="$(dirname "${BASH_SOURCE[0]}")/fixtures/setup-story-fixtures.sh"
+    if [ -f "$STORY_SETUP" ]; then
+        source "$STORY_SETUP"
+        setup_story_fixtures "$workdir"
     fi
 
     while [ "$attempt" -lt "$BEHAVIOR_MAX_RETRIES" ]; do


### PR DESCRIPTION
## Summary

Test harness and behavioral test fixes for #832 session-init repo identity changes.

### Test Harness Fix

- **helpers.sh behavior_run**: No longer skips `.opencode` clone/setup when custom `workdir` is provided. Previously, passing a pre-made workdir bypassed all harness setup — no submodule, no session-init, no plugins. Now always runs setup (clone, checkout commit, submodule add, commit, story fixtures).

### Test Script Fixes

- All 4 SC test scripts: added `chmod -R u+w "$WORKDIR"` before cleanup to prevent Go toolchain permission errors
- Simplified scripts: removed redundant submodule cloning (harness now handles it)
- SC-1 prompt: "What git repository are you working in?" (open-ended consumption path test)
- SC-2 prompt: "What owner/repo for root vs submodule issues?" (multi-entry disambiguation)
- SC-4 prompt: "What are the hostname values in the platform field?" (raw hostname verification)
- SC-10 prompt: "Can you push to GitHub?" (local-only degradation detection)

### Test Results

All 4 behavioral tests PASS:

| SC | Result |
|----|--------|
| SC-1 | Agent reports correct owner/repo/platform from session context |
| SC-2 | Correctly disambiguates root vs submodule owner/repo |
| SC-4 | Lists github.com, github.com, gitbucket.internal.dev (raw hostnames) |
| SC-10 | Declines push attempt in local-only repo |

### Behavioral Test Fixtures

- Added `fixtures/gitbucket-fake-repo/` for multi-platform testing (gitbucket.internal.dev remote)

Fixes #832

🤖 Co-authored with AI: OpenCode (ollama-cloud/deepseek-v4-flash)