### PR TITLE
#1108: plan tool — skill card + behavioral tests + --contract-path

### DIFF
--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: plan
+description: Use when generating, validating, or managing plans for phase solvability, converting between YAML and PDDL, grounding action schemas, discovering action schemas, or managing state files. Triggers on: plan plan, plan validate, plan ground, plan pddl, plan discover, plan state, PDDL, phase solvability. Agents who skip planning produce unverified phase orderings — every unplanned phase is a risk.
+type: domain
+license: MIT
+provenance: AI-generated
+compatibility: opencode
+---
+
+# Skill: plan
+
+## Overview
+
+Provides AI planning capabilities wrapping `unified-planning` with workflow integration. Supports problem definition in YAML, plan generation via Tamer/other engines, plan validation, PDDL conversion, action grounding, action schema discovery, and state file management.
+
+## Persona
+
+Planner Router. Focus: phase solvability, action schema management, PDDL conversion, state file management.
+
+## Tasks
+
+| Task | Purpose |
+|------|---------|
+| `problem` | Problem YAML schema reference |
+| `plan` | Plan generation procedure |
+| `validate` | Plan validation |
+| `pddl` | Bidirectional YAML-PDDL conversion |
+| `ground` | Action schema grounding |
+| `fallback` | Manual acyclic check when planner unavailable |
+| `state` | State file management |
+
+## Sub-Agent Tasks
+
+| `problem` | `plan` | `validate` | `pddl` | `ground` | `fallback` | `state` |
+
+### DISPATCH_GATE — Orchestrator task() Prompt Protocol
+
+> **Context cost frame:** The orchestrator's context is the most expensive resource in the pipeline — sub-agents do the work, not the orchestrator. Every byte held by the orchestrator costs `byte × remaining_dispatches²`. See `020-go-prohibitions.md` §1.1.
+
+The orchestrator MUST NOT preload execution context into `task()` prompts.
+Every sub-agent MUST independently discover scope and produce its own result contract.
+
+#### Forbidden in task() Prompts
+
+| Violation | Forbidden Pattern | Correct Pattern |
+|-----------|-------------------|-----------------|
+| Preloaded file paths | "Read tasks/problem.md then execute step 1" | "execute problem task from plan skill" |
+| Preloaded step sequences | "Step 1: build problem YAML. Step 2: run planner." | "execute plan task from plan skill" |
+| Preloaded expected outcomes | "Return { status, plan_length }" | Let sub-agent define its own result contract |
+| Preloaded orchestrator reasoning | "The phases are ordered so we need to..." | Pure objective, no narrative |
+
+#### Dispatch Context Contract
+
+Every `task()` call MUST include only:
+- `worktree.path`
+- `github.owner`
+- `github.repo`
+- `authorization_scope`
+- `halt_at`
+- `pr_strategy`
+- `pipeline_phase`
+
+Plus skill-specific fields per the task context above.
+
+Exclusions (MUST NOT be in prompt):
+- `orchestrator_reasoning`
+- `expected_outcomes`
+- `inline_file_paths`
+- `agent_memory`
+- `cached_verification_results`
+
+#### Sub-Agent Entry Criteria
+
+A sub-agent receiving a `task()` prompt MUST reject it if the prompt contains:
+- Inline file paths to task files
+- Inline step or procedure definitions
+- Expected outcome structures or schema constraints
+- Pre-loaded evidence or orchestrator-derived conclusions
+
+Return `status: BLOCKED` with `reason: PRELOADED_CONTEXT_REJECTED`.
+
+## Invocation
+
+`skill({name: "plan"})` — call the skill, then call via task():
+
+| Task | Call via task() |
+|------|----------------|
+| `problem` | `task(..., prompt: "execute problem task from plan skill")` |
+| `plan` | `task(..., prompt: "execute plan task from plan skill")` |
+| `validate` | `task(..., prompt: "execute validate task from plan skill")` |
+| `pddl` | `task(..., prompt: "execute pddl task from plan skill")` |
+| `ground` | `task(..., prompt: "execute ground task from plan skill")` |
+| `fallback` | `task(..., prompt: "execute fallback task from plan skill")` |
+| `state` | `task(..., prompt: "execute state task from plan skill")` |
+
+**CLI equivalent (for human TUI use):** `/skill plan --task <task>`
+
+** Completion Guarantee:** If this workflow halts at ANY point — including error, failure, or early termination — you MUST invoke `--task completion` before halting.
+
+## Cross-References
+
+- `git-workflow` skill — phase order management in multi-phase plans
+- `approval-gate` skill — authorization scope for plan creation
+- `writing-plans` skill — writing implementation plans from approved specs
+- `executing-plans` skill — executing approved plans step by step
+-`.opencode/tools/plan` — CLI tool wrapping unified-planning
+
+## Worktree Mode
+
+When `worktree.path` is set, all file operations and tool invocations MUST use it as the base directory.
+
+```yaml+symbolic
+schema_version: "1.0"
+last_updated: "2026-06-12T00:00:00Z"
+rules:
+  - id: plan-001
+    title: "Problem YAML must be validated before planner invocation"
+    conditions:
+      all:
+        - "plan_generation_pending == true"
+        - "problem_yaml_validated == false"
+    actions:
+      - HALT
+      - RUN(schema validation)
+    conflicts_with: []
+    requires: []
+    triggers: []
+    source: "plan/SKILL.md"
+```

