### PR TITLE
#957: standardize dispatch fields for VbC, completeness-gate, cross-validate sub-agents

### DIFF
--- a/skills/adversarial-audit/tasks/cross-validate.md
+++ b/skills/adversarial-audit/tasks/cross-validate.md
@@ -11,7 +11,7 @@ Accept an evidence payload, evaluation criteria, and pre-resolved auditor verdic
 ## Entry Criteria
 
 - `spec_local_dir`: Local directory containing Markdown spec files
-- `auditor_artifact_paths`: Array of two artifact paths from the orchestrator, pointing to YAML verdict files on disk — resolved by `resolve-models`, written by auditor task dispatch, and passed by the orchestrator BEFORE this task
+- `artifact_evidence_dir`: Path(s) to directories containing auditor YAML verdict artifacts on disk
 - Lightweight audit-type structural criteria (SC-1/PF-1/CS-1/GA-1 templates) provided as task-file-defined templates WITHOUT embedded spec SC content
 - `auditor_metadata`: Optional array of `{ auditor_type, family, parseable }` for auditor identity context
 
@@ -19,7 +19,7 @@ Accept an evidence payload, evaluation criteria, and pre-resolved auditor verdic
 
 - [ ] 1. Load Spec + extract SCs from spec_local_dir
 - [ ] 2. Pre-Inspection Classification Gate — runtime-behavioral uplift check for each SC
-- [ ] 3. Load both auditor verdict artifacts (auditor_artifact_paths)
+- [ ] 3. Load both auditor verdict artifacts (artifact_evidence_dir)
 - [ ] 4. Per-SC comparison: Auditor-A verdict vs Auditor-B verdict
 - [ ] 5. **Do NOT reclassify FAIL** — a FAIL from either auditor is a FAIL in the cross-validate verdict
 - [ ] 6. PASS only when BOTH auditors returned PASS for the SC
@@ -97,9 +97,9 @@ The following states are **terminal BLOCKED states** with no fallback or recover
 | Gate | Condition | Error Code | Action |
 |------|-----------|------------|--------|
 | MISSING_INPUT | `spec_local_dir` missing or empty, or no .md files readable | `MISSING_INPUT` | Return `{ status: "BLOCKED", error: "MISSING_INPUT", missing: "<field>" }` |
-| MISSING_ARTIFACT_PATHS | `auditor_artifact_paths` missing, null, or empty array | `MISSING_ARTIFACT_PATHS` | Return `{ status: "BLOCKED", error: "MISSING_ARTIFACT_PATHS" }` |
+| MISSING_EVIDENCE_DIR | `artifact_evidence_dir` missing, null, or empty | `MISSING_EVIDENCE_DIR` | Return `{ status: "BLOCKED", error: "MISSING_EVIDENCE_DIR" }` |
 | ARTIFACT_UNREADABLE | Auditor YAML artifact file cannot be read or parsed | `ARTIFACT_UNREADABLE` | Return `{ status: "BLOCKED", error: "ARTIFACT_UNREADABLE" }` |
-| INSUFFICIENT_ARTIFACTS | `auditor_artifact_paths` contains fewer than 2 entries OR both auditors share the same family | `INSUFFICIENT_ARTIFACTS` | Return `{ status: "BLOCKED", error: "INSUFFICIENT_ARTIFACTS" }` |
+| INSUFFICIENT_ARTIFACTS | Each auditor produces fewer than 1 verdict OR both auditors share the same family | `INSUFFICIENT_ARTIFACTS` | Return `{ status: "BLOCKED", error: "INSUFFICIENT_ARTIFACTS" }` |
 
 These gates are **non-recovery** per adversarial-audit-017. Do NOT attempt to resolve models inline, re-dispatch auditors, or fabricate verdicts. The ONLY valid path is: resolve-models → auditor dispatch → cross-validate with results. NO fallback, NO single-auditor mode, NO alternative paths.
 
@@ -113,18 +113,18 @@ This section is obsolete with binary PASS/FAIL verdicts. Auditors now return onl
 
 Confirm `spec_local_dir` is present and non-empty. Glob `**/*.md` in `<spec_local_dir>/`, read all discovered files via `read` tool. If `spec_local_dir` is missing, empty, or no .md files can be read: return `{ status: "BLOCKED", error: "MISSING_INPUT", missing: "<field>" }`.
 
