### PR TITLE
feat: init + sync verbs, qualified mutations, sync-from-remote task, test timeout docs

### DIFF
--- a/skills/issue-operations/SKILL.md
+++ b/skills/issue-operations/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: issue-operations
-description: Use when creating, commenting on, or closing GitHub Issues. Routes to GitHub MCP or GitBucket API based on github.platform. Triggers on: create issue, new issue, spec creation, submit issue, issue, bug report, comment, progress update, issue comment, PR comment, post to GitHub, byline, status indicator, sub-issue, phase issue, multi-task, create sub issue, link issue, task breakdown, subtask, parent issue, close issue, verify merge. Bypassing issue tracking produces untracked work that gets lost. Tracked work is the only work that matters.
+description: Use when creating, commenting on, or closing GitHub Issues. Routes to GitHub MCP or GitBucket API based on github.platform. Triggers on: create issue, new issue, spec creation, submit issue, issue, bug report, comment, progress update, issue comment, PR comment, post to GitHub, byline, status indicator, sub-issue, phase issue, multi-task, create sub issue, link issue, task breakdown, subtask, parent issue, close issue, verify merge, sync-from-remote, post-sync reconcile, reconcile remote issues. Bypassing issue tracking produces untracked work that gets lost. Tracked work is the only work that matters.
 type: discipline-enforcing
 license: MIT
 provenance: AI-generated
@@ -38,6 +38,7 @@ Issue Operations Router. Focus: spec-first workflow, validation, labeling, platf
 | `read-sub-issues` | ≈120 | Read sub-issues via dispatcher — authorization cascade and closure order verification |
 | `list-issues` | ≈130 | List issues with filters via dispatcher — dedup checks, label search, overlap detection |
 | `search-issues` | ≈130 | Search issues via dispatcher — title dedup, spec/plan overlap detection |
+| `sync-from-remote` | ≈500 | Reconcile remote issues against local `.issues/` after `local-issues sync` — detect staleness in both directions, auto-import missing remote issues |
 | `update-issue` | ≈160 | Update issue body/labels/state via dispatcher — body-preservation safeguard enforced |
 | `sync-pull-to-local` | ≈600 | Mirror remote issue body to `.issues/<N>/spec.md` after any `read-issue` — enforces Operating Protocol §3 spec.md mirror mandate |
 | `import-remote` | ≈690 | Retroactively import a pre-existing remote issue into local `.issues/` — full mirror with body, comments, frontmatter, and `promotion_type: retroactive_import` |
@@ -64,6 +65,7 @@ Issue Operations Router. Focus: spec-first workflow, validation, labeling, platf
 | `search-issues` | `task(..., prompt: "execute search-issues task from issue-operations")` |
 | `update-issue` | `task(..., prompt: "execute update-issue task from issue-operations")` |
 | `sync-pull-to-local` | `task(..., prompt: "execute sync-pull-to-local task from issue-operations")` |
+| `sync-from-remote` | `task(..., prompt: "execute sync-from-remote task from issue-operations")` |
 | `import-remote` | `task(..., prompt: "execute import-remote task from issue-operations")` |
 | `push-artifacts` | `task(..., prompt: "execute push-artifacts task from issue-operations")` |
 

--- a/skills/issue-operations/tasks/sync-from-remote.md
+++ b/skills/issue-operations/tasks/sync-from-remote.md
@@ -1,0 +1,42 @@
+## Task: sync-from-remote
+
+**Trigger:** After `local-issues sync` — reconcile remote issues against local `.issues/`.
+
+### Purpose
+
+Ensure local `.issues/` mirrors all open remote issues. Detect staleness in both directions.
+
+### Procedure
+
+1. Call `local-issues sync` (ensure git state is current across all repos)
+2. For each repo in cascade (current repo + child repos):
+   a. List open issues from remote via platform dispatcher
+   b. Call `local-issues list` and parse issue numbers
+   c. Diff: for each remote issue not in local → call `import-remote` task
+   d. For issues in both: compare `updated_at` on remote vs local
+      - remote newer → call `sync-pull-to-local` (update `remote.md`)
+      - local newer → flag: `local_ahead: "issue {qualifier}#{N} is ahead of remote"`
+3. Report structured YAML:
+   ```yaml
+   sync-from-remote:
+     repos:
+       - qualifier: opencode-config
+         imported: [N, N, N]
+         stale_remote_ahead: [{number: N, title: "..."}]
+         stale_local_ahead: [{number: N, title: "..."}]
+   ```
+
+### Dispatch Context
+
+- `worktree.path`
+- `github.owner`
+- `github.repo`
+- `github.platform`
+
+### Output
+
+Always output YAML. If no remote is configured (platform == local), report `no_remote: true` and skip.
+
+### Authorization
+
+Authorization-free — reconciling local state against remote is read-only metadata sync per `.issues/AGENTS.md`. No `"approved"` or `"go"` needed.

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -4,6 +4,10 @@
 
 Every behavioral test script generates model-run artifacts and exits 0. Evaluation is the orchestrator's job — scripts NEVER evaluate model output.
 
