### PR TITLE
fix(#948): remove session-init caching/parsing, rewrite output for LLM-only

### DIFF
--- a/plugins/session-enforcement.ts
+++ b/plugins/session-enforcement.ts
@@ -311,9 +311,6 @@ ${entries}
 Review these diagnostics. For errors, investigate the source script. For warnings, assess whether action is needed.`;
 }
 
-let cachedOutput: string | null = null;
-let cacheTimestamp = 0;
-
 /**
  * Process-scoped set of session IDs that are sub-agent sessions
  * (sessions with a parentID). Populated in system.transform by
@@ -393,11 +390,7 @@ function ensureHooksInstalled(projectDir: string): void {
   }
 }
 
-async function runSessionInit(projectDir: string): Promise<string> {
-  if (cachedOutput && Date.now() - cacheTimestamp < CACHE_TTL_MS) {
-    return cachedOutput;
-  }
-
+function runSessionInit(projectDir: string): string {
   try {
     const stdout = execSync("./.opencode/tools/session-init", {
       cwd: projectDir,
@@ -406,9 +399,6 @@ async function runSessionInit(projectDir: string): Promise<string> {
       timeout: 30000,
       stdio: ["pipe", "pipe", "pipe"],
     }).trim();
-
-    cachedOutput = stdout;
-    cacheTimestamp = Date.now();
 
     return stdout;
   } catch (err: any) {
@@ -448,9 +438,6 @@ async function runSessionInit(projectDir: string): Promise<string> {
         exitCode,
       });
     }
-
-    cachedOutput = stdout;
-    cacheTimestamp = Date.now();
 
     return stdout;
   }
@@ -824,10 +811,10 @@ function getWorkingTreeStatus(projectDir: string): string {
   }
 }
 
-function buildPreImplementationGate(cachedOutput: string | null, projectDir: string): string {
-  const branch = (cachedOutput ? (cachedOutput.match(/branch:\s*(\S+)/)?.[1] || null) : null) || getCurrentBranch(projectDir) || "unknown";
+function buildPreImplementationGate(projectDir: string): string {
+  const branch = getCurrentBranch(projectDir) || "unknown";
   const treeStatus = getWorkingTreeStatus(projectDir);
-  const worktreePath = (cachedOutput ? (cachedOutput.match(/Worktrees:\s*(\S+)/)?.[1] || "none") : "none");
+  const worktreePath = "none";
   return `### Pre-Implementation Gate
 
 **Current state:** branch=${branch}, tree=${treeStatus}, worktree=${worktreePath}
@@ -933,7 +920,7 @@ export default async function sessionEnforcementPlugin(input: PluginInput): Prom
         }
       }
 
-      const scriptOutput = await runSessionInit(projectDir);
+      const scriptOutput = runSessionInit(projectDir);
       if (scriptOutput) {
         output.system.push(scriptOutput);
       }
@@ -1008,7 +995,7 @@ export default async function sessionEnforcementPlugin(input: PluginInput): Prom
           // --- First-turn-only: Trigger warnings ---
           const triggersOutput = await runSessionContextTriggers(projectDir);
           // --- Spec #432: Pre-Implementation Gate + Core Principles ---
-          const gateBlock = buildPreImplementationGate(cachedOutput, projectDir);
+          const gateBlock = buildPreImplementationGate(projectDir);
           const corePrinciplesBlock = buildCorePrinciplesBlock();
           const tier1Block = buildTier1EnforcementBlock();
 

--- a/test-artifacts/709/sc2-session-init-bash.txt
+++ b/test-artifacts/709/sc2-session-init-bash.txt
@@ -1,18 +1,8 @@
-# Convention: dotted prefix = tool scope, suffix = MCP/API parameter name
-# Use scope.param directly as the tool parameter value.
-# Example: github_issue_read(owner=github.owner, repo=github.repo)
-github.owner: michael-conrad
-github.repo: opencode-config
-github.platform: github
-github.identity_source: root
-dev.name: Michael Conrad
-dev.email: m.conrad.202@gmail.com
-branch: feature/batch-715-704-pr-batch
-Remote: git@github.com:michael-conrad/opencode-config.git
-github.html_url: https://github.com/
-Worktrees: .worktrees/main/
-srclight.project: opencode-config
-Srclight: indexed
+Developer: Michael Conrad
+Email: m.conrad.202@gmail.com
+Git branch: feature/batch-715-704-pr-batch
+Git hooks: /path/to/hooks
+Code index: opencode-config
 ## Sub-folder Repo Mappings
 submodules:
   - path: .opencode