-### Step 2: Validate Auditor Artifact Paths
+### Step 2: Validate Evidence Directory
 
-Confirm `auditor_artifact_paths` is present, non-null, and contains exactly two paths pointing to existing YAML files on disk. Each entry MUST contain `{ artifact_path, auditor_type, family, parseable }`. Read each YAML file via `read` tool to verify it exists and is parseable.
+Confirm `artifact_evidence_dir` is present, non-null, and non-empty. The sub-agent reads auditor YAML verdict artifacts from files discovered in the evidence directory via `glob`/`read`. Each discovered YAML file MUST contain `{ criterion_id, result, evidence, explanation, remediation, next_step }`.
 
-- If `auditor_artifact_paths` is missing or null: return `{ status: "BLOCKED", error: "MISSING_ARTIFACT_PATHS" }`.
-- If `auditor_artifact_paths` has fewer than 2 entries: return `{ status: "BLOCKED", error: "INSUFFICIENT_ARTIFACTS" }`.
-- If either artifact file cannot be read: return `{ status: "BLOCKED", error: "ARTIFACT_UNREADABLE" }`.
-- If both entries share the same `family`: return `{ status: "BLOCKED", error: "INSUFFICIENT_FAMILIES" }`.
+- If `artifact_evidence_dir` is missing or null: return `{ status: "BLOCKED", error: "MISSING_EVIDENCE_DIR" }`.
+- If `artifact_evidence_dir` has fewer than 2 YAML files: return `{ status: "BLOCKED", error: "INSUFFICIENT_ARTIFACTS" }`.
+- If artifact file cannot be read: return `{ status: "BLOCKED", error: "ARTIFACT_UNREADABLE" }`.
+- If both files share the same `family`: return `{ status: "BLOCKED", error: "INSUFFICIENT_FAMILIES" }`.
 
 ### Step 3: Read and Parse Auditor Verdicts from Disk
 
-For each entry in `auditor_artifact_paths`, read the YAML verdict file from disk using the `read` tool. Each file contains the full YAML verdict artifact. Expected format per verdict file:
+For each YAML file discovered via glob/read in `artifact_evidence_dir`, read the verdict file from disk using the `read` tool. Each file contains the full YAML verdict artifact. Expected format per verdict file:
 
 ```
 ---
@@ -367,12 +367,12 @@ The `next_step` field:
 ## Context Required
 
 - `spec_local_dir`: Local directory containing Markdown spec files
-- `auditor_artifact_paths`: Pre-resolved array of two artifact paths from orchestrator (each with `{ artifact_path, auditor_type, family, parseable }`)
+- `artifact_evidence_dir`: Path(s) to directories containing auditor YAML verdict artifacts
 - `audit_phase`: Current audit phase for task context
 
 ## Red Flags
 
-- Never task() auditors from within cross-validate — the orchestrator dispatches auditors, cross-validate receives artifact paths only
+- Never task() auditors from within cross-validate — the orchestrator dispatches auditors, cross-validate discovers artifacts via evidence dir
 - Never leak orchestrator reasoning into verdict parsing — clean-room means evidence + criteria ONLY
 - Never soft-pass a mismatch — `PASS`/`FAIL` split = FAIL per adversarial-audit-004
 - Never fabricate verdicts when auditor YAML artifact is unreadable or unparseable — missing data = FAIL per adversarial-audit-005
@@ -399,7 +399,7 @@ The `next_step` field:
 
 | Scope of Context | Exclusions | Pre-Analysis Contract | Includes Inline Work? |
 |---|---|---|---|---|
-| `spec_local_dir`, `auditor_artifact_paths`, `audit_phase` | Implementation context, agent memory, orchestrator reasoning, prior verification, spec_body, evaluation_criteria, verdict content | N/A — cross-validate receives artifact paths, does not dispatch auditors | NO |
+| `spec_local_dir`, `artifact_evidence_dir`, `audit_phase` | Implementation context, agent memory, orchestrator reasoning, prior verification, spec_body, evaluation_criteria, verdict content | N/A — cross-validate discovers artifacts via evidence dir, does not dispatch auditors | NO |
 
 ```yaml+symbolic
 schema_version: "2.0"
@@ -413,10 +413,10 @@ rules:
     source: "cross-validate.md §Step 1"
 
   - id: cross-validate-002
-    title: "Pre-resolved artifact paths must be provided by orchestrator — cross-validate does not dispatch auditors"
+    title: "Evidence directory must be provided — cross-validate discovers artifacts via glob/read"
     conditions:
