### PR TITLE
feat(#1065,p1): qualified list output format with spec_path and sort order

### DIFF
--- a/tests/behaviors/local-issues-list-qualified-format.sh
+++ b/tests/behaviors/local-issues-list-qualified-format.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# RED phase: local-issues-list-qualified-format
+# This script is a direct verification test — it evaluates tool output directly.
+#
+# SC-1: list outputs qualified {repo}#{N} format excluding current repo prefix.
+# MUST FAIL in RED phase — current cmd_list prints bare #N [status] title.
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TOOL_REAL="$(cd "$SCRIPT_DIR/../.." && pwd)/tools/local-issues"
+
+TEST_DIR=$(mktemp -d)
+trap 'rm -rf "$TEST_DIR"' EXIT
+
+for n in 1 42 50; do
+  mkdir -p "$TEST_DIR/.issues/$n"
+  printf 'title: Test %d\nstatus: open\nlabels: []\nbody: ""\ncreated_at: "2026-06-09T12:00:00Z"\nupdated_at: "2026-06-09T12:00:00Z"\n' "$n" > "$TEST_DIR/.issues/$n/issue.yaml"
+  echo "comments: []" > "$TEST_DIR/.issues/$n/comments.yaml"
+  echo "links: []" > "$TEST_DIR/.issues/$n/links.yaml"
+done
+
+cd "$TEST_DIR"
+output=$(uv run --python 3.12 --script "$TOOL_REAL" list 2>&1 || true)
+
+# REQUIRED: Output lines must contain {repo}#{N} pattern (qualified format)
+# Current: bare #N — test MUST FAIL in RED phase
+if echo "$output" | grep -qE '[a-zA-Z0-9_.-]+#[0-9]+'; then
+  echo "PASS: Qualified {repo}#{N} format found"
+  exit 0
+else
+  echo "FAIL (RED expected): No qualified {repo}#{N} format in output"
+  echo "$output"
+  exit 1
+fi

--- a/tests/behaviors/local-issues-list-qualified-format.sh
+++ b/tests/behaviors/local-issues-list-qualified-format.sh
@@ -1,34 +1,86 @@
 #!/bin/bash
-# RED phase: local-issues-list-qualified-format
-# This script is a direct verification test — it evaluates tool output directly.
+# Behavioral test: local-issues-list-qualified-format
+# See .opencode/tests/AGENTS.md for the test harness specification and paradigm.
+# This script is an artifact-only generator — it does NOT evaluate model output.
 #
 # SC-1: list outputs qualified {repo}#{N} format excluding current repo prefix.
-# MUST FAIL in RED phase — current cmd_list prints bare #N [status] title.
+#
+# Setup: creates a main git repo with a child sub-repo, both with .issues/ entries.
 
 set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-TOOL_REAL="$(cd "$SCRIPT_DIR/../.." && pwd)/tools/local-issues"
 
 TEST_DIR=$(mktemp -d)
 trap 'rm -rf "$TEST_DIR"' EXIT
 
-for n in 1 42 50; do
-  mkdir -p "$TEST_DIR/.issues/$n"
-  printf 'title: Test %d\nstatus: open\nlabels: []\nbody: ""\ncreated_at: "2026-06-09T12:00:00Z"\nupdated_at: "2026-06-09T12:00:00Z"\n' "$n" > "$TEST_DIR/.issues/$n/issue.yaml"
-  echo "comments: []" > "$TEST_DIR/.issues/$n/comments.yaml"
-  echo "links: []" > "$TEST_DIR/.issues/$n/links.yaml"
-done
+# --- Main repo setup ---
+mkdir -p "$TEST_DIR/.issues/100"
+cat > "$TEST_DIR/.issues/100/issue.yaml" << 'YAML'
+title: Main issue
+status: open
+labels: []
+body: ""
+created_at: "2026-06-09T12:00:00Z"
+updated_at: "2026-06-09T12:00:00Z"
+YAML
+echo "comments: []" > "$TEST_DIR/.issues/100/comments.yaml"
+echo "links: []" > "$TEST_DIR/.issues/100/links.yaml"
 
+# --- Child repo (simulated sibling) setup ---
+mkdir -p "$TEST_DIR/childrepo/.git"
+
+pushd "$TEST_DIR/childrepo" >/dev/null
+git init --quiet
+git config user.email "test@test.com"
+git config user.name "Test"
+git commit --allow-empty --quiet -m "init"
+popd >/dev/null
+
+mkdir -p "$TEST_DIR/childrepo/.issues/42"
+cat > "$TEST_DIR/childrepo/.issues/42/issue.yaml" << 'YAML'
+title: Child issue
+status: open
+labels: []
+body: ""
+created_at: "2026-06-09T12:00:00Z"
+updated_at: "2026-06-09T12:00:00Z"
+YAML
+echo "comments: []" > "$TEST_DIR/childrepo/.issues/42/comments.yaml"
+echo "links: []" > "$TEST_DIR/childrepo/.issues/42/links.yaml"
+
+# Init the main repo tracking the child as sibling
+cd "$TEST_DIR" && git init --quiet
+git config user.email "test@test.com"
+git config user.name "Test"
+git add .
+git commit --allow-empty --quiet -m "initial"
+
+# --- Run tool ---
+TOOL_REAL="$(cd "$SCRIPT_DIR/../.." && pwd)/tools/local-issues"
 cd "$TEST_DIR"
 output=$(uv run --python 3.12 --script "$TOOL_REAL" list 2>&1 || true)
+echo "$output"
 
-# REQUIRED: Output lines must contain {repo}#{N} pattern (qualified format)
-# Current: bare #N — test MUST FAIL in RED phase
-if echo "$output" | grep -qE '[a-zA-Z0-9_.-]+#[0-9]+'; then
-  echo "PASS: Qualified {repo}#{N} format found"
-  exit 0
+# Verify: current repo issues are bare #N, child repo issues have childrepo#N
+if echo "$output" | grep -qE '^#100 '; then
+  echo "PASS: Bare #N for current repo found"
 else
-  echo "FAIL (RED expected): No qualified {repo}#{N} format in output"
-  echo "$output"
+  echo "FAIL: Expected bare #100 for current repo"
   exit 1
 fi
+
+if echo "$output" | grep -qE '^childrepo#42 '; then
+  echo "PASS: Qualified childrepo#42 found"
+else
+  echo "FAIL: Expected childrepo#42 for child repo"
+  exit 1
+fi
+
+# Verify NO qualified prefix for current repo
+if echo "$output" | grep -qE '^opencode-config#'; then
+  echo "FAIL: Current repo should NOT have qualified prefix"
+  exit 1
+fi
+
+echo "PASS: SC-1 verified"
+exit 0

--- a/tests/behaviors/local-issues-list-sort-order.sh
+++ b/tests/behaviors/local-issues-list-sort-order.sh
@@ -1,63 +1,107 @@
 #!/bin/bash
-# RED phase: local-issues-list-sort-order
-# This script is a direct verification test — it evaluates tool output behavior.
+# Behavioral test: local-issues-list-sort-order
+# See .opencode/tests/AGENTS.md for the test harness specification and paradigm.
+# This script is an artifact-only generator — it does NOT evaluate model output.
 #
 # SC-3: list sorts: main repo first, submodules alpha, issue number descending.
-# MUST FAIL in RED phase — current cmd_list outputs flat unsorted #N [status] title.
 
 set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-TOOL_REAL="$(cd "$SCRIPT_DIR/../.." && pwd)/tools/local-issues"
 
 TEST_DIR=$(mktemp -d)
 trap 'rm -rf "$TEST_DIR"' EXIT
 
-for n in 1 42 50; do
+# --- Main repo issues (various numbers) ---
+for n in 7 100 42; do
   mkdir -p "$TEST_DIR/.issues/$n"
-  printf 'title: Test %d\nstatus: open\nlabels: []\nbody: ""\ncreated_at: "2026-06-09T12:00:00Z"\nupdated_at: "2026-06-09T12:00:00Z"\n' "$n" > "$TEST_DIR/.issues/$n/issue.yaml"
+  cat > "$TEST_DIR/.issues/$n/issue.yaml" << YAML
+title: Main issue $n
+status: open
+labels: []
+body: ""
+created_at: "2026-06-09T12:00:00Z"
+updated_at: "2026-06-09T12:00:00Z"
+YAML
   echo "comments: []" > "$TEST_DIR/.issues/$n/comments.yaml"
   echo "links: []" > "$TEST_DIR/.issues/$n/links.yaml"
 done
 
+# --- Child repo A (should sort before B) ---
+mkdir -p "$TEST_DIR/achildrepo/.git"
+pushd "$TEST_DIR/achildrepo" >/dev/null
+git init --quiet
+git config user.email "test@test.com"
+git config user.name "Test"
+git commit --allow-empty --quiet -m "init"
+popd >/dev/null
+
+for n in 3 99; do
+  mkdir -p "$TEST_DIR/achildrepo/.issues/$n"
+  cat > "$TEST_DIR/achildrepo/.issues/$n/issue.yaml" << YAML
+title: A child issue $n
+status: open
+labels: []
+body: ""
+created_at: "2026-06-09T12:00:00Z"
+updated_at: "2026-06-09T12:00:00Z"
+YAML
+  echo "comments: []" > "$TEST_DIR/achildrepo/.issues/$n/comments.yaml"
+  echo "links: []" > "$TEST_DIR/achildrepo/.issues/$n/links.yaml"
+done
+
+# --- Child repo B (should sort after A) ---
+mkdir -p "$TEST_DIR/bchildrepo/.git"
+pushd "$TEST_DIR/bchildrepo" >/dev/null
+git init --quiet
+git config user.email "test@test.com"
+git config user.name "Test"
+git commit --allow-empty --quiet -m "init"
+popd >/dev/null
+
+for n in 5 1; do
+  mkdir -p "$TEST_DIR/bchildrepo/.issues/$n"
+  cat > "$TEST_DIR/bchildrepo/.issues/$n/issue.yaml" << YAML
+title: B child issue $n
+status: open
+labels: []
+body: ""
+created_at: "2026-06-09T12:00:00Z"
+updated_at: "2026-06-09T12:00:00Z"
+YAML
+  echo "comments: []" > "$TEST_DIR/bchildrepo/.issues/$n/comments.yaml"
+  echo "links: []" > "$TEST_DIR/bchildrepo/.issues/$n/links.yaml"
+done
+
+cd "$TEST_DIR" && git init --quiet
+git config user.email "test@test.com"
+git config user.name "Test"
+git add .
+git commit --allow-empty --quiet -m "initial" 2>/dev/null || true
+
+# --- Run tool ---
+TOOL_REAL="$(cd "$SCRIPT_DIR/../.." && pwd)/tools/local-issues"
 cd "$TEST_DIR"
 output=$(uv run --python 3.12 --script "$TOOL_REAL" list 2>&1 || true)
+echo "$output"
 
-# Current output is bare "#N [status] title" — no {repo}#{N} format.
-# Expected (post-GREEN): repo-grouped, repo prefix, desc by issue number.
-# RED phase MUST FAIL because format is wrong.
-if ! echo "$output" | grep -qE '[a-zA-Z0-9_.-]+#[0-9]+'; then
-  echo "FAIL (RED expected): No qualified {repo}#{N} format — sort order unverifiable"
-  echo "$output"
-  exit 1
-fi
+# Expected order:
+# Main repo first: #100, #42, #7 (desc order)
+# achildrepo: achildrepo#99, achildrepo#3
+# bchildrepo: bchildrepo#5, bchildrepo#1
 
-# Verify main repo group appears first
-first_line=$(echo "$output" | head -1)
-if ! echo "$first_line" | grep -qE '^opencode-config#'; then
-  echo "FAIL (RED expected): Main repo not first in sort order"
-  echo "First line: $first_line"
-  echo "$output"
-  exit 1
-fi
+# Extract just the display_num (first token)
+lines=$(echo "$output" | grep -oE '^[^ ]+')
+expected=("#100" "#42" "#7" "achildrepo#99" "achildrepo#3" "bchildrepo#5" "bchildrepo#1")
 
-# Within each repo group, verify descending issue number
-last_num=999999
-sort_errors=0
-while IFS= read -r line; do
-  if echo "$line" | grep -qE '^([a-zA-Z0-9_.-]+)#([0-9]+)'; then
-    num=$(echo "$line" | sed -nE 's/^[a-zA-Z0-9_.-]+#([0-9]+).*/\1/p')
-    if [ "$num" -gt "$last_num" ]; then
-      sort_errors=$((sort_errors + 1))
-    fi
-    last_num=$num
+idx=0
+for expected_token in "${expected[@]}"; do
+  actual=$(echo "$lines" | sed -n "$((idx+1))p")
+  if [ "$actual" != "$expected_token" ]; then
+    echo "FAIL: Line $((idx+1)) expected '$expected_token' but got '$actual'"
+    exit 1
   fi
-done <<< "$output"
+  idx=$((idx+1))
+done
 
-if [ "$sort_errors" -gt 0 ]; then
-  echo "FAIL (RED expected): $sort_errors descending-order violations"
-  echo "$output"
-  exit 1
-fi
-
-echo "PASS: Sort order verified"
+echo "PASS: Sort order verified (main repo first, child repos alpha, numbers desc)"
 exit 0

--- a/tests/behaviors/local-issues-list-sort-order.sh
+++ b/tests/behaviors/local-issues-list-sort-order.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+# RED phase: local-issues-list-sort-order
+# This script is a direct verification test — it evaluates tool output behavior.
+#
+# SC-3: list sorts: main repo first, submodules alpha, issue number descending.
+# MUST FAIL in RED phase — current cmd_list outputs flat unsorted #N [status] title.
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TOOL_REAL="$(cd "$SCRIPT_DIR/../.." && pwd)/tools/local-issues"
+
+TEST_DIR=$(mktemp -d)
+trap 'rm -rf "$TEST_DIR"' EXIT
+
+for n in 1 42 50; do
+  mkdir -p "$TEST_DIR/.issues/$n"
+  printf 'title: Test %d\nstatus: open\nlabels: []\nbody: ""\ncreated_at: "2026-06-09T12:00:00Z"\nupdated_at: "2026-06-09T12:00:00Z"\n' "$n" > "$TEST_DIR/.issues/$n/issue.yaml"
+  echo "comments: []" > "$TEST_DIR/.issues/$n/comments.yaml"
+  echo "links: []" > "$TEST_DIR/.issues/$n/links.yaml"
+done
+
+cd "$TEST_DIR"
+output=$(uv run --python 3.12 --script "$TOOL_REAL" list 2>&1 || true)
+
+# Current output is bare "#N [status] title" — no {repo}#{N} format.
+# Expected (post-GREEN): repo-grouped, repo prefix, desc by issue number.
+# RED phase MUST FAIL because format is wrong.
+if ! echo "$output" | grep -qE '[a-zA-Z0-9_.-]+#[0-9]+'; then
+  echo "FAIL (RED expected): No qualified {repo}#{N} format — sort order unverifiable"
+  echo "$output"
+  exit 1
+fi
+
+# Verify main repo group appears first
+first_line=$(echo "$output" | head -1)
+if ! echo "$first_line" | grep -qE '^opencode-config#'; then
+  echo "FAIL (RED expected): Main repo not first in sort order"
+  echo "First line: $first_line"
+  echo "$output"
+  exit 1
+fi
+
+# Within each repo group, verify descending issue number
+last_num=999999
+sort_errors=0
+while IFS= read -r line; do
+  if echo "$line" | grep -qE '^([a-zA-Z0-9_.-]+)#([0-9]+)'; then
+    num=$(echo "$line" | sed -nE 's/^[a-zA-Z0-9_.-]+#([0-9]+).*/\1/p')
+    if [ "$num" -gt "$last_num" ]; then
+      sort_errors=$((sort_errors + 1))
+    fi
+    last_num=$num
+  fi
+done <<< "$output"
+
+if [ "$sort_errors" -gt 0 ]; then
+  echo "FAIL (RED expected): $sort_errors descending-order violations"
+  echo "$output"
+  exit 1
+fi
+
+echo "PASS: Sort order verified"
+exit 0

--- a/tests/behaviors/local-issues-list-spec-path.sh
+++ b/tests/behaviors/local-issues-list-spec-path.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# RED phase: local-issues-list-spec-path
+# This script is a direct verification test — it evaluates tool output directly.
+#
+# SC-2: list outputs spec_path column relative to project root.
+# MUST FAIL in RED phase — current cmd_list has no columnar output.
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TOOL_REAL="$(cd "$SCRIPT_DIR/../.." && pwd)/tools/local-issues"
+
+TEST_DIR=$(mktemp -d)
+trap 'rm -rf "$TEST_DIR"' EXIT
+
+for n in 1 42 50; do
+  mkdir -p "$TEST_DIR/.issues/$n"
+  printf 'title: Test %d\nstatus: open\nlabels: []\nbody: ""\ncreated_at: "2026-06-09T12:00:00Z"\nupdated_at: "2026-06-09T12:00:00Z"\n' "$n" > "$TEST_DIR/.issues/$n/issue.yaml"
+  echo "comments: []" > "$TEST_DIR/.issues/$n/comments.yaml"
+  echo "links: []" > "$TEST_DIR/.issues/$n/links.yaml"
+done
+
+cd "$TEST_DIR"
+output=$(uv run --python 3.12 --script "$TOOL_REAL" list 2>&1 || true)
+
+# REQUIRED: Output has a spec_path column header or per-line spec_path values
+# Current: bare #N [status] title — no columns — test MUST FAIL in RED phase
+if echo "$output" | grep -qiE 'spec_path|spec-path|spec\.path'; then
+  echo "PASS: spec_path column found in output"
+  exit 0
+else
+  echo "FAIL (RED expected): No spec_path column in output"
+  echo "$output"
+  exit 1
+fi

--- a/tests/behaviors/local-issues-list-spec-path.sh
+++ b/tests/behaviors/local-issues-list-spec-path.sh
@@ -1,34 +1,77 @@
 #!/bin/bash
-# RED phase: local-issues-list-spec-path
-# This script is a direct verification test — it evaluates tool output directly.
+# Behavioral test: local-issues-list-spec-path
+# See .opencode/tests/AGENTS.md for the test harness specification and paradigm.
+# This script is an artifact-only generator — it does NOT evaluate model output.
 #
 # SC-2: list outputs spec_path column relative to project root.
-# MUST FAIL in RED phase — current cmd_list has no columnar output.
 
 set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-TOOL_REAL="$(cd "$SCRIPT_DIR/../.." && pwd)/tools/local-issues"
 
 TEST_DIR=$(mktemp -d)
 trap 'rm -rf "$TEST_DIR"' EXIT
 
-for n in 1 42 50; do
-  mkdir -p "$TEST_DIR/.issues/$n"
-  printf 'title: Test %d\nstatus: open\nlabels: []\nbody: ""\ncreated_at: "2026-06-09T12:00:00Z"\nupdated_at: "2026-06-09T12:00:00Z"\n' "$n" > "$TEST_DIR/.issues/$n/issue.yaml"
-  echo "comments: []" > "$TEST_DIR/.issues/$n/comments.yaml"
-  echo "links: []" > "$TEST_DIR/.issues/$n/links.yaml"
-done
+# --- Main repo setup ---
+mkdir -p "$TEST_DIR/.issues/100"
+cat > "$TEST_DIR/.issues/100/issue.yaml" << 'YAML'
+title: Main issue
+status: open
+labels: []
+body: ""
+created_at: "2026-06-09T12:00:00Z"
+updated_at: "2026-06-09T12:00:00Z"
+YAML
+echo "comments: []" > "$TEST_DIR/.issues/100/comments.yaml"
+echo "links: []" > "$TEST_DIR/.issues/100/links.yaml"
 
+# --- Child repo setup ---
+mkdir -p "$TEST_DIR/childrepo/.git"
+pushd "$TEST_DIR/childrepo" >/dev/null
+git init --quiet
+git config user.email "test@test.com"
+git config user.name "Test"
+git commit --allow-empty --quiet -m "init"
+popd >/dev/null
+
+mkdir -p "$TEST_DIR/childrepo/.issues/42"
+cat > "$TEST_DIR/childrepo/.issues/42/issue.yaml" << 'YAML'
+title: Child issue
+status: open
+labels: []
+body: ""
+created_at: "2026-06-09T12:00:00Z"
+updated_at: "2026-06-09T12:00:00Z"
+YAML
+echo "comments: []" > "$TEST_DIR/childrepo/.issues/42/comments.yaml"
+echo "links: []" > "$TEST_DIR/childrepo/.issues/42/links.yaml"
+
+cd "$TEST_DIR" && git init --quiet
+git config user.email "test@test.com"
+git config user.name "Test"
+git add .
+git commit --allow-empty --quiet -m "initial"
+
+# --- Run tool ---
+TOOL_REAL="$(cd "$SCRIPT_DIR/../.." && pwd)/tools/local-issues"
 cd "$TEST_DIR"
 output=$(uv run --python 3.12 --script "$TOOL_REAL" list 2>&1 || true)
+echo "$output"
 
-# REQUIRED: Output has a spec_path column header or per-line spec_path values
-# Current: bare #N [status] title — no columns — test MUST FAIL in RED phase
-if echo "$output" | grep -qiE 'spec_path|spec-path|spec\.path'; then
+# Verify spec_path column header or values
+if echo "$output" | grep -q 'spec_path'; then
   echo "PASS: spec_path column found in output"
-  exit 0
 else
-  echo "FAIL (RED expected): No spec_path column in output"
-  echo "$output"
+  echo "FAIL: spec_path column not found"
   exit 1
 fi
+
+# Verify spec_path values are relative paths
+if echo "$output" | grep -qE 'spec_path=\.issues'; then
+  echo "PASS: spec_path contains relative paths"
+else
+  echo "FAIL: spec_path values missing or not relative"
+  exit 1
+fi
+
+echo "PASS: SC-2 verified"
+exit 0

--- a/tools/local-issues
+++ b/tools/local-issues
@@ -829,7 +829,7 @@ def cmd_list(args: argparse.Namespace) -> None:
                 status = "open"
 
             display_num = f"{repo_name}#{num}" if repo_name != current_repo_name else f"#{num}"
-            all_entries.append((sort_prio, repo_name, display_num, "open", title, spec_path, num))
+            all_entries.append((sort_prio, repo_name, display_num, status, title, spec_path, num))
 
     if not all_entries:
         return

--- a/tools/local-issues
+++ b/tools/local-issues
@@ -828,23 +828,8 @@ def cmd_list(args: argparse.Namespace) -> None:
                 title = ""
                 status = "open"
 
-            display_num = f"{repo_name}#{num}"
-            all_entries.append((sort_prio, repo_name, display_num, status, title, spec_path, num))
-
-        open_dir = repo_issues_dir / "open"
-        if open_dir.is_dir():
-            for entry in sorted(open_dir.iterdir()):
-                num = _parse_number(entry)
-                if num is None or num in seen:
-                    continue
-                seen.add(num)
-                issue_file = entry / "issue.yaml"
-                if not issue_file.exists():
-                    continue
-                issue_data = yaml_load(read_file(issue_file))
-                title = issue_data.get("title", "") if isinstance(issue_data, dict) else ""
-                display_num = f"{repo_name}#{num}"
-                all_entries.append((sort_prio, repo_name, display_num, "open", title, spec_path, num))
+            display_num = f"{repo_name}#{num}" if repo_name != current_repo_name else f"#{num}"
+            all_entries.append((sort_prio, repo_name, display_num, "open", title, spec_path, num))
 
     if not all_entries:
         return

--- a/tools/local-issues
+++ b/tools/local-issues
@@ -558,7 +558,7 @@ def cmd_create(args: argparse.Namespace) -> None:
         print(f"  branches: {', '.join(dual['branches'])}", file=sys.stderr)
         print(f"  divergence (left/right count): {dual['divergence']}", file=sys.stderr)
         if dual['timestamps']:
-            print(f"  commit history:", file=sys.stderr)
+            print("  commit history:", file=sys.stderr)
             for line in dual['timestamps'].split('\n'):
                 if line.strip():
                     print(f"    {line}", file=sys.stderr)
@@ -763,42 +763,96 @@ def cmd_search(args: argparse.Namespace) -> None:
         print(f"#{num} [{status}] {title}")
 
 
+def _resolve_repo_name() -> str:
+    tool_script = Path(__file__).resolve()
+    for parent in tool_script.parents:
+        if (parent / ".gitmodules").exists():
+            return parent.name
+    for parent in tool_script.parents:
+        git_ref = parent / ".git"
+        if git_ref.is_dir():
+            return parent.name
+        if git_ref.is_file():
+            contents = git_ref.read_text().strip()
+            if "gitdir:" not in contents:
+                return parent.name
+    return Path(os.getcwd()).name
+
+
 def cmd_list(args: argparse.Namespace) -> None:
-    issues_dir = Path(ISSUES_DIR)
-    if not issues_dir.is_dir():
-        return
-    entries = []
-    seen: set[int] = set()
-    for entry in sorted(issues_dir.iterdir()):
-        num = _parse_number(entry)
-        if num is None:
+    current_repo_name = _resolve_repo_name()
+    current_cwd = Path(os.getcwd()).resolve()
+
+    child_repos = _discover_repos()
+
+    repo_infos: list[tuple[Path, str, int]] = [(current_cwd, current_repo_name, 0)]
+    for idx, child in enumerate(child_repos):
+        repo_infos.append((child, child.name, idx + 1))
+
+    all_entries: list[tuple[int, str, str, str, str]] = []
+
+    for repo_path, repo_name, sort_prio in repo_infos:
+        repo_issues_dir = repo_path / ISSUES_DIR
+        if not repo_issues_dir.is_dir():
             continue
-        if num in seen:
-            continue
-        seen.add(num)
-        if not issue_exists(num):
-            continue
-        issue = yaml_load(read_file(get_issue_path(num) / "issue.yaml"))
-        title = issue.get("title", "")
-        status = issue.get("status", "open")
-        entries.append((num, status, title))
-    # Also check open/ directory
-    open_dir = issues_dir / "open"
-    if open_dir.is_dir():
-        for entry in sorted(open_dir.iterdir()):
+
+        try:
+            spec_path = str(repo_issues_dir.relative_to(current_cwd))
+        except ValueError:
+            spec_path = str(repo_issues_dir)
+
+        seen: set[int] = set()
+
+        for entry in sorted(repo_issues_dir.iterdir()):
             num = _parse_number(entry)
             if num is None or num in seen:
                 continue
             seen.add(num)
-            if not issue_exists(num):
+
+            issue_file = entry / "issue.yaml"
+            spec_file = entry / "spec.md"
+            has_yaml = issue_file.exists()
+            has_spec = spec_file.exists()
+            if not has_yaml and not has_spec:
                 continue
-            issue = yaml_load(read_file(get_issue_path(num) / "issue.yaml"))
-            title = issue.get("title", "")
-            entries.append((num, "open", title))
-    if not entries:
+
+            if has_yaml:
+                issue_data = yaml_load(read_file(issue_file))
+                if isinstance(issue_data, dict):
+                    title = issue_data.get("title", "")
+                    status = issue_data.get("status", "open")
+                else:
+                    title = ""
+                    status = "open"
+            else:
+                title = ""
+                status = "open"
+
+            display_num = f"{repo_name}#{num}"
+            all_entries.append((sort_prio, repo_name, display_num, status, title, spec_path, num))
+
+        open_dir = repo_issues_dir / "open"
+        if open_dir.is_dir():
+            for entry in sorted(open_dir.iterdir()):
+                num = _parse_number(entry)
+                if num is None or num in seen:
+                    continue
+                seen.add(num)
+                issue_file = entry / "issue.yaml"
+                if not issue_file.exists():
+                    continue
+                issue_data = yaml_load(read_file(issue_file))
+                title = issue_data.get("title", "") if isinstance(issue_data, dict) else ""
+                display_num = f"{repo_name}#{num}"
+                all_entries.append((sort_prio, repo_name, display_num, "open", title, spec_path, num))
+
+    if not all_entries:
         return
-    for num, status, title in entries:
-        print(f"#{num} [{status}] {title}")
+
+    all_entries.sort(key=lambda e: (e[0], e[1], -e[6]))
+
+    for _, _, display_num, status, title, spec_path, _ in all_entries:
+        print(f"{display_num} [{status}] {title} spec_path={spec_path}")
 
 
 def cmd_link(args: argparse.Namespace) -> None:


### PR DESCRIPTION
## Summary

Phase 1 of spec #1065: standardize `local-issues` tool output format for LLM consumption.

- Qualified `{repo}#{N}` format (current repo: bare `#N`, child repos: `childrepo#N`)
- `spec_path` column in list output (relative to project root)
- Sort order: main repo first, child repos alphabetically, issue numbers descending
- Fixed: status from YAML (was hardcoded to "open")

## Changes

| File | Change |
|------|--------|
| `tools/local-issues` | Rewrote `cmd_list()` with cross-repo iteration, qualified format, spec_path, sort |
| `tests/behaviors/local-issues-list-qualified-format.sh` | RED/GREEN test for SC-1 |
| `tests/behaviors/local-issues-list-spec-path.sh` | RED/GREEN test for SC-2 |
| `tests/behaviors/local-issues-list-sort-order.sh` | RED/GREEN test for SC-3 |

## Outcome

| SC | Criterion | Status |
|----|-----------|--------|
| SC-1 | `list` outputs qualified `{repo}#{N}` format excluding current repo prefix | ✅ |
| SC-2 | `list` outputs `spec_path` column relative to project root | ✅ |
| SC-3 | `list` sorts: main repo first, submodules alpha, issue number descending | ✅ |

🤖 Co-authored with AI: OpenCode (deepseek-v4-flash)