+> **MANDATORY: Bash tool timeout MUST be >= 600 seconds when running behavioral tests.**
+> No `timeout` command inside scripts (nested timeouts create orphaned processes).
+> See §Infrastructure Details — Bash Tool Timeout Mandate.
+
 ## Table of Contents
 
 1. [Paradigm: Artifact-Only Generators](#1-paradigm-artifact-only-generators)
@@ -244,7 +248,35 @@ bash .opencode/tests/with-test-home --clean-all
 
 The wrapper creates an isolated temporary home directory (`tmp/test-home-<timestamp>`) with clean XDG state.
 
+### Bash Tool Timeout Mandate — ZERO TOLERANCE
+
+**The bash tool's `timeout` parameter is the ONLY kill signal that may be used when running behavioral tests.** Any use of the `timeout` command (or timer-equivalent utilities) inside a bash script invoked by the bash tool is FORBIDDEN.
+
+**Reason:** When the bash tool kills a script via its outer `timeout` mechanism, SIGTERM hits the script's shell process. If that shell has spawned a child process wrapped in `timeout`, GNU `timeout` does NOT forward SIGTERM to its child — it only kills its own `wait()`. The inner `opencode-cli run` becomes orphaned, still holding resources (the `flock` lock, test home directory handles, possibly the model connection). Every subsequent test invocation hangs on the orphaned lock. Recovery requires `kill -9` on the orphan process.
+
+The prohibition covers ALL timer commands and constructs — not just `timeout(1)` but also `alarm()`, `SIGALRM` traps, timer-based `sleep N && kill $$` patterns, and any other mechanism that delivers a timed kill signal inside the bash script. The bash tool's single outer timeout is the ONLY allowed kill mechanism.
+
+**Allowed — NOT a timer:**
+- `opencode-cli run` session resumption: on SSE read timeout or transient model error, use `opencode-cli run "continue" --task_id <prior-task_id>` to resume the session. This is a model-level retry, not a process-level kill. Multi-turn sessions are the correct way to retry after SSE timeouts.
+- `sleep` between retry attempts (sleep is not a kill mechanism)
+- Pattern-matching stderr for `sse.*timeout` to trigger session resumption
+
+**Mandated bash tool invocation:**
+```
+# timeout=600000 (600 seconds, milliseconds). NEVER omit.
+```
+
+**Existing violations:** `test-enforcement.sh:886` and `test-verification-honesty.sh:83` use `timeout` wrapping `opencode-cli run`. These MUST be refactored to remove the inner `timeout` and use session resumption for transient errors.
+
+No exceptions. No justifications. No "it worked in testing." Every nested `timeout` will eventually orphan a child and hang the test suite.
+
 ### Isolated Test Repo Construction
+
+**MANDATORY: Behavioral tests MUST NOT touch the main project root or its .issues/ directory.**
+
+The test repo created by `behavior_run` is a fully isolated git repository. It clones `.opencode` from remote, checks out the feature branch commit, seeds fixture data, and runs `opencode-cli` inside itself. The main project's `.issues/`, `.opencode/` state, SQLite database, and any other mutable state MUST never be read, written, or otherwise touched by a behavioral test.
+
+The `with-test-home` wrapper, combined with `behavior_run`'s isolated repo construction, enforces this: the test runs in `$TEST_HOME` with `$TEST_WORKDIR` pointing to the isolated repo. No path in the test chain resolves to the main project.
 
 When `behavior_run` does not receive an explicit workdir, it creates an isolated git repository:
 

--- a/tests/behaviors/1102-sc-1-init-bootstrap.sh
+++ b/tests/behaviors/1102-sc-1-init-bootstrap.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# Behavioral test: 1102-sc-1-init-bootstrap
+# See .opencode/tests/AGENTS.md for the test harness specification and paradigm.
+# This script is an artifact-only generator — it does NOT evaluate model output.
+#
+# SC-1: local-issues init bootstraps orphan issues-data branch + worktree
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../helpers.sh"
+
+SCENARIO_NAME="1102-sc-1-init-bootstrap"
+SCENARIO_PROMPT="Run \`local-issues init\` in a fresh repo. Report the output and whether it shows per-repo YAML with repo, qualifier, status, issues_count, and pull_result fields."
+
+behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT"
+exit 0

--- a/tests/behaviors/1102-sc-2-init-delegates-to-sync.sh
+++ b/tests/behaviors/1102-sc-2-init-delegates-to-sync.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# Behavioral test: 1102-sc-2-init-delegates-to-sync
+# See .opencode/tests/AGENTS.md for the test harness specification and paradigm.
+# This script is an artifact-only generator — it does NOT evaluate model output.
+#
+# SC-2: local-issues init delegates to sync when worktree exists
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../helpers.sh"
+
+SCENARIO_NAME="1102-sc-2-init-delegates-to-sync"
+SCENARIO_PROMPT="Run \`local-issues init\` on a repo where .issues/ worktree already exists. Report whether the output shows sync delegation (pull + push)."
+
+behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT"
+exit 0

--- a/tests/behaviors/1102-sc-3-init-conflict-report.sh
+++ b/tests/behaviors/1102-sc-3-init-conflict-report.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# Behavioral test: 1102-sc-3-init-conflict-report
+# See .opencode/tests/AGENTS.md for the test harness specification and paradigm.
+# This script is an artifact-only generator — it does NOT evaluate model output.
+#
+# SC-3: init reports per-repo YAML with qualifier + conflict hint
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../helpers.sh"
+
+SCENARIO_NAME="1102-sc-3-init-conflict-report"
+SCENARIO_PROMPT="Run \`local-issues init\`. Report whether the output contains 'status: conflict' with a qualifier string and a git -C command hint for manual resolution."
+
+behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT"
+exit 0

--- a/tests/behaviors/1102-sc-4-sync-git-ops.sh
+++ b/tests/behaviors/1102-sc-4-sync-git-ops.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# Behavioral test: 1102-sc-4-sync-git-ops
+# See .opencode/tests/AGENTS.md for the test harness specification and paradigm.
+# This script is an artifact-only generator — it does NOT evaluate model output.
+#
+# SC-4: local-issues sync commits, pull-rebase, pushes
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../helpers.sh"
+
+SCENARIO_NAME="1102-sc-4-sync-git-ops"
+SCENARIO_PROMPT="Run \`local-issues sync\`. Report whether the output shows git operations: adding pending changes, committing, pulling remote with rebase, and pushing merged result."
+
+behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT"
+exit 0

--- a/tests/behaviors/1102-sc-5-sync-ok-conflict.sh
+++ b/tests/behaviors/1102-sc-5-sync-ok-conflict.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# Behavioral test: 1102-sc-5-sync-ok-conflict
+# See .opencode/tests/AGENTS.md for the test harness specification and paradigm.
+# This script is an artifact-only generator — it does NOT evaluate model output.
+#
+# SC-5: sync reports ok/conflict with qualifier per repo
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../helpers.sh"
+
+SCENARIO_NAME="1102-sc-5-sync-ok-conflict"
+SCENARIO_PROMPT="Run \`local-issues sync\`. Report whether the output per-repo YAML contains 'status: ok' or 'status: conflict' alongside a qualifier field."
+
+behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT"
+exit 0

--- a/tests/behaviors/1102-sc-6-qualified-format.sh
+++ b/tests/behaviors/1102-sc-6-qualified-format.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# Behavioral test: 1102-sc-6-qualified-format
+# See .opencode/tests/AGENTS.md for the test harness specification and paradigm.
+# This script is an artifact-only generator — it does NOT evaluate model output.
+#
+# SC-6: All output uses dirname#N, never bare #N
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../helpers.sh"
+
+SCENARIO_NAME="1102-sc-6-qualified-format"
+SCENARIO_PROMPT="Run \`local-issues list\` and check the output format. Report whether ALL issues use the format 'dirname#N' (e.g. 'opencode-config#42') or whether some use bare '#N'."
+
+behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT"
+exit 0

--- a/tests/behaviors/1102-sc-7-sync-from-remote-task.sh
+++ b/tests/behaviors/1102-sc-7-sync-from-remote-task.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# Behavioral test: 1102-sc-7-sync-from-remote-task
+# See .opencode/tests/AGENTS.md for the test harness specification and paradigm.
+# This script is an artifact-only generator — it does NOT evaluate model output.
+#
+# SC-7: sync-from-remote skill task exists and reconciles remote->local
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../helpers.sh"
+
+SCENARIO_NAME="1102-sc-7-sync-from-remote-task"
+SCENARIO_PROMPT="Check whether the file .opencode/skills/issue-operations/tasks/sync-from-remote.md exists. If yes, describe its content purpose. If no, report it doesn't exist."
+
+behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT"
+exit 0

--- a/tests/behaviors/1102-sc-8-mutation-auto-commit.sh
+++ b/tests/behaviors/1102-sc-8-mutation-auto-commit.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# Behavioral test: 1102-sc-8-mutation-auto-commit
+# See .opencode/tests/AGENTS.md for the test harness specification and paradigm.
+# This script is an artifact-only generator — it does NOT evaluate model output.
+#
+# SC-8: Mutation commands still auto-commit + push (unchanged)
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../helpers.sh"
+
+SCENARIO_NAME="1102-sc-8-mutation-auto-commit"
+SCENARIO_PROMPT="Run \`local-issues create --number 1 --title test --labels SPEC\` in a repo with .issues/ worktree. After creation, run \`git -C .issues log --oneline -1\`. Report whether the create command triggered an auto-commit on the issues-data branch."
+
+behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT"
+exit 0

--- a/tests/behaviors/helpers.sh
+++ b/tests/behaviors/helpers.sh
@@ -11,10 +11,32 @@
 # All paths are relative to the project root, discovered by walking up from
 # the helper's own location until a directory containing .opencode/ is found.
 # This works identically in isolated test repos and the live repo.
+#
+# ╔══════════════════════════════════════════════════════════════════════════════╗
+# ║  MANDATORY: BASH TOOL TIMEOUT MUST BE >= 600 SECONDS (timeout: 600000ms)   ║
+# ║                                                                              ║
+# ║  DO NOT omit the bash tool `timeout` parameter — NEVER use default 120s.     ║
+# ║  This script spawns `opencode-cli run` which can take 5+ minutes. Default    ║
+# ║  bash tool timeout (120s) WILL kill this script mid-execution, leaving        ║
+# ║  orphaned processes, orphaned test homes, corrupted lock files, and zombie    ║
+# ║  opencode-cli processes.                                                      ║
+# ║                                                                              ║
+# ║  Always pass `timeout: 600000` (600 seconds, milliseconds) to the bash tool  ║
+# ║  when invoking any script in tests/behaviors/.                               ║
+# ║                                                                              ║
+# ║  NO NESTED TIMEOUTS — the bash tool timeout is the ONLY kill signal.         ║
+# ║  Do NOT use the `timeout` command or any timer utility inside this script.   ║
+# ║  GNU timeout does NOT forward SIGTERM to its children — orphaned opencode-   ║
+# ║  cli processes hold the flock lock and hang all subsequent test runs.        ║
+# ║                                                                              ║
+# ║  On SSE read timeout or transient model error: resume the session via        ║
+# ║  `opencode-cli run "continue" --task_id <id>` — NEVER kill and restart.      ║
+# ║                                                                              ║
+# ║  Violation = orphaned processes = hang = manual kill -9 required.            ║
+# ╚══════════════════════════════════════════════════════════════════════════════╝
 
 set -euo pipefail
 
-BEHAVIOR_TIMEOUT="${BEHAVIOR_TIMEOUT:-420}"
 BEHAVIOR_MODEL="${BEHAVIOR_MODEL:-ollama/deepseek-v4-flash:cloud}"
 BEHAVIOR_PHASE="${BEHAVIOR_PHASE:-GREEN}"
 BEHAVIOR_TEST_HOME="${BEHAVIOR_TEST_HOME:-.opencode/tests/with-test-home}"

--- a/tools/local-issues
+++ b/tools/local-issues
@@ -509,31 +509,6 @@ def _count_issues(repo_path: Path) -> int:
     return count
 
 
-def _pull_and_report(repo_path: Path, qualifier: str) -> dict:
-    """Pull remote issues-data branch with rebase, return structured result.
-
-    Returns dict with status: ok|conflict|no_worktree|timeout.
-    """
-    issues_path = repo_path / ISSUES_DIR
-    if not (issues_path / ".git").is_file():
-        return {"status": "no_worktree", "pull_result": ""}
-    try:
-        result = subprocess.run(
-            ["git", "-C", str(issues_path), "pull", "--rebase", "origin", WORKTREE_BRANCH],
-            capture_output=True, text=True, timeout=30,
-        )
-        if result.returncode == 0:
-            return {"status": "ok", "pull_result": result.stdout.strip()}
-        return {
-            "status": "conflict",
-            "pull_result": result.stdout.strip(),
-            "conflict_hint": f"git -C {repo_path}/{ISSUES_DIR} rebase --abort && git -C {repo_path}/{ISSUES_DIR} pull origin {WORKTREE_BRANCH}",
-            "conflict_stderr": result.stderr.strip(),
-        }
-    except subprocess.TimeoutExpired:
-        return {"status": "timeout", "pull_result": ""}
-
-
 def _collect_repos() -> list[tuple[Path, str]]:
     """Collect (repo_path, qualifier) for current repo and all child repos."""
     current = Path(os.getcwd()).resolve()
@@ -1273,72 +1248,66 @@ def cmd_promote(args: argparse.Namespace) -> None:
     print(f"  github_url: {gh_url or '(not set)'}")
 
 
+def _sync_repo(repo_path: Path, qualifier: str, issues_dir: Path | None = None) -> dict:
+    """Core sync logic for a single repo. Returns status dict."""
+    if issues_dir is None:
+        issues_dir = repo_path / ISSUES_DIR
+    entry: dict = {"qualifier": qualifier, "path": str(repo_path)}
+
+    if not (issues_dir / ".git").is_file():
+        entry["status"] = "no_worktree"
+        return entry
+
+    try:
+        subprocess.run(
+            ["git", "-C", str(issues_dir), "add", "-A"],
+            capture_output=True, timeout=15,
+        )
+        subprocess.run(
+            ["git", "-C", str(issues_dir), "commit", "--allow-empty", "-m", "auto: sync"],
+            capture_output=True, timeout=15,
+        )
+        pull = subprocess.run(
+            ["git", "-C", str(issues_dir), "pull", "--rebase", "origin", WORKTREE_BRANCH],
+            capture_output=True, text=True, timeout=30,
+        )
+        if pull.returncode != 0:
+            entry["status"] = "conflict"
+            entry["pull_result"] = pull.stderr.strip()
+            entry["conflict_hint"] = f"git -C {issues_dir} pull --rebase origin {WORKTREE_BRANCH}"
+            return entry
+        push = subprocess.run(
+            ["git", "-C", str(issues_dir), "push", "origin", WORKTREE_BRANCH],
+            capture_output=True, text=True, timeout=30,
+        )
+        if push.returncode == 0:
+            entry["status"] = "ok"
+            entry["pull_result"] = pull.stdout.strip() or "up_to_date"
+        else:
+            entry["status"] = "push_failed"
+            entry["push_result"] = push.stderr.strip()
+    except subprocess.TimeoutExpired:
+        entry["status"] = "timeout"
+    return entry
+
+
 def cmd_init(args: argparse.Namespace) -> None:
-    """Initialize worktrees and pull remote issues-data for all repos."""
+    """Bootstrap worktrees and sync for all repos. Delegates to _sync_repo()."""
     _ensure_all_worktrees()
     repos_info: list[dict] = []
     for repo_path, qualifier in _collect_repos():
         issues_count = _count_issues(repo_path)
-        pull_result = _pull_and_report(repo_path, qualifier)
-        entry = {
-            "repo": qualifier,
-            "qualifier": qualifier,
-            "path": str(repo_path),
-            "status": pull_result["status"],
-            "issues_count": issues_count,
-            "pull_result": pull_result["pull_result"],
-        }
-        if "conflict_hint" in pull_result:
-            entry["conflict_hint"] = pull_result["conflict_hint"]
-        if "conflict_stderr" in pull_result:
-            entry["conflict_stderr"] = pull_result["conflict_stderr"]
-        repos_info.append(entry)
+        result = _sync_repo(repo_path, qualifier)
+        result["issues_count"] = issues_count
+        repos_info.append(result)
     print(yaml_dump({"init": True, "repos": repos_info}))
 
 
 def cmd_sync(args: argparse.Namespace) -> None:
-    """Commit pending changes, pull-rebase, then push for all repos."""
+    """Commit, pull-rebase, and push for all repos."""
     repos_info: list[dict] = []
     for repo_path, qualifier in _collect_repos():
-        issues_path = repo_path / ISSUES_DIR
-        has_worktree = (issues_path / ".git").is_file()
-        if not has_worktree:
-            repos_info.append({
-                "qualifier": qualifier,
-                "path": str(repo_path),
-                "status": "no_worktree",
-                "pull_result": "",
-            })
-            continue
-        try:
-            subprocess.run(
-                ["git", "-C", str(issues_path), "add", "-A"],
-                capture_output=True, timeout=15,
-            )
-            subprocess.run(
-                ["git", "-C", str(issues_path), "commit", "--allow-empty", "-m", "auto: sync"],
-                capture_output=True, timeout=15,
-            )
-        except Exception:
-            pass
-        pull_result = _pull_and_report(repo_path, qualifier)
-        if pull_result["status"] in ("ok", "conflict"):
-            try:
-                subprocess.run(
-                    ["git", "-C", str(issues_path), "push", "origin", WORKTREE_BRANCH],
-                    capture_output=True, timeout=30,
-                )
-            except Exception:
-                pass
-        entry = {
-            "qualifier": qualifier,
-            "path": str(repo_path),
-            "status": pull_result["status"],
-            "pull_result": pull_result["pull_result"],
-        }
-        if "conflict_hint" in pull_result:
-            entry["conflict_hint"] = pull_result["conflict_hint"]
-        repos_info.append(entry)
+        repos_info.append(_sync_repo(repo_path, qualifier))
     print(yaml_dump({"sync": True, "repos": repos_info}))
 
 

--- a/tools/local-issues
+++ b/tools/local-issues
@@ -487,6 +487,66 @@ def _ensure_worktree(repo_path: Path | None = None) -> bool:
         return False
 
 
+def _count_issues(repo_path: Path) -> int:
+    """Count issue directories by _parse_number() in a repo's .issues/ dir."""
+    issues_dir = repo_path / ISSUES_DIR
+    if not issues_dir.is_dir():
+        return 0
+    count = 0
+    seen: set[int] = set()
+    for entry in sorted(issues_dir.iterdir()):
+        num = _parse_number(entry)
+        if num is not None and num not in seen:
+            seen.add(num)
+            count += 1
+    open_dir = issues_dir / "open"
+    if open_dir.is_dir():
+        for entry in sorted(open_dir.iterdir()):
+            num = _parse_number(entry)
+            if num is not None and num not in seen:
+                seen.add(num)
+                count += 1
+    return count
+
+
+def _pull_and_report(repo_path: Path, qualifier: str) -> dict:
+    """Pull remote issues-data branch with rebase, return structured result.
+
+    Returns dict with status: ok|conflict|no_worktree|timeout.
+    """
+    issues_path = repo_path / ISSUES_DIR
+    if not (issues_path / ".git").is_file():
+        return {"status": "no_worktree", "pull_result": ""}
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(issues_path), "pull", "--rebase", "origin", WORKTREE_BRANCH],
+            capture_output=True, text=True, timeout=30,
+        )
+        if result.returncode == 0:
+            return {"status": "ok", "pull_result": result.stdout.strip()}
+        return {
+            "status": "conflict",
+            "pull_result": result.stdout.strip(),
+            "conflict_hint": f"git -C {repo_path}/{ISSUES_DIR} rebase --abort && git -C {repo_path}/{ISSUES_DIR} pull origin {WORKTREE_BRANCH}",
+            "conflict_stderr": result.stderr.strip(),
+        }
+    except subprocess.TimeoutExpired:
+        return {"status": "timeout", "pull_result": ""}
+
+
+def _collect_repos() -> list[tuple[Path, str]]:
+    """Collect (repo_path, qualifier) for current repo and all child repos."""
+    current = Path(os.getcwd()).resolve()
+    current_name = _resolve_repo_name()
+    repos: list[tuple[Path, str]] = [(current, current_name)]
+    seen: set[str] = {current_name}
+    for child in _discover_repos():
+        if child.name not in seen:
+            seen.add(child.name)
+            repos.append((child.resolve(), child.name))
+    return repos
+
+
 def _push_orphan_if_needed(repo_path: Path | None = None) -> None:
     """Push the worktree branch to origin if a remote exists."""
     git_dir = str(repo_path) if repo_path else os.getcwd()