--- a/skills/plan/tasks/fallback.md
+++ b/skills/plan/tasks/fallback.md
@@ -1,0 +1,50 @@
+# Task: fallback
+
+## Purpose
+
+Perform a manual acyclic check when the `plan` tool is unavailable. Use this fallback when the planner itself is the subject of a spec fix or when infrastructure constraints prevent planner invocation.
+
+## Entry Criteria
+
+- `plan` tool is unavailable or inapplicable
+- Phases and their dependencies are enumerated
+
+## Procedure
+
+### Step 1: Collect Phases and Dependencies
+
+List all phases and their dependencies. Format: each phase has zero or more prerequisite phases.
+
+### Step 2: Build Directed Graph
+
+Construct a directed graph where edge from phase A to phase B indicates A depends on B:
+
+```
+A → B  means "A depends on B" (B must complete before A)
+```
+
+### Step 3: Topological Sort
+
+Run topological sort on the dependency graph. If the sort succeeds, no cycles exist. If the sort fails, a cycle is detected.
+
+For small graphs, manual inspection suffices. For larger graphs, use Python/networkx:
+
+```python
+import networkx as nx
+G = nx.DiGraph()
+G.add_edges_from([("A", "B"), ("B", "C")])
+list(nx.topological_sort(G))  # Raises NetworkXUnfeasible if cycle
+```
+
+### Step 4: Verify Dependency Validity
+
+Confirm every dependency references a valid existing phase. Orphan dependencies (dependencies on nonexistent phases) are equivalent to cycles.
+
+## Exit Criteria
+
+- Dependency graph has no cycles
+- Every dependency references a valid phase
+
+## When to Use
+
+Use this fallback instead of `plan plan` when the `plan` tool itself is the subject of a spec fix or is unavailable due to infrastructure constraints.

--- a/skills/plan/tasks/ground.md
+++ b/skills/plan/tasks/ground.md
@@ -1,0 +1,42 @@
+# Task: ground
+
+## Purpose
+
+Ground action schemas by binding all action parameters to concrete objects. Grounding produces a flat list of parameter-free action instances that can be directly planned over.
+
+## Entry Criteria
+
+- Problem YAML file exists with action schemas (parameterized actions)
+- Objects are declared in the problem
+
+## Procedure
+
+### Step 1: Load Problem YAML
+
+Ensure the problem YAML has action schemas with `params` and concrete `objects` that provide values for parameter types.
+
+### Step 2: Run Grounding
+
+```bash
+./.opencode/tools/plan ground --problem <problem.yaml>
+```
+
+To write output to a file:
+
+```bash
+./.opencode/tools/plan ground --problem <problem.yaml> --output <grounded.yaml>
+```
+
+### Step 3: Interpret Output
+
+The grounded output lists all possible groundings of each action schema. For example, an action `go(from: location, to: location)` with two location objects `home` and `work` produces groundings: `go(home, work)` and `go(work, home)`.
+
+### Step 4: Filter Relevant Groundings (Optional)
+
+Not all groundings may be relevant. Filter the grounded list to the subset applicable to the current problem state.
+
+## Exit Criteria
+
+- Grounding completes with exit code 0
+- Grounded actions have all parameters bound to concrete objects
+- Grounded output is valid YAML

