### PR TITLE
fix(#1129): enforce RED semantics, mandatory checklists, solve/plan tools

### DIFF
--- a/skills/spec-creation/tasks/write.md
+++ b/skills/spec-creation/tasks/write.md
@@ -314,11 +314,11 @@ Review every requirement statement:
 | Remediated SC   | Re-verified independently — same PASS/FAIL gate applies; no carryover credit from prior passes                                                                                                                                                                 |
 | Re-verification | Repeat the verification command/assertion; confirm PASS before claiming remediation complete                                                                                                                                                                   |
 
-**SC Table Format (12-column):**
+**SC Table Format (14-column):**
 
-| ID   | Criterion | Verification Method | Remediation | Pipeline Step Binding | Artifact Path | Requirement Traceability | Phase Binding | Verification Gate | Integration Mode | Affinity Group | Re-Entry Step |
-| ---- | --------- | ------------------- | ----------- | --------------------- | ------------- | ------------------------ | ------------- | ----------------- | ---------------- | -------------- | ------------- |
-| SC-1 | ...       | ...                 | ...         | ...                   | ...           | ...                      | ...           | ...               | ...              | ...            | ...           |
+| ID | Criterion | Verification Method | Remediation | Pipeline Step Binding | Artifact Path | Requirement Traceability | Phase Binding | Verification Gate | Integration Mode | Affinity Group | Re-Entry Step | Test File | Phase Mapping |
+|----|-----------|-------------------|-------------|----------------------|--------------|-------------------------|--------------|-----------------|----------------|--------------|-------------|-----------|--------------|
+| SC-1 | ... | ... | ... | ... | ... | ... | ... | ... | ... | ... | ... | ... | ... |
 
 **The Verification Method column MUST specify an executable command or assertion producing deterministic PASS/FAIL. The Remediation column MUST specify what corrective action is required on FAIL and how re-verification is performed.**
 
@@ -398,7 +398,7 @@ Review the assembled spec for plan-level content that belongs in the implementat
 
 **Self-review question:** "Could two developers produce valid but different implementations from this spec?" If yes, the spec is at the right level. If no — if the spec only allows one implementation — it contains plan-level detail that should be removed.
 
-### Step 5.6: `solve` Utility Invocation (SC-2)
+### Step 5.6: `solve` and `plan` Utility Invocation (SC-2)
 
 After the spec/plan boundary check, invoke the `solve` utility to produce a dependency-ordering constraints contract:
 
@@ -409,8 +409,8 @@ After the spec/plan boundary check, invoke the `solve` utility to produce a depe
 ```
 
 On success: constraints contract written to `./tmp/{issue-N}/artifacts/constraints-contract.yaml`.
-On UNSAT: model constraints manually, log WARNING in lifecycle manifest.
-On utility unavailable: same fallback — manual constraints + WARNING in lifecycle manifest.
+On UNSAT: **HALT** with blocker report — do NOT proceed with manual fallback.
+On utility unavailable: **HALT** with blocker report — do NOT proceed without solve verification.
 
 Post-invocation verification via `solve check`:
 
@@ -420,7 +420,18 @@ Post-invocation verification via `solve check`:
   --contract-path .issues/{issue-N}/spec-artifacts/pre-approval-gate-contract.yaml
 ```
 
-MUST return SAT (or UNSAT with documented WARNING in lifecycle manifest).
+MUST return SAT. UNSAT → HALT with blocker report. No fallback paths.
+
+Then invoke the `plan` utility to validate spec phase structure for solvability:
+
+```bash
+./.opencode/tools/plan plan \
+  --problem ./tmp/{issue-N}/artifacts/phase-plan-problem.yaml \
+  --output ./tmp/{issue-N}/artifacts/phase-plan-validated.yaml
+```
+
+On success: planner returns SOLVED_SATISFICING or SOLVED_OPTIMALLY.
+On UNSOLVABLE or utility unavailable: **HALT** with blocker report. No fallback paths.
 
 ### Step 6: Self-Review
 

--- a/skills/test-driven-development/tasks/red.md
+++ b/skills/test-driven-development/tasks/red.md
@@ -12,12 +12,33 @@
 
 Test written and confirmed FAILING (or ERROR if function doesn't exist yet).
 
-## Verification Command
+## RED != FALSE Clause
 
-```bash
-uv run pytest test/test_module.py::test_<name> -v
-# Expected: FAILED (or ERROR)
-```
+RED is the event of writing an enforcement test, executing it, and observing it FAIL (non-zero exit). RED is not the absence of a feature. If there is no test file and no test run, there is no RED — there is only FALSE.
+
+### Prohibited Patterns (FALSE, not RED)
+
+The following patterns do NOT constitute RED:
+
+- `grep | wc -l` — a count is not a test execution
+- `grep -c` — same, a filter count is not a test
+- `ls` — file existence does not verify behavior
+- `"observe that X does not exist yet"` — observation without execution is not a test
+- Any information query that does not produce a non-zero exit code
+
+These are FALSE — they describe the absence of a feature, not the event of a test failing.
+
+## Required RED Structure
+
+| Field | Description |
+|-------|-------------|
+| Test file path | Permanent test storage path |
+| Execution command | Command that produces exit code |
+| Expected on FAIL | Exit code N (non-zero) |
+| Artifact output | `./tmp/{issue-N}/artifacts/{phase}-test-output.log` |
+
+Test files go to permanent storage (`.opencode/tests/` or `.issues/{N}/spec-artifacts/tests/`).
+Test output artifacts (exit code, stdout, stderr) go to `./tmp/{issue-N}/artifacts/` for auditor consumption. Auditors inspect artifacts, they do NOT re-run tests.
 
 ## Task Context Schema
 

--- a/skills/writing-plans/tasks/create.md
+++ b/skills/writing-plans/tasks/create.md
@@ -52,16 +52,55 @@ Writes plan header, stores at `.issues/{N}/spec-artifacts/plan.md`, runs self-re
 | `create/plan-structure` | Verification, combined/separate decision, file mapping, TDD definition | ≈750 |
 | `create/create-and-validate` | Document writing, local storage, validation, approval cascade | ≈650 |
 
-## Plan Phase Structure Requirements
+## Plan Phase Structure Requirements — Mandatory Enumerated Checklist with Routing Annotations
 
-Each phase MUST include (prose-driven, not rigid headers):
-- **Why this phase exists** — concern it addresses and place in overall design
-- **What it must accomplish** — tasks, deliverables, behavioral requirements
-- **How to verify completion** — success criteria and testable outcomes. Each phase's verification guidance MUST carry cost-frame identity prose that reframes verification cost using the dark-prose-007 formula from `250-dark-prose-reference.md` §Section 3. Verification MUST require real test execution commands that produce saved artifact files in `./tmp/{issue-N}/artifacts/`. Structural checks (file exists, grep match) are NEVER acceptable substitutes for behavioral runtime evidence — a skipped execution is a defect accepted at the point of verification. The death spiral / break dynamics are formalized in `065-verification-honesty.md` §Cost Model — behavioral verification is a break (bounded cost, zero downstream), structural-only verification is a death spiral (compounding exponential cost).
-- **What could go wrong** — edge cases, known risks, failure modes
-- **What must be done first** — dependencies on prior phases or external prerequisites
+Every plan phase MUST use EXACTLY the following 14-item enumerated checklist with routing annotations. No free-form prose outside the Concern/Files/SCs header block. No deviations.
 
-## Concern Boundary Annotations
+Each checklist item MUST include a routing annotation specifying which agent role executes it:
+- **orchestrator routes to [sub-agent-type]** — orchestrator tasks a clean-room sub-agent
+- **orchestrator inline** — orchestrator performs the action directly (only for git commits, file reads, artifact verification)
+
+The 14 gates with routing annotations:
+
+- [ ] 1. SC-COHERENCE-GATE — **orchestrator routes to pre-analysis**: verify spec SCs are internally consistent and complete for this phase
+- [ ] 2. PRE-RED-BASELINE — **orchestrator routes to exploration**: run full test suite, confirm all existing tests PASS before any changes
+- [ ] 3. RED-PHASE — **orchestrator routes to RED sub-agent**: write enforcement test at permanent path → run → capture output to `./tmp/{issue-N}/artifacts/{phase}-test-output.log` → expected FAIL (exit non-zero)
+- [ ] 4. RED-DOUBLECHECK — **orchestrator inline**: confirm RED evidence artifact exists and shows non-zero exit
+- [ ] 5. GREEN-PHASE — **orchestrator routes to GREEN sub-agent (clean-room, receives spec + test path only)**: implement change → run test → capture output → expected PASS (exit 0)
+- [ ] 6. CHECKPOINT-COMMIT — **orchestrator inline**: git commit -m "phase N checkpoint" with test + change
+- [ ] 7. STRUCTURAL-CHECKS — **orchestrator routes to structural sub-agent**: lint, format, typecheck on changed files
+- [ ] 8. GREEN-DOUBLECHECK — **orchestrator inline**: confirm GREEN evidence artifact exists and shows exit 0
+- [ ] 9. GREEN-VBC — **orchestrator routes to VbC sub-agent**: verification-before-completion against this phase's SCs
+- [ ] 10. ADVERSARIAL-AUDIT — **orchestrator routes to resolve-models**: dispatches 2 auditors for plan-fidelity + concern-separation
+- [ ] 11. CROSS-VALIDATE — **orchestrator inline**: verify dual-auditor consensus on all phase SCs
+- [ ] 12. REGRESSION-CHECK — **orchestrator routes to regression sub-agent**: full test suite, confirm nothing previously passing is now broken
+- [ ] 13. REVIEW-PREP — **orchestrator routes to review-prep sub-agent**: compare URL (verified from session-init), PR body draft for the phase
+- [ ] 14. EXEC-SUMMARY — **orchestrator inline**: read all sub-agent result contracts, produce phase completion report with SC status, artifact paths, byline
+
+### Inter-Phase Handoff
+
+Between gate 14 of phase N and gate 1 of phase N+1:
+
+- Update Z3 state file: `solve state update` with phase N's gate states
+- Run `solve check`: confirm phase N dependency contract still SAT
+- Verify checkpoint tag exists for phase N
+- Append lifecycle manifest event for phase N completion
+
+### Post-All-Phases Sweep
+
+After the last phase's gate 14:
+
+- [ ] FINISHING CHECKLIST — **orchestrator routes to finishing sub-agent**: git status clean, lint/typecheck from scratch, coverage sweep
+- [ ] PR CREATION — **orchestrator routes to git-workflow pr-creation**: via `github_create_pull_request`, extract `html_url` from response
+- [ ] POST-MERGE CLEANUP — **orchestrator routes to git-workflow cleanup**: delete merged branches, close issues, sync dev
+
+### Solve and Plan Mandatory
+
+- `solve check` on dependency contract: MUST return SAT. If UNSAT, HALT.
+- `plan plan` on phase problem: MUST return SOLVED_SATISFICING or SOLVED_OPTIMALLY. If UNSOLVABLE, HALT.
+- No fallback paths. No "If utility unavailable, validate manually." HALT on unavailability.
+
+### Concern Boundary Annotations
 
 When transitioning between architectural concerns, describe:
 - What concern being left (prior scope)

--- a/skills/writing-plans/tasks/create/create-and-validate.md
+++ b/skills/writing-plans/tasks/create/create-and-validate.md
@@ -31,12 +31,32 @@ Write plan document to `.issues/{N}/spec-artifacts/plan.md`, validate structure,
 - Write plan to `.issues/{N}/spec-artifacts/plan.md`
 - Proceed to Step 8
 
-### Phase body requirements (each phase MUST include):
-- Why this phase exists (concern it addresses)
-- What it must accomplish (tasks, deliverables, behavioral requirements)
-- How to verify completion (success criteria)
-- What could go wrong (edge cases, risks)
-- What must be done first (dependencies)
+### Phase body requirements — Mandatory 14-Item Checklist Template with Routing Annotations
+
+Each phase MUST use the following template. No prose alternative. No deviations.
+
+```
+### Phase N: title
+
+**Concern:** concern boundary
+**Files:** exact paths or glob patterns
+**SCs covered:** SC-1, SC-3
+
+- [ ] 1. SC-COHERENCE-GATE — **orchestrator routes to pre-analysis**: verify spec SCs internally consistent
+- [ ] 2. PRE-RED-BASELINE — **orchestrator routes to exploration**: full test suite PASS
+- [ ] 3. RED-PHASE — **orchestrator routes to RED sub-agent**: write test at path → run → FAIL → output to ./tmp/{issue-N}/artifacts/{phase}-test-output.log
+- [ ] 4. RED-DOUBLECHECK — **orchestrator inline**: confirm non-zero exit in artifact
+- [ ] 5. GREEN-PHASE — **orchestrator routes to GREEN sub-agent (clean-room)**: implement → run test → PASS → output to same artifact path
+- [ ] 6. CHECKPOINT-COMMIT — **orchestrator inline**: git commit -m "phase N checkpoint"
+- [ ] 7. STRUCTURAL-CHECKS — **orchestrator routes to structural sub-agent**: ruff/pyright/tsc as appropriate
+- [ ] 8. GREEN-DOUBLECHECK — **orchestrator inline**: confirm exit 0 in artifact
+- [ ] 9. GREEN-VBC — **orchestrator routes to VbC sub-agent**: verification-before-completion against phase SCs
+- [ ] 10. ADVERSARIAL-AUDIT — **orchestrator routes to resolve-models**: plan-fidelity + concern-separation
+- [ ] 11. CROSS-VALIDATE — **orchestrator inline**: dual-auditor consensus
+- [ ] 12. REGRESSION-CHECK — **orchestrator routes to regression sub-agent**: full test suite PASS
+- [ ] 13. REVIEW-PREP — **orchestrator routes to review-prep sub-agent**: compare URL, PR body draft
+- [ ] 14. EXEC-SUMMARY — **orchestrator inline**: SC status, artifact paths, byline
+```
 
 **Concern boundary annotations (prose-driven):**
 When transitioning concerns: describe what is being left, what is being entered, what information is needed for handoff.
@@ -87,6 +107,9 @@ Before finalizing the plan, verify spec-to-plan handoff artifacts:
 - Verify all steps are actionable
 - Verify success criteria are testable
 - Prose-structure check: phase descriptions remain prose
+- **Verify each phase declares test output artifact paths** using `./tmp/{issue-N}/artifacts/` convention (not bare `./tmp/`)
+- **Verify `solve check` returns SAT** — if UNSAT, HALT with blocker report
+- **Verify `plan plan` returns SOLVED_SATISFICING or SOLVED_OPTIMALLY** — if UNSOLVABLE or unavailable, HALT with blocker report
 
 ### Step 10: Verification Revisit (MANDATORY)
 

--- a/skills/writing-plans/tasks/create/plan-structure.md
+++ b/skills/writing-plans/tasks/create/plan-structure.md
@@ -37,7 +37,7 @@ After phase dependency contract is confirmed SAT, validate phase solvability:
 1. Run `.opencode/tools/plan plan --problem ./tmp/{issue-N}/artifacts/phase-plan-problem.yaml`
 1. Confirm planner returns SOLVED_SATISFICING or SOLVED_OPTIMALLY
 1. Save result to `./tmp/{issue-N}/artifacts/phase-plan-validated.yaml`
-1. If utility unavailable: log WARNING in lifecycle manifest, validate manually (acyclic check)
+1. If utility unavailable: **HALT** with blocker report — no manual fallback
 
 ### SC-ID Mapping (SC-4)
 
@@ -269,7 +269,7 @@ After Z3 contract generation, invoke the `plan` utility to validate phase solvab
 
 On success: planner returns `SOLVED_SATISFICING` or `SOLVED_OPTIMALLY` in `phase-plan-validated.yaml`.
 On UNSOLVABLE: re-examine phase ordering, add missing action/precondition, re-run.
-On utility unavailable: validate phase solvability manually (acyclic check on phase ordering), write manual validation result to `phase-plan-validated.yaml` with WARNING in lifecycle manifest.
+On utility unavailable: **HALT** with blocker report — no manual fallback.
 
 Verification steps after contract generation:
 


### PR DESCRIPTION
## Summary

Fixes 3 skill files that produce defective plans per spec #1129:

- **RED defined as FAIL event** — RED != FALSE clause, prohibited patterns, structured requirements
- **Mandatory enumerated checklists** — 14-item checklist with routing annotations replaces prose phase requirements
- **solve/plan tools mandatory** — no fallback paths, HALT on unavailability

## Changes

### Change 1: test-driven-development/tasks/red.md
- RED != FALSE clause: RED requires test file + execution + non-zero exit
- Prohibited patterns (grep, ls, observation)
- Structured RED requirements (test file path, execution command, expected exit, artifact output)

### Change 2: spec-creation/tasks/write.md
- SC table expanded to 14 columns: Test File + Phase Mapping added
- Step 5.6: solve + plan mandatory, no fallback paths — HALT on unavailability

### Change 3: writing-plans/tasks/create.md
- Prose phase requirements replaced with 14-item enumerated checklist with routing annotations
- Inter-phase handoff section (Z3 state update, solve check, checkpoint tag, lifecycle event)
- Post-all-phases sweep (finishing checklist, PR creation, cleanup)
- solve/plan mandatory with HALT on unavailability

### Change 4: writing-plans/tasks/create/create-and-validate.md
- Phase body uses mandatory 14-item checklist template with routing annotations
- Step 9 validation: artifact paths, solve check, plan validation verification

### Change 5: writing-plans/tasks/create/plan-structure.md
- Step 3.3 and Step 5.5: removed all fallback paths — HALT on utility unavailability

## SC Coverage

| SC | Evidence Type | Status |
|----|--------------|--------|
| SC-1 | string | red.md RED != FALSE clause |
| SC-2 | string | red.md structured requirements |
| SC-3 | string | spec-creation SC table columns |
| SC-4 | string | solve/plan mandatory in write.md |
| SC-5 | string | create.md 14-item checklist |
| SC-6 | string | create.md inter-phase handoff |
| SC-7 | string | create.md post-all-phases sweep |
| SC-8 | string | create-and-validate.md checklist template |
| SC-9 | string | plan-structure.md no fallback |
| SC-10 | behavioral | 14-item checklist when planning multi-phase (test in .opencode/tests/) |
| SC-11 | string | routing annotations in every checklist item |

🤖 Co-authored with AI: OpenCode (ollama-cloud/deepseek-v4-flash)