@@ -597,17 +657,21 @@ def cmd_create(args: argparse.Namespace) -> None:
                 if line.strip():
                     print(f"    {line}", file=sys.stderr)
         print("  action: no auto-merge — compare data above and resolve manually", file=sys.stderr)
+    current_repo_name = _resolve_repo_name()
     if args.number is None:
         args.number = _next_number()
+        qualified = f"{current_repo_name}#{args.number}"
     else:
-        current_repo_name = _resolve_repo_name()
-        current_cwd = Path(os.getcwd()).resolve()
+        repo_name, num = _parse_qualified(args.number)
+        if repo_name is not None:
+            _ensure_repo(repo_name)
+            current_repo_name = _resolve_repo_name()
+        args.number = num
+        qualified = f"{current_repo_name}#{args.number}"
         child_repos = _discover_repos()
-
         if issue_exists(args.number):
             print(f"Issue #{args.number} already exists in {current_repo_name}.", file=sys.stderr)
             sys.exit(1)
-
         for child in child_repos:
             child_issues_dir = child / ISSUES_DIR
             if child_issues_dir.is_dir():
@@ -628,8 +692,8 @@ def cmd_create(args: argparse.Namespace) -> None:
     write_file(path / "issue.yaml", yaml_dump(issue))
     write_file(path / "comments.yaml", "comments: []\n")
     write_file(path / "links.yaml", "links: []\n")
