### PR TITLE
[FIX] Route behavior_run through with-test-home for MCP subprocess env isolation

### DIFF
--- a/tests/behaviors/helpers.sh
+++ b/tests/behaviors/helpers.sh
@@ -254,33 +254,9 @@ behavior_run() {
 
     # --setup creates test home once before the retry loop
     local test_home=""
-    local env_file=""
     local setup_output
     setup_output=$(bash "$PARENT_REPO_DIR/$BEHAVIOR_TEST_HOME" --setup "$workdir")
     test_home=$(echo "$setup_output" | grep '^TEST_HOME=' | cut -d= -f2-)
-    if [ -n "$test_home" ]; then
-        env_file="$test_home/.env"
-        cat > "$env_file" <<ENVEOF
-HOME=$test_home
-XDG_CONFIG_HOME=$test_home/.config
-XDG_CACHE_HOME=$test_home/.cache
-XDG_RUNTIME_DIR=$test_home/.runtime
-XDG_DATA_HOME=$test_home/.local/share
-XDG_STATE_HOME=$test_home/.local/state
-PATH=$PATH
-SHELL=${SHELL:-/bin/bash}
-USER=${USER:-$(id -un)}
-LOGNAME=${LOGNAME:-$(id -un)}
-LANG=${LANG:-en_US.UTF-8}
-TERM=${TERM:-xterm-256color}
-ENVEOF
-        for var in GITHUB_TOKEN GH_TOKEN GH_AUTH_TOKEN SSH_AUTH_SOCK GIT_AUTHOR_NAME GIT_AUTHOR_EMAIL; do
-            if [ -n "${!var:-}" ]; then
-                echo "$var=${!var}" >> "$env_file"
-            fi
-        done
-    fi
-
     if [ -z "$test_home" ]; then
         echo "HARNESS_FAILURE: --setup failed to produce TEST_HOME" >&2
         return 1
@@ -290,11 +266,10 @@ ENVEOF
         attempt=$((attempt + 1))
         echo "  [attempt $attempt/$BEHAVIOR_MAX_RETRIES]"
 
-        cd "$workdir"
-        env -i /bin/sh -c ". $env_file && exec opencode-cli run \"$message\" --model \"$model\" --log-level INFO --print-logs ${agent:+--agent \"$agent\"}" \
+        TEST_WORKDIR="$workdir" \
+        bash "$PARENT_REPO_DIR/$BEHAVIOR_TEST_HOME" opencode-cli run "$message" --model "$model" --log-level INFO --print-logs ${agent:+--agent "$agent"} \
             > "$output_file" 2> "$err_file" \
             || true
-        cd "$PARENT_REPO_DIR"
 
         local output
         output=$(cat "$output_file" 2>/dev/null || true)

--- a/tests/with-test-home
+++ b/tests/with-test-home
@@ -114,7 +114,8 @@ seed_model_config() {
         $model_entries
       }
     }
-  }
+  },
+  "mcp": {}
 }
 JSONC
 
@@ -225,8 +226,12 @@ for var in GITHUB_TOKEN GH_TOKEN GH_AUTH_TOKEN SSH_AUTH_SOCK GIT_AUTHOR_NAME GIT
     fi
 done
 
+PWD_VALUE="$(pwd)"
+OPENCODE_CONFIG_CONTENT_VALUE='{"mcp":{"the-notebook-mcp":{"enabled":false}}}'
+
 env -i \
     HOME="$TEST_HOME" \
+    PWD="$PWD_VALUE" \
     XDG_CONFIG_HOME="$TEST_HOME/.config" \
     XDG_CACHE_HOME="$TEST_HOME/.cache" \
     XDG_RUNTIME_DIR="$TEST_HOME/.runtime" \
@@ -238,6 +243,7 @@ env -i \
     LOGNAME="${LOGNAME:-$(id -un)}" \
     LANG="${LANG:-en_US.UTF-8}" \
     TERM="${TERM:-xterm-256color}" \
+    OPENCODE_CONFIG_CONTENT="$OPENCODE_CONFIG_CONTENT_VALUE" \
     "${pass_through_env[@]}" \
     "$@"
 


### PR DESCRIPTION
## Summary

Replaces the manual `env -i + .env` file mechanism in `behavior_run()` with a direct call to `with-test-home`, and fixes two env isolation gaps in `with-test-home` that surfaced after the routing change.

## Changes

**`tests/behaviors/helpers.sh`** — `behavior_run()`:
- Removed `.env` file creation (23 lines of env var boilerplate)
- Replaced `env -i /bin/sh -c ". $env_file && exec opencode-cli run ..."` with `TEST_WORKDIR="$workdir" bash with-test-home opencode-cli run ...`
- Eliminated redundant `cd "$workdir"` / `cd "$PARENT_REPO_DIR"` — `with-test-home` handles working directory via `TEST_WORKDIR`

**`tests/with-test-home`** — `env -i` block:
- Added `PWD` passthrough (captured after `cd` to test directory) so `{env:PWD}` config references resolve correctly instead of empty string
- Added `OPENCODE_CONFIG_CONTENT` to override `the-notebook-mcp.enabled = false`, avoiding upstream `branding.py` crash when `--allow-root` path exceeds 52 characters

## Verification

```
opencode mcp list (in with-test-home isolated env)

the-notebook-mcp  ○ disabled     (intentional override)
srclight          ✓ connected    toolCount=25
viewport-editor   ✓ connected    toolCount=7
```

- `Executable not found in $PATH: uvx` errors: 0
- All `uvx`-based MCP servers start successfully in the isolated environment

## Fixes

https://github.com/michael-conrad/.opencode/issues/1076