### PR TITLE
Remove description truncation from buildSkillIndex()

### DIFF
--- a/plugins/session-enforcement.ts
+++ b/plugins/session-enforcement.ts
@@ -564,10 +564,8 @@ function buildSkillIndex(skillsDir: string): string {
   // Build a compact skill index table (name, description, trigger patterns)
   const skillRows = skills.map(s => {
     const triggers = extractTriggerPatterns(s.description);
-    // Shorten description to first sentence only for index
-    const shortDesc = s.description.split(".")[0].trim() + ".";
     const triggersStr = triggers.length > 0 ? triggers.slice(0, 5).join(", ") : "—";
-    return `| \`${s.name}\` | ${shortDesc} | ${triggersStr} |`;
+    return `| \`${s.name}\` | ${s.description} | ${triggersStr} |`;
   }).join("\n");
 
   if (skillRows.length === 0) return "";

--- a/tests/behaviors/sc-1124-truncation.sh
+++ b/tests/behaviors/sc-1124-truncation.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# SC-1: Verify no split(".")[0] truncation in .ts plugin files
+# SC-3: Verify buildSkillIndex() uses full s.description
+# RED: should FAIL (truncation still exists)
+# GREEN: should PASS (truncation removed)
+
+SCRIPT_DIR="$(cd "$(dirname "$(realpath "${BASH_SOURCE[0]}")")" && pwd)"
+REPO_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+fail_count=0
+
+# SC-1: Check for first-sentence truncation pattern split(".")[0]
+if grep -qE 'split\("\.\s*"\)\s*\[0\]' "$REPO_DIR/plugins/session-enforcement.ts"; then
+    echo "SC-1 FAIL: truncation pattern 'split(\".\")[0]' found in session-enforcement.ts"
+    ((fail_count++))
+else
+    echo "SC-1 PASS: no truncation pattern found"
+fi
+
+# SC-3: Check that s.description (not shortDesc) is used in the template
+if grep -q 'shortDesc' "$REPO_DIR/plugins/session-enforcement.ts"; then
+    echo "SC-3 FAIL: 'shortDesc' still referenced in session-enforcement.ts"
+    ((fail_count++))
+else
+    echo "SC-3 PASS: full s.description used"
+fi
+
+if [ "$fail_count" -gt 0 ]; then
+    echo "OVERALL: FAIL ($fail_count SCs failed)"
+    exit 1
+fi
+echo "OVERALL: PASS"
+exit 0


### PR DESCRIPTION
## Summary

Removes the first-sentence truncation in `buildSkillIndex()` at `plugins/session-enforcement.ts:568` that silently dropped routing mandates and procedural instructions from the Skill Index table in the agent system prompt.

**Change:** Removed `const shortDesc = s.description.split(".")[0].trim() + ".";` and the preceding comment, using `s.description` directly in the template.

**Why:** The truncation caused AI agents to miss critical routing information (e.g., "Routes to GitHub MCP or GitBucket API based on github.platform.") and enforcement tone that exists only in the second sentence of skill descriptions.

**Fixes:** #1124

## SC Verification

| SC | Criterion | Result |
|----|-----------|--------|
| SC-1 | No `split(".")[0]` truncation in `.ts` plugin files | PASS |
| SC-2 | No first-sentence truncation in `tools/` scripts | PASS |
| SC-3 | `buildSkillIndex()` uses full `s.description` | PASS |

🤖 Co-authored with AI: OpenCode (ollama-cloud/deepseek-v4-flash)