### PR TITLE
feat(#1086): RED/GREEN sequential pair discipline across TDD, spec, plan, and audit skills

### DIFF
--- a/skills/adversarial-audit/tasks/plan-fidelity.md
+++ b/skills/adversarial-audit/tasks/plan-fidelity.md
@@ -60,7 +60,7 @@ Read the existing plan from `spec_local_dir/`:
 | PF-3 | Steps cover ALL success criteria; missing any is automatic FAIL per spec gate | Each SC has corresponding step — missing any is automatic FAIL |
 | PF-4 | No missing critical steps | Edge cases, error recovery included |
 | PF-5 | Approach consistent | Clean-room and existing use same strategy |
-| PF-6 | TDD checkpoints present | RED GREEN REFACTOR structure |
+| PF-6 | TDD checkpoints present with RED/GREEN separation | RED GREEN REFACTOR structure present; RED and GREEN are separate phases, not combined |
 | PF-7a | Cost-frame prose + runtime execution in instructions | Each phase's implementation instructions carry cost-frame reformation prose and require real test execution with saved artifacts |
 | PF-7 | SC gate language preserved in plan tasks | Plan task structure references the all-or-nothing gate from spec; each TDD RED checkpoint is a sub-gate in the chain |
 | PF-STRUCTURAL-FAIL | Structural evidence rejected for behavioral SCs in plan instructions | If a plan phase's verification instructions accept structural evidence (grep/read/file-exists) for a behavioral SC, return FAIL with `STRUCTURAL_EVIDENCE` classification. **PF-STRUCTURAL-FAIL uplift:** When checking plan fidelity, if an implementation change affects runtime behavior, uplift the SC evidence type to `behavioral`. See `guidelines/000-critical-rules.md` §critical-rules-BEH-EV. Verification instructions MUST require behavioral test execution — structural checks do not verify behavior. |

--- a/skills/adversarial-audit/tasks/test-quality-audit.md
+++ b/skills/adversarial-audit/tasks/test-quality-audit.md
@@ -85,6 +85,14 @@ Is there evidence that the test was confirmed FAIL before implementation (in git
 - FAIL: No evidence of RED state — test was created alongside or after implementation
 - FAIL (inconclusive): Cannot determine order from available evidence
 
+#### 6. Sequential TDD (TQ-11)
+
+Across multiple test items, is there evidence of RED-before-GREEN ordering (each item's test FAILs before its implementation PASSes)?
+
+- PASS: Multiple items show individual RED/GREEN cycles — each test confirmed FAIL before its implementation was written
+- FAIL: Tests for multiple items were all written before any implementation (RED-ALL → GREEN-ALL pattern)
+- FAIL (inconclusive): Single item only, or insufficient git history to determine ordering
+
 ### Step 3: Produce Verdict
 
 ```yaml

--- a/skills/spec-creation/tasks/write.md
+++ b/skills/spec-creation/tasks/write.md
@@ -37,6 +37,8 @@ Invoke `issue-operations --task creation` with a minimal exec summary body to es
 
 **Cross-reference:** See `091-incremental-build.md` → Per-Item TDD Cycle → RED phase, `080-code-standards.md` → SC-to-Test Traceability and RED-Phase Ordering, and `080-code-standards.md` → Behavioral Enforcement Tests (PRIMARY) for the behavioral RED/GREEN gate.
 
+**Sequential per-item TDD:** Implementation phases in spec MUST enforce sequential RED/GREEN pairing per the TDD skill. Each RED must be immediately followed by its GREEN before the next RED begins. Combined RED/GREEN phases are prohibited.
+
 **Cost-frame mandate in SCs:** Each success criterion MUST carry a short cost-frame reformation statement that reframes what "expensive" means for that SC's domain. The statement uses the dark-prose-007 formula from `250-dark-prose-reference.md` §Section 3 — the implementing agent derives the exact prose autonomously based on the SC's verification method. Each SC's verification method MUST require a real test execution command — not a structural check (file exists, grep match). Structural verification is NEVER a valid substitute for behavioral execution: a skipped runtime equals a defect undiscovered. The death spiral / break dynamics are formalized in `065-verification-honesty.md` §Cost Model — behavioral PASS is a break (zero downstream cost); structural-only PASS is a death spiral (compounding exponential cost).
 
 ### Step 0.5a: Behavioral Test Definition — Stderr-Based Evidence (MANDATORY)

--- a/skills/test-driven-development/SKILL.md
+++ b/skills/test-driven-development/SKILL.md
@@ -12,10 +12,11 @@ compatibility: opencode
 ## Five Core Principles
 
 1. **FAIL=FAIL** — No soft-passing. Verify against live sources. Report PASS/FAIL truthfully.
-2. **TDD discipline** — RED phase tests before GREEN phase implementation. REFACTOR is mandatory, not optional.
-3. **Clean-room** — No inline fallback. Sub-agents receive only scoped context. No pre-determined findings.
-4. **Independent intelligence** — Autonomous analysis. If the task contains excessive instruction where your own analysis should apply, HALT and notify parent.
-5. **Verify LIVE** — Never trust training data, memory, or metadata. Verify against live docs, source code, and test results.
+2. **RED/GREEN separation** — RED and GREEN must be separate phases. They may NEVER be combined into a single phase or step. RED must complete (test written and confirmed FAIL) before GREEN begins. This is a hard gate — no authorization or developer instruction may override it.
+3. **TDD discipline** — RED phase tests before GREEN phase implementation. REFACTOR is mandatory, not optional.
+4. **Clean-room** — No inline fallback. Sub-agents receive only scoped context. No pre-determined findings.
+5. **Independent intelligence** — Autonomous analysis. If the task contains excessive instruction where your own analysis should apply, HALT and notify parent.
+6. **Verify LIVE** — Never trust training data, memory, or metadata. Verify against live docs, source code, and test results.
 
 ## ASCII Cycle Diagram
 
@@ -36,6 +37,16 @@ compatibility: opencode
 │   Next item ──► back to Phase 0                         │
 └──────────────────────────────────────────────────────────┘
 ```
+
+## Sequential Pair Mandate
+
+**RED/GREEN pairs execute sequentially.** When multiple RED/GREEN pairs exist (multiple implementation items), each RED must be immediately followed by its GREEN before the next RED begins. Running RED for multiple items before any GREEN starts is prohibited. The cycle is:
+
+```
+item-1-RED → item-1-GREEN → item-2-RED → item-2-GREEN → ...
+```
+
+Never `RED-ALL → GREEN-ALL`.
 
 ## Tasks
 

--- a/skills/test-driven-development/tasks/anti-patterns.md
+++ b/skills/test-driven-development/tasks/anti-patterns.md
@@ -15,8 +15,9 @@ Five common TDD anti-patterns with correct alternatives. Language-agnostic — a
 | 1 | **Too-Big Step** | RED→GREEN cycle takes >5 min, multiple asserts in one test | Writing too much implementation at once | Smaller test, one assertion per concept |
 | 2 | **Forgotten Red** | Test passes on first run | Test was written after implementation (or tests greenfield code) | Write test first, confirm FAIL before GREEN |
 | 3 | **Over-Mocking** | Tests pass but production breaks | Mocked interface doesn't match real behavior | Use real objects or contract tests; mock only external I/O |
-| 4 | **Green-Worship** | Code never refactored, accumulating technical debt | Fear of breaking passing tests | REFACTOR is mandatory, not optional. Tests protect you. |
-| 5 | **Test-Once** | Single test covers one happy-path only | Edge cases unaddressed, regressions slip through | Add edge-case tests in RED phase; triangulate |
+| 4 | **Combined-Phase** | RED and GREEN happen in the same step — test is written and implementation is written together without intermediate FAIL confirmation | Impatience or false efficiency | Always separate RED then GREEN. Write the test, confirm FAIL, then implement. RED and GREEN may NEVER be combined into one step. |
+| 5 | **Green-Worship** | Code never refactored, accumulating technical debt | Fear of breaking passing tests | REFACTOR is mandatory, not optional. Tests protect you. |
+| 6 | **Test-Once** | Single test covers one happy-path only | Edge cases unaddressed, regressions slip through | Add edge-case tests in RED phase; triangulate |
 
 ## Pattern Details
 
@@ -90,7 +91,33 @@ result = processor.process(validator)
 mock_post.assert_called_once()
 ```
 
-### 4. Green-Worship
+### 4. Combined-Phase
+
+**Symptom:** RED and GREEN happen in the same step — the test is written and the implementation is written together without confirming the test fails first.
+
+**Root cause:** Impatience (wanting to "save time" by doing both at once) or false efficiency (believing combined work is faster).
+
+**Fix:** Separate RED and GREEN into distinct phases. Write the test first, confirm it FAILs, then write the minimal implementation, confirm it PASSes. RED and GREEN may NEVER be combined into a single step.
+
+```python
+# WRONG — Combined-Phase (test and impl written together)
+def test_is_positive():
+    assert is_positive(5) is True
+# No RED confirmation — test might pass vacuously
+
+# RIGHT — separate RED then GREEN
+# RED: write test, confirm FAIL
+def test_is_positive():
+    assert is_positive(5) is True
+# Run → FAIL (is_positive doesn't exist yet)
+
+# GREEN: implement, confirm PASS
+def is_positive(n: int) -> bool:
+    return n > 0
+# Run → PASS
+```
+
+### 5. Green-Worship
 
 **Symptom:** Code smells accumulate. No one refactors because "tests pass."
 
@@ -118,7 +145,7 @@ def calc(a, b, op):
     return OPERATIONS[op](a, b)
 ```
 
-### 5. Test-Once
+### 6. Test-Once
 
 **Symptom:** Single happy-path test. Regressions appear in edge cases that "were never tested."
 

--- a/skills/test-driven-development/tasks/checklist.md
+++ b/skills/test-driven-development/tasks/checklist.md
@@ -25,6 +25,7 @@ Before starting a TDD cycle:
 - [ ] One assertion per test concept
 - [ ] Test makes no assumptions about implementation
 - [ ] Test correctly expresses the spec (not the implementation)
+- [ ] RED is a separate phase — no GREEN work started
 - [ ] **RUN THE TEST — confirm FAIL or ERROR**
 - [ ] Evidence of failure captured (tool call output)
 
@@ -34,6 +35,7 @@ Before starting a TDD cycle:
 - [ ] No speculative code (no "we might need this later")
 - [ ] No premature optimization
 - [ ] No new features beyond what the test requires
+- [ ] GREEN is a separate phase — RED was completed and confirmed FAIL before GREEN began
 - [ ] **RUN THE TEST — confirm PASS**
 - [ ] All previously passing tests still pass (`uv run pytest test/ -v`)
 

--- a/skills/test-driven-development/tasks/patterns.md
+++ b/skills/test-driven-development/tasks/patterns.md
@@ -49,6 +49,8 @@ uv run pytest test/ -v
 
 Use when a single test doesn't force the right generalization. Add a second, third example until the implementation naturally generalizes.
 
+**MANDATORY: Each RED must be immediately followed by its GREEN before the next RED begins.** Do not write all test cases first then implement them together — sequential pairing keeps each step small and forces generalization incrementally.
+
 ```
 RED (test case 1 → FAIL)
   ↓
@@ -81,6 +83,8 @@ Skip RED when the solution is trivially correct and the test would pass on first
 - One-liner implementation
 - No design decisions needed
 - Zero ambiguity about correctness
+
+**Even when skipping RED, GREEN is a separate phase.** RED may be omitted (per Obvious Implementation pattern rules), but RED and GREEN may NEVER be combined into a single step. When the implementation is trivially correct, write the test first, confirm it FAILs due to missing implementation, then implement.
 
 ```python
 # No RED needed — trivial

--- a/skills/writing-plans/tasks/create/plan-structure.md
+++ b/skills/writing-plans/tasks/create/plan-structure.md
@@ -100,6 +100,8 @@ Each item's RED/GREEN conditions MUST describe requirements, not implementation:
 
 **GREEN** = "what must be true when done" — the condition that proves completion. Uses "must be true" language. NO "implemented", "complete", or past-tense status language.
 
+**RED/GREEN MUST be defined as separate phases.** RED and GREEN may NEVER be combined into a single phase or step. RED describes the failure condition (what must be false), and GREEN describes the satisfaction condition (what must be true). They are separate concerns and MUST appear as separate entries in the plan structure.
+
 ```
 ✅ CORRECT RED: "The agent produces a plan with RED/GREEN conditions instead of prescriptive code"
 ✅ CORRECT GREEN: "Plans must describe what must be true, not how to achieve it"


### PR DESCRIPTION
## Summary

Adds explicit RED/GREEN separation prohibition and sequential pair mandate across the TDD skill, spec writer, plan writer, and adversarial auditors.

- TDD SKILL.md: RED/GREEN separation prohibition + sequential pair mandate
- Anti-patterns: New Combined-Phase anti-pattern
- Patterns: Triangulation and Obvious Implementation both mandate sequential pairs
- Checklist: RED/GREEN separation items added
- Spec creation: Sequential per-item TDD mandate
- Plan structure: RED/GREEN must be separate phases
- Plan-fidelity: PF-6 expanded for RED/GREEN separation
- Test quality: New TQ-11 for sequential TDD ordering

## SC Coverage

| SC | Criterion | Status |
|----|-----------|--------|
| SC-1 | RED/GREEN separation prohibition in TDD SKILL.md | ✅ |
| SC-2 | Sequential pair mandate in TDD SKILL.md | ✅ |
| SC-3 | Combined-Phase anti-pattern | ✅ |
| SC-4 | Triangulation sequential mandate | ✅ |
| SC-5 | RED/GREEN checklist separation items | ✅ |
| SC-6 | Spec-creation sequential TDD mandate | ✅ |
| SC-7 | Plan-structure RED/GREEN separate phases | ✅ |
| SC-8 | PF-6 expanded for RED/GREEN separation | ✅ |
| SC-9 | TQ-11 sequential TDD criterion | ✅ |
| SC-10 | Obvious Implementation sequential mandate | ✅ |
| SC-11 | Single concern (plan-level verification) | ✅ |

Fixes #1086

🤖 Co-authored with AI: OpenCode (deepseek-v4-flash)