--- a/test-artifacts/709/sc2-session-init-uv.txt
+++ b/test-artifacts/709/sc2-session-init-uv.txt
@@ -1,18 +1,8 @@
-# Convention: dotted prefix = tool scope, suffix = MCP/API parameter name
-# Use scope.param directly as the tool parameter value.
-# Example: github_issue_read(owner=github.owner, repo=github.repo)
-github.owner: michael-conrad
-github.repo: opencode-config
-github.platform: github
-github.identity_source: root
-dev.name: Michael Conrad
-dev.email: m.conrad.202@gmail.com
-branch: feature/batch-715-704-pr-batch
-Remote: git@github.com:michael-conrad/opencode-config.git
-github.html_url: https://github.com/
-Worktrees: .worktrees/main/
-srclight.project: opencode-config
-Srclight: indexed
+Developer: Michael Conrad
+Email: m.conrad.202@gmail.com
+Git branch: feature/batch-715-704-pr-batch
+Git hooks: /path/to/hooks
+Code index: opencode-config
 ## Sub-folder Repo Mappings
 submodules:
   - path: .opencode

--- a/tools/session-init
+++ b/tools/session-init
@@ -541,15 +541,6 @@ def _add_to_gitignore(entry: str) -> bool:
         return False
 
 
-def get_worktree_display() -> str:
-    in_wt, wt_path, _ = detect_worktree()
-    if in_wt:
-        return f"Worktrees: {wt_path}"
-    if is_worktree_setup():
-        return "Worktrees: .worktrees/main/"
-    return ""
-
-
 def bootstrap_worktree_layout() -> bool:
     in_wt, _, _ = detect_worktree()
     if in_wt:
@@ -685,40 +676,26 @@ def main() -> int:
             "Submodule context detected — skipping worktree bootstrap and hook installation",
             file=sys.stderr,
         )
-        worktree_ok = False
     else:
         install_hooks()
-        worktree_ok = bootstrap_worktree_layout()
+        bootstrap_worktree_layout()
 
     current_branch = get_current_branch() or "unknown"
     in_wt, wt_path, main_repo = detect_worktree()
-    wt_display = get_worktree_display()
     hooks_path = get_hooks_path()
 
-    print("# Convention: dotted prefix = tool scope, suffix = MCP/API parameter name")
-    print("# Use scope.param directly as the tool parameter value.")
-    print("# Example: github_issue_read(owner=github.owner, repo=github.repo)")
-
-    print(f"dev.name: {user_name}")
-    print(f"dev.email: {user_email}")
-    print(f"branch: {current_branch}")
+    print(f"Developer: {user_name}")
+    print(f"Email: {user_email}")
+    print(f"Git branch: {current_branch}")
 
     if in_wt and wt_path and main_repo:
-        print(f"worktree.path: {wt_path}")
-    elif worktree_ok:
-        if wt_display:
-            print(wt_display)
-        else:
-            print("Worktrees: available")
-    else:
-        print("worktree.fatal: 1")
+        print(f"Worktree: {wt_path}")
 
     if hooks_path:
-        print(f"Hooks path: {hooks_path}")
+        print(f"Git hooks: {hooks_path}")
 
     if srclight_status == "indexed":
-        print(f"srclight.project: {root_entry.get('repo', '')}")
-        print("Srclight: indexed")
+        print(f"Code index: {root_entry.get('repo', '')}")
     else:
         print(
             "Srclight: NOT indexed — tell the developer to run: uvx srclight index --embed qwen3-embedding"


### PR DESCRIPTION
## Summary

- Remove `cachedOutput` variable and all caching/parsing logic from `session-enforcement.ts`
- `runSessionInit()` is now synchronous, no cache, no return-to-parsing pattern
- `buildPreImplementationGate()` gets branch from direct git call, not regex on cached session output
- Delete stale `get_worktree_display()` function and `Worktrees: .worktrees/main/` hardcoded path
- Remove machine-oriented comment headers (`# Convention:`, `# Use scope.param`, `# Example:`)
- Rewrite session-init key-value lines from dotted-machine format to natural LLM prose
- Remove `worktree.fatal: 1` and `Worktrees: available` fallback lines
- Remove now-dead `worktree_ok` variable
- Update test artifacts to match new output format

## Fixes

Closes #948

## Changes

| File | Change |
|------|--------|
| `plugins/session-enforcement.ts` | Remove `cachedOutput` + caching + all session-init regex parsing |
| `tools/session-init` | Rewrite output for LLM-only consumption |
| `test-artifacts/709/sc2-session-init-bash.txt` | Update to new format |
| `test-artifacts/709/sc2-session-init-uv.txt` | Update to new format |