### PR TITLE
Unified tag convention (#950) + Checkpoint tags for pipeline rollback (#391)

### DIFF
--- a/commands/submodule-tag-prework.md
+++ b/commands/submodule-tag-prework.md
@@ -1,22 +1,37 @@
 # submodule-tag-prework
 
-Tag all submodules at dev tip with `<parent-repo>/<issue-number>` format before starting work.
+Tag submodules at dev tip BEFORE feature branch creation. Uses the unified tag convention from `git-workflow/SKILL.md` §Tag Convention.
+
+**Suffix Rule:** Tag suffix MUST be derived from submodule directory name in `.gitmodules` (e.g., `.opencode` → `-opencode`). DO NOT use issue title, phase name, or any ad-hoc string.
+
+**Tag Format:** `<parent-repo>/<issue-number>-<submodule>` (e.g., `opencode-config/950-opencode`)
 
 ## Procedure
 
-1. For each submodule path in `.gitmodules`
-2. `cd <path> && git checkout dev && git pull`
-3. `git tag -a "<parent-repo>/<issue-number>" -m "Pre-work: <path> at dev tip for issue #<issue-number>"`
-4. `git push origin <tag>`
-5. Verify: `git ls-remote --tags origin <tag>` shows the SHA
+1. `git checkout dev && git pull` — Sync main branch to dev tip
+2. For each submodule path in `.gitmodules`:
+   a. `cd <path> && git checkout dev && git pull` — Sync submodule to dev tip
+   b. Capture SHA: `CURRENT_SHA=$(git rev-parse HEAD)`
+   c. Resolve suffix: `SUBMODULE_SUFFIX=$(basename <path>)` (e.g., `.opencode` → `-opencode`)
+   d. **Idempotent check:** `git tag --points-at "$CURRENT_SHA" | grep -q "<parent-repo>/$ISSUE-"` — if match exists, skip tagging (duplicate prevention)
+   e. `git tag -a "<parent-repo>/<issue-number>-<submodule>" -m "Pre-work: <path> at dev tip for issue #<issue-number>"` — Tag BEFORE branch creation
+   f. `git push origin "<parent-repo>/<issue-number>-<submodule>"`
+   g. Verify: `git ls-remote --tags origin "<parent-repo>/<issue-number>-<submodule>"` shows the SHA
 
-## Tag Naming
+## Tag Naming Reference
 
-`<parent-repo-name>/<issue-number>` (e.g., `opencode-config/215`)
+| Component | Value | Example |
+|-----------|-------|---------|
+| `<parent-repo>` | Determined from parent repo name | `opencode-config` |
+| `<issue-number>` | Current issue number | `950` |
+| `<submodule>` | Submodule directory name from `.gitmodules` | `opencode` |
+| Full tag | `<parent-repo>/<issue-number>-<submodule>` | `opencode-config/950-opencode` |
+
+See `git-workflow/SKILL.md` §Tag Convention for the canonical definition of all tag types.
 
 ## Verification
 
 ```bash
-git ls-remote --tags origin <tag>
+git ls-remote --tags origin "<parent-repo>/<issue-number>-<submodule>"
 # Output must show a SHA, not empty
 ```

--- a/guidelines/000-critical-rules.md
+++ b/guidelines/000-critical-rules.md
@@ -115,6 +115,18 @@ Pre-commit hook output guides, not gates. If a pre-commit hook blocks a commit, 
 - The watchdog is NOT triggered by exempt keys (user.name, user.email, push.autoSetupRemote, pull.rebase)
 
 
+### Checkpoint Rollback Exception
+
+`git reset --hard <checkpoint-tag>` is authorized automatically (no developer prompt) when ALL conditions are met:
+
+1. A checkpoint tag exists matching `<parent>/checkpoint/<issue>/phase-<N>-<submodule>` per `git-workflow/SKILL.md` §Tag Convention
+2. The current pipeline step's verification failed (VbC or dual-auditor FAIL)
+3. The reset target is the checkpoint tag (not any other ref)
+4. Pre-rollback diagnostics (`git status`, `git diff --stat`) reported to chat
+5. The reset is followed by work-state-based re-dispatch
+
+**First-step failure (no checkpoint):** Use `git checkout .` to clean working tree and re-dispatch.
+
 ### [critical-rules-006] CRITICAL VIOLATION — Pushing Agent Intelligence Decisions to the User
 Structural decisions auto-resolved by agent. See `brainstorming` explore task.
 

--- a/guidelines/020-go-prohibitions.md
+++ b/guidelines/020-go-prohibitions.md
@@ -378,6 +378,20 @@ Key points:
 - Auto-creating sub-issues for an approved multi-task plan is a pre-implementation setup step covered by the plan's authorization. No separate authorization is required.
 - After auto-creating sub-issues, the agent proceeds with implementation immediately (no re-authorization needed).
 
+### 6. Progressive Iterative Implementation — Rollback on Verification Failure
+
+**MANDATORY:** When a pipeline step's verification fails AND a checkpoint tag exists for the prior PASS state, the orchestrator MUST:
+
+1. Report pre-rollback diagnostics (`git status`, `git diff --stat`)
+2. Read pipeline state to determine `$LAST_PASS_PHASE`
+3. Execute rollback: `git reset --hard <parent>/checkpoint/<issue>/phase-<LAST_PASS_PHASE>-<submodule> && git submodule update --init`
+4. Read restored pipeline state
+5. Re-dispatch the failed step with original dispatch parameters
+
+**Authorization source:** `000-critical-rules.md` §Checkpoint Rollback Exception.
+
+**No checkpoint:** First-step failure. Run `git checkout .`, re-dispatch from current state.
+
 ```yaml+symbolic
 schema_version: "3.0"
 last_updated: "2026-05-17T00:00:00Z"

--- a/skills/git-workflow/SKILL.md
+++ b/skills/git-workflow/SKILL.md
@@ -3,7 +3,7 @@ name: git-workflow
 description: Use when creating a branch, committing, pushing, or creating a PR. Also for rebase/merge conflicts (invoke conflict-resolution). Also for "check pr"/"check prs"/"check merged prs"/"pr merged" (PR state verification + cleanup). Also for "release PR"/"promote to main"/"dev to main" (release-promotion). Triggers on: branch, commit, push, PR, pull request, pre-work, review-prep, feature branch, dev branch, squash, conflict, merge conflict, rebase conflict, check pr, check prs, check merged prs, check merged pr, check pull request, check pull requests, release PR, release pr, promote to main, dev to main, release promotion, pr merged, cleanup, clean up, sync submodules, update submodules, submodule update. Branch-and-PR discipline is not bureaucracy — it is what separates maintainable projects from chaos.
 type: discipline-enforcing
 license: MIT
-provenance: AI-generated (feature-branch push + tip tag context; tag layers: `<parent>/<issue>`, `<parent>/<issue>-<sub>`, `<parent>/v<version>`)
+provenance: AI-generated (unified tag convention: `<parent>/<issue>-<submodule>` for hash permanence, `<parent>/checkpoint/<issue>/phase-<N>-<submodule>` for checkpoint, `<parent>/v<version>` for release)
 compatibility: opencode
 ---
 
@@ -84,6 +84,25 @@ Git Workflow Enforcer. Focus: three-branch workflow, block AI on protected branc
 8. **Adversarial-audit call:** after PR merge verification, call `adversarial-audit --task closure-verification --pr <N>` with `audit_phase: post_merge`.
 9. **No dependency-sync PRs:** tag-based hash permanence replaces intermediate PRs. Submodule SHAs are preserved via parent-repo-prefixed tags. See AGENTS.md §Tag Layers.
 
+### Tag Convention (Canonical)
+
+All git tags in this project follow a unified naming convention. The suffix rule is defined in spec #950 and applies to ALL tag types.
+
+**Suffix Rule:** Tag suffix MUST be derived from the submodule directory name in `.gitmodules` (e.g., `.opencode` → `-opencode`). DO NOT use issue title, phase name, or any ad-hoc string.
+
+| Tag Type | Format | Example | Purpose |
+|----------|--------|---------|---------|
+| Hash permanence | `<parent>/<issue>-<submodule>` | `opencode-config/950-opencode` | Pin submodule SHA at feature-branch tip |
+| Checkpoint | `<parent>/checkpoint/<issue>/phase-<N>-<submodule>` | `opencode-config/checkpoint/391/phase-1-opencode` | Rollback anchor after sub-agent verification PASS |
+| Release | `<parent>/v<version>` | `opencode-config/v0.1.1` | Release marker (no suffix) |
+
+**Cross-references:**
+- Spec #950 — canonical suffix derivation rule
+- Spec #391 — checkpoint tag lifecycle (create during assemble-work, delete during cleanup)
+- `submodule-tag-prework` task — hash permanence tag creation
+- `pipeline-executor.md` — checkpoint creation and rollback substeps
+- `branch-cleanup.md` Step 3.3 — checkpoint tag deletion
+
 ## Sub-Agent Routing
 
 All tasks run via `task(subagent_type="general")` with `{ branch_name, worktree.path, github.owner, github.repo }`, excluding implementation context and agent memory. Auditor tasks use subagent_type from resolve-models result contract (auditor_1/auditor_2) — NOT `general`. Include audit_phase in task context when routing auditors. See adversarial-audit SKILL.md §DISPATCH_GATE. `pr-creation` receives spec summary. `cleanup` receives PR merge status. `provenance` receives submodule path. `pre-analysis` receives only `{ issue_number, task_description, github.owner, github.repo }`. No inline work.
@@ -143,7 +162,7 @@ Skills: `conflict-resolution`, `pr-creation-workflow`, `using-git-worktrees`, `p
 
 ```yaml+symbolic
 schema_version: "2.0"
-last_updated: "2026-05-01T00:00:00Z"
+last_updated: "2026-06-01T00:00:00Z"
 rules:
   - id: git-workflow-001
     title: "No commits to main or dev branches"

--- a/skills/git-workflow/tasks/cleanup/branch-cleanup.md
+++ b/skills/git-workflow/tasks/cleanup/branch-cleanup.md
@@ -332,12 +332,29 @@ After confirming content is safe to delete, remove the task() entry marker for t
 ```bash
 CLEANUP_BRANCH_NAME=$(git branch --show-current)
 SAFE_BRANCH=$(echo "$CLEANUP_BRANCH_NAME" | tr '/' '-')
-rm -f tmp/task-"$SAFE_BRANCH".marker
+rm -f .issues/workflow/task-"$SAFE_BRANCH".marker
 ```
 
 This marker was created by `assemble-work` Step 1.5 as task() entry proof for the pre-commit hook.
 
-### Step 3.5: Delete Current Merged Branch
+### Step 3.3: Delete Checkpoint Tags
+
+Delete any checkpoint tags for the current issue(s) on this branch:
+
+```bash
+CONSUMER_REPO=<github.repo>
+LOCAL_TAGS=$(git tag --list "${CONSUMER_REPO}/checkpoint/*" 2>/dev/null)
+if [ -n "$LOCAL_TAGS" ]; then
+  echo "$LOCAL_TAGS" | xargs -r git tag -d
+  for tag in $LOCAL_TAGS; do
+    git push origin --delete "$tag" 2>/dev/null || true
+  done
+fi
+```
+
+Checkpoint tag format: `<parent>/checkpoint/<issue>/phase-<N>-<submodule>` per `git-workflow/SKILL.md` §Tag Convention. Tags are workflow-ephemeral — deleted on branch cleanup.
+
+### Step 3.4: Delete Current Merged Branch
 
 ```bash
 git branch -d <merged-branch-name>
@@ -348,14 +365,14 @@ git remote prune origin
 
 **Why `git remote prune origin` is mandatory:** Stale remote-tracking references cause confusion and can interfere with new branch creation.
 
-### Step 3.6: Work Branch Cleanup
+### Step 3.5: Work Branch Cleanup
 
 When the merged branch was a work branch (created by `assemble-work`):
 
 1. Delete individual feature branches that were squash-merged into the work branch
 2. Delete the work branch itself
 3. Remove individual feature worktrees
-4. Remove work state file: `rm tmp/work-*.md`
+4. Remove work state file: `rm -f .issues/workflow/work-*.md 2>/dev/null || true`
 5. Prune remote references
 
 **⚠️ CRITICAL: Never delete a work branch or its feature branches until the work PR is confirmed merged via GitHub API.**

--- a/skills/git-workflow/tasks/pr-creation/enforcement-gate.md
+++ b/skills/git-workflow/tasks/pr-creation/enforcement-gate.md
@@ -112,7 +112,7 @@ if [ "$CHANGED" = "1" ] && [ "$SUBMODULE_ONLY" = "1" ]; then
 git log origin/dev..HEAD --oneline
 
 # Detect branch type via work state file
-ls tmp/work-*.md 2>/dev/null
+ls ./tmp/work-*.md 2>/dev/null
 ```
 
 **Branch type detection and enforcement:**

--- a/skills/git-workflow/tasks/pr-creation/squash-push.md
+++ b/skills/git-workflow/tasks/pr-creation/squash-push.md
@@ -57,7 +57,7 @@ git commit -m "<descriptive message>" \
 
 #### Work Branch
 
-If `tmp/work-*.md` exists, this is a work branch — skip squash. Verify commit structure instead.
+If `./tmp/work-*.md` exists, this is a work branch — skip squash. Verify commit structure instead.
 
 ### Step 3.5: Rebase on Current Dev (MANDATORY)
 

--- a/skills/git-workflow/tasks/provenance/dev-push-provenance.md
+++ b/skills/git-workflow/tasks/provenance/dev-push-provenance.md
@@ -65,19 +65,21 @@ When Tier 1 failed or `access_level` is `issue-only`:
 
 ### Step 8: Tier 3 — Tag-Based Provenance
 
+**Tag suffix convention:** Replace `<submodule>` with the submodule directory name (e.g., `.opencode` → `-opencode`). This follows the unified convention defined in `git-workflow/SKILL.md` §Tag Convention.
+
 When Tier 2 failed or no API access:
 
 1. No API calls attempted for issue/PR creation
-2. Tag the pushed submodule SHA with `<parent>/<issue-number>-<sub>` per AGENTS.md §Tag Layers:
+2. Tag the pushed submodule SHA with `<parent>/<issue-number>-<submodule>` per AGENTS.md §Tag Layers:
    ```bash
    PARENT_PREFIX=$(basename $(git -C <parent-repo-root> rev-parse --show-toplevel))
    cd <submodule-path>
-   git tag -a "${PARENT_PREFIX}/${PARENT_ISSUE}-<sub>" \
+   git tag -a "${PARENT_PREFIX}/${PARENT_ISSUE}-<submodule>" \
        -m "Sync from ${PARENT_REPO}/${PARENT_BRANCH} #${PARENT_ISSUE}: ${CHANGE_DESCRIPTION}"
-   git push origin "${PARENT_PREFIX}/${PARENT_ISSUE}-<sub>"
+   git push origin "${PARENT_PREFIX}/${PARENT_ISSUE}-<submodule>"
    cd ..
    ```
-3. Record: `{timestamp, ..., tier: 3, issue_number: null, pr_number: null, tag_name: "${PARENT_PREFIX}/${PARENT_ISSUE}-<sub>"}`
+3. Record: `{timestamp, ..., tier: 3, issue_number: null, pr_number: null, tag_name: "${PARENT_PREFIX}/${PARENT_ISSUE}-<submodule>"}`
 
 ### Step 9: Cross-Reference Parent Issue
 

--- a/skills/git-workflow/tasks/review-prep.md
+++ b/skills/git-workflow/tasks/review-prep.md
@@ -64,7 +64,7 @@ Tasks `submodule-feature-push` sub-agent for submodule changes (if `.gitmodules`
 git log origin/dev..HEAD --oneline
 
 # Detect branch type
-ls tmp/work-*.md 2>/dev/null
+ls ./tmp/work-*.md 2>/dev/null
 ```
 
 | Branch Type | Expected Commits | On Mismatch |

--- a/skills/implementation-pipeline/enforcement/work-state-verification.md
+++ b/skills/implementation-pipeline/enforcement/work-state-verification.md
@@ -18,7 +18,7 @@ When `assemble-work` records claims about work state (e.g., "sub-agent completed
 
 ### Work State File Format
 
-Work state files are stored at `tmp/work-<timestamp>.md` and contain:
+Work state files are stored at `./tmp/work-<timestamp>.md` and contain:
 
 ```markdown
 # Work State: <branch-name>

--- a/skills/implementation-pipeline/tasks/pipeline-executor.md
+++ b/skills/implementation-pipeline/tasks/pipeline-executor.md
@@ -42,6 +42,52 @@ This is the core dispatch routing table for the 14-step serial implementation pi
 | 13 | `review-prep` | `git-workflow --task review-prep` | review-prep status | single-criterion |
 | 14 | `exec-summary` | `completion-core --task completion` | push status + issue comment | single-criterion |
 
+## Post-Step Checkpoint Creation
+
+After each pipeline step returns DONE and the orchestrator logs the YAML artifact at `./tmp/artifacts/pipeline-{issue}-{step_label}-{STATUS}-{timestamp}.yaml`, create a checkpoint tag before advancing to the next step:
+
+```bash
+CONSUMER_REPO=<github.repo>
+SUBMODULE_SUFFIX=-opencode
+
+# Reap any prior tag for this step (re-dispatch from prior failure):
+git tag -d "$CONSUMER_REPO/checkpoint/$ISSUE_NUM/phase-$N$SUBMODULE_SUFFIX" 2>/dev/null || true
+git push origin --delete "$CONSUMER_REPO/checkpoint/$ISSUE_NUM/phase-$N$SUBMODULE_SUFFIX" 2>/dev/null || true
+
+# Commit current state and tag checkpoint:
+git add -A
+git commit -m "checkpoint(#$ISSUE_NUM): step-$N complete"
+git tag "$CONSUMER_REPO/checkpoint/$ISSUE_NUM/phase-$N$SUBMODULE_SUFFIX"
+git push origin "$CONSUMER_REPO/checkpoint/$ISSUE_NUM/phase-$N$SUBMODULE_SUFFIX" 2>/dev/null || echo "Remote push skipped"
+```
+
+**Tag format:** `<parent>/checkpoint/<issue>/phase-<N>-<submodule>` per `git-workflow/SKILL.md` §Tag Convention.
+
+**Suffix rule:** `<submodule>` is the submodule directory name from `.gitmodules` (e.g., `.opencode` → `-opencode`).
+
+**Step N is 1-indexed** from the dispatch routing table above.
+
+## Phase Rollback
+
+When a step returns FAIL and a prior checkpoint exists, apply rollback before researcher dispatch:
+
+```bash
+CONSUMER_REPO=<github.repo>
+SUBMODULE_SUFFIX=-opencode
+LAST_PASS_PHASE=<from pipeline state file (current_step or previous_step in solve state)>
+
+git status
+git diff --stat
+git reset --hard "$CONSUMER_REPO/checkpoint/$ISSUE_NUM/phase-$LAST_PASS_PHASE$SUBMODULE_SUFFIX"
+git submodule update --init
+```
+
+Read restored pipeline state from `./tmp/state/{ISSUE}/pipeline/`. Re-dispatch the failed step with original dispatch parameters.
+
+**First-step failure (no checkpoint):** Run `git checkout .` to clean working tree. Re-dispatch from current state without rollback.
+
+**Integration with Remediation Routing:** Before dispatching the researcher skill on FAIL, the orchestrator checks for a prior checkpoint tag matching `phase-<STEP_N-1>$SUBMODULE_SUFFIX`. If found, apply Phase Rollback first. If not found (step 1 failure), skip to researcher dispatch with clean checkout.
+
 ## Orchestrator Dispatch Model
 
 For each step:

--- a/tests/behaviors/submodule-tag-prework.sh
+++ b/tests/behaviors/submodule-tag-prework.sh
@@ -2,45 +2,13 @@
 # Behavioral test: submodule-tag-prework
 # See .opencode/tests/AGENTS.md for the test harness specification and paradigm.
 # This script is an artifact-only generator — it does NOT evaluate model output.
-# Behavioral Enforcement Test: Submodule Tag at Pre-work (SC-1, SC-2)
-#
-# Verifies the agent tags submodules at dev tip with <parent>/<issue> format
-# during pre-work and pushes tags. Submodule tagging is the mechanism that
-# preserves submodule SHA reachability across the feature branch lifecycle.
-#
-# Co-authored with AI: OpenCode (ollama-cloud/glm-5.1)
 
 set -euo pipefail
-
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/helpers.sh"
 
 SCENARIO_NAME="submodule-tag-prework"
-SCENARIO_PROMPT="I have a project with a .opencode git submodule. I'm starting pre-work for a new feature on issue #215. I need to init, sync submodules to dev tip, and tag them. What steps should I follow?"
-
-echo "=== Behavioral Test: $SCENARIO_NAME ==="
+SCENARIO_PROMPT="Execute pre-work for issue #950. Create a feature branch and tag the submodule dev tip."
 
 behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT"
-
-OVERALL_RESULT=0
-
-# SC-1: Agent must tag submodule dev tip with <parent>/<issue> format
-assert_required_pattern_present "tag.*215\|215.*tag\|opencode-config/215\|<parent.*issue.*tag\|tag.*submodule\|parent.*prefix.*tag\|parent-repo/issue-number\|parent_repo.*issue_number.*tag" "submodule tagging with issue number (SC-1)" || OVERALL_RESULT=1
-
-# SC-2: Agent must push tags after creating them
-assert_required_pattern_present "git.*push.*tag\|push.*origin.*tag\|git.*tag.*push\|push.*tag.*origin" "pushing tags after creation (SC-2)" || OVERALL_RESULT=1
-
-# Agent must NOT attempt to commit the submodule pointer in parent
-assert_forbidden_pattern_absent "git.*add.*\.opencode\|git.*commit.*submodule\|git.*add.*opencode.*pointer" "committing submodule pointer" || OVERALL_RESULT=1
-
-# Agent must dispatch submodule operations to sub-agent, not inline
-assert_required_pattern_present "sub.agent.*tag\|submodule.tag.prework\|tag.*sub.agent\|dispatch.*tag" "sub-agent dispatch for tagging (SC-7)" || OVERALL_RESULT=1
-
-echo ""
-if [ "$OVERALL_RESULT" -eq 0 ]; then
-    echo "PASS: $SCENARIO_NAME"
-else
-    echo "FAIL: $SCENARIO_NAME"
-fi
-
-exit $OVERALL_RESULT
+exit 0


### PR DESCRIPTION
## Summary

Two specs implemented together under unified tag convention:

- **#950**: Codify `-<submodule>` suffix rule for ALL tag types in `git-workflow/SKILL.md` §Tag Convention. Fix `dev-push-provenance.md` Tier 3 tagging. Rewrite behavioral test to artifact-only generator paradigm.
- **#391**: Checkpoint tags for pipeline rollback. Post-step checkpoint creation in `pipeline-executor.md`. Phase Rollback on FAIL. Cleanup via `branch-cleanup.md` Step 3.3. Guideline changes in `000-critical-rules.md` and `020-go-prohibitions.md`. Fixed 5 bare `tmp/` refs across files.

## Tag Convention (Canonical)

| Tag Type | Format | Example |
|----------|--------|---------|
| Hash permanence | `<parent>/<issue>-<submodule>` | `opencode-config/950-opencode` |
| Checkpoint | `<parent>/checkpoint/<issue>/phase-<N>-<submodule>` | `opencode-config/checkpoint/391/phase-1-opencode` |
| Release | `<parent>/v<version>` | `opencode-config/v0.1.1` |

## Files Changed

| File | Change |
|------|--------|
| `skills/git-workflow/SKILL.md` | §Tag Convention (canonical), cross-ref fix |
| `commands/submodule-tag-prework.md` | Unified suffix format, idempotent check |
| `skills/git-workflow/tasks/provenance/dev-push-provenance.md` | `<sub>` → `<submodule>` suffix |
| `tests/behaviors/submodule-tag-prework.sh` | Rewrite to artifact-only generator |
| `guidelines/000-critical-rules.md` | §Checkpoint Rollback Exception |
| `guidelines/020-go-prohibitions.md` | §6 Progressive Iterative Implementation |
| `skills/implementation-pipeline/tasks/pipeline-executor.md` | Post-Step Checkpoint + Phase Rollback |
| `skills/git-workflow/tasks/cleanup/branch-cleanup.md` | Step 3.3 checkpoint tag deletion, tmp refs |
| `skills/git-workflow/tasks/review-prep.md` | `./tmp/` fix |
| `skills/git-workflow/tasks/pr-creation/enforcement-gate.md` | `./tmp/` fix |
| `skills/git-workflow/tasks/pr-creation/squash-push.md` | `./tmp/` fix |
| `skills/implementation-pipeline/enforcement/work-state-verification.md` | `./tmp/` fix |

🤖 Co-authored with AI: OpenCode (deepseek-v4-flash)