-    print(yaml_dump({"created": True, "number": args.number, "title": args.title}))
-    _auto_commit(f"auto: create #{args.number}")
+    print(yaml_dump({"created": True, "number": qualified, "title": args.title}))
+    _auto_commit(f"auto: create #{qualified}")
 
 
 def _recent_issue_numbers() -> list[int]:
@@ -906,14 +970,14 @@ def cmd_update(args: argparse.Namespace) -> None:
     if changed:
         issue["updated_at"] = now_iso()
         write_file(path, yaml_dump(issue))
-    _auto_commit(f"auto: update #{args.number}")
-    print(yaml_dump({"updated": True, "number": args.number}))
+    qualified = f"{_repo_name}#{args.number}"
+    _auto_commit(f"auto: update #{qualified}")
+    print(yaml_dump({"updated": True, "number": qualified}))
 
 
 def cmd_comment(args: argparse.Namespace) -> None:
-    _repo_name, args.number = _parse_qualified(str(args.number))
-    if _repo_name is not None:
-        _ensure_repo(_repo_name)
+    _repo_name, args.number = _require_qualified(args.number)
+    _ensure_repo(_repo_name)
     if not issue_exists(args.number):
         _not_found(args.number)
     path = get_issue_path(args.number) / "comments.yaml"