-      all: ["auditor_artifact_paths == null OR auditor_artifact_paths_count < 2"]
-    actions: [RETURN_BLOCKED, REPORT_MISSING_ARTIFACT_PATHS]
+      all: ["artifact_evidence_dir == null OR artifact_evidence_dir_empty == true"]
+    actions: [RETURN_BLOCKED, REPORT_MISSING_EVIDENCE_DIR]
     source: "cross-validate.md §Step 2"
 
   - id: cross-validate-003
@@ -550,9 +550,9 @@ rules:
     source: "cross-validate.md §Step 6"
 
   - id: cross-validate-018
-    title: "Non-recovery gate — MISSING_INPUT, MISSING_ARTIFACT_PATHS, ARTIFACT_UNREADABLE, INSUFFICIENT_ARTIFACTS are terminal with no fallback"
+    title: "Non-recovery gate — MISSING_INPUT, MISSING_EVIDENCE_DIR, ARTIFACT_UNREADABLE, INSUFFICIENT_ARTIFACTS are terminal with no fallback"
     conditions:
-      any: ["error == 'MISSING_INPUT'", "error == 'MISSING_ARTIFACT_PATHS'", "error == 'ARTIFACT_UNREADABLE'", "error == 'INSUFFICIENT_ARTIFACTS'"]
+      any: ["error == 'MISSING_INPUT'", "error == 'MISSING_EVIDENCE_DIR'", "error == 'ARTIFACT_UNREADABLE'", "error == 'INSUFFICIENT_ARTIFACTS'"]
     actions: [RETURN_BLOCKED, NO_RECOVERY]
     source: "cross-validate.md §Non-Recovery Gates"
 ```

--- a/skills/completeness-gate/tasks/check.md
+++ b/skills/completeness-gate/tasks/check.md
@@ -6,10 +6,8 @@ Non-adversarial completeness check after RED/GREEN sub-agent returns. Verifies t
 
 ## Entry Criteria
 
-- Spec success criteria received in task context
-- Deliverable path(s) received in task context
-- Spec body received for criterion reference
-- Audit readiness criteria received (if applicable)
+- spec_local_dir received in task context (REQUIRED — local issue directories containing spec.md)
+- artifact_evidence_dir received in task context (OPTIONAL — RED/GREEN sub-agent output directories)
 
 ## Authorization Context
 
@@ -19,6 +17,8 @@ halt_at: <analysis_complete|spec_created|plan_created|verification_complete|revi
 pr_strategy: <none|stacked>
 pipeline_phase: <current_phase_name>
 authorization_source: "User approved #N on YYYY-MM-DD"
+spec_local_dir: <path> | [<path>, ...]     # REQUIRED — local issue directories
+artifact_evidence_dir: <path> | [<path>, ...]  # OPTIONAL — behavioral evidence directories
 ```
 
 ### Routing Rules
@@ -33,15 +33,16 @@ authorization_source: "User approved #N on YYYY-MM-DD"
 ## Input Contract
 
 ```yaml
+spec_local_dir:
+  - "<path to local issue directory>"
+artifact_evidence_dir:
+  - "<path to behavioral evidence directory>"
 spec_success_criteria:
   - id: "SC-1"
-    description: "<success criterion description>"
-  - id: "SC-2"
     description: "<success criterion description>"
 deliverable:
   paths: ["path/to/deliverable1", "path/to/deliverable2"]
   type: "file|PR|branch"
-spec: "<full spec body text>"
 audit_readiness_criteria:
   - "deliverable exists and is non-empty"
   - "all spec SCs addressed"
@@ -75,8 +76,9 @@ For each deliverable path in the input contract:
 
 For each success criterion in the input:
 
-1. Read the deliverable content relevant to the criterion
-2. Inspect whether the criterion is addressed:
+1. Read `spec_local_dir` for the spec's success criteria definitions
+2. Read the deliverable content relevant to the criterion
+3. Inspect whether the criterion is addressed:
    - **present**: Deliverable includes content addressing this SC
    - **partial**: Some aspects covered, some missing
    - **missing**: No content found addressing this SC

--- a/skills/verification-before-completion/tasks/structural-verify.md
+++ b/skills/verification-before-completion/tasks/structural-verify.md
@@ -9,7 +9,7 @@ Verify that ALL structural components required by the spec are present in the im
 ## Entry Criteria
 
 - Implementation claimed complete
-- Spec or plan issue available with structural component requirements
+- Spec or plan issue available with structural component requirements, or `spec_local_dir` provided for local spec access
 - Target skill/guideline files exist
 
 ## Exit Criteria
@@ -22,8 +22,8 @@ Verify that ALL structural components required by the spec are present in the im
 
 This task MUST be task()'d as a sub-agent receiving ONLY:
 
-1. **Spec acceptance criteria list** — the SC table from the spec issue
-2. **File paths to verify** — list of files that were modified during implementation
+1. **spec_local_dir** — REQUIRED path(s) to local issue directories containing spec.md. If absent: BLOCKED with MISSING_INPUT_DIR.
+2. **Target files** — list of files that were modified during implementation
 3. **Required structural components** — list derived from parent spec's requirements
 
 The sub-agent MUST NOT receive:
@@ -114,6 +114,8 @@ Each structural component check MUST be verified by reading the actual file. Cla
 ## Task Context Schema
 
 ```yaml
