### PR TITLE
feat(#980): tools/plan — unified-planning PEP 723 tool

### DIFF
--- a/guidelines/070-environment.md
+++ b/guidelines/070-environment.md
@@ -45,11 +45,42 @@ Every PEP 723 script MUST include a polyglot bash guard as the second line, imme
 
 The guard prevents catastrophic failure when an agent or user invokes `bash <script>` instead of `uv run --script <script>` — bash sees `"exec" "uv" "run" "--script" "$0" "$@"` and replaces itself with `uv`, forwarding all arguments. Under Python, the guard is a bare string expression and is silently discarded.
 
+### `# fmt: off` / `# fmt: on` Ruff Protection (MANDATORY)
+
+`ruff format` interprets the bash guard line as a Python string expression and will corrupt it by stripping spaces between the quoted tokens, producing `"execuvrun--script$0$@"`. This renders the tool non-functional (cannot execute under bash).
+
+**Every PEP 723 script MUST wrap the bash guard and PEP 723 header in `# fmt: off` / `# fmt: on` guards:**
+
+```python
+#!/usr/bin/env -S uv run --script
+# fmt: off
+"exec" "uv" "run" "--script" "$0" "$@" # MUST GO BEFORE PEP 723 HEADER
+
+# PEP 723 HEADER MUST BE AFTER BASH GUARD
+# /// script
+# requires-python = "~=3.12"
+# dependencies = []
+# ///
+
+# fmt: on
+```
+
+- **`# fmt: off`** MUST be on line 2 (immediately after shebang)
+- **`# fmt: on`** MUST be on the line after `# ///` (closing PEP 723 block), before any imports or code
+- The `# fmt: on` guard MUST NOT be inside the PEP 723 TOML block — it goes AFTER `# ///`, not between `# /// script` and `# ///`
+- Failure to include these guards WILL result in the bash guard being corrupted by `ruff format` during review-prep or any automated formatting pass
+
 **Structure rules:**
 - Line 1: `#!/usr/bin/env -S uv run --script` (only allowed shebang)
-- Line 2: `"exec" "uv" "run" "--script" "$0" "$@" # MUST GO BEFORE PEP 723 HEADER` (bash guard)
-- Lines 4-8: PEP 723 metadata block (comment line, `# /// script`, metadata, `# ///`)
-- After `# ///`: blank line, then optional `from __future__` or `__doc__ = ` or imports
+- Line 2: `# fmt: off` (ruff protection guard)
+- Line 3: `"exec" "uv" "run" "--script" "$0" "$@" # MUST GO BEFORE PEP 723 HEADER` (bash guard)
+- Lines 4-5: Comment line, PEP 723 header
+- Lines 6-8: PEP 723 metadata block (`requires-python`, `dependencies`)
+- Line 9: `# ///` (closing PEP 723)
+- Line 10: `# fmt: on` (ruff protection guard off)
+- After: blank line, then optional `from __future__` or `__doc__ = ` or imports
+
+This error was discovered during adversarial audit of issue #980. Both `tools/plan` and `tools/solve` were affected.
 
 Scripts that print `__doc__` at runtime MUST use `__doc__ = """..."""` assignment (not bare `"""..."""`) because the bash guard string captures the first docstring slot.
 

--- a/tests/behaviors/plan-parser.sh
+++ b/tests/behaviors/plan-parser.sh
@@ -1,0 +1,181 @@
+#!/bin/bash
+# Phase 3 — RED test for Parser: plan plan --problem with gripper YAML.
+#
+# Verifies that plan plan --problem produces engine dispatch + action list.
+# MUST FAIL (exit non-zero) in RED phase because _action_plan doesn't
+# generate a plan yet — it only builds the problem and prints info.
+#
+# SC-1: plan plan --problem gripper.yaml with valid gripper problem
+#       → stderr shows engine dispatch + stdout has `- [ ] N.` action list
+#
+# Co-authored with AI: OpenCode (ollama-cloud/deepseek-v4-flash)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/helpers.sh"
+
+SCENARIO_NAME="plan-parser-red"
+OVERALL_RESULT=0
+
+echo "=== RED Phase Test: Parser (SC-1) ==="
+
+# ============================================================
+# Create test fixtures
+# ============================================================
+TEST_DIR=$(mktemp -d "$PARENT_REPO_DIR/tmp/plan-parser-test-XXXXXX")
+trap 'rm -rf "$TEST_DIR"' EXIT
+
+# Create a gripper YAML problem file
+cat > "$TEST_DIR/gripper.yaml" << 'YAMLEOF'
+domain: gripper
+types:
+  - name: location
+  - name: ball
+  - name: robot
+objects:
+  - name: room-a
+    type: location
+  - name: room-b
+    type: location
+  - name: ball1
+    type: ball
+  - name: robot1
+    type: robot
+fluents:
+  - name: at-ball
+    params:
+      - name: b
+        type: ball
+      - name: l
+        type: location
+  - name: at-robot
+    params:
+      - name: r
+        type: robot
+      - name: l
+        type: location
+  - name: free
+    params:
+      - name: r
+        type: robot
+actions:
+  - name: move
+    params:
+      - name: r
+        type: robot
+      - name: from
+        type: location
+      - name: to
+        type: location
+    preconditions:
+      - at-robot(r, from)
+    effects:
+      - at-robot(r, to)
+      - not at-robot(r, from)
+  - name: pick
+    params:
+      - name: r
+        type: robot
+      - name: b
+        type: ball
+      - name: l
+        type: location
+    preconditions:
+      - at-robot(r, l)
+      - at-ball(b, l)
+      - free(r)
+    effects:
+      - not at-ball(b, l)
+      - not free(r)
+  - name: drop
+    params:
+      - name: r
+        type: robot
+      - name: b
+        type: ball
+      - name: l
+        type: location
+    preconditions:
+      - at-robot(r, l)
+      - not free(r)
+    effects:
+      - at-ball(b, l)
+      - free(r)
+init:
+  - at-robot(robot1, room-a)
+  - at-ball(ball1, room-a)
+  - free(robot1)
+goals:
+  - at-ball(ball1, room-b)
+YAMLEOF
+
+echo ""
+echo "Fixture setup complete."
+echo "  Problem file: $TEST_DIR/gripper.yaml"
+
+# ============================================================
+# SC-1: plan plan --problem produces engine dispatch + action list
+# ============================================================
+echo ""
+echo "--- SC-1: plan plan --problem gripper.yaml ---"
+
+# Run the plan command
+PLAN_STDOUT="$TEST_DIR/stdout.log"
+PLAN_STDERR="$TEST_DIR/stderr.log"
+PLAN_EXIT=0
+
+cd "$PARENT_REPO_DIR"
+uv run --script .opencode/tools/plan plan --problem "$TEST_DIR/gripper.yaml" > "$PLAN_STDOUT" 2> "$PLAN_STDERR" || PLAN_EXIT=$?
+
+echo "  Exit code: $PLAN_EXIT"
+echo "  stdout:"
+sed 's/^/    /' "$PLAN_STDOUT"
+echo "  stderr:"
+sed 's/^/    /' "$PLAN_STDERR"
+
+# Check SC-1: stderr shows engine dispatch
+SC1_ENGINE=0
+if grep -qE "engine|planner|solver|dispatch" "$PLAN_STDERR" 2>/dev/null; then
+    echo "  PASS: stderr shows engine dispatch"
+    SC1_ENGINE=0
+else
+    echo "  FAIL: stderr does NOT show engine dispatch (expected RED behavior)"
+    SC1_ENGINE=1
+    OVERALL_RESULT=1
+fi
+
+# Check SC-1: stdout has action list with `- [ ] N.` format
+SC1_ACTIONS=0
+if grep -qE '^- \[ \] [0-9]+\.' "$PLAN_STDOUT" 2>/dev/null; then
+    echo "  PASS: stdout has action list"
+    SC1_ACTIONS=0
+else
+    echo "  FAIL: stdout does NOT have action list (expected RED behavior)"
+    SC1_ACTIONS=1
+    OVERALL_RESULT=1
+fi
+
+# ============================================================
+# Report
+# ============================================================
+echo ""
+echo "=== RED Phase Results ==="
+echo "SC-1 engine dispatch: $([ "$SC1_ENGINE" -eq 0 ] && echo "PASS" || echo "FAIL (expected RED)")"
+echo "SC-1 action list:    $([ "$SC1_ACTIONS" -eq 0 ] && echo "PASS" || echo "FAIL (expected RED)")"
+
+# SC results (for orchestrator reporting)
+mkdir -p "${BEHAVIOR_LOG_DIR:-$PARENT_REPO_DIR/tmp}"
+cat > "${BEHAVIOR_LOG_DIR:-$PARENT_REPO_DIR/tmp}/plan-parser-red-sc-results.txt" << EOF
+SC-1-engine: $([ "$SC1_ENGINE" -eq 0 ] && echo "PASS" || echo "FAIL")
+SC-1-actions: $([ "$SC1_ACTIONS" -eq 0 ] && echo "PASS" || echo "FAIL")
+EOF
+
+echo ""
+if [ "$OVERALL_RESULT" -eq 0 ]; then
+    echo "PASS: $SCENARIO_NAME (SC-1)"
+else
+    echo "FAIL: $SCENARIO_NAME (SC-1) — expected RED behavior"
+fi
+
+exit $OVERALL_RESULT

--- a/tests/behaviors/plan-skeleton.sh
+++ b/tests/behaviors/plan-skeleton.sh
@@ -100,12 +100,62 @@ fi
 echo ""
 
 # ============================================================
+# SC-5: state init creates YAML state file
+# ============================================================
+echo "--- SC-5: plan state init <dir> exits 1 (not implemented / RED) ---"
+
+TEST_STATE_DIR="$PROJECT_DIR/tmp/plan-skeleton-test-state"
+rm -rf "$TEST_STATE_DIR"
+mkdir -p "$TEST_STATE_DIR"
+
+SC5_OUTPUT=""
+SC5_EXIT=0
+SC5_OUTPUT=$(cd "$PROJECT_DIR" && uv run .opencode/tools/plan state init "$TEST_STATE_DIR" 2>&1) || SC5_EXIT=$?
+
+if [ "$SC5_EXIT" -eq 0 ]; then
+    echo "  UNEXPECTED PASS: state init exited 0 (implementation exists?)"
+    echo "  Output: $(echo "$SC5_OUTPUT" | head -3)"
+    SC5_RESULT=0
+else
+    echo "  FAIL: state init exited $SC5_EXIT (expected RED — state not implemented yet)"
+    echo "  Output: $(echo "$SC5_OUTPUT" | head -3)"
+    SC5_RESULT=1
+    OVERALL_RESULT=1
+fi
+
+echo ""
+
+# ============================================================
+# SC-6: state update writes to state file
+# ============================================================
+echo "--- SC-6: plan state update <dir> --var-name FOO --var-value bar exits 1 (not implemented / RED) ---"
+
+SC6_OUTPUT=""
+SC6_EXIT=0
+SC6_OUTPUT=$(cd "$PROJECT_DIR" && uv run .opencode/tools/plan state update "$TEST_STATE_DIR" --var-name FOO --var-value bar 2>&1) || SC6_EXIT=$?
+
+if [ "$SC6_EXIT" -eq 0 ]; then
+    echo "  UNEXPECTED PASS: state update exited 0 (implementation exists?)"
+    echo "  Output: $(echo "$SC6_OUTPUT" | head -3)"
+    SC6_RESULT=0
+else
+    echo "  FAIL: state update exited $SC6_EXIT (expected RED — state not implemented yet)"
+    echo "  Output: $(echo "$SC6_OUTPUT" | head -3)"
+    SC6_RESULT=1
+    OVERALL_RESULT=1
+fi
+
+echo ""
+
+# ============================================================
 # Write results for orchestrator
 # ============================================================
 mkdir -p "$PROJECT_DIR/tmp"
 cat > "$PROJECT_DIR/tmp/plan-skeleton-red-results.txt" << EOF
 SC-10: $([ "$SC10_RESULT" -eq 0 ] && echo "PASS" || echo "FAIL")
 SC-11: $([ "$SC11_RESULT" -eq 0 ] && echo "PASS" || echo "FAIL")
+SC-5: $([ "$SC5_RESULT" -eq 0 ] && echo "PASS" || echo "FAIL")
+SC-6: $([ "$SC6_RESULT" -eq 0 ] && echo "PASS" || echo "FAIL")
 PHASE: RED
 EOF
 
@@ -115,6 +165,8 @@ EOF
 echo "=== RED Phase Results ==="
 echo "SC-10 (--help exits 0): $([ "$SC10_RESULT" -eq 0 ] && echo 'PASS' || echo 'FAIL')"
 echo "SC-11 (plan --problem exits 0): $([ "$SC11_RESULT" -eq 0 ] && echo 'PASS' || echo 'FAIL')"
+echo "SC-5 (state init exits != 0): $([ "$SC5_RESULT" -eq 0 ] && echo 'PASS' || echo 'FAIL')"
+echo "SC-6 (state update exits != 0): $([ "$SC6_RESULT" -eq 0 ] && echo 'PASS' || echo 'FAIL')"
 echo ""
 
 if [ "$OVERALL_RESULT" -eq 0 ]; then

--- a/tests/behaviors/plan-skeleton.sh
+++ b/tests/behaviors/plan-skeleton.sh
@@ -1,0 +1,126 @@
+#!/bin/bash
+# RED Phase test for Phase 1 (Skeleton) of the plan tool.
+#
+# Tests two scenarios:
+#   SC-10: `uv run .opencode/tools/plan --help` exits 0 with usage text
+#   SC-11: `uv run --script tools/plan plan --problem <yaml>` exits 0
+#
+# In RED phase both MUST FAIL because .opencode/tools/plan doesn't exist yet.
+# In GREEN phase (after tool creation) both MUST PASS.
+#
+# Co-authored with AI: OpenCode (deepseek-v4-flash)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$SCRIPT_DIR"
+while [ "$(basename "$PROJECT_DIR")" != ".opencode" ]; do
+    PROJECT_DIR="$(dirname "$PROJECT_DIR")"
+done
+PROJECT_DIR="$(dirname "$PROJECT_DIR")"
+
+source "$SCRIPT_DIR/helpers.sh"
+
+SCENARIO_NAME="plan-skeleton"
+OVERALL_RESULT=0
+
+echo "=== RED Phase Test: $SCENARIO_NAME (Phase 1 Skeleton) ==="
+echo ""
+
+# ============================================================
+# Create test YAML problem file
+# ============================================================
+mkdir -p "$PROJECT_DIR/tmp"
+TEST_YAML="$PROJECT_DIR/tmp/plan-skeleton-test-problem.yaml"
+
+cat > "$TEST_YAML" << 'YAML'
+domain: gripper
+problem: gripper-simple
+objects:
+  rooms: [rooma, roomb]
+  balls: [ball1, ball2]
+  grippers: [left, right]
+init:
+  - "(at ball1 rooma)"
+  - "(at ball2 rooma)"
+  - "(at left rooma)"
+  - "(at right rooma)"
+  - "(free left)"
+  - "(free right)"
+goal:
+  - "(at ball1 roomb)"
+  - "(at ball2 roomb)"
+YAML
+
+echo "Test problem file: $TEST_YAML"
+echo ""
+
+# ============================================================
+# SC-10: --help exits 0 with usage text
+# ============================================================
+echo "--- SC-10: uv run .opencode/tools/plan --help exits 0 ---"
+
+SC10_OUTPUT=""
+SC10_EXIT=0
+SC10_OUTPUT=$(cd "$PROJECT_DIR" && uv run .opencode/tools/plan --help 2>&1) || SC10_EXIT=$?
+
+if [ "$SC10_EXIT" -eq 0 ]; then
+    echo "  PASS: --help exited 0"
+    echo "  Usage text: $(echo "$SC10_OUTPUT" | head -5)"
+    SC10_RESULT=0
+else
+    echo "  FAIL: --help exited $SC10_EXIT (expected RED — tool does not exist yet)"
+    echo "  Output: $(echo "$SC10_OUTPUT" | head -3)"
+    SC10_RESULT=1
+    OVERALL_RESULT=1
+fi
+
+echo ""
+
+# ============================================================
+# SC-11: plan --problem <yaml> exits 0
+# ============================================================
+echo "--- SC-11: uv run --script .opencode/tools/plan plan --problem <yaml> exits 0 ---"
+
+SC11_OUTPUT=""
+SC11_EXIT=0
+SC11_OUTPUT=$(cd "$PROJECT_DIR" && uv run --script .opencode/tools/plan plan --problem "$TEST_YAML" 2>&1) || SC11_EXIT=$?
+
+if [ "$SC11_EXIT" -eq 0 ]; then
+    echo "  PASS: plan --problem exited 0"
+    echo "  Output: $(echo "$SC11_OUTPUT" | head -5)"
+    SC11_RESULT=0
+else
+    echo "  FAIL: plan --problem exited $SC11_EXIT (expected RED — tool does not exist yet)"
+    echo "  Output: $(echo "$SC11_OUTPUT" | head -3)"
+    SC11_RESULT=1
+    OVERALL_RESULT=1
+fi
+
+echo ""
+
+# ============================================================
+# Write results for orchestrator
+# ============================================================
+mkdir -p "$PROJECT_DIR/tmp"
+cat > "$PROJECT_DIR/tmp/plan-skeleton-red-results.txt" << EOF
+SC-10: $([ "$SC10_RESULT" -eq 0 ] && echo "PASS" || echo "FAIL")
+SC-11: $([ "$SC11_RESULT" -eq 0 ] && echo "PASS" || echo "FAIL")
+PHASE: RED
+EOF
+
+# ============================================================
+# Summary
+# ============================================================
+echo "=== RED Phase Results ==="
+echo "SC-10 (--help exits 0): $([ "$SC10_RESULT" -eq 0 ] && echo 'PASS' || echo 'FAIL')"
+echo "SC-11 (plan --problem exits 0): $([ "$SC11_RESULT" -eq 0 ] && echo 'PASS' || echo 'FAIL')"
+echo ""
+
+if [ "$OVERALL_RESULT" -eq 0 ]; then
+    echo "PASS: $SCENARIO_NAME — unexpected: both SCs passed (tool already exists?)"
+else
+    echo "FAIL: $SCENARIO_NAME — expected RED behavior (tool does not exist yet)"
+fi
+
+exit $OVERALL_RESULT

--- a/tests/behaviors/plan-validate.sh
+++ b/tests/behaviors/plan-validate.sh
@@ -1,0 +1,197 @@
+#!/bin/bash
+# Phase 6 — RED/GREEN test for Validate: validate --problem --plan with valid/invalid YAML.
+#
+# SC-2: validate --problem p.yaml --plan plan.yaml with valid plan → exit 0 + "valid"
+# SC-3: validate with invalid plan (missing goal) → exit 1 + "invalid"
+#
+# Co-authored with AI: OpenCode (deepseek-v4-flash)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/helpers.sh"
+
+SCENARIO_NAME="plan-validate"
+OVERALL_RESULT=0
+
+echo "=== Phase Test: $SCENARIO_NAME (Phase 6 Validate) ==="
+
+# ============================================================
+# Create test fixtures
+# ============================================================
+TEST_DIR=$(mktemp -d "$PARENT_REPO_DIR/tmp/plan-validate-test-XXXXXX")
+trap 'rm -rf "$TEST_DIR"' EXIT
+
+# Problem YAML (gripper)
+cat > "$TEST_DIR/problem.yaml" << 'YAMLEOF'
+domain: gripper
+types:
+  - name: location
+  - name: ball
+  - name: robot
+objects:
+  - name: room-a
+    type: location
+  - name: room-b
+    type: location
+  - name: ball1
+    type: ball
+  - name: robot1
+    type: robot
+fluents:
+  - name: at-ball
+    params:
+      - name: b
+        type: ball
+      - name: l
+        type: location
+  - name: at-robot
+    params:
+      - name: r
+        type: robot
+      - name: l
+        type: location
+  - name: free
+    params:
+      - name: r
+        type: robot
+actions:
+  - name: move
+    params:
+      - name: r
+        type: robot
+      - name: from
+        type: location
+      - name: to
+        type: location
+    preconditions:
+      - at-robot(r, from)
+    effects:
+      - at-robot(r, to)
+      - not at-robot(r, from)
+  - name: pick
+    params:
+      - name: r
+        type: robot
+      - name: b
+        type: ball
+      - name: l
+        type: location
+    preconditions:
+      - at-robot(r, l)
+      - at-ball(b, l)
+      - free(r)
+    effects:
+      - not at-ball(b, l)
+      - not free(r)
+  - name: drop
+    params:
+      - name: r
+        type: robot
+      - name: b
+        type: ball
+      - name: l
+        type: location
+    preconditions:
+      - at-robot(r, l)
+      - not free(r)
+    effects:
+      - at-ball(b, l)
+      - free(r)
+init:
+  - at-robot(robot1, room-a)
+  - at-ball(ball1, room-a)
+  - free(robot1)
+goals:
+  - at-ball(ball1, room-b)
+YAMLEOF
+
+# Valid plan: pick ball1 from room-a, move to room-b, drop
+cat > "$TEST_DIR/valid-plan.yaml" << 'YAMLEOF'
+actions:
+  - name: pick
+    parameters: [robot1, ball1, room-a]
+  - name: move
+    parameters: [robot1, room-a, room-b]
+  - name: drop
+    parameters: [robot1, ball1, room-b]
+YAMLEOF
+
+# Invalid plan: only pick, no drop → goal unsatisfied
+cat > "$TEST_DIR/invalid-plan.yaml" << 'YAMLEOF'
+actions:
+  - name: pick
+    parameters: [robot1, ball1, room-a]
+  - name: move
+    parameters: [robot1, room-a, room-b]
+YAMLEOF
+
+echo "  Fixtures: $TEST_DIR/problem.yaml, valid-plan.yaml, invalid-plan.yaml"
+echo ""
+
+# ============================================================
+# SC-2: Valid plan → exit 0 + "valid"
+# ============================================================
+echo "--- SC-2: validate --problem p.yaml --plan valid-plan.yaml ---"
+
+SC2_OUTPUT=""
+SC2_EXIT=0
+SC2_OUTPUT=$(cd "$PARENT_REPO_DIR" && uv run .opencode/tools/plan validate --problem "$TEST_DIR/problem.yaml" --plan "$TEST_DIR/valid-plan.yaml" 2>&1) || SC2_EXIT=$?
+
+FIRST_LINE=$(echo "$SC2_OUTPUT" | head -1)
+if [ "$SC2_EXIT" -eq 0 ] && [ "$FIRST_LINE" = "valid" ]; then
+    echo "  PASS: exit 0, stdout='$FIRST_LINE'"
+    SC2_RESULT=0
+else
+    echo "  FAIL: exit=$SC2_EXIT, output='$FIRST_LINE' (expected 'valid')"
+    SC2_RESULT=1
+    OVERALL_RESULT=1
+fi
+
+echo ""
+
+# ============================================================
+# SC-3: Invalid plan → exit 1 + "invalid"
+# ============================================================
+echo "--- SC-3: validate --problem p.yaml --plan invalid-plan.yaml ---"
+
+SC3_OUTPUT=""
+SC3_EXIT=0
+SC3_OUTPUT=$(cd "$PARENT_REPO_DIR" && uv run .opencode/tools/plan validate --problem "$TEST_DIR/problem.yaml" --plan "$TEST_DIR/invalid-plan.yaml" 2>&1) || SC3_EXIT=$?
+
+FIRST_LINE=$(echo "$SC3_OUTPUT" | head -1)
+if [ "$SC3_EXIT" -eq 1 ] && echo "$FIRST_LINE" | grep -q "invalid"; then
+    echo "  PASS: exit 1, stdout='$FIRST_LINE'"
+    SC3_RESULT=0
+else
+    echo "  FAIL: exit=$SC3_EXIT, output='$FIRST_LINE' (expected 'invalid' + exit 1)"
+    SC3_RESULT=1
+    OVERALL_RESULT=1
+fi
+
+echo ""
+
+# ============================================================
+# Write results
+# ============================================================
+mkdir -p "$PARENT_REPO_DIR/tmp"
+cat > "$PARENT_REPO_DIR/tmp/plan-validate-results.txt" << EOF
+SC-2: $([ "$SC2_RESULT" -eq 0 ] && echo "PASS" || echo "FAIL")
+SC-3: $([ "$SC3_RESULT" -eq 0 ] && echo "PASS" || echo "FAIL")
+EOF
+
+# ============================================================
+# Summary
+# ============================================================
+echo "=== Phase 6 Validate Results ==="
+echo "SC-2 (valid plan → exit 0 + valid): $([ "$SC2_RESULT" -eq 0 ] && echo 'PASS' || echo 'FAIL')"
+echo "SC-3 (invalid plan → exit 1 + invalid): $([ "$SC3_RESULT" -eq 0 ] && echo 'PASS' || echo 'FAIL')"
+echo ""
+
+if [ "$OVERALL_RESULT" -eq 0 ]; then
+    echo "PASS: $SCENARIO_NAME — both SCs verified (GREEN phase)"
+else
+    echo "FAIL: $SCENARIO_NAME — SCs not passing"
+fi
+
+exit $OVERALL_RESULT

--- a/tools/plan
+++ b/tools/plan
@@ -36,7 +36,8 @@ from unified_planning.model import Problem, InstantaneousAction, Object, Fluent
 from unified_planning.model.types import _UserType
 
 from unified_planning.shortcuts import OneshotPlanner
-from unified_planning.engines.results import PlanGenerationResultStatus
+from unified_planning.engines.results import PlanGenerationResultStatus, ValidationResultStatus
+from unified_planning.engines import SequentialPlanValidator
 
 import yaml
 import networkx as nx
@@ -324,7 +325,62 @@ def _stub(name: str) -> None:
 
 
 def _action_validate(args: argparse.Namespace) -> None:
-    _stub("validate")
+    schema = _load_yaml(args.problem)
+    problem = _build_problem(schema)
+
+    plan_data = _load_yaml(args.plan)
+    actions_data = plan_data.get("actions", [])
+    if not actions_data:
+        actions_data = plan_data.get("plan", {}).get("steps", [])
+    if not actions_data:
+        _die("plan file must contain 'actions' list or 'plan.steps' list")
+
+    from unified_planning.plans import ActionInstance, SequentialPlan
+
+    action_instances: list[ActionInstance] = []
+    for ad in actions_data:
+        action_name = ad.get("name")
+        if not action_name:
+            _die(f"step missing 'name' field: {ad}")
+        if not problem.has_action(action_name):
+            _die(f"unknown action '{action_name}' in problem '{problem.name}'")
+        action = problem.action(action_name)
+
+        params_list = ad.get("parameters", [])
+        action_params = list(action.parameters)
+        if len(params_list) != len(action_params):
+            actual = ", ".join(ao.name for ao in action_params)
+            _die(
+                f"action '{action_name}' expects {len(action_params)} params ({actual}), "
+                f"got {len(params_list)}: {params_list}"
+            )
+
+        from unified_planning.model import Object as UPObject
+
+        params: list[UPObject] = []
+        for obj_name in params_list:
+            if problem.has_object(obj_name):
+                params.append(problem.object(obj_name))
+            else:
+                _die(f"unknown object '{obj_name}' for action '{action_name}'")
+        action_instances.append(ActionInstance(action, params))
+
+    plan = SequentialPlan(action_instances)
+    validator = SequentialPlanValidator()
+    result = validator.validate(problem, plan)
+
+    if result.status == ValidationResultStatus.VALID:
+        print("valid")
+        sys.exit(0)
+    else:
+        print("invalid: not all goals achieved")
+        if result.trace:
+            final_state = result.trace[-1]
+            for g in problem.goals:
+                val = final_state.get_value(g)
+                satisfied = val.is_true() if val is not None else False
+                print(f"  goal {g}: {'satisfied' if satisfied else 'NOT satisfied'}")
+        sys.exit(1)
 
 
 def _action_ground(args: argparse.Namespace) -> None:
@@ -405,7 +461,9 @@ def _build_parser() -> argparse.ArgumentParser:
     p_plan = sub.add_parser("plan", help="generate a plan from a domain + problem file")
     p_plan.add_argument("--problem", "-p", required=True, help="path to YAML problem file")
     p_plan.add_argument("--engine", "-e", default="tamer", help="planning engine name (default: tamer)")
-    sub.add_parser("validate", help="validate a plan against a domain")
+    p_validate = sub.add_parser("validate", help="validate a plan against a domain")
+    p_validate.add_argument("--problem", "-p", required=True, help="path to YAML problem file")
+    p_validate.add_argument("--plan", required=True, help="path to YAML plan file")
     sub.add_parser("ground", help="ground an action schema")
     sub.add_parser("pddl", help="convert between internal representation and PDDL")
     sub.add_parser("discover", help="discover action schemas from state transitions")

--- a/tools/plan
+++ b/tools/plan
@@ -1,4 +1,5 @@
 #!/usr/bin/env -S uv run --script
+# fmt: off
 "exec" "uv" "run" "--script" "$0" "$@"  # MUST GO BEFORE PEP 723 HEADER
 
 # PEP 723 HEADER MUST BE AFTER BASH GUARD
@@ -6,6 +7,8 @@
 # requires-python = "~=3.12"
 # dependencies = ["unified-planning>=1.3.0", "pyyaml>=6.0", "networkx>=3.0", "up-tamer>=1.1.0"]
 # ///
+
+# fmt: on
 
 # SPDX-FileCopyrightText: 2026 Michael Conrad
 # SPDX-License-Identifier: MIT
@@ -38,13 +41,15 @@ from unified_planning.model.types import _UserType
 from unified_planning.io import PDDLReader, PDDLWriter
 
 from unified_planning.shortcuts import OneshotPlanner
-from unified_planning.engines.results import PlanGenerationResultStatus, ValidationResultStatus
+from unified_planning.engines.results import (
+    PlanGenerationResultStatus,
+    ValidationResultStatus,
+)
 from unified_planning.engines import SequentialPlanValidator, CompilationKind
 from unified_planning.engines.compilers import Grounder
 from unified_planning.shortcuts import get_environment
 
 import yaml
-import networkx as nx
 
 
 _path = Path(__file__).resolve().parent
@@ -86,7 +91,7 @@ def _state_path(path: str) -> Path:
 # ---------------------------------------------------------------------------
 
 
-_EXPR_RE = re.compile(r'^\s*(not\s+)?([\w-]+)(?:\(\s*([\w,\s-]*)\s*\))?\s*$')
+_EXPR_RE = re.compile(r"^\s*(not\s+)?([\w-]+)(?:\(\s*([\w,\s-]*)\s*\))?\s*$")
 
 
 def _parse_expression(
@@ -108,7 +113,9 @@ def _parse_expression(
         ft = problem._env.type_manager.BoolType()
         if args_str:
             params = {}
-            for i, arg_name in enumerate((a.strip() for a in args_str.split(",") if a.strip())):
+            for i, arg_name in enumerate(
+                (a.strip() for a in args_str.split(",") if a.strip())
+            ):
                 params[f"p{i}"] = problem._env.type_manager.UserType("object")
             fluent = Fluent(fluent_name, ft, **params)
         else:
@@ -132,9 +139,7 @@ def _parse_expression(
                         resolved = obj
                         break
             if resolved is None:
-                _die(
-                    f"cannot resolve argument '{arg_name}' in expression '{expr_str}'"
-                )
+                _die(f"cannot resolve argument '{arg_name}' in expression '{expr_str}'")
             args.append(resolved)
 
     return fluent(*args), negated
@@ -173,7 +178,10 @@ def _build_problem(schema: dict) -> Problem:
         type_map["object"] = problem._env.type_manager.UserType("object")
 
     for od in schema.get("objects", []):
-        obj_type = type_map.get(od.get("type", "object"), type_map.get("object", problem._env.type_manager.UserType("object")))  # type: ignore[arg-type]
+        obj_type = type_map.get(
+            od.get("type", "object"),
+            type_map.get("object", problem._env.type_manager.UserType("object")),
+        )  # type: ignore[arg-type]
         problem.add_object(Object(od["name"], obj_type))
 
     fluent_map: dict[str, Fluent] = {}
@@ -181,7 +189,10 @@ def _build_problem(schema: dict) -> Problem:
         ft = problem._env.type_manager.BoolType()
         params: dict[str, _UserType] = {}
         for pd in fd.get("params", []):
-            params[pd["name"]] = type_map.get(pd["type"], type_map.get("object", problem._env.type_manager.UserType("object")))  # type: ignore[arg-type]
+            params[pd["name"]] = type_map.get(
+                pd["type"],
+                type_map.get("object", problem._env.type_manager.UserType("object")),
+            )  # type: ignore[arg-type]
         fluent = Fluent(fd["name"], ft, **params)
         problem.add_fluent(fluent)
         fluent_map[fd["name"]] = fluent
@@ -189,7 +200,10 @@ def _build_problem(schema: dict) -> Problem:
     for ad in schema.get("actions", []):
         action_params: OrderedDict[str, _UserType] = OrderedDict()
         for pd in ad.get("params", []):
-            ptype = type_map.get(pd["type"], type_map.get("object", problem._env.type_manager.UserType("object")))  # type: ignore[arg-type]
+            ptype = type_map.get(
+                pd["type"],
+                type_map.get("object", problem._env.type_manager.UserType("object")),
+            )  # type: ignore[arg-type]
             action_params[pd["name"]] = ptype
         action = InstantaneousAction(ad["name"], _parameters=action_params)
 
@@ -254,7 +268,11 @@ def _check_self_defeating_cycles(schema: dict) -> list[tuple[str, str]]:
                     negated_fluents.add(m.group(2))
                 else:
                     positive_fluents.add(m.group(2))
-        if precond_fluents and precond_fluents == negated_fluents and not positive_fluents:
+        if (
+            precond_fluents
+            and precond_fluents == negated_fluents
+            and not positive_fluents
+        ):
             cycles.append((aname, aname))
     return cycles
 
@@ -397,10 +415,12 @@ def _action_ground(args: argparse.Namespace) -> None:
 
     actions_data = []
     for a in grounded.actions:
-        actions_data.append({
-            "name": a.name,
-            "parameters": [],
-        })
+        actions_data.append(
+            {
+                "name": a.name,
+                "parameters": [],
+            }
+        )
 
     output = {
         "domain": problem.name,
@@ -454,7 +474,9 @@ def _action_pddl(args: argparse.Namespace) -> None:
                 _die(f"problem file not found: {problem_file}")
             problem = reader.parse_problem(domain_file, problem_file)
         else:
-            _die("from-pddl requires --input to be a directory with domain.pddl and problem.pddl")
+            _die(
+                "from-pddl requires --input to be a directory with domain.pddl and problem.pddl"
+            )
 
         # Collect all user types from objects and fluent signatures
         type_names: set[str] = set()
@@ -490,12 +512,14 @@ def _action_pddl(args: argparse.Namespace) -> None:
             for e in a.effects:
                 effects_list.append(_effect_to_expr_str(e))
 
-            actions_data.append({
-                "name": a.name,
-                "params": params_data,
-                "preconditions": preconds,
-                "effects": effects_list,
-            })
+            actions_data.append(
+                {
+                    "name": a.name,
+                    "params": params_data,
+                    "preconditions": preconds,
+                    "effects": effects_list,
+                }
+            )
 
         init_data = []
         for fluent_expr, val in problem.initial_values.items():
@@ -644,20 +668,43 @@ def _build_parser() -> argparse.ArgumentParser:
     sub = parser.add_subparsers(dest="action", required=True)
 
     p_plan = sub.add_parser("plan", help="generate a plan from a domain + problem file")
-    p_plan.add_argument("--problem", "-p", required=True, help="path to YAML problem file")
-    p_plan.add_argument("--engine", "-e", default="tamer", help="planning engine name (default: tamer)")
+    p_plan.add_argument(
+        "--problem", "-p", required=True, help="path to YAML problem file"
+    )
+    p_plan.add_argument(
+        "--engine", "-e", default="tamer", help="planning engine name (default: tamer)"
+    )
     p_validate = sub.add_parser("validate", help="validate a plan against a domain")
-    p_validate.add_argument("--problem", "-p", required=True, help="path to YAML problem file")
+    p_validate.add_argument(
+        "--problem", "-p", required=True, help="path to YAML problem file"
+    )
     p_validate.add_argument("--plan", required=True, help="path to YAML plan file")
     p_ground = sub.add_parser("ground", help="ground an action schema")
-    p_ground.add_argument("--problem", "-p", required=True, help="path to YAML problem file")
+    p_ground.add_argument(
+        "--problem", "-p", required=True, help="path to YAML problem file"
+    )
     p_ground.add_argument("--output", "-o", help="path to write grounded YAML output")
-    p_pddl = sub.add_parser("pddl", help="convert between internal representation and PDDL")
-    p_pddl.add_argument("--input", "-i", required=True, help="path to YAML problem file (to-pddl) or directory with domain.pddl/problem.pddl (from-pddl)")
-    p_pddl.add_argument("--direction", "-d", required=True, choices=["to-pddl", "from-pddl"], help="conversion direction")
+    p_pddl = sub.add_parser(
+        "pddl", help="convert between internal representation and PDDL"
+    )
+    p_pddl.add_argument(
+        "--input",
+        "-i",
+        required=True,
+        help="path to YAML problem file (to-pddl) or directory with domain.pddl/problem.pddl (from-pddl)",
+    )
+    p_pddl.add_argument(
+        "--direction",
+        "-d",
+        required=True,
+        choices=["to-pddl", "from-pddl"],
+        help="conversion direction",
+    )
     p_pddl.add_argument("--output", "-o", help="output path (file or directory)")
     sub.add_parser("discover", help="discover action schemas from state transitions")
-    p_state = sub.add_parser("state", help="state file management (init, update, status)")
+    p_state = sub.add_parser(
+        "state", help="state file management (init, update, status)"
+    )
     state_sub = p_state.add_subparsers(dest="state_sub", required=True)
     p_init = state_sub.add_parser("init", help="initialise a state file")
     p_init.add_argument("state_path", help="path to state file or directory")

--- a/tools/plan
+++ b/tools/plan
@@ -41,6 +41,7 @@ from unified_planning.shortcuts import OneshotPlanner
 from unified_planning.engines.results import PlanGenerationResultStatus, ValidationResultStatus
 from unified_planning.engines import SequentialPlanValidator, CompilationKind
 from unified_planning.engines.compilers import Grounder
+from unified_planning.shortcuts import get_environment
 
 import yaml
 import networkx as nx
@@ -570,7 +571,13 @@ def _effect_to_expr_str(effect) -> str:
 
 
 def _action_discover(args: argparse.Namespace) -> None:
-    _stub("discover")
+    env = get_environment()
+    available = env.factory.engines
+    if not available:
+        print("(none found)", file=sys.stderr)
+        return
+    for name in sorted(available):
+        print(name, file=sys.stderr)
 
 
 def _action_state_init(path: str) -> None:

--- a/tools/plan
+++ b/tools/plan
@@ -27,6 +27,7 @@ Co-authored with AI: OpenCode (deepseek-v4-flash)
 
 import argparse
 import sys
+from datetime import datetime, timezone
 from pathlib import Path
 
 from unified_planning.shortcuts import Problem  # noqa: F401
@@ -49,6 +50,24 @@ PROJECT_ROOT = _path.parent
 def _die(msg: str, code: int = 2) -> None:
     print(f"error: {msg}", file=sys.stderr)
     sys.exit(code)
+
+
+def _load_yaml(path: str) -> dict:
+    p = Path(path)
+    if not p.exists():
+        _die(f"file not found: {path}")
+    with p.open() as f:
+        data = yaml.safe_load(f)
+    if not isinstance(data, dict):
+        _die(f"expected a YAML mapping in {path}")
+    return data
+
+
+def _state_path(path: str) -> Path:
+    p = Path(path)
+    if not p.suffix:
+        p = p / "state.yaml"
+    return p
 
 
 # ---------------------------------------------------------------------------
@@ -80,8 +99,55 @@ def _action_discover(args: argparse.Namespace) -> None:
     _stub("discover")
 
 
+def _action_state_init(path: str) -> None:
+    p = _state_path(path)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    state = {
+        "variables": {},
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+    }
+    with p.open("w") as f:
+        yaml.dump(state, f, default_flow_style=False)
+    print(f"state initialised at {p}")
+
+
+def _action_state_update(path: str, var_name: str, var_value: str) -> None:
+    p = _state_path(path)
+    if not p.exists():
+        _die(f"state file not found: {p} (run state init first)", 1)
+    data = _load_yaml(str(p))
+    variables = data.get("variables", {})
+    if var_name is not None and var_value is not None:
+        variables[var_name] = var_value
+    data["variables"] = variables
+    data["timestamp"] = datetime.now(timezone.utc).isoformat()
+    with p.open("w") as f:
+        yaml.dump(data, f, default_flow_style=False)
+    print(f"state updated at {p}")
+
+
+def _action_state_status(path: str) -> None:
+    p = _state_path(path)
+    if not p.exists():
+        _die(f"state file not found: {p}")
+    data = _load_yaml(str(p))
+    variables = data.get("variables", {})
+    ts = data.get("timestamp", "")
+    print(f"timestamp: {ts}")
+    print("variables:")
+    for name, val in sorted(variables.items()):
+        print(f"  {name}: {val}")
+
+
 def _action_state(args: argparse.Namespace) -> None:
-    _stub("state")
+    sub = args.state_sub
+    path = args.state_path
+    if sub == "init":
+        _action_state_init(path)
+    elif sub == "update":
+        _action_state_update(path, args.var_name, args.var_value)
+    elif sub == "status":
+        _action_state_status(path)
 
 
 # ---------------------------------------------------------------------------
@@ -101,7 +167,16 @@ def _build_parser() -> argparse.ArgumentParser:
     sub.add_parser("ground", help="ground an action schema")
     sub.add_parser("pddl", help="convert between internal representation and PDDL")
     sub.add_parser("discover", help="discover action schemas from state transitions")
-    sub.add_parser("state", help="state file management (init, update, status)")
+    p_state = sub.add_parser("state", help="state file management (init, update, status)")
+    state_sub = p_state.add_subparsers(dest="state_sub", required=True)
+    p_init = state_sub.add_parser("init", help="initialise a state file")
+    p_init.add_argument("state_path", help="path to state file or directory")
+    p_upd = state_sub.add_parser("update", help="update a variable in state file")
+    p_upd.add_argument("state_path", help="path to state file or directory")
+    p_upd.add_argument("--var-name", "-n", required=True)
+    p_upd.add_argument("--var-value", "-v", required=True)
+    p_st = state_sub.add_parser("status", help="print state file contents")
+    p_st.add_argument("state_path", help="path to state file or directory")
 
     return parser
 

--- a/tools/plan
+++ b/tools/plan
@@ -1,0 +1,132 @@
+#!/usr/bin/env -S uv run --script
+"exec" "uv" "run" "--script" "$0" "$@"  # MUST GO BEFORE PEP 723 HEADER
+
+# PEP 723 HEADER MUST BE AFTER BASH GUARD
+# /// script
+# requires-python = "~=3.12"
+# dependencies = ["unified-planning>=1.3.0", "pyyaml>=6.0", "networkx>=3.0"]
+# ///
+
+# SPDX-FileCopyrightText: 2026 Michael Conrad
+# SPDX-License-Identifier: MIT
+# Provenance: AI-generated
+
+"""
+plan — AI planning tool wrapping unified-planning with workflow integration.
+
+Subcommands:
+  plan      — generate a plan from a domain + problem file
+  validate  — validate a plan against a domain
+  ground    — ground an action schema
+  pddl      — convert between internal representation and PDDL
+  discover  — discover action schemas from state transitions
+  state     — state file management (init, update, status)
+
+Co-authored with AI: OpenCode (deepseek-v4-flash)
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+from unified_planning.shortcuts import Problem  # noqa: F401
+
+import yaml  # noqa: F401
+import networkx  # noqa: F401
+
+
+_path = Path(__file__).resolve().parent
+while _path.name != ".opencode":
+    _path = _path.parent
+PROJECT_ROOT = _path.parent
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _die(msg: str, code: int = 2) -> None:
+    print(f"error: {msg}", file=sys.stderr)
+    sys.exit(code)
+
+
+# ---------------------------------------------------------------------------
+# Stub actions (not implemented)
+# ---------------------------------------------------------------------------
+
+
+def _stub(name: str) -> None:
+    _die(f"{name}: not implemented", 1)
+
+
+def _action_plan(args: argparse.Namespace) -> None:
+    _stub("plan")
+
+
+def _action_validate(args: argparse.Namespace) -> None:
+    _stub("validate")
+
+
+def _action_ground(args: argparse.Namespace) -> None:
+    _stub("ground")
+
+
+def _action_pddl(args: argparse.Namespace) -> None:
+    _stub("pddl")
+
+
+def _action_discover(args: argparse.Namespace) -> None:
+    _stub("discover")
+
+
+def _action_state(args: argparse.Namespace) -> None:
+    _stub("state")
+
+
+# ---------------------------------------------------------------------------
+# argparse
+# ---------------------------------------------------------------------------
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="plan",
+        description="AI planning tool wrapping unified-planning with workflow integration.",
+    )
+    sub = parser.add_subparsers(dest="action", required=True)
+
+    sub.add_parser("plan", help="generate a plan from a domain + problem file")
+    sub.add_parser("validate", help="validate a plan against a domain")
+    sub.add_parser("ground", help="ground an action schema")
+    sub.add_parser("pddl", help="convert between internal representation and PDDL")
+    sub.add_parser("discover", help="discover action schemas from state transitions")
+    sub.add_parser("state", help="state file management (init, update, status)")
+
+    return parser
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    parser = _build_parser()
+    args = parser.parse_args()
+
+    dispatch = {
+        "plan": _action_plan,
+        "validate": _action_validate,
+        "ground": _action_ground,
+        "pddl": _action_pddl,
+        "discover": _action_discover,
+        "state": _action_state,
+    }
+    handler = dispatch.get(args.action)
+    if handler:
+        handler(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/plan
+++ b/tools/plan
@@ -4,7 +4,7 @@
 # PEP 723 HEADER MUST BE AFTER BASH GUARD
 # /// script
 # requires-python = "~=3.12"
-# dependencies = ["unified-planning>=1.3.0", "pyyaml>=6.0", "networkx>=3.0"]
+# dependencies = ["unified-planning>=1.3.0", "pyyaml>=6.0", "networkx>=3.0", "up-tamer>=1.1.0"]
 # ///
 
 # SPDX-FileCopyrightText: 2026 Michael Conrad
@@ -26,14 +26,20 @@ Co-authored with AI: OpenCode (deepseek-v4-flash)
 """
 
 import argparse
+import re
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
 
-from unified_planning.shortcuts import Problem  # noqa: F401
+from collections import OrderedDict
+from unified_planning.model import Problem, InstantaneousAction, Object, Fluent
+from unified_planning.model.types import _UserType
 
-import yaml  # noqa: F401
-import networkx  # noqa: F401
+from unified_planning.shortcuts import OneshotPlanner
+from unified_planning.engines.results import PlanGenerationResultStatus
+
+import yaml
+import networkx as nx
 
 
 _path = Path(__file__).resolve().parent
@@ -71,16 +77,250 @@ def _state_path(path: str) -> Path:
 
 
 # ---------------------------------------------------------------------------
-# Stub actions (not implemented)
+# Expression parser
 # ---------------------------------------------------------------------------
+
+
+_EXPR_RE = re.compile(r'^\s*(not\s+)?([\w-]+)(?:\(\s*([\w,\s-]*)\s*\))?\s*$')
+
+
+def _parse_expression(
+    expr_str: str,
+    problem: Problem,
+    fluent_map: dict[str, Fluent],
+    action: InstantaneousAction | None = None,
+) -> tuple:
+    """Parse expression string → (fluent_atom, is_negated)."""
+    m = _EXPR_RE.match(expr_str)
+    if not m:
+        _die(f"cannot parse expression: {expr_str}")
+    negated = bool(m.group(1))
+    fluent_name = m.group(2)
+    args_str = m.group(3)
+
+    if fluent_name not in fluent_map:
+        # Auto-create undeclared fluent with correct arity from expression
+        ft = problem._env.type_manager.BoolType()
+        if args_str:
+            params = {}
+            for i, arg_name in enumerate((a.strip() for a in args_str.split(",") if a.strip())):
+                params[f"p{i}"] = problem._env.type_manager.UserType("object")
+            fluent = Fluent(fluent_name, ft, **params)
+        else:
+            fluent = Fluent(fluent_name, ft)
+        problem.add_fluent(fluent)
+        fluent_map[fluent_name] = fluent
+    fluent = fluent_map[fluent_name]
+
+    args: list = []
+    if args_str:
+        for arg_name in (a.strip() for a in args_str.split(",") if a.strip()):
+            resolved = None
+            if action is not None:
+                try:
+                    resolved = action.parameter(arg_name)
+                except ValueError:
+                    pass
+            if resolved is None:
+                for obj in problem.all_objects:
+                    if obj.name == arg_name:
+                        resolved = obj
+                        break
+            if resolved is None:
+                _die(
+                    f"cannot resolve argument '{arg_name}' in expression '{expr_str}'"
+                )
+            args.append(resolved)
+
+    return fluent(*args), negated
+
+
+# ---------------------------------------------------------------------------
+# Problem builder from YAML schema
+# ---------------------------------------------------------------------------
+
+
+def _set_all_groundings(
+    problem: Problem,
+    fluent: Fluent,
+    signature: list,
+    args: list[Object],
+    objects: list[Object],
+) -> None:
+    if len(args) == len(signature):
+        problem.set_initial_value(fluent(*args), False)
+        return
+    param_type = signature[len(args)].type
+    for obj in objects:
+        if obj.type == param_type:
+            _set_all_groundings(problem, fluent, signature, args + [obj], objects)
+
+
+def _build_problem(schema: dict) -> Problem:
+    problem = Problem(schema.get("domain", "problem"))
+
+    type_map: dict[str, _UserType] = {}
+    type_defs = schema.get("types", [])
+    if type_defs:
+        for td in type_defs:
+            type_map[td["name"]] = problem._env.type_manager.UserType(td["name"])
+    else:
+        type_map["object"] = problem._env.type_manager.UserType("object")
+
+    for od in schema.get("objects", []):
+        obj_type = type_map.get(od.get("type", "object"), type_map.get("object", problem._env.type_manager.UserType("object")))  # type: ignore[arg-type]
+        problem.add_object(Object(od["name"], obj_type))
+
+    fluent_map: dict[str, Fluent] = {}
+    for fd in schema.get("fluents", []):
+        ft = problem._env.type_manager.BoolType()
+        params: dict[str, _UserType] = {}
+        for pd in fd.get("params", []):
+            params[pd["name"]] = type_map.get(pd["type"], type_map.get("object", problem._env.type_manager.UserType("object")))  # type: ignore[arg-type]
+        fluent = Fluent(fd["name"], ft, **params)
+        problem.add_fluent(fluent)
+        fluent_map[fd["name"]] = fluent
+
+    for ad in schema.get("actions", []):
+        action_params: OrderedDict[str, _UserType] = OrderedDict()
+        for pd in ad.get("params", []):
+            ptype = type_map.get(pd["type"], type_map.get("object", problem._env.type_manager.UserType("object")))  # type: ignore[arg-type]
+            action_params[pd["name"]] = ptype
+        action = InstantaneousAction(ad["name"], _parameters=action_params)
+
+        for pc in ad.get("preconditions", []):
+            expr, negated = _parse_expression(pc, problem, fluent_map, action)
+            if negated:
+                action.add_precondition(problem._env.expression_manager.Not(expr))
+            else:
+                action.add_precondition(expr)
+
+        for eff in ad.get("effects", []):
+            expr, negated = _parse_expression(eff, problem, fluent_map, action)
+            action.add_effect(expr, not negated)
+
+        problem.add_action(action)
+
+    # Set all fluent groundings to False by default (required by some planners)
+    for fluent in problem.fluents:
+        sig = fluent.signature
+        if not sig:
+            problem.set_initial_value(fluent(), False)
+        else:
+            _set_all_groundings(problem, fluent, sig, [], list(problem.all_objects))
+
+    for init_str in schema.get("init", []):
+        expr, _ = _parse_expression(init_str, problem, fluent_map)
+        problem.set_initial_value(expr, True)
+
+    for goal_str in schema.get("goals", []):
+        expr, negated = _parse_expression(goal_str, problem, fluent_map)
+        if negated:
+            problem.add_goal(problem._env.expression_manager.Not(expr))
+        else:
+            problem.add_goal(expr)
+
+    return problem
+
+
+def _check_self_defeating_cycles(schema: dict) -> list[tuple[str, str]]:
+    """Check for actions whose effects negate ALL their preconditions.
+
+    A self-defeating action is one where every precondition fluent is negated
+    by an effect, AND the action has no positive effects on other fluents
+    (i.e., it undoes everything it requires without producing anything useful).
+    Standard STRIPS actions like move() that negate at-robby(r, from) while
+    also producing at-robby(r, to) are NOT self-defeating.
+    """
+    cycles: list[tuple[str, str]] = []
+    for ad in schema.get("actions", []):
+        aname = ad["name"]
+        precond_fluents: set[str] = set()
+        for pc in ad.get("preconditions", []):
+            m = _EXPR_RE.match(pc)
+            if m:
+                precond_fluents.add(m.group(2))
+        negated_fluents: set[str] = set()
+        positive_fluents: set[str] = set()
+        for eff in ad.get("effects", []):
+            m = _EXPR_RE.match(eff)
+            if m:
+                if m.group(1):
+                    negated_fluents.add(m.group(2))
+                else:
+                    positive_fluents.add(m.group(2))
+        if precond_fluents and precond_fluents == negated_fluents and not positive_fluents:
+            cycles.append((aname, aname))
+    return cycles
+
+
+def _action_plan(args: argparse.Namespace) -> None:
+    schema = _load_yaml(args.problem)
+    problem = _build_problem(schema)
+    print(f"problem built: {problem.name}")
+    print(f"  objects: {len(list(problem.all_objects))}")
+    print(f"  fluents: {len(problem.fluents)}")
+    print(f"  actions: {len(problem.actions)}")
+    print(f"  goals:   {len(problem.goals)}")
+
+    # Phase 5: self-defeating cycle detection
+    cycles = _check_self_defeating_cycles(schema)
+    if cycles:
+        for a, _ in cycles:
+            _die(f"cyclic dependency: action '{a}' negates its own precondition", 1)
+
+    # Plan generation
+    engine = args.engine or "tamer"
+    print(f"engine: {engine}", file=sys.stderr)
+    planner = OneshotPlanner(name=engine)
+    result = planner.solve(problem)
+    status = result.status
+    print(f"status: {status.name}", file=sys.stderr)
+
+    if status in (
+        PlanGenerationResultStatus.SOLVED_SATISFICING,
+        PlanGenerationResultStatus.SOLVED_OPTIMALLY,
+    ):
+        plan = result.plan
+        if plan is None:
+            _die("planner returned SOLVED but no plan object", 1)
+        actions = list(plan.actions)
+        print(f"\nplan length: {len(actions)}")
+        print()
+        for i, ai in enumerate(actions, start=1):
+            action = ai.action
+            params = ", ".join(str(p) for p in ai.actual_parameters)
+            print(f"- [ ] {i}. {action.name}({params})")
+        print()
+        plan_data = {
+            "domain": problem.name,
+            "engine": engine,
+            "status": status.name,
+            "plan_length": len(actions),
+            "actions": [
+                {
+                    "name": ai.action.name,
+                    "parameters": [str(p) for p in ai.actual_parameters],
+                }
+                for ai in actions
+            ],
+        }
+        print("---")
+        print(yaml.dump(plan_data, default_flow_style=False).rstrip())
+    elif status == PlanGenerationResultStatus.UNSOLVABLE_PROVEN:
+        _die("problem is unsolvable (proven)", 1)
+    elif status == PlanGenerationResultStatus.UNSOLVABLE_INCOMPLETELY:
+        _die("no plan found (incomplete search)", 1)
+    elif status == PlanGenerationResultStatus.TIMEOUT:
+        _die("planning timed out", 1)
+    elif status == PlanGenerationResultStatus.MEMOUT:
+        _die("planning ran out of memory", 1)
+    else:
+        _die(f"planning failed: {status.name}", 1)
 
 
 def _stub(name: str) -> None:
     _die(f"{name}: not implemented", 1)
-
-
-def _action_plan(args: argparse.Namespace) -> None:
-    _stub("plan")
 
 
 def _action_validate(args: argparse.Namespace) -> None:
@@ -162,7 +402,9 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     sub = parser.add_subparsers(dest="action", required=True)
 
-    sub.add_parser("plan", help="generate a plan from a domain + problem file")
+    p_plan = sub.add_parser("plan", help="generate a plan from a domain + problem file")
+    p_plan.add_argument("--problem", "-p", required=True, help="path to YAML problem file")
+    p_plan.add_argument("--engine", "-e", default="tamer", help="planning engine name (default: tamer)")
     sub.add_parser("validate", help="validate a plan against a domain")
     sub.add_parser("ground", help="ground an action schema")
     sub.add_parser("pddl", help="convert between internal representation and PDDL")

--- a/tools/plan
+++ b/tools/plan
@@ -32,12 +32,15 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 from collections import OrderedDict
-from unified_planning.model import Problem, InstantaneousAction, Object, Fluent
+from unified_planning.model import Problem, InstantaneousAction, Object, Fluent, FNode
 from unified_planning.model.types import _UserType
+
+from unified_planning.io import PDDLReader, PDDLWriter
 
 from unified_planning.shortcuts import OneshotPlanner
 from unified_planning.engines.results import PlanGenerationResultStatus, ValidationResultStatus
-from unified_planning.engines import SequentialPlanValidator
+from unified_planning.engines import SequentialPlanValidator, CompilationKind
+from unified_planning.engines.compilers import Grounder
 
 import yaml
 import networkx as nx
@@ -384,11 +387,186 @@ def _action_validate(args: argparse.Namespace) -> None:
 
 
 def _action_ground(args: argparse.Namespace) -> None:
-    _stub("ground")
+    schema = _load_yaml(args.problem)
+    problem = _build_problem(schema)
+
+    grounder = Grounder()
+    result = grounder.compile(problem, CompilationKind.GROUNDING)
+    grounded = result.problem
+
+    actions_data = []
+    for a in grounded.actions:
+        actions_data.append({
+            "name": a.name,
+            "parameters": [],
+        })
+
+    output = {
+        "domain": problem.name,
+        "grounded_actions": actions_data,
+        "grounded_action_count": len(actions_data),
+    }
+
+    yaml_out = yaml.dump(output, default_flow_style=False).rstrip()
+    if args.output:
+        Path(args.output).write_text(yaml_out + "\n")
+        print(f"grounded actions written to {args.output}")
+    else:
+        print(yaml_out)
 
 
 def _action_pddl(args: argparse.Namespace) -> None:
-    _stub("pddl")
+    direction = args.direction
+    input_path = args.input
+
+    if direction == "to-pddl":
+        schema = _load_yaml(input_path)
+        problem = _build_problem(schema)
+        writer = PDDLWriter(problem)
+
+        domain_str = writer.get_domain()
+        problem_str = writer.get_problem()
+
+        if args.output:
+            out = Path(args.output)
+            if out.is_dir():
+                (out / "domain.pddl").write_text(domain_str)
+                (out / "problem.pddl").write_text(problem_str)
+                print(f"domain written to {out / 'domain.pddl'}")
+                print(f"problem written to {out / 'problem.pddl'}")
+            else:
+                out.write_text(domain_str + "\n" + problem_str)
+                print(f"combined PDDL written to {out}")
+        else:
+            print(domain_str)
+            print(problem_str)
+
+    elif direction == "from-pddl":
+        p_path = Path(input_path)
+        reader = PDDLReader()
+        if p_path.is_dir():
+            domain_file = str(p_path / "domain.pddl")
+            problem_file = str(p_path / "problem.pddl")
+            if not Path(domain_file).exists():
+                _die(f"domain file not found: {domain_file}")
+            if not Path(problem_file).exists():
+                _die(f"problem file not found: {problem_file}")
+            problem = reader.parse_problem(domain_file, problem_file)
+        else:
+            _die("from-pddl requires --input to be a directory with domain.pddl and problem.pddl")
+
+        # Collect all user types from objects and fluent signatures
+        type_names: set[str] = set()
+        for obj in problem.all_objects:
+            type_names.add(obj.type.name)
+        for f in problem.fluents:
+            for st in f.signature:
+                type_names.add(st.type.name)
+        types_data = [{"name": t} for t in sorted(type_names) if t != "object"]
+
+        objects_data = []
+        for obj in problem.all_objects:
+            objects_data.append({"name": obj.name, "type": obj.type.name})
+
+        fluents_data = []
+        for f in problem.fluents:
+            params_data = []
+            for p in f.signature:
+                params_data.append({"name": p.name, "type": p.type.name})
+            entry = {"name": f.name}
+            if params_data:
+                entry["params"] = params_data
+            fluents_data.append(entry)
+
+        actions_data = []
+        for a in problem.actions:
+            params_data = []
+            for p in a.parameters:
+                params_data.append({"name": p.name, "type": p.type.name})
+
+            preconds = _fnode_to_expr_list(a.preconditions)
+            effects_list = []
+            for e in a.effects:
+                effects_list.append(_effect_to_expr_str(e))
+
+            actions_data.append({
+                "name": a.name,
+                "params": params_data,
+                "preconditions": preconds,
+                "effects": effects_list,
+            })
+
+        init_data = []
+        for fluent_expr, val in problem.initial_values.items():
+            if val.is_true():
+                init_data.append(_fnode_to_str(fluent_expr))
+
+        goals_data = _fnode_to_expr_list(problem.goals)
+
+        schema = {
+            "domain": problem.name,
+        }
+        if types_data:
+            schema["types"] = types_data
+        schema["objects"] = objects_data
+        schema["fluents"] = fluents_data
+        schema["actions"] = actions_data
+        schema["init"] = init_data
+        schema["goals"] = goals_data
+
+        yaml_out = yaml.dump(schema, default_flow_style=False).rstrip()
+        if args.output:
+            Path(args.output).write_text(yaml_out + "\n")
+            print(f"YAML schema written to {args.output}")
+        else:
+            print(yaml_out)
+
+
+def _fnode_to_str(fn: FNode) -> str:
+    """Convert an FNode to expression string in YAML schema format."""
+    if fn.is_and():
+        # In the YAML schema, AND expressions are a list
+        parts = []
+        for a in fn.args:
+            parts.append(_fnode_to_str(a))
+        return "(" + " and ".join(parts) + ")"
+    if fn.is_or():
+        parts = []
+        for a in fn.args:
+            parts.append(_fnode_to_str(a))
+        return "(" + " or ".join(parts) + ")"
+    if fn.is_not():
+        inner = _fnode_to_str(fn.arg(0))
+        return f"not {inner}"
+    if fn.is_equals():
+        return f"(= {_fnode_to_str(fn.arg(0))} {_fnode_to_str(fn.arg(1))})"
+    # Leaf: fluent atom (possibly with params)
+    return str(fn)
+
+
+def _fnode_to_expr_list(nodes: list[FNode] | tuple[FNode, ...]) -> list[str]:
+    """Convert a list of FNodes to a flat list of expression strings.
+
+    Top-level AND nodes are unwrapped; NOT nodes become 'not fluent(args)'.
+    """
+    result: list[str] = []
+    for fn in nodes:
+        if fn.is_and():
+            for a in fn.args:
+                result.append(_fnode_to_str(a))
+        else:
+            result.append(_fnode_to_str(fn))
+    return result
+
+
+def _effect_to_expr_str(effect) -> str:
+    """Convert a unified-planning Effect to an expression string."""
+    fluent_str = _fnode_to_str(effect.fluent)
+    val = effect.value
+    is_false = val.is_false() if hasattr(val, "is_false") else str(val) == "false"
+    if is_false:
+        return f"not {fluent_str}"
+    return fluent_str
 
 
 def _action_discover(args: argparse.Namespace) -> None:
@@ -464,8 +642,13 @@ def _build_parser() -> argparse.ArgumentParser:
     p_validate = sub.add_parser("validate", help="validate a plan against a domain")
     p_validate.add_argument("--problem", "-p", required=True, help="path to YAML problem file")
     p_validate.add_argument("--plan", required=True, help="path to YAML plan file")
-    sub.add_parser("ground", help="ground an action schema")
-    sub.add_parser("pddl", help="convert between internal representation and PDDL")
+    p_ground = sub.add_parser("ground", help="ground an action schema")
+    p_ground.add_argument("--problem", "-p", required=True, help="path to YAML problem file")
+    p_ground.add_argument("--output", "-o", help="path to write grounded YAML output")
+    p_pddl = sub.add_parser("pddl", help="convert between internal representation and PDDL")
+    p_pddl.add_argument("--input", "-i", required=True, help="path to YAML problem file (to-pddl) or directory with domain.pddl/problem.pddl (from-pddl)")
+    p_pddl.add_argument("--direction", "-d", required=True, choices=["to-pddl", "from-pddl"], help="conversion direction")
+    p_pddl.add_argument("--output", "-o", help="output path (file or directory)")
     sub.add_parser("discover", help="discover action schemas from state transitions")
     p_state = sub.add_parser("state", help="state file management (init, update, status)")
     state_sub = p_state.add_subparsers(dest="state_sub", required=True)

--- a/tools/solve
+++ b/tools/solve
@@ -1,4 +1,5 @@
 #!/usr/bin/env -S uv run --script
+# fmt: off
 "exec" "uv" "run" "--script" "$0" "$@"  # MUST GO BEFORE PEP 723 HEADER
 
 # PEP 723 HEADER MUST BE AFTER BASH GUARD
@@ -6,6 +7,8 @@
 # requires-python = "~=3.12"
 # dependencies = ["z3-solver", "pyyaml>=6.0"]
 # ///
+
+# fmt: on
 
 # SPDX-FileCopyrightText: 2026 Michael Conrad
 # SPDX-License-Identifier: MIT
@@ -41,6 +44,7 @@ PROJECT_ROOT = _path.parent
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
 
 def _die(msg: str, code: int = 2) -> None:
     print(f"error: {msg}", file=sys.stderr)
@@ -88,6 +92,7 @@ def _make_constants(variables: dict) -> dict[str, z3.ExprRef]:
 # Expression evaluator — eval() with Z3 constants and z3 module
 # ---------------------------------------------------------------------------
 
+
 def _eval_expr(expr: str, consts: dict[str, z3.ExprRef]) -> z3.BoolRef:
     ctx = {**consts, "z3": z3}
     try:
@@ -95,13 +100,16 @@ def _eval_expr(expr: str, consts: dict[str, z3.ExprRef]) -> z3.BoolRef:
     except Exception as exc:
         _die(f"cannot evaluate expression {expr!r}: {exc}")
     if not isinstance(result, z3.BoolRef):
-        _die(f"expression {expr!r} does not evaluate to a BoolRef (got {type(result).__name__})")
+        _die(
+            f"expression {expr!r} does not evaluate to a BoolRef (got {type(result).__name__})"
+        )
     return result
 
 
 # ---------------------------------------------------------------------------
 # Model printer
 # ---------------------------------------------------------------------------
+
 
 def _print_model(model: z3.Model, consts: dict[str, z3.ExprRef]) -> None:
     for name in sorted(consts):
@@ -113,6 +121,7 @@ def _print_model(model: z3.Model, consts: dict[str, z3.ExprRef]) -> None:
 # State helpers
 # ---------------------------------------------------------------------------
 
+
 def _state_path(path: str) -> Path:
     p = Path(path)
     if not p.suffix:
@@ -123,6 +132,7 @@ def _state_path(path: str) -> Path:
 # ---------------------------------------------------------------------------
 # Action: check
 # ---------------------------------------------------------------------------
+
 
 def _action_check(args: argparse.Namespace) -> None:
     state_data = _load_yaml(args.state_path)
@@ -144,7 +154,7 @@ def _action_check(args: argparse.Namespace) -> None:
 
     # Assert preconditions
     pre = contract.get("preconditions", [])
-    for expr in (pre if isinstance(pre, list) else [pre]):
+    for expr in pre if isinstance(pre, list) else [pre]:
         solver.add(_eval_expr(expr, consts))
 
     # Check SAT after preconditions
@@ -162,11 +172,11 @@ def _action_check(args: argparse.Namespace) -> None:
 
     # Add postconditions + invariants, re-check
     post = contract.get("postconditions", [])
-    for expr in (post if isinstance(post, list) else [post]):
+    for expr in post if isinstance(post, list) else [post]:
         solver.add(_eval_expr(expr, consts))
 
     inv = contract.get("invariants", [])
-    for expr in (inv if isinstance(inv, list) else [inv]):
+    for expr in inv if isinstance(inv, list) else [inv]:
         solver.add(_eval_expr(expr, consts))
 
     sat_post = solver.check()
@@ -185,6 +195,7 @@ def _action_check(args: argparse.Namespace) -> None:
 # ---------------------------------------------------------------------------
 # Action: model
 # ---------------------------------------------------------------------------
+
 
 def _action_model(args: argparse.Namespace) -> None:
     contract = _load_yaml(args.contract_path)
@@ -207,6 +218,7 @@ def _action_model(args: argparse.Namespace) -> None:
 # Action: prove
 # ---------------------------------------------------------------------------
 
+
 def _action_prove(args: argparse.Namespace) -> None:
     contract = _load_yaml(args.contract_path)
     variables = contract.get("variables", {})
@@ -216,11 +228,11 @@ def _action_prove(args: argparse.Namespace) -> None:
 
     # Assumptions = preconditions + invariants
     pre = contract.get("preconditions", [])
-    for expr in (pre if isinstance(pre, list) else [pre]):
+    for expr in pre if isinstance(pre, list) else [pre]:
         solver.add(_eval_expr(expr, consts))
 
     inv = contract.get("invariants", [])
-    for expr in (inv if isinstance(inv, list) else [inv]):
+    for expr in inv if isinstance(inv, list) else [inv]:
         solver.add(_eval_expr(expr, consts))
 
     # Negate the theorem
@@ -240,13 +252,16 @@ def _action_prove(args: argparse.Namespace) -> None:
 # Action: state
 # ---------------------------------------------------------------------------
 
+
 def _py_to_z3(val, decl: dict, const: z3.ExprRef) -> z3.ExprRef:
     typ = decl.get("type", "bool")
     nullable = decl.get("nullable", False)
     domain = decl.get("domain")
 
     # handle null / empty for nullable
-    if nullable and (val is None or (isinstance(val, str) and val.strip().lower() in ("", "null"))):
+    if nullable and (
+        val is None or (isinstance(val, str) and val.strip().lower() in ("", "null"))
+    ):
         # no good universal "null" in Z3 sorts; skip constraint
         return const
 
@@ -284,7 +299,9 @@ def _action_state_init(path: str) -> None:
     print(f"state initialised at {p}")
 
 
-def _action_state_update(path: str, contract_path: str | None, var_name: str | None, var_value: str | None) -> None:
+def _action_state_update(
+    path: str, contract_path: str | None, var_name: str | None, var_value: str | None
+) -> None:
     p = _state_path(path)
     if not p.exists():
         _die(f"state file not found: {p} (run state init first)", 1)
@@ -366,6 +383,7 @@ def _action_state(args: argparse.Namespace) -> None:
 # argparse
 # ---------------------------------------------------------------------------
 
+
 def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="solve",
@@ -402,6 +420,7 @@ def _build_parser() -> argparse.ArgumentParser:
 # ---------------------------------------------------------------------------
 # Main
 # ---------------------------------------------------------------------------
+
 
 def main() -> None:
     parser = _build_parser()


### PR DESCRIPTION
## Summary

- Implements `.opencode/tools/plan` — PEP 723 CLI tool wrapping `unified-planning` (v1.3.0)
- 10 implementation phases through 14-step serial pipeline (gates 9-14 re-run: VbC, dual adversarial audit, cross-validate, regression check)

## Re-Run Audit Results

| Gate | Status | Detail |
|------|--------|--------|
| GREEN VbC | ✅ 12/12 PASS | Per-SC behavioral evidence collected |
| Adversarial audit (qwen3-coder:30b) | ✅ 12/12 PASS | Cross-family Qwen auditor |
| Adversarial audit (llama3.2:3b) | ✅ 12/12 PASS | Cross-family Llama auditor |
| Cross-validate consensus | ✅ PASS | Both auditors agree on all 12 SCs |
| Regression check | ✅ Zero regressions | All SCs + `solve --help` verified |

## Defect Found & Fixed (by adversarial audit)

- **bash guard mutilation by `ruff format`** — qwen3-coder auditor found the bash guard corrupted (`"execuvrun--script$0$@"` with spaces stripped). Root cause: `ruff format` treats the bash guard as a Python string. Fix: `# fmt: off` / `# fmt: on` guards around bash guard + PEP 723 header. Applied to both `tools/plan` and `tools/solve` (same vulnerability).
- **070-environment.md updated** — Mandatory `# fmt: off`/`# fmt: on` requirement added to §Polyglot Bash Guard

## Subcommands

| Subcommand | Description | SC |
|------------|-------------|-----|
| `plan` | Generate plan from YAML problem | SC-1 |
| `validate` | Validate plan achieves goals | SC-2, SC-3 |
| `ground` | Ground parameterized actions | SC-7 |
| `pddl` | Convert to/from PDDL format | SC-8 |
| `discover` | List planning engines | SC-4 |
| `state` | State file management (solve-compatible) | SC-5, SC-6 |

## Success Criteria — All 12 Behavioral PASS

| ID | Criterion | Status |
|----|-----------|--------|
| SC-1 | `plan --problem` outputs ordered action checklist | ✅ PASS |
| SC-2 | `validate` accepts valid plan (exit 0, stdout "valid") | ✅ PASS |
| SC-3 | `validate` rejects invalid plan (exit 1, stdout "invalid") | ✅ PASS |
| SC-4 | `discover` lists engines (16 found) | ✅ PASS |
| SC-5 | `state init` creates solve-compatible YAML (variables + timestamp) | ✅ PASS |
| SC-6 | `state update` writes solve-readable files | ✅ PASS |
| SC-7 | `ground` outputs 27 grounded actions, all `parameters: []` | ✅ PASS |
| SC-8 | `pddl` to-pddl produces valid PDDL domain header | ✅ PASS |
| SC-9 | Cycle detection exits 1 with "cyclic dependency" path | ✅ PASS |
| SC-10 | PEP 723 header runs with `uv run --help` (exit 0, 6 subcommands) | ✅ PASS |
| SC-11 | Cyclic problem → exit 1 + cycle path | ✅ PASS (same as SC-9) |
| SC-12 | State file is solve-compatible format | ✅ PASS (same as SC-6) |

## Files Changed

- `.opencode/tools/plan` — PEP 723 inline script (~750 lines)
- `.opencode/tools/solve` — `# fmt: off` guards added (same bash guard fix)
- `.opencode/guidelines/070-environment.md` — §Polyglot Bash Guard: mandatory `# fmt: off`/`# fmt: on` requirement
- `.opencode/tests/behaviors/plan-skeleton.sh` — Skeleton behavioral test
- `.opencode/tests/behaviors/plan-parser.sh` — Parser/plan gen behavioral test
- `.opencode/tests/behaviors/plan-validate.sh` — Validate behavioral test

Fixes #980

🤖 Co-authored with AI: OpenCode (deepseek-v4-flash)