--- a/skills/plan/tasks/pddl.md
+++ b/skills/plan/tasks/pddl.md
@@ -1,0 +1,39 @@
+# Task: pddl
+
+## Purpose
+
+Convert between the internal YAML problem representation and standard PDDL (Planning Domain Definition Language). Enables interop with external planning tools and PDDL-based workflows.
+
+## Entry Criteria
+
+- YAML problem file (to-pddl) or directory with `domain.pddl`/`problem.pddl` (from-pddl)
+
+## Procedure
+
+### Step 1: YAML to PDDL
+
+```bash
+./.opencode/tools/plan pddl --direction to-pddl --input <problem.yaml>
+```
+
+To write output to a directory (creates `domain.pddl` and `problem.pddl`):
+
+```bash
+./.opencode/tools/plan pddl --direction to-pddl --input <problem.yaml> --output <dir>
+```
+
+### Step 2: PDDL to YAML
+
+```bash
+./.opencode/tools/plan pddl --direction from-pddl --input <dir-with-domain-and-problem-pddl>
+```
+
+### Limitations
+
+PDDL round-trips (YAML → PDDL → YAML) may lose structural information. Complex PDDL constructs including quantified expressions, conditional effects, and type hierarchies may not survive a round-trip. Verify the converted output before using it downstream.
+
+## Exit Criteria
+
+- Conversion succeeds with exit code 0
+- For to-pddl: domain.pddl and problem.pddl are valid PDDL syntax
+- For from-pddl: output YAML validates against the problem schema

--- a/skills/plan/tasks/plan.md
+++ b/skills/plan/tasks/plan.md
@@ -1,0 +1,54 @@
+# Task: plan
+
+## Purpose
+
+Generate a plan from a problem YAML file. Produces a sequence of grounded actions that transform the initial state to satisfy all goal conditions.
+
+## Entry Criteria
+
+- Problem YAML file exists and validates against the schema
+
+## Procedure
+
+### Step 1: Build Problem YAML
+
+Create a problem YAML file conforming to the schema documented in `problem.md`. Include at minimum: `domain`, `objects`, `init`, `goals`, and at least one `action` definition.
+
+### Step 2: Run Planner
+
+```bash
+./.opencode/tools/plan plan --problem <path-to-problem.yaml>
+```
+
+Optional engine selection:
+
+```bash
+./.opencode/tools/plan plan --problem <path> --engine <engine>
+```
+
+Default engine is `tamer`.
+
+### Step 3: Interpret Result
+
+| Status | Meaning | Action |
+|--------|---------|--------|
+| `SOLVED_SATISFICING` | Feasible plan found | Accept plan |
+| `SOLVED_OPTIMALLY` | Optimal plan found | Accept plan |
+| `UNSOLVABLE_PROVEN` | No solution exists | Revise problem |
+| `UNSOLVABLE_INCOMPLETELY` | No solution found (incomplete search) | Revise or retry |
+| `TIMEOUT` | Planner timed out | Increase timeout or simplify |
+| `MEMOUT` | Planner ran out of memory | Simplify problem |
+
+### Step 4: Store Plan Output
+
+The planner outputs YAML plan data to stdout after a separator (`---`). Capture and save it:
+
+```bash
+./.opencode/tools/plan plan --problem <path> > plan-output.yaml
+```
+
+## Exit Criteria
+
+- Plan generation exits with code 0
+- Status is `SOLVED_SATISFICING` or `SOLVED_OPTIMALLY`
+- Plan output is stored as valid YAML with `actions` list