@@ -929,8 +993,9 @@ def cmd_comment(args: argparse.Namespace) -> None:
     }
     data["comments"].append(entry)
     write_file(path, yaml_dump(data))
-    _auto_commit(f"auto: comment #{args.number}")
-    print(yaml_dump({"commented": True, "number": args.number}))
+    qualified = f"{_repo_name}#{args.number}"
+    _auto_commit(f"auto: comment #{qualified}")
+    print(yaml_dump({"commented": True, "number": qualified}))
 
 
 def cmd_close(args: argparse.Namespace) -> None:
@@ -947,8 +1012,9 @@ def cmd_close(args: argparse.Namespace) -> None:
         issue["duplicate_of"] = args.duplicate_of
     issue["updated_at"] = now_iso()
     write_file(path, yaml_dump(issue))
-    _auto_commit(f"auto: close #{args.number}")
-    print(yaml_dump({"closed": True, "number": args.number, "reason": args.reason}))
+    qualified = f"{_repo_name}#{args.number}"
+    _auto_commit(f"auto: close #{qualified}")
+    print(yaml_dump({"closed": True, "number": qualified, "reason": args.reason}))
 
 
 def cmd_delete(args: argparse.Namespace) -> None:
@@ -968,8 +1034,9 @@ def cmd_delete(args: argparse.Namespace) -> None:
         sys.exit(1)
     path = get_issue_path(args.number)
     shutil.rmtree(path)
