### PR TITLE
fix: generate release PR body dynamically instead of boilerplate (#1075)

### DIFF
--- a/skills/git-workflow/tasks/release-promotion.md
+++ b/skills/git-workflow/tasks/release-promotion.md
@@ -214,7 +214,9 @@ github_create_pull_request(
     title="Release $NEXT_TAG: promote dev → main",
     head="$RELEASE_BRANCH",
     base="master",
-    body="Release $NEXT_TAG\n\nAutomated dev → main promotion.\n\n⚠️ This PR was prepared by an AI agent. Human review required before merge."
+    body=$(printf "Release $NEXT_TAG\n\n## Changes\n\n%s\n\n## Files Changed\n\n%s\n\n⚠️ This PR was prepared by an AI agent. Human review required before merge." \
+        "$(git log main..dev --oneline)" \
+        "$(git diff main...dev --stat)")
 )
 ```
 
@@ -255,7 +257,7 @@ Then create release via GitHub API with:
 ```markdown
 Release $NEXT_TAG
 
-Automated dev → main promotion.
+See PR description for changelog.
 ```
 
 **For GitBucket:** Use GitBucket API per `gitbucket-api` skill.
@@ -265,7 +267,7 @@ Automated dev → main promotion.
 ```markdown
 Release $NEXT_TAG
 
-Automated dev → main promotion.
+See PR description for changelog.
 ```
 
 ---

--- a/skills/git-workflow/tasks/release-promotion.md
+++ b/skills/git-workflow/tasks/release-promotion.md
@@ -203,11 +203,14 @@ git push origin "$RELEASE_BRANCH"
 
 ### Step N4: Create PR Targeting Main
 
-Create a release PR targeting `main`:
+Create a release PR targeting `main`.
+
+**Capture the delta between dev and main** — both commands below reference the same scope (what changed in dev since diverging from main). They are complementary views:
+
+- `RELEASE_COMMITS` — commit log shows individual commits (from `git log`)
+- `RELEASE_FILES` — file diff shows aggregate changes (from `git diff`)
 
 **For GitHub:**
-
-First capture the log output with a fallback for empty results:
 
 ```bash
 RELEASE_COMMITS=$(git log main..dev --oneline)
@@ -258,6 +261,33 @@ git push origin main --tags
 
 ### Step N8: (Post-merge) Create Platform Release
 
+The release body is generated dynamically from git history to capture a snapshot of the release content at the time of creation — it does not rely on the PR description, which may be stale or edited after merge.
+
+**Capture release content from git:**
+
+```bash
+RELEASE_DATE=$(date +%Y-%m-%d)
+RELEASE_COMMITS=$(git log "$(git tag --sort=-v:refname | head -1)..main" --oneline 2>/dev/null || echo "No previous tag found — listing recent commits:")
+if [ "$RELEASE_COMMITS" = "No previous tag found — listing recent commits:" ]; then
+    RELEASE_COMMITS+=$'\n'"$(git log --oneline -20 main)"
+fi
+RELEASE_FILES=$(git diff "$(git tag --sort=-v:refname | head -1)..main" --stat 2>/dev/null || echo "Full release — no prior tag to diff against.")
+
+RELEASE_BODY="Release $NEXT_TAG ($RELEASE_DATE)
+
+## Changes Since Last Release
+
+$RELEASE_COMMITS
+
+## Files Changed
+
+$RELEASE_FILES
+
+---
+
+*This release was prepared by an AI agent. Release snapshot created at $RELEASE_DATE.*"
+```
+
 **For GitHub:**
 
 Use GitHub MCP to create release:
@@ -266,23 +296,9 @@ Use GitHub MCP to create release:
 github_get_latest_release(owner=<github.owner>, repo=<github.repo>)
 ```
 
-Then create release via GitHub API with:
-
-```markdown
-Release $NEXT_TAG
-
-See PR description for changelog.
-```
+Then create release via GitHub API with the `$RELEASE_BODY` content above.
 
 **For GitBucket:** Use GitBucket API per `gitbucket-api` skill.
-
-**Release body template:**
-
-```markdown
-Release $NEXT_TAG
-
-See PR description for changelog.
-```
 
 ______________________________________________________________________
 

--- a/skills/git-workflow/tasks/release-promotion.md
+++ b/skills/git-workflow/tasks/release-promotion.md
@@ -54,7 +54,17 @@ ______________________________________________________________________
 
 ## Submodule Path
 
-### Step 0.5: Detect Semver Tags on Each Submodule
+### Step 0.5: Detect Default Branch for Submodules
+
+For each submodule `<path>`:
+
+```bash
+cd <path>
+DEFAULT_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD | sed 's|refs/remotes/origin/||')
+cd ..
+```
+
+### Step 0.75: Detect Semver Tags on Each Submodule
 
 For each submodule listed in `.gitmodules`:
 
@@ -167,6 +177,12 @@ ______________________________________________________________________
 
 ## Non-Submodule Path
 
+### Step N0: Detect Default Branch
+
+```bash
+DEFAULT_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD | sed 's|refs/remotes/origin/||')
+```
+
 ### Step N1: Determine Next Semver Tag
 
 **Auto-increment patch version:**
@@ -190,7 +206,7 @@ fi
 ### Step N2: Create Release Branch from Dev
 
 ```bash