+spec_local_dir: <path> | [<path>, ...]     # REQUIRED — local issue directories
+artifact_evidence_dir: <path> | [<path>, ...]  # OPTIONAL — behavioral evidence directories
 spec_issue: <N>
 target_files: [<path_list>]
 required_components: [<component_list>]

--- a/skills/verification-before-completion/tasks/verify.md
+++ b/skills/verification-before-completion/tasks/verify.md
@@ -41,9 +41,23 @@ halt_at: <analysis_complete|spec_created|plan_created|verification_complete|revi
 pr_strategy: <none|stacked>
 pipeline_phase: <current_phase_name>
 authorization_source: "User approved #N on YYYY-MM-DD"
+spec_local_dir: <path> | [<path>, ...]     # REQUIRED — one or more local issue directories containing spec.md
+artifact_evidence_dir: <path> | [<path>, ...]  # OPTIONAL — one or more behavioral evidence directories
 ```
 - Missing `authorization_scope` → return `status: BLOCKED`
 - Instructed to exceed `halt_at` → return `status: BLOCKED`
+
+### VbC Pre-Check (MANDATORY)
+
+**`spec_local_dir` semantics:**
+All entries equally relevant. Sub-agent scans each folder for spec files, extracts SCs from each.
+
+**`artifact_evidence_dir` semantics:**
+Sub-agent searches all listed directories for evidence files via `glob`/`read`.
+
+1. **`spec_local_dir`** — REQUIRED. If absent from context: BLOCKED with MISSING_INPUT_DIR. If present but path not found: BLOCKED with SPEC_NOT_FOUND.
+2. **`artifact_evidence_dir`** — OPTIONAL. Absent or empty: handle gracefully.
+3. Both fields are PROCEED — standard evidence input directories, not contamination.
 
 ### 0.75. Coverage Completeness Gate (MANDATORY — After Structural Completeness, Before Per-SC Verification)
 
@@ -99,7 +113,7 @@ Inline execution bypasses every quality gate — clean-room isolation, cross-fam
 
 ### 1. Query Success Criteria
 
-- Read plan issue for defined success criteria
+- Read spec files from `spec_local_dir` directories for defined success criteria
 - Parse each criterion as a testable statement
 - Identify evidence needed for each
 


### PR DESCRIPTION
## Summary

Standardize dispatch fields for VbC, completeness-gate, and cross-validate sub-agents -- replacing inline SC lists and auditor_artifact_paths with spec_local_dir and artifact_evidence_dir.

## Changes

| File | Change |
|------|--------|
| skills/verification-before-completion/tasks/verify.md | Added spec_local_dir + artifact_evidence_dir as standard dispatch fields; VbC Pre-Check (MISSING_INPUT_DIR, SPEC_NOT_FOUND) |
| skills/verification-before-completion/tasks/structural-verify.md | Added spec_local_dir to entry criteria, clean-room protocol, task context schema |
| skills/completeness-gate/tasks/check.md | Replaced inline deliverable summaries with artifact_evidence_dir |
| skills/adversarial-audit/tasks/cross-validate.md | Replaced auditor_artifact_paths with artifact_evidence_dir; MISSING_ARTIFACT_PATHS with MISSING_EVIDENCE_DIR |

## Verification

All 4 SCs verified PASS. Closes #957.