-    _auto_commit(f"auto: delete #{args.number}")
-    print(yaml_dump({"deleted": True, "number": args.number}))
+    qualified = f"{_repo_name}#{args.number}"
+    _auto_commit(f"auto: delete #{qualified}")
+    print(yaml_dump({"deleted": True, "number": qualified}))
 
 
 def _parse_number(entry: Path) -> int | None:
@@ -1026,7 +1093,7 @@ def cmd_search(args: argparse.Namespace) -> None:
 
             title = issue.get("title", "")
             status = issue.get("status", "open")
-            display_num = f"{repo_name}#{num}" if repo_name != current_repo_name else f"#{num}"
+            display_num = f"{repo_name}#{num}"
             found.append((repo_name, display_num, status, title, spec_path))
 
     for repo_name, display_num, status, title, spec_path in found:
@@ -1111,7 +1178,7 @@ def cmd_list(args: argparse.Namespace) -> None:
                 title = ""
                 status = "open"
 
-            display_num = f"{repo_name}#{num}" if repo_name != current_repo_name else f"#{num}"
+            display_num = f"{repo_name}#{num}"
             all_entries.append((sort_prio, repo_name, display_num, status, title, spec_path, num))
 
     if not all_entries:
@@ -1124,37 +1191,51 @@ def cmd_list(args: argparse.Namespace) -> None:
 
 
 def cmd_link(args: argparse.Namespace) -> None:
-    if not issue_exists(args.number):
-        _not_found(args.number)
-    for sub_num in args.sub:
+    parent_repo, parent_num = _require_qualified(args.number)
+    _ensure_repo(parent_repo)
+    if not issue_exists(parent_num):
+        _not_found(parent_num)
+    sub_list: list[int] = []
+    for sub_item in args.sub:
+        _sub_repo, sub_num = _parse_qualified(sub_item)
         if not issue_exists(sub_num):
             _not_found(sub_num)