-RELEASE_BRANCH="release/dev-to-main-v${NEXT_TAG#v}"
+RELEASE_BRANCH="release/dev-to-${DEFAULT_BRANCH}-v${NEXT_TAG#v}"
 git checkout dev
 git checkout -b "$RELEASE_BRANCH"
 ```
@@ -201,11 +217,11 @@ git checkout -b "$RELEASE_BRANCH"
 git push origin "$RELEASE_BRANCH"
 ```
 
-### Step N4: Create PR Targeting Main
+### Step N4: Create PR Targeting $DEFAULT_BRANCH
 
-Create a release PR targeting `main`.
+Create a release PR targeting `$DEFAULT_BRANCH`.
 
-**Capture the delta between dev and main** — both commands below reference the same scope (what changed in dev since diverging from main). They are complementary views:
+**Capture the delta between dev and $DEFAULT_BRANCH** — both commands below reference the same scope (what changed in dev since diverging from $DEFAULT_BRANCH). They are complementary views:
 
 - `RELEASE_COMMITS` — commit log shows individual commits (from `git log`)
 - `RELEASE_FILES` — file diff shows aggregate changes (from `git diff`)
@@ -213,8 +229,8 @@ Create a release PR targeting `main`.
 **For GitHub:**
 
 ```bash
-RELEASE_COMMITS=$(git log main..dev --oneline)
-RELEASE_FILES=$(git diff main...dev --stat)
+RELEASE_COMMITS=$(git log "$DEFAULT_BRANCH"..dev --oneline)
+RELEASE_FILES=$(git diff "$DEFAULT_BRANCH"...dev --stat)
 
 if [ -z "$RELEASE_COMMITS" ]; then
     RELEASE_COMMITS="No unreleased changes found — this release may be a dependency-sync or infrastructure update."
@@ -228,9 +244,9 @@ Then create the PR:
 github_create_pull_request(
     owner=<github.owner>,
     repo=<github.repo>,
-    title="Release $NEXT_TAG: promote dev → main",
+    title="Release $NEXT_TAG: promote dev → $DEFAULT_BRANCH",
     head="$RELEASE_BRANCH",
-    base="main",
+    base="$DEFAULT_BRANCH",
     body=$(printf "Release $NEXT_TAG\n\n## Changes\n\n%s\n\n## Files Changed\n\n%s\n\n⚠️ This PR was prepared by an AI agent. Human review required before merge." \
         "$RELEASE_COMMITS" \
         "$RELEASE_FILES")
@@ -245,18 +261,18 @@ Report the PR URL to chat. HALT and wait for the human to merge the PR.
 
 After human merges the PR, proceed to post-merge steps (N6-N8). These may be run in a subsequent session using `--task release-promotion --post-merge`.
 
-### Step N6: (Post-merge) Tag Main with Semver Tag
+### Step N6: (Post-merge) Tag $DEFAULT_BRANCH with Semver Tag
 
 ```bash
-git checkout main
-git pull origin main
+git checkout "$DEFAULT_BRANCH"
+git pull origin "$DEFAULT_BRANCH"
 git tag -a "$NEXT_TAG" -m "Release $NEXT_TAG"
 ```
 
 ### Step N7: (Post-merge) Push Tags
 
 ```bash
-git push origin main --tags
+git push origin "$DEFAULT_BRANCH" --tags
 ```
 
 ### Step N8: (Post-merge) Create Platform Release
@@ -267,11 +283,8 @@ The release body is generated dynamically from git history to capture a snapshot
 
 ```bash
 RELEASE_DATE=$(date +%Y-%m-%d)
