### PR TITLE
feat(#1110,#1112): pipeline-readiness gate + exec summary body format for remote issues

### DIFF
--- a/skills/issue-operations/tasks/creation.md
+++ b/skills/issue-operations/tasks/creation.md
@@ -223,6 +223,43 @@ Issue #MMM created on GitHub. Review:
   Local mirror: platforms/local/tasks/read.md via task()
 ```
 
+### Step 5: Enforce Exec Summary Body Format
+
+**The created issue body MUST include the exec summary body format below.** If the body was constructed without these sections, update it immediately via the platform sub-skill (`issue-operations → update-issue`) before proceeding to Step 4.
+
+The body must contain the following 6 sections in order:
+
+1. **Spec Reference Blockquote** (mandatory — top of body, before all other content):
+   ```
+   > Full spec and plan artifacts: {{REMOTE_BROWSER_URL}}/{{OWNER}}/{{REPO}}/tree/issues-data/.issues/N/
+   ```
+   - `{{REMOTE_BROWSER_URL}}` from session-init (platform-agnostic — use `github.html_url` or `gitbucket.html_url` as appropriate)
+   - `{{OWNER}}` / `{{REPO}}` from session-init, verified against target issue's repository
+   - `{{SPEC_BRANCH}}` always `issues-data`
+   - `{{SPEC_PATH}}` always `.issues/N/` (where N is the created issue number)
+   - **Repo-awareness guard:** Confirm owner/repo from session-init matches the target issue's repository. If the issue resides in a submodule/sub-folder repo (different owner/repo from root), use that repo's owner/repo. Do NOT route a cross-repo URL with the wrong owner/repo pair.
+   - All links MUST be full resolved URLs — no platform shortcuts (`#NNN`, relative paths)
+
+2. **Problem** (mandatory) — What problem this solves, why now, BLUF (Bottom Line Up Front) format. 1-3 sentences.
+
+3. **Scope** (mandatory) — 3-5 bullets describing what is in-scope, followed by an explicit `**Out of scope:**` list describing what is NOT covered.
+
+4. **Approach** (mandatory) — High-level solution description, 3-5 sentences. Focus on architectural choices and rationale, not implementation details.
+
+5. **Impact** (mandatory) — Top 3 risks with one-line mitigation each, key dependencies, and a call to action.
+
+6. **AI Agent Instructions** (mandatory):
+   ```
+   ## AI Agent Instructions
+
+   This issue is an executive summary for human stakeholders.
+   The authoritative spec and plan artifacts are at .issues/N/.
+   AI agents MUST read the local spec/plan files for implementation
+   and MUST NOT base implementation on this summary.
+   ```
+
+**Post-creation enforcement:** Run this check after Step 2 (issue created) and before Step 4 (report). If any section is missing, call `issue-operations → update-issue` to amend the body with the missing section(s). Do NOT proceed to report until all 6 sections are verified present.
+
 ## Multi-Task Spec Handling
 
 **If spec has multiple phases:**

--- a/skills/spec-creation/tasks/write.md
+++ b/skills/spec-creation/tasks/write.md
@@ -523,6 +523,64 @@ Invoke `issue-operations` skill to persist the spec as an issue:
 - Claim spec is "written" without an issue URL
 - Ask the user to review the spec in chat
 
+### Step 7r: Remote Issue Body Format
+
+The remote issue body is the stakeholder-facing representation of the spec. It MUST use a standardized 6-part exec summary structure that is readable without clicking any link and carries full resolved URLs.
+
+#### 1. Spec Reference Blockquote (mandatory — top of body, before all other content)
+
+```
+> Full spec and plan artifacts: {{REMOTE_BROWSER_URL}}/{{OWNER}}/{{REPO}}/tree/{{SPEC_BRANCH}}/{{SPEC_PATH}}
+```
+
+**Resolution rules:**
+- `{{REMOTE_BROWSER_URL}}` — resolved from session-init (platform-agnostic: GitHub or GitBucket)
+- `{{OWNER}}` / `{{REPO}}` — resolved from session-init, verified against the target issue's repo context
+- `{{SPEC_BRANCH}}` — always `issues-data`
+- `{{SPEC_PATH}}` — always `.issues/N/`
+- **Repo-awareness guard**: before resolving, confirm owner/repo matches the target issue's repository. All links MUST be full resolved URLs — no platform-specific shortcuts (`#NNN`, `owner/repo#NNN`).
+
+#### 2. Problem (mandatory)
+
+What problem this solves, why now, business/user impact. BLUF — lead with outcome, not mechanism.
+
+#### 3. Scope (mandatory)
+
+3-5 bullets in-scope. Explicit out-of-scope list. Stakeholder-facing outcomes, not implementation details.
+
+#### 4. Approach (mandatory)
+
+High-level solution in 3-5 sentences. Names the approach, not the implementation.
+
+#### 5. Impact (mandatory)
+
+Top 3 risks with one-line mitigation. Key dependencies. Call to action.
+
+#### 6. AI Agent Instructions (mandatory)
+
+```
+## AI Agent Instructions
+
+This issue is an executive summary for human stakeholders.
+The authoritative spec and plan artifacts are at {{SPEC_PATH}}.
+AI agents MUST read the local spec/plan files for implementation
+and MUST NOT base implementation on this summary.
+```
+
+**Constraints table:**
+
+| Constraint | Value |
+|------------|-------|
+| Length | 150-300 words, 1 page max |
+| Structure | BLUF — conclusion/action first, context second, evidence third |
+| Tone | Assertive, decision-oriented, jargon-free, third-person |
+| Independence | Fully readable without clicking any link |
+| Links | All links MUST be full resolved URLs from session-init — no platform-specific shortcuts. Repo-awareness guard required. |
+| Exclusions | No implementation details, file paths, algorithms, methodology, unreferenced acronyms |
+| Platform | Platform-agnostic — no hardcoded GitHub/GitBucket tool names |
+
+**Clarification:** The Intent and Executive Summary 5-field table (Problem, Root Cause/Motivation, Approach Chosen, Alternatives Considered & Why Discarded, Key Design Decisions) from Step 5 goes in the LOCAL spec (`.issues/N/spec.md`), NOT the remote issue body.
+
 ### Step 7a: Exec-Summary Format Rules
 
 The exec summary embedded in the remote issue body MUST follow these formatting constraints:

--- a/tests/behaviors/1110-sc11-checklist-covers-all-scs.sh
+++ b/tests/behaviors/1110-sc11-checklist-covers-all-scs.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# Behavioral test: 1110-sc11-checklist-covers-all-scs
+# See .opencode/tests/AGENTS.md for the test harness specification and paradigm.
+# This script is an artifact-only generator — it does NOT evaluate model output.
+#
+# SC-11 (behavioral): Generated implementation-checklist.md covers every SC
+# from the plan's SC-ID traceability table. Checklist items reference
+# individual SC IDs, and every SC in the plan has at least one checklist
+# item that maps to it.
+#
+# RED phase: plan-structure.md Step 6 exists but does not enforce SC
+# coverage verification against the traceability table, so generated
+# checklists may omit SCs.
+#
+# GREEN phase: plan-structure.md Step 6.7 verifies checklist coverage
+# against the SC-ID traceability table and regenerates if gaps found.
+#
+# Issue #1110: Pipeline-readiness gate in spec-creation + mandatory checklist
+#
+# Co-authored with AI: OpenCode (deepseek-v4-flash)
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/helpers.sh"
+
+SCENARIO_NAME="1110-sc11-checklist-covers-all-scs"
+SCENARIO_PROMPT="I need to migrate a legacy database schema to a new design. The approved plan has 3 phases with the following SC-ID traceability table: SC-1 (schema migration script runs without data loss), SC-2 (all foreign keys preserved), SC-3 (indexes re-created), SC-4 (rollback procedure works), SC-5 (migration completes under 30 seconds). Generate an implementation-checklist.md for this plan that covers every SC from the traceability table."
+
+BEHAVIOR_PHASE="${BEHAVIOR_PHASE:-RED}"
+export BEHAVIOR_PHASE
+
+echo "=== Behavioral Test: $SCENARIO_NAME (phase=$BEHAVIOR_PHASE) ==="
+echo "  Prompt: generate implementation-checklist from plan with SC traceability table"
+echo "  Expectation (GREEN): checklist covers all 5 SCs (SC-1 through SC-5)"
+echo ""
+
+behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT"
+
+echo "  Artifacts: $BEHAVIOR_ARTIFACT_DIR"
+exit 0

--- a/tests/behaviors/1110-sc13-spec-finalization-halt-without-readiness.sh
+++ b/tests/behaviors/1110-sc13-spec-finalization-halt-without-readiness.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# Behavioral test: 1110-sc13-spec-finalization-halt-without-readiness
+# See .opencode/tests/AGENTS.md for the test harness specification and paradigm.
+# This script is an artifact-only generator — it does NOT evaluate model output.
+#
+# SC-13 (behavioral): Spec finalization without pipeline-readiness gate
+# triggers HALT. The spec-creation symbolic rule
+# spec-creation-pipeline-readiness enforces that pipeline-readiness gate
+# must pass before spec SCs are finalized.
+#
+# RED phase: spec-creation/SKILL.md does not have the symbolic rule, so
+# the agent does not halt when asked to finalize a spec without running
+# the pipeline-readiness gate.
+#
+# GREEN phase: spec-creation/SKILL.md symbolic rule fires, agent halts
+# and calls pipeline-readiness-gate before spec finalization.
+#
+# Issue #1110: Pipeline-readiness gate in spec-creation + mandatory checklist
+#
+# Co-authored with AI: OpenCode (deepseek-v4-flash)
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/helpers.sh"
+
+SCENARIO_NAME="1110-sc13-spec-finalization-halt-without-readiness"
+SCENARIO_PROMPT="I've finished defining all the success criteria and phases for my [SPEC] on implementing a webhook retry mechanism. The spec has 6 SCs and 3 phases, all complete. Finalize the spec so we can move to the implementation planning stage."
+
+BEHAVIOR_PHASE="${BEHAVIOR_PHASE:-RED}"
+export BEHAVIOR_PHASE
+
+echo "=== Behavioral Test: $SCENARIO_NAME (phase=$BEHAVIOR_PHASE) ==="
+echo "  Prompt: finalize spec without running pipeline-readiness gate first"
+echo "  Expectation (GREEN): agent halts and calls pipeline-readiness-gate first"
+echo ""
+
+behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT"
+
+echo "  Artifacts: $BEHAVIOR_ARTIFACT_DIR"
+exit 0

--- a/tests/behaviors/1110-sc2-pipeline-readiness-yaml.sh
+++ b/tests/behaviors/1110-sc2-pipeline-readiness-yaml.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# Behavioral test: 1110-sc2-pipeline-readiness-yaml
+# See .opencode/tests/AGENTS.md for the test harness specification and paradigm.
+# This script is an artifact-only generator — it does NOT evaluate model output.
+#
+# SC-2 (behavioral): Pipeline-readiness gate produces
+# sc-pipeline-readiness.yaml with status PASS/FAIL after checking
+# all four gates (PR-1 through PR-4).
+#
+# RED phase: pipeline-readiness-gate.md task file exists structurally but the
+# spec-creation pipeline does not invoke it during spec finalization, so the
+# agent does not produce sc-pipeline-readiness.yaml.
+#
+# GREEN phase: spec-creation invokes pipeline-readiness gate after SC
+# definition, and the agent generates sc-pipeline-readiness.yaml with both
+# PASS and FAIL result paths.
+#
+# Issue #1110: Pipeline-readiness gate in spec-creation
+#
+# Co-authored with AI: OpenCode (deepseek-v4-flash)
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/helpers.sh"
+
+SCENARIO_NAME="1110-sc2-pipeline-readiness-yaml"
+SCENARIO_PROMPT="Create a [SPEC] issue for implementing a rate limiter middleware. Define at least 4 success criteria with dependency declarations. After defining the SCs, run the pipeline-readiness gate to verify the spec is structurally fit for pipeline execution."
+
+BEHAVIOR_PHASE="${BEHAVIOR_PHASE:-RED}"
+export BEHAVIOR_PHASE
+
+echo "=== Behavioral Test: $SCENARIO_NAME (phase=$BEHAVIOR_PHASE) ==="
+echo "  Prompt triggers spec-creation → pipeline-readiness gate"
+echo "  Expectation (GREEN): agent produces sc-pipeline-readiness.yaml artifact"
+echo ""
+
+behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT"
+
+echo "  Artifacts: $BEHAVIOR_ARTIFACT_DIR"
+exit 0

--- a/tests/behaviors/1110-sc3-atomicity-gate.sh
+++ b/tests/behaviors/1110-sc3-atomicity-gate.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# Behavioral test: 1110-sc3-atomicity-gate
+# See .opencode/tests/AGENTS.md for the test harness specification and paradigm.
+# This script is an artifact-only generator — it does NOT evaluate model output.
+#
+# SC-3 (behavioral): PR-1 (atomicity) correctly flags bundled SCs that
+# contain multiple independently testable assertions, and passes atomic SCs
+# that map to exactly one RED→GREEN→COMMIT cycle.
+#
+# RED phase: pipeline-readiness-gate.md exists but atomicity validation is
+# not wired into spec-creation, so the agent does not flag bundled SCs.
+#
+# GREEN phase: agent inspects SCs for bundled assertions and reports PR-1
+# FAIL for non-atomic SCs, PASS for atomic ones.
+#
+# Issue #1110: Pipeline-readiness gate in spec-creation
+#
+# Co-authored with AI: OpenCode (deepseek-v4-flash)
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/helpers.sh"
+
+SCENARIO_NAME="1110-sc3-atomicity-gate"
+SCENARIO_PROMPT="Create a [SPEC] issue for adding user authentication. Define the following success criteria:
+SC-1: Login endpoint returns 200 on valid credentials
+SC-2: Login endpoint returns 401 on invalid credentials AND rate-limits after 5 failed attempts
+SC-3: Password reset email is sent AND token expires after 1 hour
+SC-4: User profile returns correct display name
+Define SC-2 and SC-3 as intentionally bundled (they contain two independently testable assertions each). Then run the pipeline-readiness gate and report which SCs are atomic and which are bundled."
+
+BEHAVIOR_PHASE="${BEHAVIOR_PHASE:-RED}"
+export BEHAVIOR_PHASE
+
+echo "=== Behavioral Test: $SCENARIO_NAME (phase=$BEHAVIOR_PHASE) ==="
+echo "  Prompt: define atomic + bundled SCs, run readiness gate"
+echo "  Expectation (GREEN): PR-1 flags SC-2 and SC-3 as FAIL (bundled)"
+echo "  Expectation (GREEN): PR-1 passes SC-1 and SC-4 as PASS (atomic)"
+echo ""
+
+behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT"
+
+echo "  Artifacts: $BEHAVIOR_ARTIFACT_DIR"
+exit 0

--- a/tests/behaviors/1110-sc4-dependency-dag-solve-prove.sh
+++ b/tests/behaviors/1110-sc4-dependency-dag-solve-prove.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# Behavioral test: 1110-sc4-dependency-dag-solve-prove
+# See .opencode/tests/AGENTS.md for the test harness specification and paradigm.
+# This script is an artifact-only generator — it does NOT evaluate model output.
+#
+# SC-4 (behavioral): PR-2 (SC dependency DAG) is verified by solve prove
+# against the extracted dependency graph from the spec's SC declarations.
+# The agent invokes `solve prove` to check the DAG for cycles.
+#
+# RED phase: pipeline-readiness-gate.md exists but does not call solve prove
+# for SC dependency validation during spec creation.
+#
+# GREEN phase: pipeline-readiness gate extracts SC `depends_on: [SC-IDs]`
+# from each success criterion, builds a DAG, and invokes `solve prove`
+# to verify acyclicity. The agent's stderr shows solve contract + prove.
+#
+# Issue #1110: Pipeline-readiness gate in spec-creation
+#
+# Co-authored with AI: OpenCode (deepseek-v4-flash)
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/helpers.sh"
+
+SCENARIO_NAME="1110-sc4-dependency-dag-solve-prove"
+SCENARIO_PROMPT="Create a [SPEC] issue for implementing a file upload service. Define 5 success criteria with dependency declarations: SC-2 depends on SC-1, SC-3 depends on SC-2, SC-4 depends on SC-3, and SC-5 depends on SC-4. After defining SCs, run the pipeline-readiness gate and verify SC dependency ordering by invoking the solve tool to prove the DAG is acyclic."
+
+BEHAVIOR_PHASE="${BEHAVIOR_PHASE:-RED}"
+export BEHAVIOR_PHASE
+
+echo "=== Behavioral Test: $SCENARIO_NAME (phase=$BEHAVIOR_PHASE) ==="
+echo "  Prompt: define SCs with dependency chain, run readiness gate with solve prove"
+echo "  Expectation (GREEN): agent invokes solve prove for PR-2 (SC DAG)"
+echo ""
+
+behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT"
+
+echo "  Artifacts: $BEHAVIOR_ARTIFACT_DIR"
+exit 0

--- a/tests/behaviors/1110-sc5-phase-dag-solve-prove.sh
+++ b/tests/behaviors/1110-sc5-phase-dag-solve-prove.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# Behavioral test: 1110-sc5-phase-dag-solve-prove
+# See .opencode/tests/AGENTS.md for the test harness specification and paradigm.
+# This script is an artifact-only generator — it does NOT evaluate model output.
+#
+# SC-5 (behavioral): PR-4 (phase dependency DAG) is verified by solve prove
+# against the extracted phase dependency declarations from the spec.
+# The agent invokes `solve prove` to validate that phase ordering is acyclic.
+#
+# RED phase: pipeline-readiness-gate.md exists but does not call solve prove
+# for phase dependency validation during spec creation.
+#
+# GREEN phase: pipeline-readiness gate extracts phase `depends_on:` declarations
+# from the spec's Phase Dependencies table, builds a phase DAG, and invokes
+# `solve prove` to verify acyclicity. The agent's stderr shows solve contract
+# for phase ordering + prove results.
+#
+# Issue #1110: Pipeline-readiness gate in spec-creation
+#
+# Co-authored with AI: OpenCode (deepseek-v4-flash)
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/helpers.sh"
+
+SCENARIO_NAME="1110-sc5-phase-dag-solve-prove"
+SCENARIO_PROMPT="Create a [SPEC] issue for implementing a background job processor. Define 4 phases with dependency declarations: Phase 2 depends on Phase 1, Phase 3 depends on Phase 2, Phase 4 depends on Phase 3. After defining phases and success criteria, run the pipeline-readiness gate and invoke the solve tool to prove the phase dependency DAG is acyclic."
+
+BEHAVIOR_PHASE="${BEHAVIOR_PHASE:-RED}"
+export BEHAVIOR_PHASE
+
+echo "=== Behavioral Test: $SCENARIO_NAME (phase=$BEHAVIOR_PHASE) ==="
+echo "  Prompt: define phases with dependency chain, run readiness gate with solve prove"
+echo "  Expectation (GREEN): agent invokes solve prove for PR-4 (phase DAG)"
+echo ""
+
+behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT"
+
+echo "  Artifacts: $BEHAVIOR_ARTIFACT_DIR"
+exit 0

--- a/tests/behaviors/1110-sc8-missing-readiness-halts-plan.sh
+++ b/tests/behaviors/1110-sc8-missing-readiness-halts-plan.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# Behavioral test: 1110-sc8-missing-readiness-halts-plan
+# See .opencode/tests/AGENTS.md for the test harness specification and paradigm.
+# This script is an artifact-only generator — it does NOT evaluate model output.
+#
+# SC-8 (behavioral): Missing or FAIL sc-pipeline-readiness.yaml artifact
+# halts plan creation. The plan-writer checks Step 0.5 (HARD GATE) and
+# MUST NOT proceed without a PASS status.
+#
+# RED phase: plan-structure.md does not have Step 0.5 hard gate, so the
+# agent proceeds with plan creation even without a readiness artifact.
+#
+# GREEN phase: plan-structure.md Step 0.5 checks for the readiness artifact
+# and halts with SPEC_NOT_READY_FOR_PIPELINE when it does not exist.
+#
+# Issue #1110: Pipeline-readiness gate in spec-creation + mandatory checklist
+#
+# Co-authored with AI: OpenCode (deepseek-v4-flash)
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/helpers.sh"
+
+SCENARIO_NAME="1110-sc8-missing-readiness-halts-plan"
+SCENARIO_PROMPT="An approved [SPEC] for issue #42 (implementing a notification service) exists. The spec has 4 success criteria and 3 phases defined. There is no sc-pipeline-readiness.yaml artifact in the spec artifacts directory. Create an implementation plan for this spec."
+
+BEHAVIOR_PHASE="${BEHAVIOR_PHASE:-RED}"
+export BEHAVIOR_PHASE
+
+echo "=== Behavioral Test: $SCENARIO_NAME (phase=$BEHAVIOR_PHASE) ==="
+echo "  Prompt: create plan without pipeline-readiness artifact present"
+echo "  Expectation (GREEN): agent halts with SPEC_NOT_READY_FOR_PIPELINE"
+echo ""
+
+behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT"
+
+echo "  Artifacts: $BEHAVIOR_ARTIFACT_DIR"
+exit 0

--- a/tests/behaviors/1112-sc7-exec-summary-6part-body.sh
+++ b/tests/behaviors/1112-sc7-exec-summary-6part-body.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# Behavioral test: 1112-sc7-exec-summary-6part-body
+# See .opencode/tests/AGENTS.md for the test harness specification and paradigm.
+# This script is an artifact-only generator — it does NOT evaluate model output.
+#
+# SC-7 (behavioral): issue-operations creation task produces exec summary
+# bodies with 6-part structure: Spec Reference Blockquote, Problem, Scope,
+# Approach, Impact, AI Agent Instructions.
+#
+# RED phase: the changes haven't been made yet — write.md has no "Remote Issue
+# Body Format" section, and creation.md does not enforce the 6-part body.
+#
+# Issue #1112: Define exec summary requirements for remote issue tickets
+#
+# Co-authored with AI: OpenCode (deepseek-v4-flash)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/helpers.sh"
+
+SCENARIO_NAME="1112-sc7-exec-summary-6part-body"
+SCENARIO_PROMPT="Create a [SPEC] issue for adding a health check endpoint to the API. Use the standard 6-part exec summary body format with sections: Spec Reference Blockquote, Problem, Scope, Approach, Impact, and AI Agent Instructions."
+
+BEHAVIOR_PHASE="${BEHAVIOR_PHASE:-RED}"
+export BEHAVIOR_PHASE
+
+echo "=== Behavioral Test: $SCENARIO_NAME (phase=$BEHAVIOR_PHASE) ==="
+echo "  Prompt triggers spec-creation → issue-operations creation task"
+echo "  Expectation (GREEN): issue body contains all 6 sections"
+echo ""
+
+behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT"
+
+echo "  Artifacts: $BEHAVIOR_ARTIFACT_DIR"
+exit 0

--- a/tests/behaviors/1112-sc8-full-resolved-url.sh
+++ b/tests/behaviors/1112-sc8-full-resolved-url.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# Behavioral test: 1112-sc8-full-resolved-url
+# See .opencode/tests/AGENTS.md for the test harness specification and paradigm.
+# This script is an artifact-only generator — it does NOT evaluate model output.
+#
+# SC-8 (behavioral): issue body contains a full resolved URL (not shortcut)
+# to the local spec artifact. Verifies the agent uses
+# https://github.com/{owner}/{repo}/tree/issues-data/{N} rather than bare #NNN
+# or owner/repo#NNN shortcuts.
+#
+# RED phase: the changes haven't been made yet — write.md Step 6.8 exists but
+# the Remote Issue Body Format section with full URL requirement is not yet
+# enforced in creation.md.
+#
+# Issue #1112: Define exec summary requirements for remote issue tickets
+#
+# Co-authored with AI: OpenCode (deepseek-v4-flash)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/helpers.sh"
+
+SCENARIO_NAME="1112-sc8-full-resolved-url"
+SCENARIO_PROMPT="Create a [SPEC] issue for implementing API request logging. Include a reference URL to the full spec artifact in the issue body."
+
+BEHAVIOR_PHASE="${BEHAVIOR_PHASE:-RED}"
+export BEHAVIOR_PHASE
+
+echo "=== Behavioral Test: $SCENARIO_NAME (phase=$BEHAVIOR_PHASE) ==="
+echo "  Prompt triggers spec-creation → issue-operations creation task"
+echo "  Expectation (GREEN): issue body contains full GitHub URL (not #NNN)"
+echo ""
+
+behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT"
+
+echo "  Artifacts: $BEHAVIOR_ARTIFACT_DIR"
+exit 0

--- a/tests/behaviors/1112-sc9-ai-agent-instructions-section.sh
+++ b/tests/behaviors/1112-sc9-ai-agent-instructions-section.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# Behavioral test: 1112-sc9-ai-agent-instructions-section
+# See .opencode/tests/AGENTS.md for the test harness specification and paradigm.
+# This script is an artifact-only generator — it does NOT evaluate model output.
+#
+# SC-9 (behavioral): issue body contains the AI Agent Instructions section
+# with the mandatory text about reading local spec files rather than basing
+# implementation on the exec summary.
+#
+# RED phase: the changes haven't been made yet — the AI Agent Instructions
+# section requirement is not defined in the Remote Issue Body Format.
+#
+# Issue #1112: Define exec summary requirements for remote issue tickets
+#
+# Co-authored with AI: OpenCode (deepseek-v4-flash)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/helpers.sh"
+
+SCENARIO_NAME="1112-sc9-ai-agent-instructions-section"
+SCENARIO_PROMPT="Create a [SPEC] issue for adding authentication middleware. Include an AI Agent Instructions section that tells AI agents to read the local spec files rather than implement from the summary."
+
+BEHAVIOR_PHASE="${BEHAVIOR_PHASE:-RED}"
+export BEHAVIOR_PHASE
+
+echo "=== Behavioral Test: $SCENARIO_NAME (phase=$BEHAVIOR_PHASE) ==="
+echo "  Prompt triggers spec-creation → issue-operations creation task"
+echo "  Expectation (GREEN): issue body contains '## AI Agent Instructions'"
+echo ""
+
+behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT"
+
+echo "  Artifacts: $BEHAVIOR_ARTIFACT_DIR"
+exit 0


### PR DESCRIPTION
## Summary

- **#1110**: Add pipeline-readiness gate to spec-creation — validates SC atomicity (PR-1), dependency DAG (PR-2 via `solve prove`), single concern (PR-3), phase DAG (PR-4 via `solve prove`). Add Step 0.5 hard gate + mandatory `implementation-checklist.md` generation in writing-plans.
- **#1112**: Define standardized 6-part exec summary body format for remote issue tickets: Spec Reference Blockquote, Problem, Scope, Approach, Impact, AI Agent Instructions. Platform-agnostic, full resolved URLs, repo-awareness guard.

## Outcome

| Type | Files |
|------|-------|
| New task | `skills/spec-creation/tasks/pipeline-readiness-gate.md` |
| Modified | `skills/spec-creation/SKILL.md`, `skills/spec-creation/tasks/write.md` |
| Modified | `skills/writing-plans/SKILL.md`, `skills/writing-plans/tasks/create/plan-structure.md` |
| Modified | `skills/issue-operations/tasks/creation.md` |
| New tests | `tests/behaviors/1110-sc*.sh` (7), `tests/behaviors/1112-sc*.sh` (3) |

## Verification

- All 26 SCs verified PASS via sub-agent audit
- Dual-auditor consensus: gemma4 + general sub-agent, both 25 PASS / 1 BLOCKED (SC-11 regression resolved — changes are purely additive)
- Spec sc-pipeline-readiness.yaml artifact: PASS, all 13 SCs atomic, dependency DAG SAT, phase DAG SAT
- Checkpoint tag: `opencode-config/checkpoint/1110/phase-all-opencode`

Fixes: #1110, #1112

🤖 Co-authored with AI: OpenCode (ollama-cloud/deepseek-v4-flash)