--- a/skills/plan/tasks/problem.md
+++ b/skills/plan/tasks/problem.md
@@ -1,0 +1,69 @@
+# Task: problem
+
+## Purpose
+
+Reference for the Problem YAML schema used by the `plan` tool. All planning subcommands consume a problem YAML file conforming to this schema.
+
+## Entry Criteria
+
+- Knowledge of the domain and objects to model
+
+## Schema Structure
+
+| Key | Type | Required | Description |
+|-----|------|----------|-------------|
+| `domain` | string | yes | Domain name |
+| `types` | list[{name}] | no | Type definitions for object classification |
+| `objects` | list[{name, type}] | no | Concrete objects in the problem |
+| `fluents` | list[{name, params?, type?}] | no | Predicate/fluent definitions |
+| `actions` | list[{name, params?, preconditions?, effects?}] | no | Action schemas |
+| `init` | list[string] | no | Initial state (fluent expressions true at start) |
+| `goals` | list[string] | no | Goal conditions to satisfy |
+
+### Action Schema
+
+Each action has: `name` (string), `params` (list of {name, type}), `preconditions` (list of fluent expressions), `effects` (list of fluent expressions). Negation uses the `not` prefix.
+
+### Expression Syntax
+
+Boolean expressions: `fluent-name`, `fluent-name(arg1, arg2)`, `not fluent-name(...)`.
+
+## Example
+
+```yaml
+domain: robot-move
+types:
+  - name: location
+objects:
+  - name: home
+    type: location
+  - name: work
+    type: location
+fluents:
+  - name: at
+    params:
+      - name: x
+        type: location
+actions:
+  - name: go
+    params:
+      - name: from
+        type: location
+      - name: to
+        type: location
+    preconditions:
+      - at(from)
+    effects:
+      - at(to)
+      - not at(from)
+init:
+  - at(home)
+goals:
+  - at(work)
+```
+
+## Exit Criteria
+
+- Problem YAML validates against schema with no unknown keys
+- All object types reference declared types
+- All fluent expressions reference declared fluents or objects

--- a/skills/plan/tasks/state.md
+++ b/skills/plan/tasks/state.md
@@ -1,0 +1,47 @@
+# Task: state
+
+## Purpose
+
+Manage pipeline state files. State files track variable values across workflow phases, enabling cross-phase data sharing with optional type validation via contract files.
+
+## Entry Criteria
+
+- State file path is determined
+
+## Procedure
+
+### Initialize State File
+
+```bash
+./.opencode/tools/plan state init <path>/
+```
+
+Creates a `state.yaml` file at the given directory with empty `variables` dict and a `timestamp`.
+
+### Update a Variable
+
+```bash
+./.opencode/tools/plan state update <path>/ --var-name <name> --var-value <value>
+```
+
+Optional contract-based validation:
+
+```bash
+./.opencode/tools/plan state update <path>/ --var-name <name> --var-value <value> --contract-path <contract.yaml>
+```
+
+- `--contract-path` enables type/domain validation against a contract YAML's variable declarations
+- `--var-type` enables type coercion (bool/int/real/string) without a full contract
+
+### View State
+
+```bash
+./.opencode/tools/plan state status <path>/
+```
+
+Prints all variables and the last update timestamp.
+
+## Exit Criteria
+
+- State file exists at the specified path
+- Variable values are correctly stored and typed

--- a/skills/plan/tasks/validate.md
+++ b/skills/plan/tasks/validate.md
@@ -1,0 +1,43 @@
+# Task: validate
+
+## Purpose
+
+Validate a generated plan against a problem domain. Confirms the plan's action sequence satisfies all goal conditions when executed from the initial state.
+
+## Entry Criteria
+
+- Problem YAML file exists and validates
+- Plan YAML file exists with an `actions` list
+
+## Procedure
+
+### Step 1: Load Plan and Problem
+
+Ensure both the problem YAML and the plan YAML are accessible. The plan file must contain an `actions` list where each entry has `name` and optionally `parameters`:
+
+```yaml
+actions:
+  - name: go
+    parameters: ["home", "work"]
+```
+
+### Step 2: Run Validation
+
+```bash
+./.opencode/tools/plan validate --plan <plan-path> --problem <problem-path>
+```
+
+### Step 3: Interpret Result
+
+| Status | Meaning | Action |
+|--------|---------|--------|
+| `valid` (exit 0) | Plan satisfies all goals | Accept |
+| `invalid` (exit 1) | Not all goals achieved | Revise plan or problem |
+
+When validation fails, the output lists which goals remain unsatisfied in the final state.
+
+## Exit Criteria
+
+- Validation confirms plan satisfies all goals (exit 0)
+- Every action in the plan exists in the problem's action schema
+- Parameter counts and object references are correct

--- a/skills/spec-creation/tasks/write.md
+++ b/skills/spec-creation/tasks/write.md
@@ -422,7 +422,13 @@ Post-invocation verification via `solve check`:
 
 MUST return SAT. UNSAT → HALT with blocker report. No fallback paths.
 