-RELEASE_COMMITS=$(git log "$(git tag --sort=-v:refname | head -1)..main" --oneline 2>/dev/null || echo "No previous tag found — listing recent commits:")
-if [ "$RELEASE_COMMITS" = "No previous tag found — listing recent commits:" ]; then
-    RELEASE_COMMITS+=$'\n'"$(git log --oneline -20 main)"
-fi
-RELEASE_FILES=$(git diff "$(git tag --sort=-v:refname | head -1)..main" --stat 2>/dev/null || echo "Full release — no prior tag to diff against.")
+RELEASE_COMMITS=$(git log "$(git tag --sort=-v:refname | head -1)..$DEFAULT_BRANCH" --oneline 2>/dev/null)
+RELEASE_FILES=$(git diff "$(git tag --sort=-v:refname | head -1)..$DEFAULT_BRANCH" --stat 2>/dev/null)
 
 RELEASE_BODY="Release $NEXT_TAG ($RELEASE_DATE)
 

--- a/skills/git-workflow/tasks/release-promotion.md
+++ b/skills/git-workflow/tasks/release-promotion.md
@@ -247,7 +247,7 @@ github_create_pull_request(
     title="Release $NEXT_TAG: promote dev → $DEFAULT_BRANCH",
     head="$RELEASE_BRANCH",
     base="$DEFAULT_BRANCH",
-    body=$(printf "Release $NEXT_TAG\n\n## Changes\n\n%s\n\n## Files Changed\n\n%s\n\n⚠️ This PR was prepared by an AI agent. Human review required before merge." \
+    body=$(printf "Release $NEXT_TAG\n\n## Changes\n\n%s\n\n## Files Changed\n\n%s" \
         "$RELEASE_COMMITS" \
         "$RELEASE_FILES")
 )
@@ -298,7 +298,7 @@ $RELEASE_FILES
 
 ---
 
-*This release was prepared by an AI agent. Release snapshot created at $RELEASE_DATE.*"
+*Release snapshot created at $RELEASE_DATE.*"
 ```
 
 **For GitHub:**

--- a/skills/git-workflow/tasks/release-promotion.md
+++ b/skills/git-workflow/tasks/release-promotion.md
@@ -50,7 +50,7 @@ test -f .gitmodules
 - If `.gitmodules` EXISTS: Proceed to **Submodule Path** (Step 1)
 - If `.gitmodules` does NOT exist: Proceed to **Non-Submodule Path** (Step N1)
 
----
+______________________________________________________________________
 
 ## Submodule Path
 
@@ -163,7 +163,7 @@ After all submodules are tagged:
 
 After Step 3 passes, the parent repository may proceed with its own dev → main promotion via the Non-Submodule Path below. Submodule SHAs are already tagged and reachable — no submodule PR dependencies block parent promotion.
 
----
+______________________________________________________________________
 
 ## Non-Submodule Path
 
@@ -270,7 +270,7 @@ Release $NEXT_TAG
 See PR description for changelog.
 ```
 
----
+______________________________________________________________________
 
 ## Acceptance Criteria
 

--- a/skills/git-workflow/tasks/release-promotion.md
+++ b/skills/git-workflow/tasks/release-promotion.md
@@ -190,7 +190,7 @@ fi
 ### Step N2: Create Release Branch from Dev
 
 ```bash
-RELEASE_BRANCH="release/dev-to-master-v${NEXT_TAG#v}"
+RELEASE_BRANCH="release/dev-to-main-v${NEXT_TAG#v}"
 git checkout dev
 git checkout -b "$RELEASE_BRANCH"
 ```
@@ -201,11 +201,25 @@ git checkout -b "$RELEASE_BRANCH"
 git push origin "$RELEASE_BRANCH"
 ```
 
-### Step N4: Create PR Targeting Master
+### Step N4: Create PR Targeting Main
 
-Create a release PR targeting `master` (or `main`):
+Create a release PR targeting `main`:
 
 **For GitHub:**
+
+First capture the log output with a fallback for empty results:
+
+```bash
+RELEASE_COMMITS=$(git log main..dev --oneline)
+RELEASE_FILES=$(git diff main...dev --stat)
+
+if [ -z "$RELEASE_COMMITS" ]; then
+    RELEASE_COMMITS="No unreleased changes found — this release may be a dependency-sync or infrastructure update."
+    RELEASE_FILES=""
+fi
+```
+
+Then create the PR:
 
 ```
 github_create_pull_request(
@@ -213,10 +227,10 @@ github_create_pull_request(
     repo=<github.repo>,
     title="Release $NEXT_TAG: promote dev → main",
     head="$RELEASE_BRANCH",
-    base="master",
+    base="main",
     body=$(printf "Release $NEXT_TAG\n\n## Changes\n\n%s\n\n## Files Changed\n\n%s\n\n⚠️ This PR was prepared by an AI agent. Human review required before merge." \
-        "$(git log main..dev --oneline)" \
-        "$(git diff main...dev --stat)")
+        "$RELEASE_COMMITS" \
+        "$RELEASE_FILES")
 )
 ```
 
@@ -228,18 +242,18 @@ Report the PR URL to chat. HALT and wait for the human to merge the PR.
 
 After human merges the PR, proceed to post-merge steps (N6-N8). These may be run in a subsequent session using `--task release-promotion --post-merge`.
 
-### Step N6: (Post-merge) Tag Master with Semver Tag
+### Step N6: (Post-merge) Tag Main with Semver Tag
 
 ```bash
-git checkout master
-git pull origin master
+git checkout main
+git pull origin main
 git tag -a "$NEXT_TAG" -m "Release $NEXT_TAG"
 ```
 
 ### Step N7: (Post-merge) Push Tags
 
 ```bash
-git push origin master --tags
+git push origin main --tags
 ```
 
 ### Step N8: (Post-merge) Create Platform Release

--- a/skills/git-workflow/tasks/release-promotion.md
+++ b/skills/git-workflow/tasks/release-promotion.md
@@ -219,26 +219,20 @@ git push origin "$RELEASE_BRANCH"
 
 ### Step N4: Create PR Targeting $DEFAULT_BRANCH
 
-Create a release PR targeting `$DEFAULT_BRANCH`.
+Create a release PR targeting `$DEFAULT_BRANCH`. The PR body MUST summarize what changed, why, and the functional impact — not just dump raw commit messages.
 
-**Capture the delta between dev and $DEFAULT_BRANCH** — both commands below reference the same scope (what changed in dev since diverging from $DEFAULT_BRANCH). They are complementary views:
+**Synthesize the PR body from issue context:**
 
-- `RELEASE_COMMITS` — commit log shows individual commits (from `git log`)
-- `RELEASE_FILES` — file diff shows aggregate changes (from `git diff`)
+1. Capture the commit log: `git log "$DEFAULT_BRANCH"..dev --oneline`
+2. For each commit, extract the issue number from the commit message and read the corresponding issue body to determine the change's intent and impact
+3. Categorize changes by type: new features, bug fixes, refactors, maintenance
+4. Generate a structured PR body with:
+   - Summary paragraph: what this release encompasses (1-3 sentences synthesizing intent across all changes)
+   - Changes section: per-category breakdown with issue references and functional impact descriptions
+   - Files changed: `git diff "$DEFAULT_BRANCH"...dev --stat`
+5. If no unreleased changes exist (`git log` output is empty), state that explicitly
 
 **For GitHub:**
-
-```bash
-RELEASE_COMMITS=$(git log "$DEFAULT_BRANCH"..dev --oneline)
-RELEASE_FILES=$(git diff "$DEFAULT_BRANCH"...dev --stat)
-
-if [ -z "$RELEASE_COMMITS" ]; then
-    RELEASE_COMMITS="No unreleased changes found — this release may be a dependency-sync or infrastructure update."
-    RELEASE_FILES=""
-fi
-```
-
-Then create the PR:
 
 ```
 github_create_pull_request(
@@ -247,9 +241,7 @@ github_create_pull_request(
     title="Release $NEXT_TAG: promote dev → $DEFAULT_BRANCH",
     head="$RELEASE_BRANCH",
     base="$DEFAULT_BRANCH",
-    body=$(printf "Release $NEXT_TAG\n\n## Changes\n\n%s\n\n## Files Changed\n\n%s" \
-        "$RELEASE_COMMITS" \
-        "$RELEASE_FILES")
+    body=<synthesized body per above>
 )
 ```
 
@@ -277,33 +269,21 @@ git push origin "$DEFAULT_BRANCH" --tags
 
 ### Step N8: (Post-merge) Create Platform Release
 
-The release body is generated dynamically from git history to capture a snapshot of the release content at the time of creation — it does not rely on the PR description, which may be stale or edited after merge.
+Generate the release body by summarizing what changed since the last release, organized by category with functional impact. Do not dump raw commit messages — synthesize intent from commit messages and any linked issue context.
 
-**Capture release content from git:**
+**Capture release context:**
 
 ```bash
 RELEASE_DATE=$(date +%Y-%m-%d)
-RELEASE_COMMITS=$(git log "$(git tag --sort=-v:refname | head -1)..$DEFAULT_BRANCH" --oneline 2>/dev/null)
-RELEASE_FILES=$(git diff "$(git tag --sort=-v:refname | head -1)..$DEFAULT_BRANCH" --stat 2>/dev/null)
-
-RELEASE_BODY="Release $NEXT_TAG ($RELEASE_DATE)
-
-## Changes Since Last Release
-
-$RELEASE_COMMITS
-
-## Files Changed
-
-$RELEASE_FILES
-
----
-
-*Release snapshot created at $RELEASE_DATE.*"
+LAST_TAG=$(git tag --sort=-v:refname | head -1)
+RELEASE_COMMITS=$(git log "$LAST_TAG..$DEFAULT_BRANCH" --oneline 2>/dev/null)
 ```
 
-**For GitHub:**
-
-Use GitHub MCP to create release:
+Then synthesize a release body with:
+- Release version and date
+- Summary paragraph of what this release encompasses
+- Changes section: category grouping by feature/fix/maintenance with per-item descriptions
+- No boilerplate, no raw commit dumps, no disclaimers
 
 ```
 github_get_latest_release(owner=<github.owner>, repo=<github.repo>)

--- a/tests/behaviors/test-release-pr-body-behavioral.sh
+++ b/tests/behaviors/test-release-pr-body-behavioral.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# Behavioral test: release-pr-body-behavioral
+# See .opencode/tests/AGENTS.md for the test harness specification and paradigm.
+# This script is an artifact-only generator — it does NOT evaluate model output.
+#
+# SPDX-FileCopyrightText: 2026 michael-conrad
+# SPDX-License-Identifier: MIT
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/helpers.sh"
+
+SCENARIO_NAME="release-pr-body-behavioral"
+SCENARIO_PROMPT="Perform a release promotion to v1.2.3"
+BEHAVIOR_PHASE="RED"
+
+behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT"
+exit 0

--- a/tests/behaviors/test-release-pr-body-desired.sh
+++ b/tests/behaviors/test-release-pr-body-desired.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# SC: Release promotion PR body uses dynamically generated content from git log/git diff,
+# NOT generic boilerplate like "Automated dev → main promotion"
+# RED phase: test FAILS because boilerplate IS still present
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+RELEASE_TASK="$SCRIPT_DIR/../../skills/git-workflow/tasks/release-promotion.md"
+
+if [ ! -f "$RELEASE_TASK" ]; then
+  echo "FAIL: release-promotion.md not found at $RELEASE_TASK"
+  exit 1
+fi
+
+# Check for generic boilerplate pattern — if found, test fails (RED = bug exists)
+if grep -q "Automated dev → main promotion" "$RELEASE_TASK"; then
+  echo "RED: Boilerplate 'Automated dev → main promotion' IS present (bug confirmed, test fails as expected)"
+  exit 1
+else
+  echo "GREEN: Boilerplate removed (desired behavior achieved)"
+  exit 0
+fi


### PR DESCRIPTION
## Summary

Replaced generic `"Automated dev → main promotion"` boilerplate in `release-promotion.md` with semantic PR body synthesis: the agent reads issue bodies from commits, categorizes changes, and summarizes intent and functional impact.

## Key Changes

- **Step N4**: Agent reads issue bodies, categorizes changes (feature/fix/maintenance), writes structured PR with summary + categorized changes + functional impact
- **Step N8**: Same synthesis approach for release body vs last tag
- **$DEFAULT_BRANCH**: Dynamic detection to support both `main` and `master` repos
- **No noise**: AI-disclaimers removed (byline signals authorship), dead code removed

## Files

- `skills/git-workflow/tasks/release-promotion.md`
- `tests/behaviors/test-release-pr-body-desired.sh` (new)
- `tests/behaviors/test-release-pr-body-behavioral.sh` (new)
- `.issues/1075/spec.md` — authoritative spec

## Audit

Cross-family dual audit (mistral-large + qwen3.5): **5/5 SCs PASS**

🤖 OpenCode (ollama-cloud/deepseek-v4-flash)