-    path = get_issue_path(args.number) / "links.yaml"
+        sub_list.append(sub_num)
+    path = get_issue_path(parent_num) / "links.yaml"
     data = yaml_load(read_file(path))
     if not isinstance(data, dict):
         data = {"links": []}
     if "links" not in data or not isinstance(data.get("links"), list):
         data["links"] = []
     linked_nums = {lnk.get("number") for lnk in data["links"]}
-    for sub_num in args.sub:
+    for sub_num in sub_list:
         if sub_num not in linked_nums:
             data["links"].append({"number": sub_num, "type": args.type})
     write_file(path, yaml_dump(data))
-    _auto_commit(f"auto: link #{args.number}")
-    print(yaml_dump({"linked": True, "parent": args.number, "subs": list(args.sub)}))
+    qualified = f"{parent_repo}#{parent_num}"
+    _auto_commit(f"auto: link #{qualified}")
+    print(yaml_dump({"linked": True, "parent": qualified, "subs": sub_list}))
 
 
 def cmd_renumber(args: argparse.Namespace) -> None:
-    if not issue_exists(args.from_num):
-        _not_found(args.from_num)
-    if issue_exists(args.to_num):
-        print(f"Target #{args.to_num} already exists.", file=sys.stderr)
+    from_repo, from_num = _require_qualified(args.from_num)
+    to_repo, to_num = _require_qualified(args.to_num)
+    if from_repo != to_repo:
+        print("Error: --from and --to must be in the same repo.", file=sys.stderr)
         sys.exit(1)
-    src = get_issue_path(args.from_num)
-    dst = get_issue_path(args.to_num)
+    _ensure_repo(from_repo)
+    if not issue_exists(from_num):
+        _not_found(from_num)
+    if issue_exists(to_num):
+        print(f"Target #{to_num} already exists.", file=sys.stderr)
+        sys.exit(1)
+    src = get_issue_path(from_num)
+    dst = get_issue_path(to_num)
     src.rename(dst)
-    _auto_commit(f"auto: renumber #{args.from_num} -> #{args.to_num}")
-    print(yaml_dump({"renumbered": True, "from": args.from_num, "to": args.to_num}))
+    qualified_from = f"{from_repo}#{from_num}"
+    qualified_to = f"{from_repo}#{to_num}"
+    _auto_commit(f"auto: renumber {qualified_from} -> {qualified_to}")
+    print(yaml_dump({"renumbered": True, "from": qualified_from, "to": qualified_to}))
     issues_dir = Path(ISSUES_DIR)
     for entry in issues_dir.iterdir():
         if not entry.is_dir():
@@ -1168,8 +1249,8 @@ def cmd_renumber(args: argparse.Namespace) -> None:
         links = data.get("links", []) or []
         changed = False
         for link in links:
-            if link.get("number") == args.from_num:
-                link["number"] = args.to_num
+            if link.get("number") == from_num:
+                link["number"] = to_num
                 changed = True
         if changed:
             write_file(links_path, yaml_dump(data))
@@ -1192,6 +1273,75 @@ def cmd_promote(args: argparse.Namespace) -> None:
     print(f"  github_url: {gh_url or '(not set)'}")
 
 
+def cmd_init(args: argparse.Namespace) -> None:
+    """Initialize worktrees and pull remote issues-data for all repos."""
+    _ensure_all_worktrees()
+    repos_info: list[dict] = []
+    for repo_path, qualifier in _collect_repos():
+        issues_count = _count_issues(repo_path)
+        pull_result = _pull_and_report(repo_path, qualifier)
+        entry = {
+            "repo": qualifier,
+            "qualifier": qualifier,
+            "path": str(repo_path),
+            "status": pull_result["status"],
+            "issues_count": issues_count,
+            "pull_result": pull_result["pull_result"],
+        }
+        if "conflict_hint" in pull_result:
+            entry["conflict_hint"] = pull_result["conflict_hint"]
+        if "conflict_stderr" in pull_result:
+            entry["conflict_stderr"] = pull_result["conflict_stderr"]
+        repos_info.append(entry)
+    print(yaml_dump({"init": True, "repos": repos_info}))
+
+
+def cmd_sync(args: argparse.Namespace) -> None:
+    """Commit pending changes, pull-rebase, then push for all repos."""
+    repos_info: list[dict] = []
+    for repo_path, qualifier in _collect_repos():
+        issues_path = repo_path / ISSUES_DIR
+        has_worktree = (issues_path / ".git").is_file()
+        if not has_worktree:
+            repos_info.append({
+                "qualifier": qualifier,
+                "path": str(repo_path),
+                "status": "no_worktree",
+                "pull_result": "",
+            })
+            continue
+        try:
+            subprocess.run(
+                ["git", "-C", str(issues_path), "add", "-A"],
+                capture_output=True, timeout=15,
+            )
+            subprocess.run(
+                ["git", "-C", str(issues_path), "commit", "--allow-empty", "-m", "auto: sync"],
+                capture_output=True, timeout=15,
+            )
+        except Exception:
+            pass
+        pull_result = _pull_and_report(repo_path, qualifier)
+        if pull_result["status"] in ("ok", "conflict"):
+            try:
+                subprocess.run(
+                    ["git", "-C", str(issues_path), "push", "origin", WORKTREE_BRANCH],
+                    capture_output=True, timeout=30,
+                )
+            except Exception:
+                pass
+        entry = {
+            "qualifier": qualifier,
+            "path": str(repo_path),
+            "status": pull_result["status"],
+            "pull_result": pull_result["pull_result"],
+        }
+        if "conflict_hint" in pull_result:
+            entry["conflict_hint"] = pull_result["conflict_hint"]
+        repos_info.append(entry)
+    print(yaml_dump({"sync": True, "repos": repos_info}))
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="local-issues",
@@ -1200,7 +1350,7 @@ def build_parser() -> argparse.ArgumentParser:
     sub = parser.add_subparsers(dest="command", required=True)
 
     p = sub.add_parser("create", help="Create a new issue (autonumber when --number omitted). Flags: --number, --title, --labels")
