### PR TITLE
[#1110] Pipeline-readiness gate in spec-creation + mandatory checklist generation in writing-plans

### DIFF
--- a/skills/adversarial-audit/SKILL.md
+++ b/skills/adversarial-audit/SKILL.md
@@ -15,7 +15,7 @@ Dual cross-family audit via clean-room sub-agents. Auditors write YAML verdicts 
 ## Tasks
 
 | Task | Purpose |
-|------|---------|
+
 | `resolve-models` | Select two cross-family auditors via capability probe |
 | `verification-audit` | Audit implemented code against spec SCs using behavioral evidence. Default audit task. Requires artifact_evidence_dir. |
 | `spec-audit` | Pre-implementation spec quality audit. Verifies spec structure, determinism, and live documentation sources. Evidence dir optional. |

--- a/skills/brainstorming/SKILL.md
+++ b/skills/brainstorming/SKILL.md
@@ -19,20 +19,19 @@ Requirements Explorer. Focus: understand what user wants through natural convers
 
 ## Tasks
 
-| Task | Words |
-|------|-------|
-| `explore` | ≈1000 |
-| `top-down-analysis` | ≈400 |
-| `enforcement` | ≈600 |
-| `cross-scope` | ≈350 |
-| `completion` | ≈200 |
+
+| `explore` |
+| `top-down-analysis` |
+| `enforcement` |
+| `cross-scope` |
+| `completion` |
 
 ## Invocation
 
 `skill({name: "brainstorming"})` — call the skill, then call via task():
 
 | Task | Call via task() |
-|------|----------|
+
 | `explore` | `task(..., prompt: "execute explore task from brainstorming")` |
 | `top-down-analysis` | `task(..., prompt: "execute top-down-analysis task from brainstorming")` |
 | `enforcement` | `task(..., prompt: "execute enforcement task from brainstorming")` |

--- a/skills/changelog-generator/SKILL.md
+++ b/skills/changelog-generator/SKILL.md
@@ -15,19 +15,18 @@ Transforms git commits into polished, user-friendly changelogs. Category-based o
 
 ## Tasks
 
-| Task | Words |
-|------|-------|
-| `since-last-release` | ≈170 |
-| `date-range` | ≈90 |
-| `backfill` | ≈120 |
-| `completion` | ≈200 |
+
+| `since-last-release` |
+| `date-range` |
+| `backfill` |
+| `completion` |
 
 ## Invocation
 
 `skill({name: "changelog-generator"})` — call the skill, then call via task():
 
 | Task | Call via task() |
-|------|----------|
+
 | `since-last-release` | `task(..., prompt: "execute since-last-release task from changelog-generator")` |
 | `date-range` | `task(..., prompt: "execute date-range task from changelog-generator with --from DATE --to DATE")` |
 | `backfill` | `task(..., prompt: "execute backfill task from changelog-generator")` |

--- a/skills/completeness-gate/SKILL.md
+++ b/skills/completeness-gate/SKILL.md
@@ -19,17 +19,15 @@ You are a Completeness Gate Sub-Agent. Your focus is verifying that a deliverabl
 
 ## Tasks
 
-| Task | Words | Purpose |
 |------|-------|---------|
-| `check` | ≈200 | Run completeness check on deliverable |
-| `completion` | ≈100 | Ensure mandatory completion steps run |
+| `check` | Run completeness check on deliverable |
+| `completion` | Ensure mandatory completion steps run |
 
 ## Sub-Agent Tasks
 
-| Task | Words |
-|------|-------|
-| `check` | ≈200 |
-| `completion` | ≈100 |
+
+| `check` |
+| `completion` |
 
 ### DISPATCH_GATE — Orchestrator task() Prompt Protocol
 
@@ -83,7 +81,7 @@ Return `status: BLOCKED` with `reason: PRELOADED_CONTEXT_REJECTED`.
 `skill({name: "completeness-gate"})` — call the skill, then call via task():
 
 | Task | Call via task() |
-|------|----------|
+
 | `check` | `task(..., prompt: "execute check task from completeness-gate")` |
 | `completion` | `task(..., prompt: "execute completion task from completeness-gate")` |
 

--- a/skills/conflict-resolution/SKILL.md
+++ b/skills/conflict-resolution/SKILL.md
@@ -19,10 +19,9 @@ Conflict Resolution Specialist. Focus: no committed work or spec intent silently
 
 ## Tasks
 
-| Task | Words |
-|------|-------|
-| `classify-and-resolve` | ≈550 |
-| `completion` | ≈200 |
+
+| `classify-and-resolve` |
+| `completion` |
 
 ## Invocation
 
@@ -31,7 +30,7 @@ Automatic from `git-workflow` when conflicts detected. Manual invocation:
 `skill({name: "conflict-resolution"})` — call the skill, then call via task():
 
 | Task | Call via task() |
-|------|----------|
+
 | `classify-and-resolve` | `task(..., prompt: "execute classify-and-resolve task from conflict-resolution")` |
 | `completion` | `task(..., prompt: "execute completion task from conflict-resolution")` |
 

--- a/skills/correspondence/SKILL.md
+++ b/skills/correspondence/SKILL.md
@@ -15,17 +15,16 @@ Enforces multipart/alternative format (text/plain + text/html) for email, stakeh
 
 ## Tasks
 
-| Task | Words |
-|------|-------|
-| `draft` | ≈800 |
-| `completion` | ≈200 |
+
+| `draft` |
+| `completion` |
 
 ## Invocation
 
 `skill({name: "correspondence"})` — call the skill, then call via task():
 
 | Task | Call via task() |
-|------|----------|
+
 | `draft` | `task(..., prompt: "execute draft task from correspondence")` |
 | `completion` | `task(..., prompt: "execute completion task from correspondence")` |
 

--- a/skills/engineering-approach/SKILL.md
+++ b/skills/engineering-approach/SKILL.md
@@ -15,19 +15,18 @@ Engineering discipline checklist enforcing: understand before solving, design be
 
 ## Tasks
 
-| Task | Words |
-|------|-------|
-| `verify-understanding` | ≈300 |
-| `design-before-code` | ≈300 |
-| `verify-before-complete` | ≈300 |
-| `completion` | ≈100 |
+
+| `verify-understanding` |
+| `design-before-code` |
+| `verify-before-complete` |
+| `completion` |
 
 ## Invocation
 
 `skill({name: "engineering-approach"})` — call the skill, then call via task():
 
 | Task | Call via task() |
-|------|----------|
+
 | `verify-understanding` | `task(..., prompt: "execute verify-understanding task from engineering-approach")` |
 | `design-before-code` | `task(..., prompt: "execute design-before-code task from engineering-approach")` |
 | `verify-before-complete` | `task(..., prompt: "execute verify-before-complete task from engineering-approach")` |

--- a/skills/executing-plans/SKILL.md
+++ b/skills/executing-plans/SKILL.md
@@ -17,17 +17,16 @@ No single-issue bypass — single = work of one = one sub-agent.
 
 ## Tasks
 
-| Task | Words |
-|------|-------|
-| `execute` | ≈300 |
-| `completion` | ≈150 |
+
+| `execute` |
+| `completion` |
 
 ## Invocation
 
 `skill({name: "executing-plans"})` — call the skill, then call via task():
 
 | Task | Call via task() |
-|------|----------|
+
 | `execute` | `task(..., prompt: "execute execute task from executing-plans")` |
 | `completion` | `task(..., prompt: "execute completion task from executing-plans")` |
 

--- a/skills/finishing-a-development-branch/SKILL.md
+++ b/skills/finishing-a-development-branch/SKILL.md
@@ -19,18 +19,17 @@ Branch completion workflow ensuring feature branch is fully ready for PR. Verifi
 
 ## Tasks
 
-| Task | Words |
-|------|-------|
-| `prepare` | ≈450 |
-| `checklist` | ≈350 |
-| `completion` | ≈200 |
+
+| `prepare` |
+| `checklist` |
+| `completion` |
 
 ## Invocation
 
 `skill({name: "finishing-a-development-branch"})` — call the skill, then call via task():
 
 | Task | Call via task() |
-|------|----------|
+
 | `prepare` | `task(..., prompt: "execute prepare task from finishing-a-development-branch")` |
 | `checklist` | `task(..., prompt: "execute checklist task from finishing-a-development-branch")` |
 | `completion` | `task(..., prompt: "execute completion task from finishing-a-development-branch")` |

--- a/skills/git-workflow/SKILL.md
+++ b/skills/git-workflow/SKILL.md
@@ -19,28 +19,27 @@ Git Workflow Enforcer. Focus: three-branch workflow, block AI on protected branc
 
 ## Tasks
 
-| Task | Words |
-|------|-------|
-| `pre-work` | ≈480 |
-| `implementation` | ≈400 |
-| `review-prep` | ≈390 |
-| `pr-creation` | ≈385 |
-| `rebase-pending` | ≈1666 |
-| `cleanup` | ≈950 |
-| `release-promotion` | ≈500 |
-| `check-pr` | ≈50 |
-| `provenance` | ≈460 |
-| `pair-pre-work` | ≈400 |
-| `pair-commit` | ≈350 |
-| `pair-pr-creation` | ≈300 |
-| `pair-cleanup` | ≈350 |
-| `pair-mode-resume` | ≈300 |
-| `completion` | ≈200 |
+
+| `pre-work` |
+| `implementation` |
+| `review-prep` |
+| `pr-creation` |
+| `rebase-pending` |
+| `cleanup` |
+| `release-promotion` |
+| `check-pr` |
+| `provenance` |
+| `pair-pre-work` |
+| `pair-commit` |
+| `pair-pr-creation` |
+| `pair-cleanup` |
+| `pair-mode-resume` |
+| `completion` |
 
 ## Routing: Feature PR vs Release PR
 
 | Request Type | Target |
-|---|---|
+
 | Feature PR (feature/* → dev) | `pr-creation-workflow` skill |
 | Release PR (dev → main) | `git-workflow --task release-promotion` |
 
@@ -49,7 +48,7 @@ Git Workflow Enforcer. Focus: three-branch workflow, block AI on protected branc
 `skill({name: "git-workflow"})` — call the skill, then call via task():
 
 | Task | Call via task() |
-|------|----------|
+
 | `pre-work` | `task(..., prompt: "execute pre-work task from git-workflow")` |
 | `implementation` | `task(..., prompt: "execute implementation task from git-workflow")` |
 | `review-prep` | `task(..., prompt: "execute review-prep task from git-workflow")` |
@@ -65,12 +64,12 @@ Git Workflow Enforcer. Focus: three-branch workflow, block AI on protected branc
 
 ## Sub-Agent Tasks for Submodule Operations
 
-| Sub-Agent Task | Trigger | Task Context (MUST receive) | Exclusions (MUST NOT receive) | Config | Words |
-|----------------|---------|----------------------------------|-------------------------------|--------|-------|
-| `submodule-tag-prework` | pre-work Step 3.5 | parent_repo, issue_number, submodule_paths | Implementation context, agent memory, other sub-agent results | `.opencode/agents/submodule-tag-prework.jsonc` | ≈400 |
-| `submodule-feature-push` | review-prep Step 0 | parent_repo, issue_number, submodule_paths, submodule_branches | Implementation context, agent memory, orchestrator reasoning | `.opencode/agents/submodule-feature-push.jsonc` | ≈450 |
-| `submodule-liveness-check` | enforcement-gate Step 0, PR-time | submodule_paths, referenced_hashes, parent_repo, issue_number | Implementation context, agent memory, prior verification results | `.opencode/agents/submodule-liveness-check.jsonc` | ≈350 |
-| `submodule-dev-restore` | cleanup Step 1.9 | submodule_paths | Implementation context, agent memory, other sub-agent results | `.opencode/agents/submodule-dev-restore.jsonc` | ≈300 |
+| Sub-Agent Task | Trigger | Task Context (MUST receive) | Exclusions (MUST NOT receive) | Config |
+|----------------|---------|----------------------------------|-------------------------------|--------|
+| `submodule-tag-prework` | pre-work Step 3.5 | parent_repo, issue_number, submodule_paths | Implementation context, agent memory, other sub-agent results | `.opencode/agents/submodule-tag-prework.jsonc` |
+| `submodule-feature-push` | review-prep Step 0 | parent_repo, issue_number, submodule_paths, submodule_branches | Implementation context, agent memory, orchestrator reasoning | `.opencode/agents/submodule-feature-push.jsonc` |
+| `submodule-liveness-check` | enforcement-gate Step 0, PR-time | submodule_paths, referenced_hashes, parent_repo, issue_number | Implementation context, agent memory, prior verification results | `.opencode/agents/submodule-liveness-check.jsonc` |
+| `submodule-dev-restore` | cleanup Step 1.9 | submodule_paths | Implementation context, agent memory, other sub-agent results | `.opencode/agents/submodule-dev-restore.jsonc` |
 
 ## Operating Protocol
 

--- a/skills/implementation-pipeline/SKILL.md
+++ b/skills/implementation-pipeline/SKILL.md
@@ -49,7 +49,7 @@ The orchestrator is a pure router — never reads task file content, never perfo
 `skill({name: "implementation-pipeline"})` — call the skill, then dispatch each step via task():
 
 | Step | Call via task() |
-|------|-----------------|
+
 | Any dispatch step | `task(..., prompt: "execute <step_label> from implementation-pipeline")` |
 
 Every task context MUST include the authorization context block:
@@ -136,7 +136,7 @@ When a step returns FAIL, the orchestrator:
 ## Enforcement Reference
 
 | Document | Purpose |
-|----------|---------|
+
 | Sub-agent context shape | Context shape and exclusions for task() routing |
 | `enforcement/overflow-signal.md` | OVERFLOW contract and re-routing strategies |
 | `enforcement/work-state-verification.md` | Verification table and work state format |
@@ -156,7 +156,7 @@ Artifacts under `./tmp/{issue-N}/` are ephemeral — they are cleaned at PR merg
 At the start of each pipeline step, clean previous-run artifacts for that step to prevent stale state contamination:
 
 | Step Label | Pre-Cleanup Action |
-|------------|-------------------|
+
 | `pre-red-baseline` | `rm -f ./tmp/{issue-N}/artifacts/pipeline-pre-red-baseline-*` |
 | `red-phase` | `rm -f ./tmp/{issue-N}/artifacts/pipeline-red-phase-*` |
 | `green-phase` | `rm -f ./tmp/{issue-N}/artifacts/pipeline-green-phase-*` |

--- a/skills/issue-operations/SKILL.md
+++ b/skills/issue-operations/SKILL.md
@@ -19,37 +19,36 @@ Issue Operations Router. Focus: spec-first workflow, validation, labeling, platf
 
 ## Tasks
 
-| Task | Words | Description |
 |------|-------|-------------|
-| `pre-creation` | ≈240 | |
-| `single-task-check` | ≈160 | |
-| `creation` | ≈200 | |
-| `post-creation` | ≈180 | |
-| `comment` | ≈400 | |
-| `close` | ≈250 | |
-| `link-sub-issue` | ≈200 | |
-| `verify-merge` | ≈200 | |
-| `capabilities` | ≈150 | |
-| `completion` | ≈200 | |
-| `body-edit` | ≈200 | Edit remote.md body via 4-agent dispatch (fetch → transform → verify → post) — body edits without structural verification propagate corruption upstream; every remote edit requires verified integrity before propagation |
-| `read-issue` | ≈120 | Read single issue via dispatcher — routes to platform sub-skill, no direct `github_*` calls |
-| `read-comments` | ≈130 | Read issue comments via dispatcher — context completeness, all comments before action |
-| `read-labels` | ≈100 | Read issue labels via dispatcher — authorization scope verification |
-| `read-sub-issues` | ≈120 | Read sub-issues via dispatcher — authorization cascade and closure order verification |
-| `list-issues` | ≈130 | List issues with filters via dispatcher — dedup checks, label search, overlap detection |
-| `search-issues` | ≈130 | Search issues via dispatcher — title dedup, spec/plan overlap detection |
-| `sync-from-remote` | ≈500 | Reconcile remote issues against local `.issues/` after `local-issues sync` — detect staleness in both directions, auto-import missing remote issues |
-| `update-issue` | ≈160 | Update issue body/labels/state via dispatcher — body-preservation safeguard enforced |
-| `sync-pull-to-local` | ≈600 | Mirror remote issue body to `.issues/<N>/spec.md` after any `read-issue` — enforces Operating Protocol §3 spec.md mirror mandate |
-| `import-remote` | ≈690 | Retroactively import a pre-existing remote issue into local `.issues/` — full mirror with body, comments, frontmatter, and `promotion_type: retroactive_import` |
-| `push-artifacts` | ≈60 | Push spec artifacts directory to issues-data — produces artifact directory with URL |
+| `pre-creation` | |
+| `single-task-check` | |
+| `creation` | |
+| `post-creation` | |
+| `comment` | |
+| `close` | |
+| `link-sub-issue` | |
+| `verify-merge` | |
+| `capabilities` | |
+| `completion` | |
+| `body-edit` | Edit remote.md body via 4-agent dispatch (fetch → transform → verify → post) — body edits without structural verification propagate corruption upstream; every remote edit requires verified integrity before propagation |
+| `read-issue` | Read single issue via dispatcher — routes to platform sub-skill, no direct `github_*` calls |
+| `read-comments` | Read issue comments via dispatcher — context completeness, all comments before action |
+| `read-labels` | Read issue labels via dispatcher — authorization scope verification |
+| `read-sub-issues` | Read sub-issues via dispatcher — authorization cascade and closure order verification |
+| `list-issues` | List issues with filters via dispatcher — dedup checks, label search, overlap detection |
+| `search-issues` | Search issues via dispatcher — title dedup, spec/plan overlap detection |
+| `sync-from-remote` | Reconcile remote issues against local `.issues/` after `local-issues sync` — detect staleness in both directions, auto-import missing remote issues |
+| `update-issue` | Update issue body/labels/state via dispatcher — body-preservation safeguard enforced |
+| `sync-pull-to-local` | Mirror remote issue body to `.issues/<N>/spec.md` after any `read-issue` — enforces Operating Protocol §3 spec.md mirror mandate |
+| `import-remote` | Retroactively import a pre-existing remote issue into local `.issues/` — full mirror with body, comments, frontmatter, and `promotion_type: retroactive_import` |
+| `push-artifacts` | Push spec artifacts directory to issues-data — produces artifact directory with URL |
 
 ## Invocation
 
 `skill({name: "issue-operations"})` — call the skill, then call via task():
 
 | Task | Call via task() |
-|------|----------|
+
 | `pre-creation` | `task(..., prompt: "execute pre-creation task from issue-operations")` |
 | `creation` | `task(..., prompt: "execute creation task from issue-operations")` |
 | `comment` | `task(..., prompt: "execute comment task from issue-operations")` |

--- a/skills/issue-operations/platforms/gitbucket-api/SKILL.md
+++ b/skills/issue-operations/platforms/gitbucket-api/SKILL.md
@@ -49,14 +49,14 @@ GitBucket platform implementation using Python client. Implements a GitHub-compa
 
 ## Tasks
 
-| Task | Purpose | Words |
-|------|---------|-------|
-| `issue-operations` | Issue CRUD patterns, create/update/list workarounds | ≈500 |
-| `label-operations` | Label CRUD, auto-creation, post-creation limitations | ≈400 |
-| `error-recovery` | Error handling, retry logic, credential failures | ≈320 |
-| `mcp-operations` | MCP tool mapping, alternative API paths | ≈250 |
-| `repository-operations` | Repository CRUD, branch operations | ≈300 |
-| `session-integration` | Session init integration, env var detection | ≈200 |
+| Task | Purpose |
+|------|---------|
+| `issue-operations` | Issue CRUD patterns, create/update/list workarounds |
+| `label-operations` | Label CRUD, auto-creation, post-creation limitations |
+| `error-recovery` | Error handling, retry logic, credential failures |
+| `mcp-operations` | MCP tool mapping, alternative API paths |
+| `repository-operations` | Repository CRUD, branch operations |
+| `session-integration` | Session init integration, env var detection |
 
 ## Sub-Agent Tasks
 
@@ -77,7 +77,7 @@ GitBucket platform implementation using Python client. Implements a GitHub-compa
 GitBucket API supports labels via creation only (post-creation label mutation is broken). The eight `approved-for-*` labels are:
 
 | Label | Purpose |
-|---|---|
+
 | `approved-for-spec` | Authorization through spec creation |
 | `approved-for-plan` | Authorization through plan creation |
 | `approved-for-implementation` | Authorization through implementation |
@@ -106,7 +106,7 @@ Token authentication ONLY. Basic auth is broken in GitBucket (returns "Bad crede
 ### Command Reference
 
 | Command | Description |
-|---------|-------------|
+
 | `me` | Get current user |
 | `issues <owner> <repo> [--state open\|closed\|all]` | List issues |
 | `issue <owner> <repo> <number>` | Get single issue |
@@ -138,7 +138,7 @@ All `list_*` endpoints return arrays (`List[Dict]`), NOT objects. The Python cli
 ## Cross-References
 
 | Guideline | Section |
-|-----------|---------|
+
 | Router | `../../SKILL.md` (issue-operations) |
 | GitHub platform | `../github-mcp/SKILL.md` |
 | Session init plugin | GitBucket detection and credentials |

--- a/skills/issue-operations/platforms/github-mcp/SKILL.md
+++ b/skills/issue-operations/platforms/github-mcp/SKILL.md
@@ -50,7 +50,7 @@ All operations routed through the `github_*` MCP tool family. No Python client n
 GitHub MCP supports the following `approved-for-*` labels for issue labeling:
 
 | Label | Purpose |
-|---|---|
+
 | `approved-for-spec` | Authorization through spec creation (scope: `for_spec`) |
 | `approved-for-analysis` | Authorization through analysis (scope: `for_analysis`) |
 | `approved-for-plan` | Authorization through plan creation (scope: `for_plan`) |
@@ -71,7 +71,7 @@ None required. GitHub MCP provides complete API coverage.
 Every `github_issue_read(method="get")` call MUST mirror the spec body to `.issues/<issue_number>/spec.md`:
 
 | Event | Action |
-|-------|--------|
+
 | `github_issue_read(method="get")` success | Write `.issues/<issue_number>/spec.md` with header `# Synced from GitHub Issue #<N> at <ISO8601-timestamp>` followed by the issue body |
 | `github_issue_read(method="get")` repeated | Overwrite `spec.md` with updated timestamp and body |
 | API unreachable (network error, rate limit, auth failure) | Read `.issues/<issue_number>/spec.md` from disk, note staleness in chat: `"spec.md last synced at <timestamp>, may be stale"` |

--- a/skills/issue-operations/platforms/local/SKILL.md
+++ b/skills/issue-operations/platforms/local/SKILL.md
@@ -4,9 +4,14 @@
 
 <!-- Provenance: AI-generated -->
 
-______________________________________________________________________
-
-## name: local description: Use when local .issues/ tracking is needed. Local .issues/ directory platform for issue tracking. Used when github.platform is local or unset. Routes all issue operations to .issues/ directory with YAML frontmatter and markdown files. Untracked work is work that can be lost. Even local issues deserve structured tracking. type: discipline-enforcing license: MIT provenance: AI-generated compatibility: opencode
+---
+name: local
+description: "Use when local .issues/ tracking is needed. Local .issues/ directory platform for issue tracking. Used when github.platform is local or unset. Routes all issue operations to .issues/ directory with YAML frontmatter and markdown files. Untracked work is work that can be lost. Even local issues deserve structured tracking."
+type: discipline-enforcing
+license: MIT
+provenance: AI-generated
+compatibility: opencode
+---
 
 # Local Platform Sub-Skill
 

--- a/skills/issue-review/SKILL.md
+++ b/skills/issue-review/SKILL.md
@@ -19,14 +19,14 @@ Issue Review Orchestrator. Focus: gather context, classify path, delegate to cor
 
 ## Tasks
 
-| Task | Words |
-|------|-------|
-| `gather` | ≈500 |
-| `triage` | ≈600 |
-| `audit` | ≈350 |
-| `qa` | ≈500 |
-| `analyze-and-spec` | ≈600 |
-| `completion` | ≈200 |
+| Task |
+|------|
+| `gather` |
+| `triage` |
+| `audit` |
+| `qa` |
+| `analyze-and-spec` |
+| `completion` |
 
 ## Invocation
 

--- a/skills/mcp-tool-usage/SKILL.md
+++ b/skills/mcp-tool-usage/SKILL.md
@@ -15,9 +15,9 @@ Tool Priority Enforcer ensuring all operations use the correct tool according to
 
 ## Tasks
 
-| Task | Purpose | Words |
-|------|---------|-------|
-| `selection-guide` | Decision trees for Python code, file ops, notebooks | ≈500 |
+| Task | Purpose |
+|------|---------|
+| `selection-guide` | Decision trees for Python code, file ops, notebooks |
 
 ## Sub-Agent Tasks
 
@@ -80,7 +80,7 @@ Return `status: BLOCKED` with `reason: PRELOADED_CONTEXT_REJECTED`.
 `skill({name: "mcp-tool-usage"})` — call the skill, then call via task():
 
 | Task | Call via task() |
-|------|----------|
+
 | `selection-guide` | `task(..., prompt: "execute selection-guide task from mcp-tool-usage")` |
 
 **CLI equivalent (for human TUI use):** `/skill mcp-tool-usage --task <task>`
@@ -100,7 +100,7 @@ ABSOLUTE EXCEPTION: .ipynb files → the-notebook-mcp MANDATORY (zero tolerance,
 ### TIER 1: opencode Built-in Tools (PRIMARY for basic file ops)
 
 | Operation | Tool |
-|-----------|------|
+
 | Read file | `read` |
 | Write file | `write` |
 | Edit file | `edit` |
@@ -118,7 +118,7 @@ ABSOLUTE EXCEPTION: .ipynb files → the-notebook-mcp MANDATORY (zero tolerance,
 ### TIER 3: .opencode/tools/ Scripts (PRIMARY for their domains)
 
 | Tool | Domain |
-|------|--------|
+
 | `guidelines` | Guideline search/read (only tool that parses `.opencode/guidelines/` correctly) |
 | `md` | Markdown section operations |
 | `py ls` | Python package listing |

--- a/skills/multimodal-dispatch/SKILL.md
+++ b/skills/multimodal-dispatch/SKILL.md
@@ -19,18 +19,17 @@ Modality Router. Focus: probe models, resolve modality hints, task sub-agents to
 
 ## Tasks
 
-| Task | Words |
-|------|-------|
-| `probe` | ≈300 |
-| `route` | ≈400 |
-| `completion` | ≈150 |
+
+| `probe` |
+| `route` |
+| `completion` |
 
 ## Invocation
 
 `skill({name: "multimodal-dispatch"})` — call the skill, then call via task():
 
 | Task | Call via task() |
-|------|----------|
+
 | `probe` | `task(..., prompt: "execute probe task from multimodal-dispatch")` |
 | `route` | `task(..., prompt: "execute route task from multimodal-dispatch")` |
 | `completion` | `task(..., prompt: "execute completion task from multimodal-dispatch")` |

--- a/skills/pr-creation-workflow/SKILL.md
+++ b/skills/pr-creation-workflow/SKILL.md
@@ -17,18 +17,17 @@ Feature PRs target `dev` only. Release PRs (dev→main) handled by `git-workflow
 
 ## Tasks
 
-| Task | Words |
-|------|-------|
-| `pre-pr-checklist` | ≈500 |
-| `sub-issue-collection` | ≈300 |
-| `completion` | ≈200 |
+
+| `pre-pr-checklist` |
+| `sub-issue-collection` |
+| `completion` |
 
 ## Invocation
 
 `skill({name: "pr-creation-workflow"})` — call the skill, then call via task():
 
 | Task | Call via task() |
-|------|----------|
+
 | `pre-pr-checklist` | `task(..., prompt: "execute pre-pr-checklist task from pr-creation-workflow")` |
 | `sub-issue-collection` | `task(..., prompt: "execute sub-issue-collection task from pr-creation-workflow")` |
 | `completion` | `task(..., prompt: "execute completion task from pr-creation-workflow")` |

--- a/skills/pre-analysis/SKILL.md
+++ b/skills/pre-analysis/SKILL.md
@@ -19,17 +19,16 @@ You are a Pre-Analysis Gatekeeper. Your focus is independently discovering scope
 
 ## Tasks
 
-| Task | Purpose | Words |
-|------|---------|-------|
-| `analyze` | Load task files, discover scope, return task plan | ≈400 |
-| `completion` | Ensure mandatory completion steps run regardless of workflow outcome | ≈100 |
+| Task | Purpose |
+|------|---------|
+| `analyze` | Load task files, discover scope, return task plan |
+| `completion` | Ensure mandatory completion steps run regardless of workflow outcome |
 
 ## Sub-Agent Tasks
 
-| Task | Words |
-|------|-------|
-| `analyze` | ≈400 |
-| `completion` | ≈100 |
+
+| `analyze` |
+| `completion` |
 
 ### Task Routing
 
@@ -90,7 +89,7 @@ Return `status: BLOCKED` with `reason: PRELOADED_CONTEXT_REJECTED`.
 `skill({name: "pre-analysis"})` — call the skill, then call via task():
 
 | Task | Call via task() |
-|------|----------|
+
 | `analyze` | `task(..., prompt: "execute analyze task from pre-analysis")` |
 | `completion` | `task(..., prompt: "execute completion task from pre-analysis")` |
 

--- a/skills/programming-principles/SKILL.md
+++ b/skills/programming-principles/SKILL.md
@@ -15,18 +15,17 @@ compatibility: opencode
 
 ## Tasks
 
-| Task | Words |
-|------|-------|
-| `principles` | ≈2200 |
-| `check-limits` | ≈300 |
-| `decompose` | ≈400 |
+
+| `principles` |
+| `check-limits` |
+| `decompose` |
 
 ## Invocation
 
 `skill({name: "programming-principles"})` — call the skill, then call via task():
 
 | Task | Call via task() |
-|------|----------|
+
 | `principles` | `task(..., prompt: "execute principles task from programming-principles")` |
 | `check-limits` | `task(..., prompt: "execute check-limits task from programming-principles")` |
 | `decompose` | `task(..., prompt: "execute decompose task from programming-principles")` |

--- a/skills/receiving-code-review/SKILL.md
+++ b/skills/receiving-code-review/SKILL.md
@@ -15,18 +15,17 @@ Responds to PR review feedback. Ensures all comments addressed systematically, c
 
 ## Tasks
 
-| Task | Words |
-|------|-------|
-| `address` | ≈350 |
-| `respond` | ≈250 |
-| `completion` | ≈200 |
+
+| `address` |
+| `respond` |
+| `completion` |
 
 ## Invocation
 
 `skill({name: "receiving-code-review"})` — call the skill, then call via task():
 
 | Task | Call via task() |
-|------|----------|
+
 | `address` | `task(..., prompt: "execute address task from receiving-code-review")` |
 | `respond` | `task(..., prompt: "execute respond task from receiving-code-review")` |
 | `completion` | `task(..., prompt: "execute completion task from receiving-code-review")` |

--- a/skills/requesting-code-review/SKILL.md
+++ b/skills/requesting-code-review/SKILL.md
@@ -15,17 +15,16 @@ Prepares and requests code reviews. Ensures PR descriptions have proper context,
 
 ## Tasks
 
-| Task | Words |
-|------|-------|
-| `prepare` | ≈400 |
-| `request` | ≈250 |
+
+| `prepare` |
+| `request` |
 
 ## Invocation
 
 `skill({name: "requesting-code-review"})` — call the skill, then call via task():
 
 | Task | Call via task() |
-|------|----------|
+
 | `prepare` | `task(..., prompt: "execute prepare task from requesting-code-review")` |
 | `request` | `task(..., prompt: "execute request task from requesting-code-review")` |
 

--- a/skills/research/SKILL.md
+++ b/skills/research/SKILL.md
@@ -19,17 +19,16 @@ Research Agent. Focus: discover information, produce findings with source attrib
 
 ## Tasks
 
-| Task | Words |
-|------|-------|
-| `research` | ≈400 |
-| `completion` | ≈150 |
+
+| `research` |
+| `completion` |
 
 ## Invocation
 
 `skill({name: "research"})` — call the skill, then call via task():
 
 | Task | Call via task() |
-|------|----------|
+
 | `research` | `task(..., prompt: "execute research task from research")` |
 | `completion` | `task(..., prompt: "execute completion task from research")` |
 

--- a/skills/researcher/SKILL.md
+++ b/skills/researcher/SKILL.md
@@ -28,7 +28,7 @@ Exhaustive Investigator. Focus: verifiable source evidence, exhaustive research 
 ## Tasks
 
 | Task | Purpose |
-|------|---------|
+
 | `investigate` | Execute an exhaustive investigation with verifiable source evidence |
 | `findings` | Format research findings with YAML frontmatter + markdown body |
 
@@ -37,7 +37,7 @@ Exhaustive Investigator. Focus: verifiable source evidence, exhaustive research 
 `skill({name: "researcher"})` — call the skill, then call via task():
 
 | Task | Call via task() |
-|------|-----------------|
+
 | `investigate` | `task(..., prompt: "execute investigate task from researcher")` |
 | `findings` | `task(..., prompt: "execute findings task from researcher")` |
 

--- a/skills/skill-creator/SKILL.md
+++ b/skills/skill-creator/SKILL.md
@@ -17,19 +17,18 @@ Also manages duplicate text blocks across skills (formerly `fragment-manager` sk
 
 ## Tasks
 
-| Task | Words |
-|------|-------|
-| `init` | ≈200 |
-| `package` | ≈150 |
-| `validate` | ≈100 |
-| `fragment-management` | ≈300 |
+
+| `init` |
+| `package` |
+| `validate` |
+| `fragment-management` |
 
 ## Invocation
 
 `skill({name: "skill-creator"})` — call the skill, then call via task():
 
 | Task | Call via task() |
-|------|----------|
+
 | `init` | `task(..., prompt: "execute init task from skill-creator")` |
 | `package` | `task(..., prompt: "execute package task from skill-creator")` |
 | `validate` | `task(..., prompt: "execute validate task from skill-creator")` |

--- a/skills/spec-creation/SKILL.md
+++ b/skills/spec-creation/SKILL.md
@@ -1,6 +1,11 @@
-______________________________________________________________________
-
-## name: spec-creation description: "Use when creating a spec or writing a specification. Triggers on: create spec, write spec, spec creation, spec writing, structure spec, specification. Writing code without a spec is guesswork. Professional engineers spec first." type: discipline-enforcing license: MIT provenance: AI-generated compatibility: opencode
+---
+name: spec-creation
+description: "Use when creating a spec or writing a specification. Triggers on: create spec, write spec, spec creation, spec writing, structure spec, specification. Writing code without a spec is guesswork. Professional engineers spec first."
+type: discipline-enforcing
+license: MIT
+provenance: AI-generated
+compatibility: opencode
+---
 
 # Skill: spec-creation
 
@@ -16,17 +21,17 @@ Spec Architect. Focus: structure investigation results into complete, well-organ
 
 ## Tasks
 
-| Task                      | Words |
-| ------------------------- | ----- |
-| `requirements`            | ≈300  |
-| `decompose`               | ≈250  |
-| `traceability`            | ≈250  |
-| `pipeline-readiness-gate` | ≈250  |
-| `risk`                    | ≈250  |
-| `diagram`                 | ≈200  |
-| `write`                   | ≈300  |
-| `change-control`          | ≈200  |
-| `completion`              | ≈150  |
+| Task                      |
+| ------------------------- |
+| `requirements`            |
+| `decompose`               |
+| `traceability`            |
+| `pipeline-readiness-gate` |
+| `risk`                    |
+| `diagram`                 |
+| `write`                   |
+| `change-control`          |
+| `completion`              |
 
 ## Invocation
 

--- a/skills/spec-creation/SKILL.md
+++ b/skills/spec-creation/SKILL.md
@@ -1,11 +1,6 @@
----
-name: spec-creation
-description: Use when creating a spec or writing a specification. Triggers on: create spec, write spec, spec creation, spec writing, structure spec, specification. Writing code without a spec is guesswork. Professional engineers spec first.
-type: discipline-enforcing
-license: MIT
-provenance: AI-generated
-compatibility: opencode
----
+______________________________________________________________________
+
+## name: spec-creation description: "Use when creating a spec or writing a specification. Triggers on: create spec, write spec, spec creation, spec writing, structure spec, specification. Writing code without a spec is guesswork. Professional engineers spec first." type: discipline-enforcing license: MIT provenance: AI-generated compatibility: opencode
 
 # Skill: spec-creation
 
@@ -21,46 +16,46 @@ Spec Architect. Focus: structure investigation results into complete, well-organ
 
 ## Tasks
 
-| Task | Words |
-|------|-------|
-| `requirements` | ≈300 |
-| `decompose` | ≈250 |
-| `traceability` | ≈250 |
-| `pipeline-readiness-gate` | ≈250 |
-| `risk` | ≈250 |
-| `diagram` | ≈200 |
-| `write` | ≈300 |
-| `change-control` | ≈200 |
-| `completion` | ≈150 |
+| Task                      | Words |
+| ------------------------- | ----- |
+| `requirements`            | ≈300  |
+| `decompose`               | ≈250  |
+| `traceability`            | ≈250  |
+| `pipeline-readiness-gate` | ≈250  |
+| `risk`                    | ≈250  |
+| `diagram`                 | ≈200  |
+| `write`                   | ≈300  |
+| `change-control`          | ≈200  |
+| `completion`              | ≈150  |
 
 ## Invocation
 
 `skill({name: "spec-creation"})` — call the skill, then call via task():
 
-| Task | Call via task() |
-|------|----------|
-| `requirements` | `task(..., prompt: "execute requirements task from spec-creation")` |
-| `decompose` | `task(..., prompt: "execute decompose task from spec-creation")` |
-| `traceability` | `task(..., prompt: "execute traceability task from spec-creation")` |
+| Task                      | Call via task()                                                                |
+| ------------------------- | ------------------------------------------------------------------------------ |
+| `requirements`            | `task(..., prompt: "execute requirements task from spec-creation")`            |
+| `decompose`               | `task(..., prompt: "execute decompose task from spec-creation")`               |
+| `traceability`            | `task(..., prompt: "execute traceability task from spec-creation")`            |
 | `pipeline-readiness-gate` | `task(..., prompt: "execute pipeline-readiness-gate task from spec-creation")` |
-| `risk` | `task(..., prompt: "execute risk task from spec-creation")` |
-| `diagram` | `task(..., prompt: "execute diagram task from spec-creation")` |
-| `write` | `task(..., prompt: "execute write task from spec-creation")` |
-| `completion` | `task(..., prompt: "execute completion task from spec-creation")` |
+| `risk`                    | `task(..., prompt: "execute risk task from spec-creation")`                    |
+| `diagram`                 | `task(..., prompt: "execute diagram task from spec-creation")`                 |
+| `write`                   | `task(..., prompt: "execute write task from spec-creation")`                   |
+| `completion`              | `task(..., prompt: "execute completion task from spec-creation")`              |
 
 **CLI equivalent (for human TUI use):** `/skill spec-creation --task <task>`
 
 ## Operating Protocol
 
 1. **Pre-spec inspection mandatory** per `015-pre-spec-inspection.md` (code inspection checklist).
-2. **Verification-enforcement gate** before generation.
-3. **Select-existing pathway:** search GitHub Issues for existing specs before creating new one.
-4. **Requirements task mandatory** before write (unless trivial).
-5. **Persist as GitHub Issue** via `issue-operations --task creation`.
-6. **Adversarial-audit call:** after issue creation, call `adversarial-audit --task spec-audit --issue <N>` with `audit_phase: spec_creation`.
-7. **PR merge boundaries** required when dependencies exist.
-8. **Mermaid diagram** required for multi-phase specs (approved structure only, no workflow state).
-9. **Concern enumeration guard:** enumerate single concerns before writing.
+1. **Verification-enforcement gate** before generation.
+1. **Select-existing pathway:** search GitHub Issues for existing specs before creating new one.
+1. **Requirements task mandatory** before write (unless trivial).
+1. **Persist as GitHub Issue** via `issue-operations --task creation`.
+1. **Adversarial-audit call:** after issue creation, call `adversarial-audit --task spec-audit --issue <N>` with `audit_phase: spec_creation`.
+1. **PR merge boundaries** required when dependencies exist.
+1. **Mermaid diagram** required for multi-phase specs (approved structure only, no workflow state).
+1. **Concern enumeration guard:** enumerate single concerns before writing.
 
 ## Sub-Agent Routing
 
@@ -75,12 +70,12 @@ Every sub-agent MUST independently discover scope and produce its own result con
 
 #### Forbidden in task() Prompts
 
-| Violation | Forbidden Pattern | Correct Pattern |
-|-----------|-------------------|-----------------|
-| Preloaded file paths | "Read cleanup/branch-cleanup.md then execute step 1" | "execute cleanup task from git-workflow" |
-| Preloaded step sequences | "Step 1: sync dev. Step 2: delete branch." | "execute cleanup task from git-workflow" |
-| Preloaded expected outcomes | "Return { cleanup_status, branch_deleted }" | Let sub-agent define its own result contract |
-| Preloaded orchestrator reasoning | "The merge was just completed so we need to..." | Pure objective, no narrative |
+| Violation                        | Forbidden Pattern                                    | Correct Pattern                              |
+| -------------------------------- | ---------------------------------------------------- | -------------------------------------------- |
+| Preloaded file paths             | "Read cleanup/branch-cleanup.md then execute step 1" | "execute cleanup task from git-workflow"     |
+| Preloaded step sequences         | "Step 1: sync dev. Step 2: delete branch."           | "execute cleanup task from git-workflow"     |
+| Preloaded expected outcomes      | "Return { cleanup_status, branch_deleted }"          | Let sub-agent define its own result contract |
+| Preloaded orchestrator reasoning | "The merge was just completed so we need to..."      | Pure objective, no narrative                 |
 
 #### Dispatch Context Contract
 
@@ -97,6 +92,7 @@ Every `task()` call MUST include only:
 Plus skill-specific fields per the `## Sub-Agent Routing` section above.
 
 Exclusions (MUST NOT be in prompt):
+
 - `orchestrator_reasoning`
 - `expected_outcomes`
 - `inline_file_paths`
@@ -106,6 +102,7 @@ Exclusions (MUST NOT be in prompt):
 #### Sub-Agent Entry Criteria
 
 A sub-agent receiving a `task()` prompt MUST reject it if the prompt contains:
+
 - Inline file paths to task files
 - Inline step or procedure definitions
 - Expected outcome structures or schema constraints
@@ -141,3 +138,4 @@ rules:
       all: ["concern_enumeration_performed == false", "write_task_pending == true"]
     actions: [HALT, ENUMERATE_CONCERNS]
     source: "spec-creation/SKILL.md"
+```

--- a/skills/spec-creation/SKILL.md
+++ b/skills/spec-creation/SKILL.md
@@ -138,4 +138,13 @@ rules:
       all: ["concern_enumeration_performed == false", "write_task_pending == true"]
     actions: [HALT, ENUMERATE_CONCERNS]
     source: "spec-creation/SKILL.md"
+
+  - id: spec-creation-pipeline-readiness
+    title: "Pipeline-readiness gate required before spec finalization"
+    conditions:
+      all:
+        - "spec_sc_finalized == true"
+        - "pipeline_readiness_gate_passed == false"
+    actions: [HALT, CALL(spec-creation --task pipeline-readiness-gate)]
+    source: "spec-creation/SKILL.md"
 ```

--- a/skills/spec-creation/SKILL.md
+++ b/skills/spec-creation/SKILL.md
@@ -26,6 +26,7 @@ Spec Architect. Focus: structure investigation results into complete, well-organ
 | `requirements` | ≈300 |
 | `decompose` | ≈250 |
 | `traceability` | ≈250 |
+| `pipeline-readiness-gate` | ≈250 |
 | `risk` | ≈250 |
 | `diagram` | ≈200 |
 | `write` | ≈300 |
@@ -41,6 +42,7 @@ Spec Architect. Focus: structure investigation results into complete, well-organ
 | `requirements` | `task(..., prompt: "execute requirements task from spec-creation")` |
 | `decompose` | `task(..., prompt: "execute decompose task from spec-creation")` |
 | `traceability` | `task(..., prompt: "execute traceability task from spec-creation")` |
+| `pipeline-readiness-gate` | `task(..., prompt: "execute pipeline-readiness-gate task from spec-creation")` |
 | `risk` | `task(..., prompt: "execute risk task from spec-creation")` |
 | `diagram` | `task(..., prompt: "execute diagram task from spec-creation")` |
 | `write` | `task(..., prompt: "execute write task from spec-creation")` |

--- a/skills/spec-creation/tasks/pipeline-readiness-gate.md
+++ b/skills/spec-creation/tasks/pipeline-readiness-gate.md
@@ -1,0 +1,108 @@
+<!-- SPDX-FileCopyrightText: 2026 Michael Conrad -->
+<!-- SPDX-License-Identifier: MIT -->
+<!-- Provenance: AI-generated -->
+
+# Task: pipeline-readiness-gate
+
+## Purpose
+
+Validate that spec success criteria are structurally fit for the implementation pipeline. Each SC must be atomic, dependency-ordered, single-concern, and the phase DAG must be acyclic. This gate runs after traceability and before risk analysis.
+
+## Entry Criteria
+
+- Spec success criteria table populated with IDs, evidence types, and dependency declarations
+- At least one SC defined
+- Phase table populated with dependency declarations
+
+## Exit Criteria
+
+- PR-1 (atomicity): PASS — every SC maps to one RED→GREEN→COMMIT cycle
+- PR-2 (dependency ordering): PASS — `solve prove` confirms SC dependency DAG is valid
+- PR-3 (single concern): PASS — every SC targets one file category and one verification domain
+- PR-4 (phase dependency): PASS — `solve prove` confirms phase dependency graph is acyclic
+- Artifact `.issues/{issue-N}/spec-artifacts/sc-pipeline-readiness.yaml` written with status PASS/FAIL
+
+## Procedure
+
+### Step 1: Validate SC Atomicity (PR-1)
+
+For each SC, verify it maps to exactly one RED→GREEN→COMMIT cycle:
+
+| Pass Condition | Fail Condition |
+|----------------|----------------|
+| SC asserts exactly one independently testable claim | SC bundles multiple assertions (e.g., "X is correct AND Y is correct AND Z passes") |
+| PASS/FAIL of the SC cannot be split across two claims | SC references multiple files or verification domains in the same criterion |
+
+Record each SC as `atomic: true | false`.
+
+### Step 2: Validate SC Dependency Ordering (PR-2)
+
+Extract the SC dependency graph from `depends_on` fields:
+
+1. Collect all SC-ID → `depends_on: [SC-IDs]` mappings
+2. Verify every referenced SC-ID in `depends_on` is defined in the SC table
+3. Generate a Z3 ordering contract at `.issues/{N}/spec-artifacts/sc-dependency-contract.yaml`
+4. Run `solve prove --contract-path ... --ordering-assertion` to validate the DAG
+5. If any cycle or missing dependency is found: PR-2 = FAIL
+
+### Step 3: Validate Single Concern (PR-3)
+
+For each SC, verify it targets exactly one file category and one verification domain:
+
+- **File categories:** task file, SKILL.md, guideline, test, config, template
+- **Verification domains:** behavioral, semantic, string, structural
+
+An SC that spans multiple file categories or multiple verification domains is a single-concern violation.
+
+### Step 4: Validate Phase Dependency Declarations (PR-4)
+
+Extract the phase dependency graph:
+
+1. Collect all phase → `depends_on: [phase-names]` mappings
+2. Generate a Z3 ordering contract at `.issues/{N}/spec-artifacts/dependency-ordering-verification/ordering.yaml`
+3. Run `solve prove --contract-path ... --theorem "phase_dag_is_acyclic"` to validate
+4. If any cycle is found: PR-4 = FAIL
+
+### Step 5: Write Artifact
+
+Write `.issues/{issue-N}/spec-artifacts/sc-pipeline-readiness.yaml`:
+
+```yaml
+schema_version: "1.0"
+generated_at: "<timestamp>"
+status: PASS | FAIL
+checks:
+  - check_id: PR-1
+    result: PASS | FAIL
+    detail: "..."
+  - check_id: PR-2
+    result: PASS | FAIL
+    solve_contract_path: ".issues/{N}/spec-artifacts/sc-dependency-contract.yaml"
+    prove_results:
+      - theorem: "sc_dag_is_valid"
+        result: VALID | INVALID
+  - check_id: PR-3
+    result: PASS | FAIL
+    detail: "..."
+  - check_id: PR-4
+    result: PASS | FAIL
+    solve_contract_path: ".issues/{N}/spec-artifacts/dependency-ordering-verification/ordering.yaml"
+    prove_results:
+      - theorem: "phase_dag_is_acyclic"
+        result: VALID | INVALID
+sc_summary:
+  total_scs: <count>
+  atomic: <count>
+  with_dependencies: <count>
+  single_concern: <count>
+```
+
+On FAIL for any check, the spec must be revised before this gate passes. The gate is re-runnable.
+
+## Context Required
+
+- Preceded by: `traceability`
+- Feeds into: `risk`
+- Note: This is a gate, not an analysis phase. FAIL halts spec progression until the spec is revised.
+
+Co-authored with AI: OpenCode (ollama-cloud/deepseek-v4-flash)

--- a/skills/spec-creation/tasks/pipeline-readiness-gate.md
+++ b/skills/spec-creation/tasks/pipeline-readiness-gate.md
@@ -1,5 +1,7 @@
 <!-- SPDX-FileCopyrightText: 2026 Michael Conrad -->
+
 <!-- SPDX-License-Identifier: MIT -->
+
 <!-- Provenance: AI-generated -->
 
 # Task: pipeline-readiness-gate
@@ -28,10 +30,10 @@ Validate that spec success criteria are structurally fit for the implementation 
 
 For each SC, verify it maps to exactly one RED→GREEN→COMMIT cycle:
 
-| Pass Condition | Fail Condition |
-|----------------|----------------|
-| SC asserts exactly one independently testable claim | SC bundles multiple assertions (e.g., "X is correct AND Y is correct AND Z passes") |
-| PASS/FAIL of the SC cannot be split across two claims | SC references multiple files or verification domains in the same criterion |
+| Pass Condition                                        | Fail Condition                                                                      |
+| ----------------------------------------------------- | ----------------------------------------------------------------------------------- |
+| SC asserts exactly one independently testable claim   | SC bundles multiple assertions (e.g., "X is correct AND Y is correct AND Z passes") |
+| PASS/FAIL of the SC cannot be split across two claims | SC references multiple files or verification domains in the same criterion          |
 
 Record each SC as `atomic: true | false`.
 
@@ -40,10 +42,10 @@ Record each SC as `atomic: true | false`.
 Extract the SC dependency graph from `depends_on` fields:
 
 1. Collect all SC-ID → `depends_on: [SC-IDs]` mappings
-2. Verify every referenced SC-ID in `depends_on` is defined in the SC table
-3. Generate a Z3 ordering contract at `.issues/{N}/spec-artifacts/sc-dependency-contract.yaml`
-4. Run `solve prove --contract-path ... --ordering-assertion` to validate the DAG
-5. If any cycle or missing dependency is found: PR-2 = FAIL
+1. Verify every referenced SC-ID in `depends_on` is defined in the SC table
+1. Generate a Z3 ordering contract at `.issues/{N}/spec-artifacts/sc-dependency-contract.yaml`
+1. Run `solve prove --contract-path ... --ordering-assertion` to validate the DAG
+1. If any cycle or missing dependency is found: PR-2 = FAIL
 
 ### Step 3: Validate Single Concern (PR-3)
 
@@ -59,9 +61,9 @@ An SC that spans multiple file categories or multiple verification domains is a 
 Extract the phase dependency graph:
 
 1. Collect all phase → `depends_on: [phase-names]` mappings
-2. Generate a Z3 ordering contract at `.issues/{N}/spec-artifacts/dependency-ordering-verification/ordering.yaml`
-3. Run `solve prove --contract-path ... --theorem "phase_dag_is_acyclic"` to validate
-4. If any cycle is found: PR-4 = FAIL
+1. Generate a Z3 ordering contract at `.issues/{N}/spec-artifacts/dependency-ordering-verification/ordering.yaml`
+1. Run `solve prove --contract-path ... --theorem "phase_dag_is_acyclic"` to validate
+1. If any cycle is found: PR-4 = FAIL
 
 ### Step 5: Write Artifact
 

--- a/skills/spec-creation/tasks/pipeline-readiness-gate.md
+++ b/skills/spec-creation/tasks/pipeline-readiness-gate.md
@@ -67,11 +67,13 @@ Extract the phase dependency graph:
 
 ### Step 5: Write Artifact
 
+Generate timestamp via `.opencode/tools/schema-version`. Store result in `$TIMESTAMP`.
+
 Write `.issues/{issue-N}/spec-artifacts/sc-pipeline-readiness.yaml`:
 
 ```yaml
 schema_version: "1.0"
-generated_at: "<timestamp>"
+generated_at: "$(./.opencode/tools/schema-version)"
 status: PASS | FAIL
 checks:
   - check_id: PR-1

--- a/skills/spec-creation/tasks/pipeline-readiness-gate.md
+++ b/skills/spec-creation/tasks/pipeline-readiness-gate.md
@@ -43,8 +43,26 @@ Extract the SC dependency graph from `depends_on` fields:
 
 1. Collect all SC-ID → `depends_on: [SC-IDs]` mappings
 1. Verify every referenced SC-ID in `depends_on` is defined in the SC table
-1. Generate a Z3 ordering contract at `.issues/{N}/spec-artifacts/sc-dependency-contract.yaml`
-1. Run `solve prove --contract-path ... --ordering-assertion` to validate the DAG
+1. Generate a Z3 ordering contract at `.issues/{issue-N}/spec-artifacts/sc-dependency-contract.yaml`
+
+   Contract schema (SC DAG ordering):
+
+   ```yaml
+   variables:
+     SC-1_DONE: {type: bool, nullable: false}
+     SC-2_DONE: {type: bool, nullable: false}
+     ...
+   invariants:
+     # Each SC's truth implies all its dependencies are true
+     - "z3.Implies(SC-2_DONE == True, SC-1_DONE == True)"
+     - "z3.Implies(SC-3_DONE == True, z3.And(SC-1_DONE == True, SC-2_DONE == True))"
+     # Theorem: all SCs can be satisfied without violating dependency order
+     - "sc_dag_is_valid"
+   ```
+
+   The theorem `sc_dag_is_valid` is a Z3 assertion that the conjunction of all implication invariants is SAT (the dependency graph has no contradictions). If Z3 returns UNSAT, the dependency graph is invalid.
+
+1. Run `solve prove --contract-path .issues/{issue-N}/spec-artifacts/sc-dependency-contract.yaml --theorem "sc_dag_is_valid"` to validate the DAG
 1. If any cycle or missing dependency is found: PR-2 = FAIL
 
 ### Step 3: Validate Single Concern (PR-3)
@@ -61,8 +79,23 @@ An SC that spans multiple file categories or multiple verification domains is a 
 Extract the phase dependency graph:
 
 1. Collect all phase → `depends_on: [phase-names]` mappings
-1. Generate a Z3 ordering contract at `.issues/{N}/spec-artifacts/dependency-ordering-verification/ordering.yaml`
-1. Run `solve prove --contract-path ... --theorem "phase_dag_is_acyclic"` to validate
+1. Generate a Z3 ordering contract at `.issues/{issue-N}/spec-artifacts/dependency-ordering-verification/ordering.yaml`
+
+   Contract schema (phase DAG ordering) — same structure as Step 2:
+
+   ```yaml
+   variables:
+     PHASE-1_DONE: {type: bool, nullable: false}
+     PHASE-2_DONE: {type: bool, nullable: false}
+     ...
+   invariants:
+     - "z3.Implies(PHASE-2_DONE == True, PHASE-1_DONE == True)"
+     - "z3.Implies(PHASE-3_DONE == True, PHASE-1_DONE == True)"
+     # Theorem: all phases can be satisfied without violating ordering
+     - "phase_dag_is_acyclic"
+   ```
+
+1. Run `solve prove --contract-path .issues/{issue-N}/spec-artifacts/dependency-ordering-verification/ordering.yaml --theorem "phase_dag_is_acyclic"` to validate
 1. If any cycle is found: PR-4 = FAIL
 
 ### Step 5: Write Artifact
@@ -81,7 +114,7 @@ checks:
     detail: "..."
   - check_id: PR-2
     result: PASS | FAIL
-    solve_contract_path: ".issues/{N}/spec-artifacts/sc-dependency-contract.yaml"
+    solve_contract_path: ".issues/{issue-N}/spec-artifacts/sc-dependency-contract.yaml"
     prove_results:
       - theorem: "sc_dag_is_valid"
         result: VALID | INVALID
@@ -90,7 +123,7 @@ checks:
     detail: "..."
   - check_id: PR-4
     result: PASS | FAIL
-    solve_contract_path: ".issues/{N}/spec-artifacts/dependency-ordering-verification/ordering.yaml"
+    solve_contract_path: ".issues/{issue-N}/spec-artifacts/dependency-ordering-verification/ordering.yaml"
     prove_results:
       - theorem: "phase_dag_is_acyclic"
         result: VALID | INVALID

--- a/skills/sre-runbook/SKILL.md
+++ b/skills/sre-runbook/SKILL.md
@@ -19,18 +19,17 @@ SRE-oriented operator writing runbooks for sysops under pressure. Runbooks are o
 
 ## Tasks
 
-| Task | Words |
-|------|-------|
-| `generate` | ≈1000 |
-| `track` | ≈450 |
-| `completion` | ≈200 |
+
+| `generate` |
+| `track` |
+| `completion` |
 
 ## Invocation
 
 `skill({name: "sre-runbook"})` — call the skill, then call via task():
 
 | Task | Call via task() |
-|------|----------|
+
 | `generate` | `task(..., prompt: "execute generate task from sre-runbook")` |
 | `track` | `task(..., prompt: "execute track task from sre-runbook")` |
 | `completion` | `task(..., prompt: "execute completion task from sre-runbook")` |

--- a/skills/sync-guidelines/SKILL.md
+++ b/skills/sync-guidelines/SKILL.md
@@ -15,20 +15,19 @@ Intelligently synchronizes guidelines, skills, and tools between repos via GitHu
 
 ## Tasks
 
-| Task | Words |
-|------|-------|
-| `classify` | ≈250 |
-| `sync-push` | ≈300 |
-| `sync-pull` | ≈300 |
-| `issue-format` | ≈350 |
-| `completion` | ≈200 |
+
+| `classify` |
+| `sync-push` |
+| `sync-pull` |
+| `issue-format` |
+| `completion` |
 
 ## Invocation
 
 `skill({name: "sync-guidelines"})` — call the skill, then call via task():
 
 | Task | Call via task() |
-|------|----------|
+
 | `classify` | `task(..., prompt: "execute classify task from sync-guidelines")` |
 | `sync-push` | `task(..., prompt: "execute sync-push task from sync-guidelines")` |
 | `sync-pull` | `task(..., prompt: "execute sync-pull task from sync-guidelines")` |

--- a/skills/systematic-debugging/SKILL.md
+++ b/skills/systematic-debugging/SKILL.md
@@ -15,18 +15,17 @@ Enforces root cause analysis, hypothesis testing, and minimal fixes. Prevents "v
 
 ## Tasks
 
-| Task | Words |
-|------|-------|
-| `diagnose` | ≈400 |
-| `fix` | ≈350 |
-| `completion` | ≈200 |
+
+| `diagnose` |
+| `fix` |
+| `completion` |
 
 ## Invocation
 
 `skill({name: "systematic-debugging"})` — call the skill, then call via task():
 
 | Task | Call via task() |
-|------|----------|
+
 | `diagnose` | `task(..., prompt: "execute diagnose task from systematic-debugging")` |
 | `fix` | `task(..., prompt: "execute fix task from systematic-debugging")` |
 | `completion` | `task(..., prompt: "execute completion task from systematic-debugging")` |

--- a/skills/test-driven-development/SKILL.md
+++ b/skills/test-driven-development/SKILL.md
@@ -50,23 +50,22 @@ Never `RED-ALL → GREEN-ALL`.
 
 ## Tasks
 
-| Task | Words | Purpose |
 |------|-------|---------|
-| `red` | ≈80 | Execution-only: write failing test |
-| `green` | ≈80 | Execution-only: minimal impl |
-| `refactor` | ≈120 | Execution-only: clean while green |
-| `patterns` | ≈400 | 4-pattern decision matrix |
-| `anti-patterns` | ≈500 | 5 anti-patterns with alternatives |
-| `checklist` | ≈350 | Quality checklists, timing, step-size |
-| `phase-0` | ≈400 | Pre-regression baseline gate |
-| `phase-4` | ≈400 | Post-regression verification gate |
+| `red` | Execution-only: write failing test |
+| `green` | Execution-only: minimal impl |
+| `refactor` | Execution-only: clean while green |
+| `patterns` | 4-pattern decision matrix |
+| `anti-patterns` | 5 anti-patterns with alternatives |
+| `checklist` | Quality checklists, timing, step-size |
+| `phase-0` | Pre-regression baseline gate |
+| `phase-4` | Post-regression verification gate |
 
 ## Invocation
 
 `skill({name: "test-driven-development"})` — call the skill, then call via task():
 
 | Task | Call via task() |
-|------|----------|
+
 | (use task name) | `task(..., prompt: "execute <task> task from test-driven-development")` |
 
 **CLI equivalent (for human TUI use):** `/skill test-driven-development --task <name>`

--- a/skills/ui-design/SKILL.md
+++ b/skills/ui-design/SKILL.md
@@ -19,20 +19,19 @@ UI Design Specialist. Focus: information architecture, component relationships, 
 
 ## Tasks
 
-| Task | Words |
-|------|-------|
-| `design` | ≈800 |
-| `wireframe` | ≈400 |
-| `mockup` | ≈400 |
-| `interaction-spec` | ≈400 |
-| `completion` | ≈150 |
+
+| `design` |
+| `wireframe` |
+| `mockup` |
+| `interaction-spec` |
+| `completion` |
 
 ## Invocation
 
 `skill({name: "ui-design"})` — call the skill, then call via task():
 
 | Task | Call via task() |
-|------|----------|
+
 | `design` | `task(..., prompt: "execute design task from ui-design")` |
 | `wireframe` | `task(..., prompt: "execute wireframe task from ui-design")` |
 | `mockup` | `task(..., prompt: "execute mockup task from ui-design")` |

--- a/skills/ui-engineer/SKILL.md
+++ b/skills/ui-engineer/SKILL.md
@@ -19,19 +19,18 @@ UI Implementation Engineer. Focus: component mapping, accessibility implementati
 
 ## Tasks
 
-| Task | Words |
-|------|-------|
-| `implement` | ≈800 |
-| `validate-impl` | ≈400 |
-| `test-ui` | ≈400 |
-| `completion` | ≈150 |
+
+| `implement` |
+| `validate-impl` |
+| `test-ui` |
+| `completion` |
 
 ## Invocation
 
 `skill({name: "ui-engineer"})` — call the skill, then call via task():
 
 | Task | Call via task() |
-|------|----------|
+
 | `implement` | `task(..., prompt: "execute implement task from ui-engineer")` |
 | `validate-impl` | `task(..., prompt: "execute validate-impl task from ui-engineer")` |
 | `test-ui` | `task(..., prompt: "execute test-ui task from ui-engineer")` |

--- a/skills/using-git-worktrees/SKILL.md
+++ b/skills/using-git-worktrees/SKILL.md
@@ -19,18 +19,17 @@ Worktree Setup Specialist. Focus: creating safe, isolated git worktrees for para
 
 ## Tasks
 
-| Task | Words |
-|------|-------|
-| `create-worktree` | ≈400 |
-| `verify-worktree` | ≈200 |
-| `completion` | ≈150 |
+
+| `create-worktree` |
+| `verify-worktree` |
+| `completion` |
 
 ## Invocation
 
 `skill({name: "using-git-worktrees"})` — call the skill, then call via task():
 
 | Task | Call via task() |
-|------|----------|
+
 | `create-worktree` | `task(..., prompt: "execute create-worktree task from using-git-worktrees")` |
 | `verify-worktree` | `task(..., prompt: "execute verify-worktree task from using-git-worktrees")` |
 | `completion` | `task(..., prompt: "execute completion task from using-git-worktrees")` |

--- a/skills/verification-before-completion/SKILL.md
+++ b/skills/verification-before-completion/SKILL.md
@@ -23,19 +23,18 @@ Verification Gatekeeper. Focus: no completion claim without verified evidence. E
 
 ## Tasks
 
-| Task | Words |
-|------|-------|
-| `verify` | ≈700 |
-| `collect` | ≈500 |
-| `structural-verify` | ≈500 |
-| `completion` | ≈150 |
+
+| `verify` |
+| `collect` |
+| `structural-verify` |
+| `completion` |
 
 ## Invocation
 
 `skill({name: "verification-before-completion"})` — call the skill, then call via task():
 
 | Task | Call via task() |
-|------|----------|
+
 | `verify` | `task(..., prompt: "execute verify task from verification-before-completion")` |
 | `structural-verify` | `task(..., prompt: "execute structural-verify task from verification-before-completion")` |
 | `collect` | `task(..., prompt: "execute collect task from verification-before-completion")` |

--- a/skills/verification-enforcement/SKILL.md
+++ b/skills/verification-enforcement/SKILL.md
@@ -21,19 +21,18 @@ Verification Gatekeeper. Not the content author — the evidence collector runni
 
 ## Tasks
 
-| Task | Words |
-|------|-------|
-| `verify` | ≈300 |
-| `revisit` | ≈250 |
-| `enforce` | ≈200 |
-| `completion` | ≈150 |
+
+| `verify` |
+| `revisit` |
+| `enforce` |
+| `completion` |
 
 ## Invocation
 
 `skill({name: "verification-enforcement"})` — call the skill, then call via task():
 
 | Task | Call via task() |
-|------|----------|
+
 | `verify` | `task(..., prompt: "execute verify task from verification-enforcement")` |
 | `revisit` | `task(..., prompt: "execute revisit task from verification-enforcement")` |
 | `enforce` | `task(..., prompt: "execute enforce task from verification-enforcement")` |

--- a/skills/verification/SKILL.md
+++ b/skills/verification/SKILL.md
@@ -19,10 +19,9 @@ Claim Verifier. Focus: verify each claim against evidence, produce PASS/FAIL/UNV
 
 ## Tasks
 
-| Task | Words |
-|------|-------|
-| `verify` | ≈300 |
-| `completion` | ≈150 |
+
+| `verify` |
+| `completion` |
 
 ## ClaimResult Schema
 
@@ -33,7 +32,7 @@ Claim Verifier. Focus: verify each claim against evidence, produce PASS/FAIL/UNV
 `skill({name: "verification"})` — call the skill, then call via task():
 
 | Task | Call via task() |
-|------|----------|
+
 | `verify` | `task(..., prompt: "execute verify task from verification")` |
 | `completion` | `task(..., prompt: "execute completion task from verification")` |
 

--- a/skills/writing-plans/SKILL.md
+++ b/skills/writing-plans/SKILL.md
@@ -1,11 +1,6 @@
----
-name: writing-plans
-description: Use when creating an implementation plan from an approved spec. Triggers on: write plan, create plan, implementation plan, plan spec, approved plan, plan creation. Implementing without a plan is wandering. Plans are the map — agents who skip them get lost.
-type: discipline-enforcing
-license: MIT
-provenance: AI-generated
-compatibility: opencode
----
+______________________________________________________________________
+
+## name: writing-plans description: Use when creating an implementation plan from an approved spec. Triggers on: write plan, create plan, implementation plan, plan spec, approved plan, plan creation. Implementing without a plan is wandering. Plans are the map — agents who skip them get lost. type: discipline-enforcing license: MIT provenance: AI-generated compatibility: opencode
 
 # Skill: writing-plans
 
@@ -45,11 +40,12 @@ Plan Author. Focus: transform spec into phased plan with file structure, TDD ste
 ## Operating Protocol
 
 1. **Plan from approved spec only.** No plan without approved spec.
-2. **Adversarial-audit call:** after plan creation, call type-specific audit tasks directly — `adversarial-audit --task plan-fidelity` and `adversarial-audit --task concern-separation` — with `audit_phase: plan_creation`.
-3. **TDD steps mandatory:** each step is RED→GREEN→REFACTOR within tasks.
-4. **No placeholders:** exact file paths, exact function/class names, exact commands.
-5. **Phase structure:** phases for concern boundaries and handoffs, tasks within phases for TDD steps.
-6. **Decision gate:** multi-task → separate plan. Single-task + simple → combined or separate per agent judgment.
+1. **Adversarial-audit call:** after plan creation, call type-specific audit tasks directly — `adversarial-audit --task plan-fidelity` and `adversarial-audit --task concern-separation` — with `audit_phase: plan_creation`.
+1. **TDD steps mandatory:** each step is RED→GREEN→REFACTOR within tasks.
+1. **No placeholders:** exact file paths, exact function/class names, exact commands.
+1. **Phase structure:** phases for concern boundaries and handoffs, tasks within phases for TDD steps.
+1. **Decision gate:** multi-task → separate plan. Single-task + simple → combined or separate per agent judgment.
+1. **Pipeline-readiness gate check (Step 0.5) + mandatory checklist generation (Step 6) required.** Plan creation must verify `sc-pipeline-readiness.yaml` PASS before proceeding, and generate `implementation-checklist.md` after plan content is finalized.
 
 ## Sub-Agent Routing
 
@@ -86,6 +82,7 @@ Every `task()` call MUST include only:
 Plus skill-specific fields per the `## Sub-Agent Routing` section above.
 
 Exclusions (MUST NOT be in prompt):
+
 - `orchestrator_reasoning`
 - `expected_outcomes`
 - `inline_file_paths`
@@ -95,6 +92,7 @@ Exclusions (MUST NOT be in prompt):
 #### Sub-Agent Entry Criteria
 
 A sub-agent receiving a `task()` prompt MUST reject it if the prompt contains:
+
 - Inline file paths to task files
 - Inline step or procedure definitions
 - Expected outcome structures or schema constraints
@@ -116,3 +114,13 @@ rules:
       all: ["plan_creation_attempted == true", "spec_approved == false"]
     actions: [HALT]
     source: "writing-plans/SKILL.md"
+
+  - id: writing-plans-pipeline-readiness
+    title: "Pipeline-readiness artifact required before plan creation"
+    conditions:
+      all:
+        - "plan_creation_pending == true"
+        - "sc_pipeline_readiness_exists == false"
+    actions: [HALT, REPORT(SPEC_NOT_READY_FOR_PIPELINE)]
+    source: "writing-plans/SKILL.md"
+```

--- a/skills/writing-plans/SKILL.md
+++ b/skills/writing-plans/SKILL.md
@@ -1,6 +1,11 @@
-______________________________________________________________________
-
-## name: writing-plans description: Use when creating an implementation plan from an approved spec. Triggers on: write plan, create plan, implementation plan, plan spec, approved plan, plan creation. Implementing without a plan is wandering. Plans are the map — agents who skip them get lost. type: discipline-enforcing license: MIT provenance: AI-generated compatibility: opencode
+---
+name: writing-plans
+description: "Use when creating an implementation plan from an approved spec. Triggers on: write plan, create plan, implementation plan, plan spec, approved plan, plan creation. Implementing without a plan is wandering. Plans are the map — agents who skip them get lost."
+type: discipline-enforcing
+license: MIT
+provenance: AI-generated
+compatibility: opencode
+---
 
 # Skill: writing-plans
 
@@ -14,10 +19,9 @@ Plan Author. Focus: transform spec into phased plan with file structure, TDD ste
 
 ## Tasks
 
-| Task | Words |
-|------|-------|
-| `create` | ≈600 |
-| `completion` | ≈200 |
+
+| `create` |
+| `completion` |
 
 ## Plan Model
 
@@ -31,7 +35,7 @@ Plan Author. Focus: transform spec into phased plan with file structure, TDD ste
 `skill({name: "writing-plans"})` — call the skill, then call via task():
 
 | Task | Call via task() |
-|------|----------|
+
 | `create` | `task(..., prompt: "execute create task from writing-plans")` |
 | `completion` | `task(..., prompt: "execute completion task from writing-plans")` |
 

--- a/skills/writing-plans/tasks/create/plan-structure.md
+++ b/skills/writing-plans/tasks/create/plan-structure.md
@@ -276,6 +276,25 @@ Verification steps after contract generation:
 1. Assert all-false state: run Z3 solver — MUST return SAT
 1. Assert D_P1=True but p1=False: run Z3 solver — MUST return UNSAT
 
+### Step 6: Generate Implementation Checklist (MANDATORY)
+
+After plan content is finalized, generate `implementation-checklist.md` as a sibling of `plan.md`:
+
+1. Read plan phases, SC-ID traceability table, and pipeline gate tables from plan.md
+1. For each phase, emit the 14-gate checklist with sub-steps:
+   - Pre-cleanup (remove stale artifacts per Rule 3)
+   - Dispatch via task()
+   - Post-step Z3 state update (3 sequential calls to `solve state update`)
+   - Checkpoint tag creation and verification (`git tag -l` confirmation)
+   - Lifecycle manifest event append
+1. Emit remediation routing section (R.1-R.10) — rollback procedure, researcher dispatch, max 3 attempts
+1. Emit phase completion section (PC.1-PC.6) — all gates PASS, all SCs verified, manifest complete
+1. Emit overall completion section (OC.1-OC.7) — all phases complete, full regression suite, final push
+1. Emit key constraints section referencing implementation-pipeline-\* rules
+1. Verify the checklist covers every SC from the SC-ID traceability table — flag any uncovered SCs
+
+The checklist generation is a mechanical transformation of plan structure — no creative decisions. Reference the pipeline-readiness `sc_summary` from sc-pipeline-readiness.yaml for SC count verification.
+
 ## Context Required
 
 - Related tasks: `create/create-and-validate`

--- a/skills/writing-plans/tasks/create/plan-structure.md
+++ b/skills/writing-plans/tasks/create/plan-structure.md
@@ -54,6 +54,17 @@ Before reading approved spec: `/skill verification-enforcement --task verify`
 
 Collects evidence artifacts for factual claims. Unverified claims marked with `⚠️ UNVERIFIED`.
 
+### Step 0.5: Pipeline-Readiness Gate Check (HARD GATE)
+
+Before any plan content is written, verify that the spec has passed pipeline-readiness validation:
+
+1. Read `.issues/{issue-N}/spec-artifacts/sc-pipeline-readiness.yaml`
+2. Assert `status: PASS`
+3. If status is FAIL or file does not exist: **HALT** with `SPEC_NOT_READY_FOR_PIPELINE` — the spec must pass the pipeline-readiness gate before plan creation
+4. If PASS: extract `sc_summary` (total_scs, atomic, with_dependencies, single_concern) and phase dependency declarations for use in plan generation
+
+This is a hard gate — the plan-writer MUST NOT proceed without a PASS from the pipeline-readiness gate. No exceptions, no "proceed anyway" path.
+
 ### Step 1: Read Approved Spec
 
 - Query GitHub Issue for spec content

--- a/skills/writing-plans/tasks/create/plan-structure.md
+++ b/skills/writing-plans/tasks/create/plan-structure.md
@@ -25,28 +25,28 @@ Structure the implementation plan from approved spec: verification gate, combine
 After defining the phase structure, create a dependency-ordering solve contract:
 
 1. Create `.issues/{issue-N}/spec-artifacts/dependency-ordering-verification/` directory
-2. Write `phase-order.yaml` with Z3 variables for each phase position and ordering constraints
-3. Run `solve model --contract-path ... --query "phase_1 < phase_2 and phase_1 < phase_3"`
-4. Confirm SAT — the phase ordering is valid
+1. Write `phase-order.yaml` with Z3 variables for each phase position and ordering constraints
+1. Run `solve model --contract-path ... --query "phase_1 < phase_2 and phase_1 < phase_3"`
+1. Confirm SAT — the phase ordering is valid
 
 ### Plan Utility Validation (SC-3)
 
 After phase dependency contract is confirmed SAT, validate phase solvability:
 
 1. Create `./tmp/{issue-N}/artifacts/phase-plan-problem.yaml` with phase structure as planning problem
-2. Run `.opencode/tools/plan plan --problem ./tmp/{issue-N}/artifacts/phase-plan-problem.yaml`
-3. Confirm planner returns SOLVED_SATISFICING or SOLVED_OPTIMALLY
-4. Save result to `./tmp/{issue-N}/artifacts/phase-plan-validated.yaml`
-5. If utility unavailable: log WARNING in lifecycle manifest, validate manually (acyclic check)
+1. Run `.opencode/tools/plan plan --problem ./tmp/{issue-N}/artifacts/phase-plan-problem.yaml`
+1. Confirm planner returns SOLVED_SATISFICING or SOLVED_OPTIMALLY
+1. Save result to `./tmp/{issue-N}/artifacts/phase-plan-validated.yaml`
+1. If utility unavailable: log WARNING in lifecycle manifest, validate manually (acyclic check)
 
 ### SC-ID Mapping (SC-4)
 
 After phase structure validated, consume `sc-summary.yaml`:
 
 1. Read `.issues/{issue-N}/spec-artifacts/sc-summary.yaml`
-2. Map each SC to its corresponding plan item by SC-ID
-3. Verify all SCs from the spec are covered
-4. Flag orphan SCs (in YAML but not mapped) and missing SCs (in spec but not in YAML)
+1. Map each SC to its corresponding plan item by SC-ID
+1. Verify all SCs from the spec are covered
+1. Flag orphan SCs (in YAML but not mapped) and missing SCs (in spec but not in YAML)
 
 ### Pre-Step: Verification Gate (MANDATORY FIRST)
 
@@ -59,9 +59,9 @@ Collects evidence artifacts for factual claims. Unverified claims marked with `�
 Before any plan content is written, verify that the spec has passed pipeline-readiness validation:
 
 1. Read `.issues/{issue-N}/spec-artifacts/sc-pipeline-readiness.yaml`
-2. Assert `status: PASS`
-3. If status is FAIL or file does not exist: **HALT** with `SPEC_NOT_READY_FOR_PIPELINE` — the spec must pass the pipeline-readiness gate before plan creation
-4. If PASS: extract `sc_summary` (total_scs, atomic, with_dependencies, single_concern) and phase dependency declarations for use in plan generation
+1. Assert `status: PASS`
+1. If status is FAIL or file does not exist: **HALT** with `SPEC_NOT_READY_FOR_PIPELINE` — the spec must pass the pipeline-readiness gate before plan creation
+1. If PASS: extract `sc_summary` (total_scs, atomic, with_dependencies, single_concern) and phase dependency declarations for use in plan generation
 
 This is a hard gate — the plan-writer MUST NOT proceed without a PASS from the pipeline-readiness gate. No exceptions, no "proceed anyway" path.
 
@@ -86,28 +86,33 @@ This is a hard gate — the plan-writer MUST NOT proceed without a PASS from the
 | Single-task AND combining makes document hard to read | **Separate** — stand-alone sections in `.issues/{N}/spec-artifacts/plan.md` |
 
 **Decision output (MANDATORY):**
+
 ```
 Plan structure decision: combined/separate
 Reason: <justification referencing evaluation criteria>
 ```
 
 **If COMBINED:**
+
 - Write to `.issues/{N}/spec-artifacts/plan.md`, reference spec content inline
 - Retain `[SPEC]` title prefix
 - Proceed to Step 2
 
 **If SEPARATE:**
+
 - Write to `.issues/{N}/spec-artifacts/plan.md` with separate phase sections
 - Proceed to Step 2
 
 ### Step 1.6: Duplicate Plan Check
 
 Look for existing plan artifacts in `.issues/` workspace:
+
 ```bash
 ls .issues/*/spec-artifacts/plan.md 2>/dev/null
 ```
 
 For each plan found referencing the same spec, present choice:
+
 - Proceed with new plan (override existing local artifact)
 - HALT and review existing plan
 
@@ -157,10 +162,10 @@ phase_dependencies:
 After defining phase structure, consume the `sc-summary.yaml` from spec artifacts to map SCs to plan items:
 
 1. Read `.issues/{issue-N}/spec-artifacts/sc-summary.yaml`
-2. For each phase in the plan, verify its SC assignments match `sc_summary.phases[].sc_ids`
-3. For each plANNED item, annotate with the corresponding SC-ID(s)
-4. Flag orphan SCs (in YAML but not mapped to any plan item) as MISSING-TRACEABILITY
-5. Flag extra SCs (in plan but not in YAML) as SCOPE-CREEP
+1. For each phase in the plan, verify its SC assignments match `sc_summary.phases[].sc_ids`
+1. For each plANNED item, annotate with the corresponding SC-ID(s)
+1. Flag orphan SCs (in YAML but not mapped to any plan item) as MISSING-TRACEABILITY
+1. Flag extra SCs (in plan but not in YAML) as SCOPE-CREEP
 
 ### Step 3.5: RED/GREEN Condition Language (SC-2, SC-4 — Forward-Looking Stance)
 
@@ -181,12 +186,14 @@ Each item's RED/GREEN conditions MUST describe requirements, not implementation:
 
 **Behavioral RED/GREEN for rule-changing items:**
 When changing guidelines or skills, use behavioral TDD:
+
 1. **Behavioral RED:** Write test sending agent prompt, verify agent does NOT follow new rule yet
-2. **Behavioral GREEN:** Make change, re-run test — now agent follows rule
+1. **Behavioral GREEN:** Make change, re-run test — now agent follows rule
 
 ### Step 4: Plan Phase Structure
 
 Organize by concern flow:
+
 - Determine phases needed
 - Write prose for phase descriptions
 - Prose-driven, not template-driven
@@ -223,12 +230,14 @@ Every unit gets its own 14-row pipeline gate table with unit-specific exit crite
 #### Z3 Contract Generation (SC-7 — Per-Unit, No Preconditions)
 
 Each unit's Z3 contract declares:
+
 - 14 boolean variables per unit representing pipeline gate states (e.g., `P1_p1..p14`)
 - 1 domain variable per unit (e.g., `D_P1`) that MUST be `False` unless all 14 gates are `True`
 - 13 serial-ordering invariants: `Implies(pN, pN-1)` for N = 2..14
 - NO preconditions — invariants + postconditions only
 
 Contract structure:
+
 ```
 (declare-const P1_p1 Bool) ... (declare-const P1_p14 Bool)
 (declare-const D_P1 Bool)
@@ -263,8 +272,9 @@ On UNSOLVABLE: re-examine phase ordering, add missing action/precondition, re-ru
 On utility unavailable: validate phase solvability manually (acyclic check on phase ordering), write manual validation result to `phase-plan-validated.yaml` with WARNING in lifecycle manifest.
 
 Verification steps after contract generation:
+
 1. Assert all-false state: run Z3 solver — MUST return SAT
-2. Assert D_P1=True but p1=False: run Z3 solver — MUST return UNSAT
+1. Assert D_P1=True but p1=False: run Z3 solver — MUST return UNSAT
 
 ## Context Required
 


### PR DESCRIPTION
## Summary

- **Phase 1:** Created pipeline-readiness-gate.md task file with PR-1 (atomicity), PR-2 (SC dependency DAG via solve prove), PR-3 (single concern), PR-4 (phase DAG via solve prove) checks. Updated spec-creation/SKILL.md.
- **Phase 2:** Added Step 0.5 hard gate in plan-structure.md — checks sc-pipeline-readiness.yaml PASS before plan creation, halts with SPEC_NOT_READY_FOR_PIPELINE on failure.
- **Phase 3:** Added Step 6 mandatory implementation-checklist.md generation in plan-structure.md with 14-gate sub-steps, lifecycle manifest, checkpoint tags, remediation routing.
- **Phase 4:** Added symbolic rules (spec-creation-pipeline-readiness, writing-plans-pipeline-readiness) to both SKILL.md files.

Fixes: https://github.com/michael-conrad/.opencode/issues/1110

Co-authored with AI: OpenCode (ollama-cloud/deepseek-v4-flash)