### PR TITLE
fix(#1127): resolve repo name from walk-up git boundary, not script path

### DIFF
--- a/tools/local-issues
+++ b/tools/local-issues
@@ -1165,19 +1165,17 @@ def cmd_search(args: argparse.Namespace) -> None:
 
 
 def _resolve_repo_name() -> str:
-    tool_script = Path(__file__).resolve()
-    for parent in tool_script.parents:
-        if (parent / ".gitmodules").exists():
-            return parent.name
-    for parent in tool_script.parents:
+    """Resolve repo name from CWD by checking for */.git dirs and */.git submodule files."""
+    cwd = Path(os.getcwd()).resolve()
+    for parent in [cwd] + list(cwd.parents):
         git_ref = parent / ".git"
         if git_ref.is_dir():
             return parent.name
         if git_ref.is_file():
             contents = git_ref.read_text().strip()
-            if "gitdir:" not in contents:
+            if "gitdir:" in contents:
                 return parent.name
-    return Path(os.getcwd()).name
+    return cwd.name
 
 
 def _print_available_repos() -> None:


### PR DESCRIPTION
## Summary

- `_resolve_repo_name()` used `__file__` parent traversal with `.gitmodules` priority, always returning the root repo name even when operating inside a submodule
- Fix resolves from CWD via `*/.git` (dir) and `*/.git` (file with `gitdir:`) boundary markers, matching the project's standard walk-up repo discovery model
- `.gitmodules` priority removed — repo boundaries determined solely by git markers

## Verification

- From root: returns `opencode-config` ✓ (unchanged)
- From `.opencode/`: returns `.opencode` ✓ (fixed)
- All call sites compatible with CWD-based resolution

Fixes #1127

🤖 Co-authored with AI: OpenCode (ollama-cloud/deepseek-v4-flash)