-    p.add_argument("--number", type=int, default=None, help="Explicit issue number (autonumber if omitted)")
+    p.add_argument("--number", type=str, default=None, help="Explicit issue number or qualified repo#N form (autonumber if omitted)")
     p.add_argument("--title", type=str, required=True)
     p.add_argument("--labels", type=str, nargs="*", default=[])
 
@@ -1255,17 +1405,20 @@ def build_parser() -> argparse.ArgumentParser:
     sub.add_parser("list", help="List all issues")
 
     p = sub.add_parser("link", help="Link sub-issues to a parent")
-    p.add_argument("--number", type=int, required=True)
-    p.add_argument("--sub", type=int, nargs="+", required=True)
+    p.add_argument("--number", type=str, required=True)
+    p.add_argument("--sub", type=str, nargs="+", required=True)
     p.add_argument("--type", type=str, default="sub-issue")
 
     p = sub.add_parser("renumber", help="Renumber an issue")
-    p.add_argument("--from", type=int, required=True, dest="from_num")
-    p.add_argument("--to", type=int, required=True, dest="to_num")
+    p.add_argument("--from", type=str, required=True, dest="from_num")
+    p.add_argument("--to", type=str, required=True, dest="to_num")
 
     p = sub.add_parser("promote", help="Check promotion readiness")
     p.add_argument("--number", type=str, required=True)
     p.add_argument("--dry-run", action="store_true")
+
+    sub.add_parser("init", help="Initialize worktrees and pull remote issues-data for all repos")
+    sub.add_parser("sync", help="Commit pending changes, pull-rebase, and push for all repos")
 
     return parser
 
@@ -1292,6 +1445,8 @@ def main() -> None:
         "link": cmd_link,
         "renumber": cmd_renumber,
         "promote": cmd_promote,
+        "init": cmd_init,
+        "sync": cmd_sync,
     }
     command_map[args.command](args)
 


### PR DESCRIPTION
## Summary

- **init + sync verbs** for `local-issues` tool: `init` bootstraps worktrees and syncs all repos; `sync` commits pending changes, pull-rebase, and pushes for all repos. Extracted `_sync_repo()` helper.
- **Fully qualified mutations**: `create`, `update`, `comment`, `close`, `delete`, `link`, and `renumber` now use `repo#N` output and commit messages. `--number`/`--sub` accept `repo#N` format. Search/list output always qualified.
- **sync-from-remote skill task**: New `issue-operations` task reconciling remote issues against local `.issues/` after `sync`. Detects bidirectional staleness, dispatches `import-remote`/`sync-pull-to-local`.
- **Test framework timeout mandate**: Bash tool timeout docs in `tests/AGENTS.md` and `tests/behaviors/helpers.sh` — &gt;=600s, no nested timeouts, session resumption for transient errors. Behavioral test repo isolation mandate.

## VbC Results

| SC | Criterion | Verdict | Evidence |
|----|-----------|---------|----------|
| SC-1 | init bootstraps worktree cascade | PASS | init returned per-repo YAML with status for both opencode-config and .opencode repos |
| SC-2 | init delegates to sync when worktree exists | PASS | Second init succeeded with identical output — delegates to _sync_repo() |
| SC-3 | init reports YAML with qualifier, status, conflict_hint | PASS | _sync_repo() populates all fields; conflict_hint present in code at pull failure path |
| SC-4 | sync commits, pull-rebase, pushes | PASS | git log shows auto: sync commits, pull result "Already up to date", push confirmed |
| SC-5 | sync reports ok/conflict with qualifier | PASS | YAML output contains status: ok per repo with qualifier |
| SC-6 | all output uses dirname#N, mutations require repo#N | PASS | list shows opencode-config#N format; update with bare number fails with qualifier error |
| SC-7 | sync-from-remote task file exists | PASS | File at skills/issue-operations/tasks/sync-from-remote.md (42 lines) |
| SC-8 | mutation auto-commit unchanged | PASS | create returned number: opencode-config#N; git log shows auto-commit |

## Adversarial Audit

| Auditor | Family | PASS | FAIL | Blocked |
|---------|--------|------|------|---------|
| deepseek-flash | deepseek | 8 | 0 | 0 |
| mistral-large | mistral | 8 | 0 | 0 |
| **Cross-validate consensus** | | **8** | **0** | **PASS** |

## Changes

| Area | Files | Description |
|------|-------|-------------|
| `local-issues` | `tools/local-issues` | init/sync verbs, `_sync_repo()` helper, qualified `repo#N` mutations, `_count_issues()`, `_collect_repos()` |
| issue-operations | `skills/issue-operations/SKILL.md`, `tasks/sync-from-remote.md` | New sync-from-remote task, trigger entry + routing |
| Test framework | `tests/AGENTS.md`, `tests/behaviors/helpers.sh` | Timeout mandate docs, isolation mandate |

🤖 Co-authored with AI: OpenCode (deepseek-v4-flash)