### PR TITLE
fix(#1072): invert plan storage from remote API to local .issues/ workspace

### DIFF
--- a/skills/writing-plans/SKILL.md
+++ b/skills/writing-plans/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: writing-plans
-description: Use when creating an implementation plan from an approved spec. Triggers on: write plan, create plan, implementation plan, plan spec, approved plan, plan creation. Implementing without a plan is wandering. Plans are the map — agents who skip them get lost.
+description: Use when creating an implementation plan from an approved spec. Plans are stored locally in `.issues/{N}/spec-artifacts/plan.md`. Triggers on: write plan, create plan, implementation plan, plan spec, approved plan, plan creation. Implementing without a plan is wandering. Plans are the map — agents who skip them get lost.
 type: discipline-enforcing
 license: MIT
 provenance: AI-generated
@@ -11,11 +11,11 @@ compatibility: opencode
 
 ## Overview
 
-Transforms approved specs into actionable implementation plans using hybrid structure: phases for sub-issue tracking, TDD steps within tasks for execution guidance. Every step is one action (2-5 min). No placeholders.
+Transforms approved specs into actionable implementation plans using hybrid structure: phases for concern boundaries, TDD steps within tasks for execution guidance. Every step is one action (2-5 min). No placeholders.
 
 ## Persona
 
-Plan Author. Focus: transform spec into phased plan with file structure, TDD steps, and sub-issue hierarchy.
+Plan Author. Focus: transform spec into phased plan with file structure, TDD steps, and concern boundary annotations.
 
 ## Tasks
 
@@ -26,7 +26,10 @@ Plan Author. Focus: transform spec into phased plan with file structure, TDD ste
 
 ## Plan Issue Model
 
-**Separate plan** (multi-task): spec body → linked reference → `[PLAN]` issue → phase sub-issues. **Combined spec+plan** (single-task): plan appended under `## Implementation Plan` in spec body, no sub-issues.
+**All plans are local artifacts.** Plans are stored at `.issues/{N}/spec-artifacts/plan.md`. No remote `[PLAN]` issue is created. No sub-issues are linked — phases are sections in the local plan file.
+
+- **Separate plan** (multi-task): `.issues/{N}/spec-artifacts/plan.md` with separate phase sections, each with concern boundary annotations
+- **Combined spec+plan** (single-task): `.issues/{N}/spec-artifacts/plan.md` referencing spec content inline
 
 ## Invocation
 
@@ -45,7 +48,7 @@ Plan Author. Focus: transform spec into phased plan with file structure, TDD ste
 2. **Adversarial-audit call:** after plan creation, call type-specific audit tasks directly — `adversarial-audit --task plan-fidelity` and `adversarial-audit --task concern-separation` — with `audit_phase: plan_creation`.
 3. **TDD steps mandatory:** each step is RED→GREEN→REFACTOR within tasks.
 4. **No placeholders:** exact file paths, exact function/class names, exact commands.
-5. **Phase structure:** phases for sub-issues, tasks within phases for TDD steps.
+5. **Phase structure:** phases for concern boundaries and handoffs, tasks within phases for TDD steps.
 6. **Decision gate:** multi-task → separate plan. Single-task + simple → combined or separate per agent judgment.
 
 ## Sub-Agent Routing

--- a/skills/writing-plans/SKILL.md
+++ b/skills/writing-plans/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: writing-plans
-description: Use when creating an implementation plan from an approved spec. Plans are stored locally in `.issues/{N}/spec-artifacts/plan.md`. Triggers on: write plan, create plan, implementation plan, plan spec, approved plan, plan creation. Implementing without a plan is wandering. Plans are the map — agents who skip them get lost.
+description: Use when creating an implementation plan from an approved spec. Triggers on: write plan, create plan, implementation plan, plan spec, approved plan, plan creation. Implementing without a plan is wandering. Plans are the map — agents who skip them get lost.
 type: discipline-enforcing
 license: MIT
 provenance: AI-generated
@@ -24,12 +24,12 @@ Plan Author. Focus: transform spec into phased plan with file structure, TDD ste
 | `create` | ≈600 |
 | `completion` | ≈200 |
 
-## Plan Issue Model
+## Plan Model
 
-**All plans are local artifacts.** Plans are stored at `.issues/{N}/spec-artifacts/plan.md`. No remote `[PLAN]` issue is created. No sub-issues are linked — phases are sections in the local plan file.
+**All plans are local artifacts.** Plans are stored at `.issues/{N}/spec-artifacts/plan.md`. Phases are sections in the local plan file.
 
-- **Separate plan** (multi-task): `.issues/{N}/spec-artifacts/plan.md` with separate phase sections, each with concern boundary annotations
-- **Combined spec+plan** (single-task): `.issues/{N}/spec-artifacts/plan.md` referencing spec content inline
+- **Separate (multi-task):** `.issues/{N}/spec-artifacts/plan.md` with stand-alone phase sections, each with concern boundary annotations
+- **Combined (single-task):** `.issues/{N}/spec-artifacts/plan.md` referencing spec content inline
 
 ## Invocation
 

--- a/skills/writing-plans/tasks/create.md
+++ b/skills/writing-plans/tasks/create.md
@@ -2,19 +2,19 @@
 
 ## Purpose
 
-Create an implementation plan from an approved spec. Plans are stored locally in `.issues/{N}/spec-artifacts/plan.md` — no remote API calls for plan storage.
+Create an implementation plan from an approved spec. Plans are stored at `.issues/{N}/spec-artifacts/plan.md`.
 
 ## Prerequisites
 
 1. Approved spec (verified by approval-gate)
-2. Spec stored locally at `.issues/{N}/spec.md`
+2. Spec stored in `.issues/{N}/spec.md`
 3. Spec has explicit approval (`approved` or `go`)
 4. (Optional) `authorization_scope` from verify-authorization — if scope >= `for_plan`, plan auto-approval triggers
 
 ## Operating Protocol
 
 1. **Verification first:** Must run verification-enforcement --task verify before reading spec
-2. **Combined or separate decision:** Early evaluation whether plan content is stored combined with spec (`spec-artifacts/`) or separate from spec
+2. **Combined or separate decision:** Early evaluation whether plan content references spec content inline (combined) or stands alone with separate phase sections (separate)
 3. **Item decomposition mandatory:** Plan must enumerate items, order dependencies, specify acceptance criteria
 4. **RED checkpoint mandatory:** Every TDD task must include explicit Step 2 checkpoint
 5. **Approval cascade auto-approve:** Pipeline scope (`for_plan+`) auto-approves plan
@@ -26,10 +26,10 @@ Create an implementation plan from an approved spec. Plans are stored locally in
 
 ## Exit Criteria
 
-- Plan stored locally at `.issues/{N}/spec-artifacts/plan.md`
+- Plan stored at `.issues/{N}/spec-artifacts/plan.md`
 - All validation passed
-- Plan reported in chat with local artifact path
-- Approval cascade applied (local-only auto-approval)
+- Plan reported in chat with `.issues/{N}/spec-artifacts/plan.md` path
+- Approval cascade applied (auto-approval for pipeline scope)
 
 ## Procedure
 
@@ -43,14 +43,14 @@ Runs verification gate, makes combined/separate decision, checks for duplicate p
 
 **Route to:** `create/create-and-validate`
 
-Writes plan header, stores locally in `.issues/{N}/spec-artifacts/plan.md`, runs self-review and validation, revisits verification, cross-references skills, and applies approval cascade with scope-aware auto-approval.
+Writes plan header, stores at `.issues/{N}/spec-artifacts/plan.md`, runs self-review and validation, revisits verification, cross-references skills, and applies approval cascade with scope-aware auto-approval.
 
 ## Sub-Task Files
 
 | Sub-Task | Purpose | Words |
 | -- | -- | -- |
 | `create/plan-structure` | Verification, combined/separate decision, file mapping, TDD definition | ≈750 |
-| `create/create-and-validate` | Document writing, local storage, validation, approval cascade | ≈651 |
+| `create/create-and-validate` | Document writing, local storage, validation, approval cascade | ≈650 |
 
 ## Plan Phase Structure Requirements
 
@@ -70,21 +70,17 @@ When transitioning between architectural concerns, describe:
 
 ## Plan Format
 
-Plan stored at `.issues/{N}/spec-artifacts/plan.md`. Combined and separate decisions affect which sections the plan document includes but not where it is stored — all plans are local.
+Plan is stored at `.issues/{N}/spec-artifacts/plan.md`. Combined and separate affect which sections the plan document includes but not where it is stored.
 
 **Combined (single-task):**
-- Write to `.issues/{N}/spec-artifacts/plan.md` and reference spec content inline
+- Write to `.issues/{N}/spec-artifacts/plan.md`, reference spec content inline
 - Retain `[SPEC]` title prefix on spec
-- Do NOT create a remote issue for the plan
 
 **Separate (multi-task):**
-- Write to `.issues/{N}/spec-artifacts/plan.md` with phase sections
-- No GitHub Issue created — plan is a local artifact
-- Sub-issues concept does not apply: phases are sections in the local plan file
+- Write to `.issues/{N}/spec-artifacts/plan.md` with separate phase sections
+- Phases are sections in the local plan file — no sub-issues
 
 ## Approval Cascade Matrix
-
-Plan approval is on the spec, not the plan artifact. No remote plan issue exists. No `needs-approval` label or comment posting needed for plan approval.
 
 | Scope | Plan Approval | Implementation |
 | -- | -- | -- |

--- a/skills/writing-plans/tasks/create.md
+++ b/skills/writing-plans/tasks/create.md
@@ -2,34 +2,34 @@
 
 ## Purpose
 
-Create an implementation plan from an approved spec. For single-task specs the agent may combine the plan into the spec issue body instead of creating a separate [PLAN] issue.
+Create an implementation plan from an approved spec. Plans are stored locally in `.issues/{N}/spec-artifacts/plan.md` — no remote API calls for plan storage.
 
 ## Prerequisites
 
 1. Approved spec (verified by approval-gate)
-2. Spec stored as GitHub Issue
+2. Spec stored locally at `.issues/{N}/spec.md`
 3. Spec has explicit approval (`approved` or `go`)
 4. (Optional) `authorization_scope` from verify-authorization — if scope >= `for_plan`, plan auto-approval triggers
 
 ## Operating Protocol
 
 1. **Verification first:** Must run verification-enforcement --task verify before reading spec
-2. **Combined or separate decision:** Early evaluation whether to append to spec or create separate issue
+2. **Combined or separate decision:** Early evaluation whether plan content is stored combined with spec (`spec-artifacts/`) or separate from spec
 3. **Item decomposition mandatory:** Plan must enumerate items, order dependencies, specify acceptance criteria
 4. **RED checkpoint mandatory:** Every TDD task must include explicit Step 2 checkpoint
 5. **Approval cascade auto-approve:** Pipeline scope (`for_plan+`) auto-approves plan
 
 ## Entry Criteria
 
-- Spec is approved and stored as GitHub Issue
+- Spec is approved and stored in `.issues/{N}/spec.md`
 - `authorization_scope` received from approval-gate (for cascade)
 
 ## Exit Criteria
 
-- Plan created (combined into spec issue OR separate [PLAN] issue)
+- Plan stored locally at `.issues/{N}/spec-artifacts/plan.md`
 - All validation passed
-- Plan reported in chat with URL
-- Approval cascade applied (or `needs-approval` retained)
+- Plan reported in chat with local artifact path
+- Approval cascade applied (local-only auto-approval)
 
 ## Procedure
 
@@ -43,14 +43,14 @@ Runs verification gate, makes combined/separate decision, checks for duplicate p
 
 **Route to:** `create/create-and-validate`
 
-Writes plan header, stores as combined section or separate issue, creates sub-issues (for separate), runs self-review and validation, revisits verification, cross-references skills, and applies approval cascade with scope-aware auto-approval.
+Writes plan header, stores locally in `.issues/{N}/spec-artifacts/plan.md`, runs self-review and validation, revisits verification, cross-references skills, and applies approval cascade with scope-aware auto-approval.
 
 ## Sub-Task Files
 
 | Sub-Task | Purpose | Words |
 | -- | -- | -- |
 | `create/plan-structure` | Verification, combined/separate decision, file mapping, TDD definition | ≈750 |
-| `create/create-and-validate` | Document writing, issue creation, validation, approval cascade | ≈650 |
+| `create/create-and-validate` | Document writing, local storage, validation, approval cascade | ≈651 |
 
 ## Plan Phase Structure Requirements
 
@@ -68,32 +68,33 @@ When transitioning between architectural concerns, describe:
 - What concern being entered (new scope)
 - What information the new concern needs from prior (handoff point)
 
-## Combined Plan Format
+## Plan Format
 
-When combined into spec:
-- Append under `## Implementation Plan` section
-- Retain `[SPEC]` title prefix
-- **Do NOT link sub-issues** — single-task by definition
+Plan stored at `.issues/{N}/spec-artifacts/plan.md`. Combined and separate decisions affect which sections the plan document includes but not where it is stored — all plans are local.
 
-## Separate Plan Format
+**Combined (single-task):**
+- Write to `.issues/{N}/spec-artifacts/plan.md` and reference spec content inline
+- Retain `[SPEC]` title prefix on spec
+- Do NOT create a remote issue for the plan
 
-When separate [PLAN] issue:
-- Title: `[PLAN] <Feature Name>`
-- Labels: `plan`, `needs-approval` (unless auto-approved)
-- Body: `Spec: #<N>` reference, then plan header, file structure, phases
-- Sub-issues linked under the plan (not the spec)
+**Separate (multi-task):**
+- Write to `.issues/{N}/spec-artifacts/plan.md` with phase sections
+- No GitHub Issue created — plan is a local artifact
+- Sub-issues concept does not apply: phases are sections in the local plan file
 
 ## Approval Cascade Matrix
 
-| Scope | Plan Creation | Plan Approval | Implementation |
-| -- | -- | -- | -- |
-| `for_review_prep` | Yes | Separate approval required | Separate approval required |
-| `for_spec` | No | N/A | N/A |
-| `for_analysis` | Yes | N/A (analysis-only) | N/A |
-| `for_plan` | Yes | Auto-approved | Separate approval required |
-| `for_implementation` | Yes | Auto-approved | Auto-approved |
-| `for_pr` | Yes | Auto-approved | Auto-approved |
-| `for_pr_only` | N/A (skip) | N/A | N/A |
+Plan approval is on the spec, not the plan artifact. No remote plan issue exists. No `needs-approval` label or comment posting needed for plan approval.
+
+| Scope | Plan Approval | Implementation |
+| -- | -- | -- |
+| `for_review_prep` | Separate approval required | Separate approval required |
+| `for_spec` | N/A | N/A |
+| `for_analysis` | N/A (analysis-only) | N/A |
+| `for_plan` | Auto-approved | Separate approval required |
+| `for_implementation` | Auto-approved | Auto-approved |
+| `for_pr` | Auto-approved | Auto-approved |
+| `for_pr_only` | N/A (skip) | N/A |
 
 ## Authorization Context
 

--- a/skills/writing-plans/tasks/create/create-and-validate.md
+++ b/skills/writing-plans/tasks/create/create-and-validate.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-Write plan document, store as combined section or separate issue, validate structure, and handle approval cascade with scope-aware auto-approval.
+Write plan document, store locally in `.issues/{N}/spec-artifacts/plan.md`, validate structure, and handle approval cascade with scope-aware auto-approval.
 
 ## Entry Criteria
 
@@ -12,10 +12,10 @@ Write plan document, store as combined section or separate issue, validate struc
 
 ## Exit Criteria
 
-- Plan document written and stored (combined or separate)
+- Plan document written and stored locally at `.issues/{N}/spec-artifacts/plan.md`
 - Self-review and validation complete
 - Verification revisit passed
-- Plan reported in chat with URL
+- Plan reported in chat with local artifact path
 - Approval cascade applied (auto-approval for pipeline scope)
 
 ## Procedure
@@ -27,18 +27,10 @@ Write plan document, store as combined section or separate issue, validate struc
 
 ### Step 7: Store Plan Document
 
-**If COMBINED (from Step 1.5):**
-- Append `## Implementation Plan` section to spec issue body
-- Retain `[SPEC]` title prefix
+**All paths (combined and separate):**
+- Write plan to `.issues/{N}/spec-artifacts/plan.md`
+- No remote API calls for plan storage — plans are local artifacts per architecture
 - Proceed to Step 8
-
-**If SEPARATE:**
-- Create GitHub Issue:
-  - Title: `[PLAN] <Feature Name>`
-  - Labels: `plan`, `needs-approval`
-  - Body: `Spec: [issue #<N>](https://github.com/<owner>/<repo>/issues/<N>)` prose reference, then plan (header, file structure, phases with TDD tasks)
-  - STATUS: prose-driven format: `STATUS: in progress — {first concern}, Step 1`
-  - Do NOT link plan as sub-issue of spec — reference only via body text
 
 **Phase body requirements (each phase MUST include):**
 - Why this phase exists (concern it addresses)
@@ -49,12 +41,6 @@ Write plan document, store as combined section or separate issue, validate struc
 
 **Concern boundary annotations (prose-driven):**
 When transitioning concerns: describe what is being left, what is being entered, what information is needed for handoff.
-
-### Step 6a: Create Sub-Issues (SEPARATE only)
-
-After plan issue created:
-- Create sub-issue for each phase via `issue-operations --task link-sub-issue`
-- Sub-issues are children of the plan, NOT the spec
 
 ### Step 8: Self-Review
 
@@ -78,26 +64,19 @@ Scans for `⚠️ UNVERIFIED` markers. Resolves if possible; escalates unresolva
 
 ### Step 11: Report Plan Creation in Chat (MANDATORY)
 
-**Format (separate plan) — SC-10: full URLs, never bare #N:**
+**Format — local artifact path, SC-10: full URLs for spec reference, local path for plan:**
 ```
-Created separate implementation plan for [<owner>/<repo>#<N>](https://github.com/<owner>/<repo>/issues/<N>) (<description>). <N> tasks across <N> files.
-
-🤖 <AgentName> (<ModelId>)
-```
-
-**Format (combined spec+plan) — SC-10: full URLs, never bare #N:**
-```
-Created combined spec+plan for [<owner>/<repo>#<N>](https://github.com/<owner>/<repo>/issues/<N>) (<description>). Plan appended under `## Implementation Plan`.
+Created plan stored at `.issues/{N}/spec-artifacts/plan.md` for [<owner>/<repo>#<N>](https://github.com/<owner>/<repo>/issues/<N>) (<description>). <N> phases across <N> items.
 
 🤖 <AgentName> (<ModelId>)
 ```
 
 ### Step 12: Cross-Reference Verification (MANDATORY)
 
-Verify referenced skills exist:
+Verify referenced skills and tasks exist:
 ```bash
 ls .opencode/skills/approval-gate/SKILL.md && grep -c "verify-authorization" .opencode/skills/approval-gate/SKILL.md
-ls .opencode/skills/issue-operations/SKILL.md && grep -c "link-sub-issue" .opencode/skills/issue-operations/SKILL.md
+ls .opencode/skills/writing-plans/tasks/create/plan-structure.md && grep -c "Step.*RED" .opencode/skills/writing-plans/tasks/create/plan-structure.md
 ```
 
 If any verification fails: flag as MISSING-TRACEABILITY.
@@ -119,7 +98,7 @@ authorization_source: "User approved #N on YYYY-MM-DD"
 
 ### Step 13: Approval Cascade Check (MANDATORY)
 
-**Scope-aware auto-approval:**
+**Scope-aware auto-approval (local only — no remote API calls):**
 
 ```python
 SCOPE_LEVELS = {
@@ -129,16 +108,13 @@ SCOPE_LEVELS = {
 }
 
 if scope_level >= SCOPE_LEVELS["for_plan"]:
-    # Pipeline authorization covers plan approval
-    issue-operations -> update-issue (github_issue_write(method="update", issue_number=<plan>, <!-- Routes through issue-operations per [spec #683](https://github.com/michael-conrad/opencode-config/issues/683) -->
-                      labels=[l for l in plan_labels if l != "needs-approval"])
-    issue-operations -> comment (github_add_issue_comment( <!-- Routes through issue-operations per [spec #683](https://github.com/michael-conrad/opencode-config/issues/683) -->
-        issue_number=<plan>,
-        body=f"Plan auto-approved via pipeline scope (authorization_scope={scope})."
-    )
+    # Plan is local — approval is on the spec, not the plan
+    # No remote label removal or comment posting needed
+    # Record: "Plan auto-approved via pipeline scope (authorization_scope={scope})"
+    pass  # Auto-approval recorded in chat report only
 ```
 
-**For combined spec+plan:** Only auto-remove `needs-approval` if `scope_level >= for_plan`.
+**For combined spec+plan:** Same as above — no remote operations. Approval is on the spec.
 
 **If `halt_at == plan_created`:** HALT after plan creation. Do NOT proceed to implementation.
 
@@ -150,11 +126,11 @@ if scope_level >= SCOPE_LEVELS["for_plan"]:
 | C2 | File structure lists all files with responsibilities |
 | C3 | TDD tasks include mandatory Step 2 RED checkpoint |
 | C4 | Phase descriptions include concern boundary annotations |
-| C5 | Sub-issues linked only under plan (not spec) for separate plans |
+| C5 | Plan stored locally at `.issues/{N}/spec-artifacts/plan.md` — no remote plan issue |
 | C6 | No TBD/TODO placeholders remain |
-| C7 | Combined plans retain `[SPEC]` prefix; separate plans use `[PLAN]` |
+| C7 | No `[PLAN]` GitHub Issue created — plan is a local artifact |
 | C8 | Status marker uses prose-driven format |
-| C9 | Approval cascade honors `authorization_scope` |
+| C9 | Approval cascade honors `authorization_scope` (local-only, no remote ops) |
 
 ## Context Required
 

--- a/skills/writing-plans/tasks/create/create-and-validate.md
+++ b/skills/writing-plans/tasks/create/create-and-validate.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-Write plan document, store locally in `.issues/{N}/spec-artifacts/plan.md`, validate structure, and handle approval cascade with scope-aware auto-approval.
+Write plan document to `.issues/{N}/spec-artifacts/plan.md`, validate structure, and handle approval cascade with scope-aware auto-approval.
 
 ## Entry Criteria
 
@@ -12,10 +12,10 @@ Write plan document, store locally in `.issues/{N}/spec-artifacts/plan.md`, vali
 
 ## Exit Criteria
 
-- Plan document written and stored locally at `.issues/{N}/spec-artifacts/plan.md`
+- Plan document written to `.issues/{N}/spec-artifacts/plan.md`
 - Self-review and validation complete
 - Verification revisit passed
-- Plan reported in chat with local artifact path
+- Plan reported in chat with `.issues/{N}/spec-artifacts/plan.md` path
 - Approval cascade applied (auto-approval for pipeline scope)
 
 ## Procedure
@@ -29,10 +29,9 @@ Write plan document, store locally in `.issues/{N}/spec-artifacts/plan.md`, vali
 
 **All paths (combined and separate):**
 - Write plan to `.issues/{N}/spec-artifacts/plan.md`
-- No remote API calls for plan storage — plans are local artifacts per architecture
 - Proceed to Step 8
 
-**Phase body requirements (each phase MUST include):**
+### Phase body requirements (each phase MUST include):
 - Why this phase exists (concern it addresses)
 - What it must accomplish (tasks, deliverables, behavioral requirements)
 - How to verify completion (success criteria)
@@ -64,9 +63,9 @@ Scans for `⚠️ UNVERIFIED` markers. Resolves if possible; escalates unresolva
 
 ### Step 11: Report Plan Creation in Chat (MANDATORY)
 
-**Format — local artifact path, SC-10: full URLs for spec reference, local path for plan:**
+**Format — reference spec via full URL, plan via local artifact path:**
 ```
-Created plan stored at `.issues/{N}/spec-artifacts/plan.md` for [<owner>/<repo>#<N>](https://github.com/<owner>/<repo>/issues/<N>) (<description>). <N> phases across <N> items.
+Created plan at `.issues/{N}/spec-artifacts/plan.md` for [<owner>/<repo>#<N>](https://github.com/<owner>/<repo>/issues/<N>) (<description>). <N> phases across <N> items.
 
 🤖 <AgentName> (<ModelId>)
 ```
@@ -96,9 +95,9 @@ authorization_source: "User approved #N on YYYY-MM-DD"
 - Instructed to exceed `halt_at` → return `status: BLOCKED`
 - The `pipeline_phase` field is used to track which phase of a multi-phase plan is being executed
 
-### Step 13: Approval Cascade Check (MANDATORY)
+### Step 13: Plan Approval
 
-**Scope-aware auto-approval (local only — no remote API calls):**
+**Scope-aware auto-approval — approval is on the spec, plan is a local artifact:**
 
 ```python
 SCOPE_LEVELS = {
@@ -108,13 +107,10 @@ SCOPE_LEVELS = {
 }
 
 if scope_level >= SCOPE_LEVELS["for_plan"]:
-    # Plan is local — approval is on the spec, not the plan
-    # No remote label removal or comment posting needed
-    # Record: "Plan auto-approved via pipeline scope (authorization_scope={scope})"
-    pass  # Auto-approval recorded in chat report only
+    # Pipeline authorization covers plan approval
+    # Plan is local — record approval in chat report
+    pass
 ```
-
-**For combined spec+plan:** Same as above — no remote operations. Approval is on the spec.
 
 **If `halt_at == plan_created`:** HALT after plan creation. Do NOT proceed to implementation.
 
@@ -126,14 +122,14 @@ if scope_level >= SCOPE_LEVELS["for_plan"]:
 | C2 | File structure lists all files with responsibilities |
 | C3 | TDD tasks include mandatory Step 2 RED checkpoint |
 | C4 | Phase descriptions include concern boundary annotations |
-| C5 | Plan stored locally at `.issues/{N}/spec-artifacts/plan.md` — no remote plan issue |
+| C5 | Plan stored at `.issues/{N}/spec-artifacts/plan.md` |
 | C6 | No TBD/TODO placeholders remain |
-| C7 | No `[PLAN]` GitHub Issue created — plan is a local artifact |
+| C7 | Plan artifact created locally in `.issues/{N}/spec-artifacts/` |
 | C8 | Status marker uses prose-driven format |
-| C9 | Approval cascade honors `authorization_scope` (local-only, no remote ops) |
+| C9 | Approval cascade honors `authorization_scope` |
 
 ## Context Required
 
 - Related tasks: `create/plan-structure`
-- Related skills: `verification-enforcement`, `issue-operations`
-- Related guidelines: `000-critical-rules.md` (URL sourcing, chat format)
+- Related skills: `verification-enforcement`
+- Related guidelines: `000-critical-rules.md` (chat format)

--- a/skills/writing-plans/tasks/create/plan-structure.md
+++ b/skills/writing-plans/tasks/create/plan-structure.md
@@ -42,9 +42,9 @@ Collects evidence artifacts for factual claims. Unverified claims marked with `�
 
 | Condition | Outcome |
 | -- | -- |
-| Multi-task spec (mixed concerns or independence) | **Always separate** — create [PLAN] issue with sub-issues |
+| Multi-task spec (mixed concerns or independence) | **Always separate** — separate phase sections in `.issues/{N}/spec-artifacts/plan.md` |
 | Single-task spec AND spec body can absorb plan content | **Candidate for combined** — agent evaluates readability |
-| Single-task AND combining makes document hard to read | **Separate** — create [PLAN] issue |
+| Single-task AND combining makes document hard to read | **Separate** — stand-alone sections in `.issues/{N}/spec-artifacts/plan.md` |
 
 **Decision output (MANDATORY):**
 ```
@@ -53,22 +53,23 @@ Reason: <justification referencing evaluation criteria>
 ```
 
 **If COMBINED:**
-- Append `## Implementation Plan` section to spec issue body
+- Write to `.issues/{N}/spec-artifacts/plan.md`, referencing spec content inline
 - Retain `[SPEC]` title prefix (not changed to `[PLAN]`)
-- Proceed to Step 2 — plan content appended to spec body
+- Proceed to Step 2
 
 **If SEPARATE:**
-- Proceed to Step 2 — plan content stored in separate [PLAN] issue
+- Write to `.issues/{N}/spec-artifacts/plan.md` with separate phase sections
+- Proceed to Step 2
 
 ### Step 1.6: Duplicate Plan Check
 
-Search for existing plans referencing the same spec:
-```python
-plans = issue-operations -> search-issues (github_search_issues(query="label:plan", owner=<owner>, repo=<repo>, state="open") <!-- Routes through issue-operations per [spec #683](https://github.com/michael-conrad/opencode-config/issues/683) -->
+Search for existing local plans in `.issues/` workspace:
+```bash
+ls .issues/*/spec-artifacts/plan.md 2>/dev/null
 ```
 
-For each plan found with `Spec: #<spec_number>`, present choice:
-- Proceed with new plan (reference existing as full URL: `[Supersedes #N](https://github.com/<owner>/<repo>/issues/<N>)`)
+For each plan found, check if it references the current spec. Present choice:
+- Proceed with new plan (override existing local artifact)
 - HALT and review existing plan
 
 ### Step 2: Map File Structure (Sub-Folder References — SC-9)

--- a/skills/writing-plans/tasks/create/plan-structure.md
+++ b/skills/writing-plans/tasks/create/plan-structure.md
@@ -53,8 +53,8 @@ Reason: <justification referencing evaluation criteria>
 ```
 
 **If COMBINED:**
-- Write to `.issues/{N}/spec-artifacts/plan.md`, referencing spec content inline
-- Retain `[SPEC]` title prefix (not changed to `[PLAN]`)
+- Write to `.issues/{N}/spec-artifacts/plan.md`, reference spec content inline
+- Retain `[SPEC]` title prefix
 - Proceed to Step 2
 
 **If SEPARATE:**
@@ -63,12 +63,12 @@ Reason: <justification referencing evaluation criteria>
 
 ### Step 1.6: Duplicate Plan Check
 
-Search for existing local plans in `.issues/` workspace:
+Look for existing plan artifacts in `.issues/` workspace:
 ```bash
 ls .issues/*/spec-artifacts/plan.md 2>/dev/null
 ```
 
-For each plan found, check if it references the current spec. Present choice:
+For each plan found referencing the same spec, present choice:
 - Proceed with new plan (override existing local artifact)
 - HALT and review existing plan
 


### PR DESCRIPTION
## Summary

Plan instructions now tell agents what TO do: write to `.issues/{N}/spec-artifacts/plan.md` — no empty negative framing.

**Changes by file:**

| File | What changed |
|------|-------------|
| `create-and-validate.md` | Step 7 writes to `.issues/{N}/spec-artifacts/plan.md` (combined + separate). Step 6a removed (phases are local plan sections). Step 11 reports local artifact path. Step 13: approval on spec, plan is local artifact. Cross-reference checks plan-structure task, not issue-operations. |
| `create.md` | Purpose, prerequisites, entry/exit criteria, format sections all reference `.issues/{N}/` paths. Plan Format replaces Combined/Separate Plan Format sections. Cascade matrix has no Plan Creation column (plans are always local). |
| `plan-structure.md` | Step 1.5 combined/separate paths write to local plan. Step 1.6 duplicate check uses local `ls` not GitHub Issues search. |
| `SKILL.md` | Overview, Persona, Plan Model, Operating Protocol rule 5 all reference concern boundaries and local artifacts — not `[PLAN]` issues or sub-issues. |

**Defects resolved:** D1–D6

🤖 OpenCode (deepseek-v4-flash) created