-Then invoke the `plan` utility to validate spec phase structure for solvability:
+Then invoke the `plan` utility to validate spec phase structure for solvability. Load the `plan` skill for subcommand reference:
+
+```bash
+skill({name: "plan"})   # load reference for plan subcommands and status codes
+```
+
+Proceed with phase solvability check:
 
 ```bash
 ./.opencode/tools/plan plan \
@@ -430,8 +436,8 @@ Then invoke the `plan` utility to validate spec phase structure for solvability:
   --output ./tmp/{issue-N}/artifacts/phase-plan-validated.yaml
 ```
 
-On success: planner returns SOLVED_SATISFICING or SOLVED_OPTIMALLY.
-On UNSOLVABLE or utility unavailable: **HALT** with blocker report. No fallback paths.
+On success: planner returns SOLVED_SATISFICING or SOLVED_OPTIMALLY per `plan` skill → `plan.md` task.
+On UNSOLVABLE or utility unavailable: **HALT** with blocker report. Refer to `plan` skill → `fallback.md` task for manual acyclic check when planner is unavailable.
 
 ### Step 6: Self-Review
 

--- a/skills/writing-plans/tasks/create/plan-structure.md
+++ b/skills/writing-plans/tasks/create/plan-structure.md
@@ -37,7 +37,7 @@ After phase dependency contract is confirmed SAT, validate phase solvability:
 1. Run `.opencode/tools/plan plan --problem ./tmp/{issue-N}/artifacts/phase-plan-problem.yaml`
 1. Confirm planner returns SOLVED_SATISFICING or SOLVED_OPTIMALLY
 1. Save result to `./tmp/{issue-N}/artifacts/phase-plan-validated.yaml`
-1. If utility unavailable: **HALT** with blocker report — no manual fallback
+1. If utility unavailable: **HALT** with blocker report — refer to `plan` skill → `fallback.md` task for manual acyclic check procedure
 
 ### SC-ID Mapping (SC-4)
 
@@ -257,9 +257,15 @@ Contract structure:
 ; Verification: defective state (D_P1=true, p1=false) → UNSAT expected
 ```
 
-### Step 5.5: `plan` Utility Invocation for Phase Solvability (SC-3)
+### Step 5.5: `plan` Utility Invocation for Phase Solvability
 
-After Z3 contract generation, invoke the `plan` utility to validate phase solvability:
+After Z3 contract generation, invoke the `plan` utility to validate phase solvability. Load the `plan` skill for subcommand details and status code interpretation:
+
+```bash
+skill({name: "plan"})   # load reference for plan subcommands, status codes, and fallback procedures
+```
+
+Then run the phase solvability check:
 
 ```bash
 ./.opencode/tools/plan plan \
@@ -267,9 +273,7 @@ After Z3 contract generation, invoke the `plan` utility to validate phase solvab
   --output ./tmp/{issue-N}/artifacts/phase-plan-validated.yaml
 ```
 
-On success: planner returns `SOLVED_SATISFICING` or `SOLVED_OPTIMALLY` in `phase-plan-validated.yaml`.
-On UNSOLVABLE: re-examine phase ordering, add missing action/precondition, re-run.
-On utility unavailable: **HALT** with blocker report — no manual fallback.
+Refer to `plan` skill → `plan.md` task for SOLVED_SATISFICING/OPTIMALLY/UNSOLVABLE interpretation. Refer to `fallback.md` task when planner is unavailable.
 
 Verification steps after contract generation:
 

--- a/tests/behaviors/test-plan-discover.sh
+++ b/tests/behaviors/test-plan-discover.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Behavioral test SC-10: plan discover exits 0 and prints engines to stdout
+set -euo pipefail
+
+TOOL="$(cd "$(dirname "$0")/../../" && pwd)/tools/plan"
+
+echo "=== SC-10: plan discover exits 0 and prints to stdout ==="
+
+stdout_file=$(mktemp)
+stderr_file=$(mktemp)
+set +e
+"$TOOL" discover > "$stdout_file" 2>"$stderr_file"
+rc=$?
+set -euo pipefail
+
+# Must exit 0
+if [ "$rc" -ne 0 ]; then
+    echo "FAIL: plan discover exit code $rc (expected 0)"
+    exit 1
+fi
+
+# Must print at least one line to stdout
+stdout_lines=$(wc -l < "$stdout_file")
+if [ "$stdout_lines" -eq 0 ]; then
+    echo "FAIL: stdout empty"
+    exit 1
+fi
+
+echo "PASS: exit=$rc, stdout=$stdout_lines lines"
+rm -f "$stdout_file" "$stderr_file"

--- a/tests/behaviors/test-plan-state-contract.sh
+++ b/tests/behaviors/test-plan-state-contract.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Behavioral test SC-11: plan state init + --contract-path enforces domain
+set -euo pipefail
+
+TOOL="$(cd "$(dirname "$0")/../../" && pwd)/tools/plan"
+
+echo "=== SC-11: state init + --contract-path domain enforcement ==="
+
+CONTRACT=$(mktemp /tmp/contract-sc11.XXXXXX.yaml)
+python3 -c "
+import yaml
+with open('$CONTRACT', 'w') as f:
+    yaml.dump({'variables': {'color': {'type': 'string', 'domain': ['red','green','blue']}}}, f)
+"
+
+STATE_DIR="/tmp/sc11-state-$$"
+mkdir -p "$STATE_DIR"
+
+# Init state
+"$TOOL" state init "$STATE_DIR/" > /dev/null 2>&1 || {
+    echo "FAIL: state init failed"
+    rm -rf "$CONTRACT" "$STATE_DIR"
+    exit 1
+}
+
+# Out-of-domain should be rejected
+set +e
+OUTPUT=$("$TOOL" state update "$STATE_DIR/" --var-name color --var-value purple --contract-path "$CONTRACT" 2>&1)
+rc=$?
+set -euo pipefail
+
+if [ "$rc" -eq 0 ]; then
+    echo "FAIL: out-of-domain value was accepted"
+    rm -rf "$CONTRACT" "$STATE_DIR"
+    exit 1
+fi
+
+echo "PASS: out-of-domain 'purple' rejected (exit=$rc)"
+
+# In-domain should be accepted
+set +e
+OUTPUT=$("$TOOL" state update "$STATE_DIR/" --var-name color --var-value red --contract-path "$CONTRACT" 2>&1)
+rc=$?
+set -euo pipefail
+
+if [ "$rc" -ne 0 ]; then
+    echo "FAIL: in-domain value was rejected"
+    rm -rf "$CONTRACT" "$STATE_DIR"
+    exit 1
+fi
+
+echo "PASS: in-domain 'red' accepted"
+
+rm -rf "$CONTRACT" "$STATE_DIR"
+echo ""
+echo "SC-11: ALL PASS"

--- a/tools/plan
+++ b/tools/plan
@@ -823,7 +823,7 @@ def _action_discover(args: argparse.Namespace) -> None:
         print("(none found)", file=sys.stderr)
         return
     for name in sorted(available):
-        print(name, file=sys.stderr)
+        print(name)
 
 
 def _action_state_init(path: str) -> None:
@@ -838,16 +838,69 @@ def _action_state_init(path: str) -> None:
     print(f"state initialised at {p}")
 
 
-def _action_state_update(path: str, var_name: str, var_value: str) -> None:
+def _action_state_update(path: str, contract_path: str | None, var_name: str, var_value: str, var_type: str | None = None) -> None:
     p = _state_path(path)
     if not p.exists():
         _die(f"state file not found: {p} (run state init first)", 1)
+
     data = _load_yaml(str(p))
     variables = data.get("variables", {})
+
+    # Load contract for validation
+    contract = None
+    schema = None
+    if contract_path:
+        contract = _load_yaml(contract_path)
+        schema = contract.get("variables", {})
+
     if var_name is not None and var_value is not None:
-        variables[var_name] = var_value
+        if schema and var_name in schema:
+            decl = schema[var_name]
+            typ = decl.get("type", "bool")
+            nullable = decl.get("nullable", False)
+            domain = decl.get("domain")
+
+            if nullable and var_value.strip().lower() in ("", "null"):
+                variables[var_name] = None
+            elif typ == "bool":
+                sv = var_value.strip().lower()
+                if sv in ("true", "1", "yes"):
+                    variables[var_name] = True
+                elif sv in ("false", "0", "no"):
+                    variables[var_name] = False
+                else:
+                    _die(f"invalid bool value {var_value!r} for {var_name}")
+            elif typ == "int":
+                variables[var_name] = int(var_value)
+            elif typ == "real":
+                variables[var_name] = float(var_value)
+            elif typ == "string":
+                sv = var_value.strip()
+                if domain is not None and sv not in domain:
+                    _die(f"value {sv!r} not in domain {domain} for {var_name}")
+                variables[var_name] = sv
+        elif var_type:
+            typ = var_type
+            if typ == "bool":
+                sv = var_value.strip().lower()
+                if sv in ("true", "1", "yes"):
+                    variables[var_name] = True
+                elif sv in ("false", "0", "no"):
+                    variables[var_name] = False
+                else:
+                    _die(f"invalid bool value {var_value!r} for {var_name}")
+            elif typ == "int":
+                variables[var_name] = int(var_value)
+            elif typ == "real":
+                variables[var_name] = float(var_value)
+            else:
+                variables[var_name] = var_value
+        else:
+            variables[var_name] = var_value
+
     data["variables"] = variables
     data["timestamp"] = datetime.now(timezone.utc).isoformat()
+
     with p.open("w") as f:
         yaml.dump(data, f, default_flow_style=False)
     print(f"state updated at {p}")
@@ -872,7 +925,7 @@ def _action_state(args: argparse.Namespace) -> None:
     if sub == "init":
         _action_state_init(path)
     elif sub == "update":
-        _action_state_update(path, args.var_name, args.var_value)
+        _action_state_update(path, args.contract_path, args.var_name, args.var_value, args.var_type)
     elif sub == "status":
         _action_state_status(path)
 
@@ -935,6 +988,8 @@ def _build_parser() -> argparse.ArgumentParser:
     p_upd.add_argument("state_path", help="path to state file or directory")
     p_upd.add_argument("--var-name", "-n", required=True)
     p_upd.add_argument("--var-value", "-v", required=True)
+    p_upd.add_argument("--contract-path", "-c", default=None, help="path to contract YAML for type/domain validation")
+    p_upd.add_argument("--var-type", "-t", default=None, choices=["bool", "int", "real", "string"], help="variable type (used when no contract available)")
     p_st = state_sub.add_parser("status", help="print state file contents")
     p_st.add_argument("state_path", help="path to state file or directory")
 


### PR DESCRIPTION
## Summary

- Phase 1: Added `--contract-path` (`-c`) and `--var-type` (`-t`) arguments to `plan state update`, with contract-based domain validation mirroring `solve state update --contract-path`
- Phase 1b: Fixed `plan discover` to print engine names to stdout instead of stderr
- Phase 2: Created `skills/plan/` skill card directory with SKILL.md + 7 task files (problem, plan, validate, pddl, ground, fallback, state)
- Phase 3: Added behavioral tests for `plan discover` (SC-10) and `plan state --contract-path` (SC-11)
- Phase 4: Updated referencing task files in `writing-plans` and `spec-creation` to route through plan skill

## Fixes

https://github.com/michael-conrad/.opencode/issues/1108

## Evidence

| SC | Criterion | Evidence | Status |
|----|-----------|----------|--------|
| SC-1 | `--contract-path` rejects out-of-domain | Behavioral test | PASS |
| SC-2 | `--contract-path` accepts in-domain | Behavioral test | PASS |
| SC-3 | Backward compat without `--contract-path` | Regression check | PASS |
| SC-4 | `plan discover` pipes to stdout | Behavioral test | PASS |
| SC-6 | Task files exist (entry/procedure/exit) | Structural | PASS |
| SC-7 | YAML schema sections in problem.md | String (grep) | PASS |
| SC-8 | Fallback documents acyclic check | String (grep) | PASS |
| SC-9 | PDDL documents both directions | String (grep) | PASS |
| SC-10 | Behavioral test for discover | Behavioral test | PASS |
| SC-11 | Behavioral test for state contract | Behavioral test | PASS |
| SC-12 | Skill registered in AGENTS.md | String (grep) | PASS |
| SC-13 | Referencing files updated | String + behavioral | PASS |

🤖 Co-authored with AI: OpenCode (deepseek-v4-flash)