### PR TITLE
fix: solve model preconditions + skill card + behavioral tests (#1107)

### DIFF
--- a/skills/adversarial-audit/tasks/coherence-extraction.md
+++ b/skills/adversarial-audit/tasks/coherence-extraction.md
@@ -248,7 +248,7 @@ write(baseline_path, json.dumps(baseline, indent=2))
 - `000-critical-rules.md` — baseline requirement
 - `skills/implementation-pipeline/pipeline-state-machine.yaml` — Z3 contract for pipeline step validation
 - `080-code-standards.md` §Evidence Type Taxonomy — evidence type declarations and enforcement matrix
-- `.opencode/tools/solve` — Z3 constraint tool for solve check
+- `skills/solve/` — Solve skill card (Z3 constraint solving, solve check, state)
 
 ```yaml+symbolic
 schema_version: "2.0"

--- a/skills/implementation-pipeline/tasks/pipeline-executor.md
+++ b/skills/implementation-pipeline/tasks/pipeline-executor.md
@@ -209,4 +209,4 @@ Example: `./tmp/928/artifacts/pipeline-red-phase-PASS-20260527T030000Z.yaml`
 - `skills/researcher/tasks/findings.md` — researcher findings formatting
 - `skills/completion-core/tasks/completion.md` — exec-summary pipeline step target
 - `skills/adversarial-audit/tasks/coherence-extraction.md` — SC coherence gate with Z3 + evidence type checks
-- `.opencode/tools/solve` — Z3 constraint tool
+- `skills/solve/` — Solve skill card (Z3 constraint solving, contracts, state)

--- a/skills/researcher/SKILL.md
+++ b/skills/researcher/SKILL.md
@@ -50,7 +50,7 @@ Exhaustive Investigator. Focus: verifiable source evidence, exhaustive research 
 3. **Exhaustive research mandate** — better to spend time than repeat work
 4. **No arbitrary attempt cap** — each remediation is a fresh investigation
 5. **Escalation only for unresolvable blockers** — developer escalation is last resort
-6. **Can use `solve model` and `solve prove`** for Z3 constraint investigation during remediation — references `.opencode/tools/solve` explicitly.
+6. **Can use `solve model` and `solve prove`** for Z3 constraint investigation during remediation — uses the `solve` skill card at `skills/solve/`.
 
 ## Artifact Format
 
@@ -102,4 +102,4 @@ escalation_required: <true | false>
 
 ## Cross-References
 
-Skills: `implementation-pipeline`, `research`. Tools: `.opencode/tools/solve`. Guidelines: `065-verification-honesty.md`.
+Skills: `implementation-pipeline`, `research`. Tools: `.opencode/tools/solve`. Skills: `solve` at `skills/solve/`. Guidelines: `065-verification-honesty.md`.

--- a/skills/researcher/tasks/investigate.md
+++ b/skills/researcher/tasks/investigate.md
@@ -117,5 +117,5 @@ summary: "<1-3 sentence summary>"
 
 - `implementation-pipeline/pipeline-executor.md` — step labels and remediation routing
 - `implementation-pipeline/pipeline-state-machine.yaml` — Z3 contract
-- `.opencode/tools/solve` — Z3 constraint tool
+- `skills/solve/` — Solve skill card (constraint solving, Z3, contracts)
 - `adversarial-audit/tasks/coherence-extraction.md` — SC evidence type analysis

--- a/skills/solve/SKILL.md
+++ b/skills/solve/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: solve
+description: Use when validating workflow constraints, verifying state against contracts, proving theorems, or checking dependency ordering. Triggers on: solve, contract, constraint, Z3, verify state, check workflow, prove, SAT, dependency cycle, acyclic, dependency chain, state validation, unsat core. Workflow constraints validated without Z3 are unchecked — every unverified constraint is a defect.
+type: tool
+license: MIT
+provenance: AI-generated
+compatibility: opencode
+---
+
+# Skill: solve
+
+## Overview
+
+The `solve` tool is a Z3 constraint solver for workflow correctness. It operates on contract YAML files (variable declarations + logical constraints) and state YAML files (variable assignments). Four subcommands: `check`, `model`, `prove`, and `state`. When Z3 is unavailable, `fallback` provides manual validation procedures.
+
+## Persona
+
+You are a Z3 Constraint Solver Specialist. Your focus is formal verification of workflow constraints using SAT solving and theorem proving. You translate pipeline rules into logical expressions, validate state against contracts, prove theorems about workflow properties, and detect unsatisfiable constraint sets. When Z3 is unavailable, you perform structure-based validation (acyclic graphs, dependency chains, ordering verification) manually.
+
+## Contract YAML Schema
+
+See `tasks/contract.md` for the full schema reference — variables section (type, domain, nullable), preconditions, invariants, postconditions, and theorem. Z3 expression syntax: Implies, And, Or, Not, StringVal, BoolVal, IntVal, Distinct.
+
+## Tasks
+
+| Task | Purpose |
+|------|---------|
+| `contract` | Contract YAML schema reference and Z3 expression syntax |
+| `state` | State file lifecycle management (init, update, status) |
+| `check` | Validate state against contract constraints with unsat core extraction |
+| `model` | SAT query with satisfying assignment, enforcing preconditions + invariants |
+| `prove` | Theorem proving with preconditions + invariants as assumptions |
+| `fallback` | Manual validation when Z3 is unavailable |
+
+## Sub-Agent Tasks
+
+| `contract` | `state` | `check` | `model` | `prove` | `fallback` |
+
+### Task Routing
+
+| Sub-Agent Task | Trigger Condition | Scope of Context | Exclusions | Inline Work? |
+|---|---|---|---|---|
+| `contract` | Contract creation or review | Contract file path, task description | Orchestrator reasoning | NO |
+| `state` | State file operations needed | State path, variable names, contract path | Orchestrator reasoning | NO |
+| `check` | State validation against contract | Contract path, state path, task description | Pre-determined unsat labels | NO |
+| `model` | SAT query for satisfying assignment | Contract path, query expression, task description | Expected assignment values | NO |
+| `prove` | Theorem proving | Contract path, theorem expression, task description | Expected validity outcome | NO |
+| `fallback` | Z3 unavailable | Contract or dependency structure, task description | Pre-determined cycle locations | NO |
+
+### DISPATCH_GATE — Orchestrator task() Prompt Protocol
+
+> **Context cost frame:** The orchestrator's context is the most expensive resource in the pipeline — sub-agents do the work, not the orchestrator.
+
+The orchestrator MUST NOT preload expected outcomes, file paths, or reasoning into task() prompts. Sub-agents independently discover scope and return result contracts.
+
+## Invocation
+
+`skill({name: "solve"})` — call the skill, then call via task():
+
+| Task | Call via task() |
+|------|-----------------|
+| `contract` | `task(..., prompt: "execute contract task from solve")` |
+| `state` | `task(..., prompt: "execute state task from solve")` |
+| `check` | `task(..., prompt: "execute check task from solve")` |
+| `model` | `task(..., prompt: "execute model task from solve")` |
+| `prove` | `task(..., prompt: "execute prove task from solve")` |
+| `fallback` | `task(..., prompt: "execute fallback task from solve")` |
+
+**CLI equivalent:** `/.opencode/tools/solve <subcommand> [args]`
+
+## Cross-References
+
+- `tools/solve` — Canonical implementation (Z3 solver with check/model/prove/state)
+- `000-critical-rules.md` — Verification mandating formal constraint checking
+- `065-verification-honesty.md` — Evidence requirements for verification claims
+- `091-incremental-build.md` — Item decomposition and TDD discipline
+
+## Worktree Mode
+
+When `worktree.path` is set, all file operations MUST use it as the base directory.
+
+<!-- SPDX-FileCopyrightText: 2026 Michael Conrad -->
+<!-- SPDX-License-Identifier: MIT -->
+<!-- Provenance: AI-generated -->
+
+*Co-authored with AI: OpenCode (deepseek-v4-flash)*

--- a/skills/solve/tasks/check.md
+++ b/skills/solve/tasks/check.md
@@ -1,0 +1,83 @@
+# Task: check — State Validation Against Contract
+
+## Purpose
+
+Validate a state YAML file against a contract YAML file using Z3. Determines whether the state assignments satisfy the contract's preconditions, postconditions, and invariants. When unsatisfiable, extracts and reports the unsat core.
+
+## Entry Criteria
+
+- Contract YAML file exists with variables and constraints
+- State YAML file exists with variable assignments
+- Z3 is available (if not, use `tasks/fallback.md`)
+
+## Procedure
+
+### 1. Invocation
+
+```
+./.opencode/tools/solve check --state-path <state.yaml> --contract-path <contract.yaml>
+```
+
+### 2. Check Sequence
+
+The tool performs a two-phase check:
+
+**Phase 1 — Preconditions only:**
+1. Load state variables as equality assertions (e.g., `step_completed == BoolVal(true)`)
+2. Assert all preconditions from the contract
+3. Check satisfiability
+
+Result:
+- **SAT**: Preconditions are satisfiable. Print the model (variable assignments).
+- **UNSAT**: Preconditions conflict with state. Print unsat core labels. HALT — state is invalid.
+
+**Phase 2 — Postconditions + Invariants:**
+4. Keep all assertions from Phase 1
+5. Assert all postconditions and invariants
+6. Check satisfiability
+
+Result:
+- **SAT**: All constraints satisfiable. Print model. State is valid.
+- **UNSAT**: State + postconditions + invariants conflict. Print unsat core labels. Exit code 1.
+
+### 3. Unsat Core Extraction
+
+When `check()` returns `z3.unsat`, the solver extracts the unsat core:
+
+```
+UNSAT (+ postconditions + invariants)
+  label: step_completed
+  label: cleanup_phase == StringVal('post_merge')
+```
+
+Each label corresponds to a constraint assertion. The core identifies the minimal conflicting set.
+
+### 4. Interpreting Results
+
+| Result | Meaning | Action |
+|--------|---------|--------|
+| SAT | State satisfies all contract constraints | State is valid |
+| UNSAT (preconditions) | State conflicts with preconditions | Fix state or contract |
+| UNSAT (+post+inv) | Postconditions/invariants conflict | Fix constraints or state |
+
+### 5. Common Failure Patterns
+
+| Unsat Core Pattern | Root Cause |
+|--------------------|------------|
+| Single precondition label | State violates a precondition |
+| Postcondition + invariant labels together | Postcondition contradicts invariant |
+| State variable + constraint label | State assignment directly conflicts with constraint |
+
+## Exit Criteria
+
+- State file is validated against contract
+- SAT result with model output confirms validity
+- UNSAT result with unsat core identifies conflicting constraints
+- Validation result reported (PASS/FAIL) with evidence
+
+## Cross-References
+
+- `tools/solve` lines 137-192: `_action_check` implementation
+- `tasks/contract.md` — Contract schema with preconditions, postconditions, invariants
+- `tasks/state.md` — State file format and lifecycle
+- `tasks/fallback.md` — Manual validation when Z3 unavailable

--- a/skills/solve/tasks/contract.md
+++ b/skills/solve/tasks/contract.md
@@ -1,0 +1,159 @@
+# Task: contract — Contract YAML Schema Reference
+
+## Purpose
+
+Define and document the Z3 contract YAML schema that the `solve` tool consumes. Contract files declare typed variables, constraints (preconditions, invariants, postconditions), and theorems for formal verification.
+
+## Entry Criteria
+
+- A contract file needs to be created or reviewed
+- Contract path is known or will be determined
+
+## Procedure
+
+### 1. Contract YAML Structure
+
+```yaml
+variables:
+  step_completed:
+    type: bool
+    nullable: false
+  pipeline_phase:
+    type: string
+    domain: ["analysis", "planning", "implementation", "verification"]
+  retry_count:
+    type: int
+    nullable: true
+  items_processed:
+    type: int
+preconditions:
+  - "z3.Not(z3.BoolVal(step_completed))"
+  - "z3.Or(pipeline_phase == z3.StringVal('analysis'), pipeline_phase == z3.StringVal('planning'))"
+invariants:
+  - "z3.Implies(items_processed >= z3.IntVal(0), items_processed <= z3.IntVal(100))"
+postconditions:
+  - "z3.BoolVal(step_completed)"
+theorem:
+  - "z3.Implies(z3.And(z3.BoolVal(step_completed), pipeline_phase == z3.StringVal('verification')), items_processed >= z3.IntVal(1))"
+```
+
+### 2. Variables Section
+
+Each variable declaration supports:
+
+| Field | Required | Type | Description |
+|-------|----------|------|-------------|
+| `type` | Yes | `string` | One of: `bool`, `int`, `string`, `real` |
+| `domain` | No | `list[str]` | Allowed values (string type only) |
+| `nullable` | No | `bool` | If true, `null`/empty skips the constraint |
+
+Supported Z3 sorts per type:
+- `bool` → `z3.BoolSort()`
+- `int` → `z3.IntSort()`
+- `string` → `z3.StringSort()`
+- `real` → `z3.RealSort()`
+
+### 3. Constraint Sections
+
+All constraint sections are lists of Z3 expression strings evaluated with `z3` module available as `z3` and variable constants available by name.
+
+#### preconditions
+
+Constraints that must hold before an action. Asserted first in check/model/prove. Used to establish the validity context.
+
+#### invariants
+
+Constraints that must hold throughout. Asserted alongside postconditions in check; used as assumptions in prove.
+
+#### postconditions
+
+Constraints that must hold after an action. Asserted after preconditions in check.
+
+#### theorem
+
+Expression to prove (used by `prove` subcommand). Negated and checked for unsatisfiability under preconditions + invariants.
+
+### 4. Z3 Expression Syntax
+
+All expressions are Python strings evaluated in a context where:
+- Variable names resolve to Z3 constants
+- `z3` module is available
+- `z3.` prefix required for Z3 functions
+
+#### Logical Operators
+
+| Expression | Z3 API | Example |
+|------------|--------|---------|
+| Implication | `z3.Implies(a, b)` | `z3.Implies(z3.BoolVal(step_completed), items_processed >= z3.IntVal(1))` |
+| Conjunction | `z3.And(a, b, ...)` | `z3.And(z3.BoolVal(phase_ok), z3.BoolVal(retry_not_exceeded))` |
+| Disjunction | `z3.Or(a, b, ...)` | `z3.Or(pipeline_phase == z3.StringVal('planning'), pipeline_phase == z3.StringVal('analysis'))` |
+| Negation | `z3.Not(a)` | `z3.Not(z3.BoolVal(step_completed))` |
+
+#### Value Constructors
+
+| Constructor | Usage | Example |
+|-------------|-------|---------|
+| `z3.BoolVal(v)` | Boolean literal | `z3.BoolVal(True)`, `z3.BoolVal(False)` |
+| `z3.IntVal(v)` | Integer literal | `z3.IntVal(42)` |
+| `z3.StringVal(v)` | String literal | `z3.StringVal('verification')` |
+| `z3.RealVal(v)` | Real literal | `z3.RealVal(3.14)` |
+
+#### Comparison Operators
+
+Standard Python operators work with Z3 constants: `==`, `!=`, `>=`, `<=`, `>`, `<`.
+
+```python
+items_processed >= z3.IntVal(0)
+pipeline_phase != z3.StringVal('')
+```
+
+#### Distinct Values
+
+```python
+z3.Distinct(z3.IntVal(1), z3.IntVal(2), z3.IntVal(3))
+```
+
+#### Full Example
+
+```yaml
+variables:
+  all_prs_merged:
+    type: bool
+  branch_deleted:
+    type: bool
+  cleanup_phase:
+    type: string
+    domain: ["pre_merge", "post_merge", "complete"]
+    nullable: true
+preconditions:
+  - "z3.Or(cleanup_phase == z3.StringVal('post_merge'), cleanup_phase == z3.StringVal('complete'))"
+invariants:
+  - "z3.Not(z3.And(z3.BoolVal(branch_deleted), z3.Not(z3.BoolVal(all_prs_merged))))"
+postconditions:
+  - "z3.BoolVal(all_prs_merged)"
+  - "z3.BoolVal(branch_deleted)"
+theorem:
+  - "z3.Implies(z3.BoolVal(all_prs_merged), z3.BoolVal(branch_deleted))"
+```
+
+### 5. Validation Rules
+
+- Every variable name in constraints must be declared in the variables section
+- String variables with `domain` set must use `z3.StringVal()` with values within the domain
+- `nullable: true` allows `null` or empty string values that skip constraint generation
+- Constraint expressions must evaluate to `z3.BoolRef`
+
+## Exit Criteria
+
+- Contract YAML file is valid and loadable by `solve`
+- Variables section declares all referenced variables
+- Every constraint expression is syntactically valid Python Z3 expressions
+- Z3 expression keywords (Implies, And, Or, Not, StringVal, BoolVal, IntVal, Distinct) are used where appropriate
+
+## Cross-References
+
+- `tools/solve` lines 66-107: Z3 factory and expression evaluator
+- `tasks/check.md` — State validation using contract
+- `tasks/model.md` — SAT query with contract constraints
+- `tasks/prove.md` — Theorem proving with contract constraints
+- `tasks/fallback.md` — Manual validation when Z3 unavailable

--- a/skills/solve/tasks/fallback.md
+++ b/skills/solve/tasks/fallback.md
@@ -1,0 +1,107 @@
+# Task: fallback — Manual Validation When Z3 Unavailable
+
+## Purpose
+
+Perform structural validation when Z3 is unavailable. Manual techniques: acyclic graph check for dependency cycles, dependency chain verification, and dependency ordering verification. These cover the most common workflow constraint patterns without a SAT solver.
+
+## Entry Criteria
+
+- Contract or dependency structure needs validation
+- Z3 solver is unavailable (not installed, import fails, or timeout)
+- Dependency relationships are known (manually specified or derived from contract variables)
+
+## Procedure
+
+### 1. Acyclic Graph Check
+
+Verify the dependency graph has no cycles. A cycle means two or more items depend on each other, making the ordering unsolvable.
+
+**Algorithm:**
+1. Build adjacency list: for each dependency `A → B`, add edge from A to B
+2. Run DFS with visited/in_stack tracking
+3. If any back-edge found (node in current recursion stack reached again), report CYCLE DETECTED
+
+**Cycle detection output:**
+```
+CYCLE DETECTED: <item1> → <item2> → <item3> → <item1>
+```
+
+**For each node in the cycle, report:**
+- Node name
+- Its dependencies
+- How it participates in the cycle
+
+**Acyclic result:**
+```
+ACYCLIC: <count> nodes, <edge_count> edges, no cycles found
+```
+
+### 2. Dependency Chain Verification
+
+Verify that a linear chain of dependencies is complete and well-ordered.
+
+**Procedure:**
+1. Collect the ordered list of items: `[item_1, item_2, ..., item_N]`
+2. For each adjacent pair `(item_i, item_{i+1})`, verify the dependency `item_i → item_{i+1}` exists
+3. Check for missing dependencies (gap in the chain)
+4. Check for transitive violations (indirect dependency exists but direct is missing)
+
+**Chain verification output:**
+```
+CHAIN VALID: <N> items, all dependencies present
+CHAIN BROKEN: missing dependency <item_i> → <item_{i+1}> at position <i>
+```
+
+### 3. Dependency Ordering Verification
+
+Verify a given ordering against a set of dependency constraints.
+
+**Procedure:**
+1. Collect the ordered list of items
+2. For each dependency constraint `A must precede B`:
+   a. Find positions of A and B in the ordering
+   b. Verify `position(A) < position(B)`
+3. Report all violations
+
+**Ordering output:**
+```
+ORDERING VALID: <N> constraints satisfied
+ORDERING VIOLATION: <A> must precede <B> but <B> appears at position <pos_B> before <pos_A>
+```
+
+### 4. Contract Variable Dependency Analysis (String-typed Only)
+
+When a contract exists (but Z3 is unavailable), analyze string-typed variables with domain constraints for ordering properties:
+
+1. Extract string-typed variables with domain declarations
+2. Identify any ordering semantics implied by the domain (e.g., pipeline phases: analysis < planning < implementation < verification)
+3. Verify no state assigns values that violate ordering
+
+This is limited to string-domain ordering and does not replace full Z3 constraint solving.
+
+### 5. Limitations
+
+| Z3 Capability | Fallback Equivalent | Limitation |
+|---------------|-------------------|------------|
+| SAT solving | Not available | Cannot find satisfying assignments for complex logical constraints |
+| Unsat core | Not available | Cannot identify minimal conflicting constraint set |
+| Theorem proving | Not available | Cannot prove logical theorems |
+| Branching constraints | Not available | Cannot handle disjunctions or implications |
+| Dependency cycle | Acyclic graph check | Available — structural only |
+| Dependency chain | Chain verification | Available — structural only |
+| Dependency ordering | Ordering verification | Available — structural only |
+
+## Exit Criteria
+
+- Acyclic check completed (cycle detected or acyclic confirmed)
+- Dependency chain verified (valid or broken identified)
+- Dependency ordering constraints verified (valid or violations reported)
+- Limitations clearly stated when reporting results
+
+## Cross-References
+
+- `tools/solve` — Full Z3 implementation (check/model/prove)
+- `tasks/contract.md` — Contract schema (preconditions, invariants for structural extraction)
+- `tasks/check.md` — Z3-based state validation (preferred when Z3 available)
+- `tasks/model.md` — Z3-based SAT query (preferred when Z3 available)
+- `000-critical-rules.md` — Verification requirements that may need fallback

--- a/skills/solve/tasks/model.md
+++ b/skills/solve/tasks/model.md
@@ -1,0 +1,81 @@
+# Task: model — SAT Query with Satisfying Assignment
+
+## Purpose
+
+Query the Z3 solver for satisfiability of a user-provided expression under the contract's preconditions and invariants. If satisfiable, return a satisfying assignment (model) showing concrete values for all variables.
+
+## Entry Criteria
+
+- Contract YAML file exists with variables, preconditions, and invariants
+- Query expression is a valid Z3 Boolean expression string
+- Z3 is available (if not, use `tasks/fallback.md`)
+
+## Procedure
+
+### 1. Invocation
+
+```
+./.opencode/tools/solve model --contract-path <contract.yaml> --query "<expression>"
+```
+
+### 2. Model Query Sequence
+
+The tool enforces preconditions and invariants before the query:
+
+1. Load contract variables as Z3 constants
+2. Assert all preconditions from the contract
+3. Assert all invariants from the contract
+4. Assert the user's query expression
+5. Check satisfiability
+
+This ordering ensures the query is evaluated only in valid contexts — preconditions establish validity, invariants enforce consistency.
+
+### 3. Result Interpretation
+
+| Result | Meaning | Action |
+|--------|---------|--------|
+| SAT | Query is satisfiable under contract constraints | Read the model to see concrete variable assignments |
+| UNSAT | Query contradicts preconditions + invariants | The query is impossible under the given contract |
+
+On SAT, the model prints all variable assignments:
+
+```
+SAT
+  items_processed = 25
+  pipeline_phase = "verification"
+  step_completed = True
+```
+
+### 4. Example Queries
+
+```
+# Is there a state where items_processed > 0?
+./.opencode/tools/solve model --contract-path contract.yaml --query "items_processed >= z3.IntVal(1)"
+
+# Can pipeline_phase be both planning and verification?
+./.opencode/tools/solve model --contract-path contract.yaml --query "z3.And(pipeline_phase == z3.StringVal('planning'), pipeline_phase == z3.StringVal('verification'))"
+
+# Is it possible for step to be completed without items?
+./.opencode/tools/solve model --contract-path contract.yaml --query "z3.And(z3.BoolVal(step_completed), items_processed == z3.IntVal(0))"
+```
+
+### 5. Common Pitfalls
+
+| Pitfall | Explanation |
+|---------|-------------|
+| Missing precondition | Query may be satisfiable in an invalid state context |
+| Overly constrained query | Adding too many And clauses produces UNSAT |
+| String domain mismatch | Query uses StringVal outside contract domain → model never assigns it |
+
+## Exit Criteria
+
+- SAT/UNSAT result produced
+- Model printed on SAT with all variable assignments
+- Query expression verified as valid Z3 syntax
+- Preconditions+invariants enforced before query
+
+## Cross-References
+
+- `tools/solve` lines 200-225: `_action_model` implementation
+- `tasks/contract.md` — Preconditions and invariants declaration
+- `tasks/check.md` — Full state validation (model with state assignments)

--- a/skills/solve/tasks/prove.md
+++ b/skills/solve/tasks/prove.md
@@ -1,0 +1,81 @@
+# Task: prove — Theorem Proving
+
+## Purpose
+
+Prove a theorem (logical expression) follows from the contract's preconditions and invariants. Uses Z3's SAT solver: negate the theorem and check unsatisfiability. If the negated theorem is UNSAT under the assumptions, the theorem is VALID.
+
+## Entry Criteria
+
+- Contract YAML file exists with variables, preconditions, and invariants
+- Theorem expression is a valid Z3 Boolean expression string
+- Z3 is available (if not, use `tasks/fallback.md`)
+
+## Procedure
+
+### 1. Invocation
+
+```
+./.opencode/tools/solve prove --contract-path <contract.yaml> --theorem "<expression>"
+```
+
+### 2. Proving Sequence
+
+1. Load contract variables as Z3 constants
+2. Assert all preconditions as assumptions
+3. Assert all invariants as assumptions
+4. Assert the negation of the theorem: `z3.Not(theorem_expression)`
+5. Check satisfiability
+
+This is the standard refutation-based proof technique: assume the axioms (preconditions + invariants) and check that the negated theorem cannot be satisfied.
+
+### 3. Result Interpretation
+
+| Result | Meaning | Action |
+|--------|---------|--------|
+| VALID (UNSAT) | Negated theorem is unsatisfiable → theorem holds under all valid states | Theorem is proven |
+| INVALID (SAT) | Counterexample exists where preconditions+invariants hold but theorem is false | Counterexample model shows why theorem fails |
+
+On INVALID, the solver prints a counterexample model:
+
+```
+INVALID
+  items_processed = 0
+  step_completed = True
+```
+
+This shows a concrete state satisfying preconditions+invariants where the theorem is false.
+
+### 4. Example Theorems
+
+```
+# All completed steps have processed at least one item
+./.opencode/tools/solve prove --contract-path contract.yaml --theorem "z3.Implies(z3.BoolVal(step_completed), items_processed >= z3.IntVal(1))"
+
+# A phase cannot be both pre and post merge
+./.opencode/tools/solve prove --contract-path contract.yaml --theorem "z3.Not(z3.And(cleanup_phase == z3.StringVal('pre_merge'), cleanup_phase == z3.StringVal('post_merge')))"
+
+# Branch deletion implies all PRs merged
+./.opencode/tools/solve prove --contract-path contract.yaml --theorem "z3.Implies(z3.BoolVal(branch_deleted), z3.BoolVal(all_prs_merged))"
+```
+
+### 5. Proof Strategy Tips
+
+| Theorem Type | Approach |
+|--------------|----------|
+| Implication | Prove `Implies(A, B)` — negate to `A ∧ ¬B`, check UNSAT |
+| Invariant property | Prove property follows from preconditions alone |
+| Safety property | Prove no valid state reaches an undesirable condition |
+| Equivalence | Prove both directions: `Implies(A, B)` ∧ `Implies(B, A)` |
+
+## Exit Criteria
+
+- Theorem VALID or INVALID result produced
+- VALID: theorem is logically guaranteed under contract
+- INVALID: counterexample model identifies why theorem fails
+- Proof is refutation-based (negated theorem → check UNSAT)
+
+## Cross-References
+
+- `tools/solve` lines 233-259: `_action_prove` implementation
+- `tasks/contract.md` — Theorem declaration and expression syntax
+- `tasks/model.md` — SAT query (prove uses SAT solver differently)

--- a/skills/solve/tasks/state.md
+++ b/skills/solve/tasks/state.md
@@ -1,0 +1,91 @@
+# Task: state — State File Lifecycle Management
+
+## Purpose
+
+Manage state YAML files used by the `solve` tool. State files hold variable assignments that are validated against contracts. Lifecycle: init → update → status.
+
+## Entry Criteria
+
+- A state file needs to be created, modified, or inspected
+- Contract path may be provided for type validation on update
+
+## Procedure
+
+### 1. State File Format
+
+```yaml
+variables:
+  step_completed: true
+  pipeline_phase: "analysis"
+  retry_count: 3
+  items_processed: 25
+timestamp: "2026-06-12T10:00:00+00:00"
+```
+
+### 2. State Subcommands
+
+#### init
+
+Create a new state file at the specified path:
+
+```
+./.opencode/tools/solve state init <path>
+```
+
+- If `path` has no suffix, `state.yaml` is appended (directory mode)
+- Creates parent directories as needed
+- Initializes with empty `variables: {}` and current UTC timestamp
+- Parent directories created automatically
+
+#### update
+
+Update one variable in an existing state file:
+
+```
+./.opencode/tools/solve state update <path> --var-name <name> --var-value <value> [--contract-path <contract>]
+```
+
+- When `--contract-path` is provided, the value is validated against the contract schema:
+  - `bool`: accepts `true`/`false`/`1`/`0`/`yes`/`no`
+  - `int`: parsed as integer
+  - `string`: validated against `domain` if declared
+  - `nullable`: accepts `null` or empty string
+- Without `--contract-path`, values are stored as raw strings
+- Timestamp is updated on every write
+
+#### status
+
+Print current state:
+
+```
+./.opencode/tools/solve state status <path>
+```
+
+Output format:
+```
+timestamp: 2026-06-12T10:00:00+00:00
+variables:
+  step_completed: true
+  pipeline_phase: "analysis"
+```
+
+### 3. Variable Scoping
+
+- Variables are flat key-value pairs in the `variables` mapping
+- Each variable corresponds to a contract declaration by name
+- Variables not declared in the contract are stored as-is (pass-through)
+- Missing variables in state are excluded from constraint assertions during `check`
+
+## Exit Criteria
+
+- State file exists at the target path
+- Variables reflect the desired assignments
+- Timestamp is current
+- Values are properly typed per contract schema (when contract path provided)
+
+## Cross-References
+
+- `tools/solve` lines 268-378: State implementation
+- `tools/solve` lines 124-129: Path resolution (directory/file suffix handling)
+- `tasks/contract.md` — Variable declaration schema
+- `tasks/check.md` — State validation against contract

--- a/tests/behaviors/1107-sc8-solve-prove-valid.sh
+++ b/tests/behaviors/1107-sc8-solve-prove-valid.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Behavioral test: 1107-sc8-solve-prove-valid
+# See .opencode/tests/AGENTS.md for the test harness specification and paradigm.
+# This script is an artifact-only generator — it does NOT evaluate model output.
+# SC-8 (#1107/Phase3): Valid theorem (preconditions+invariants imply theorem)
+#   → solve prove returns VALID
+#
+# Co-authored with AI: OpenCode (ollama-cloud/deepseek-v4-flash)
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/helpers.sh"
+
+SCENARIO_NAME="1107-sc8-solve-prove-valid"
+
+SCENARIO_PROMPT="I need to prove that x != 0 holds given my contract has precondition x > 0. The solve tool is at .opencode/tools/solve. Run solve prove with a contract that establishes this theorem is valid."
+
+echo "=== Behavioral Test (GREEN): $SCENARIO_NAME ==="
+echo "  Task: prove valid theorem via solve prove"
+echo ""
+
+behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT"
+
+echo "  Artifacts: ${BEHAVIOR_ARTIFACT_DIR:-<not set>}"
+echo "=== Done ==="
+exit 0

--- a/tests/behaviors/1107-sc9-solve-prove-invalid.sh
+++ b/tests/behaviors/1107-sc9-solve-prove-invalid.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Behavioral test: 1107-sc9-solve-prove-invalid
+# See .opencode/tests/AGENTS.md for the test harness specification and paradigm.
+# This script is an artifact-only generator — it does NOT evaluate model output.
+# SC-9 (#1107/Phase3): Invalid theorem (preconditions+invariants do not imply
+#   theorem) → solve prove returns INVALID
+#
+# Co-authored with AI: OpenCode (ollama-cloud/deepseek-v4-flash)
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/helpers.sh"
+
+SCENARIO_NAME="1107-sc9-solve-prove-invalid"
+
+SCENARIO_PROMPT="I need to prove that x == y holds given my contract has precondition x > 0 and y < 0. The solve tool is at .opencode/tools/solve. Run solve prove with a contract that establishes this theorem is NOT valid."
+
+echo "=== Behavioral Test (GREEN): $SCENARIO_NAME ==="
+echo "  Task: prove invalid theorem via solve prove"
+echo ""
+
+behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT"
+
+echo "  Artifacts: ${BEHAVIOR_ARTIFACT_DIR:-<not set>}"
+echo "=== Done ==="
+exit 0

--- a/tools/solve
+++ b/tools/solve
@@ -203,6 +203,17 @@ def _action_model(args: argparse.Namespace) -> None:
     consts = _make_constants(variables)
 
     solver = z3.Solver()
+
+    # Contract constraints: preconditions + invariants
+    pre = contract.get("preconditions", [])
+    for expr in pre if isinstance(pre, list) else [pre]:
+        solver.add(_eval_expr(expr, consts))
+
+    inv = contract.get("invariants", [])
+    for expr in inv if isinstance(inv, list) else [inv]:
+        solver.add(_eval_expr(expr, consts))
+
+    # Query constraint
     solver.add(_eval_expr(args.query, consts))
 
     sat = solver.check()


### PR DESCRIPTION
## Summary

Four phases stacked on single branch `feature/1107-solve-tool-fix`:

### Phase 1 — Tool fix
`tools/solve`: `_action_model` now asserts preconditions+invariants before query evaluation, mirroring `_action_prove` pattern.
- SC-1: Contradictory contract → UNSAT ✅
- SC-2: Valid contract + consistent query → SAT ✅
- SC-3: Inline queries unaffected ✅

### Phase 2 — Skill card
`skills/solve/` — SKILL.md + 6 task files (contract, state, check, model, prove, fallback)
- SC-5: All 7 files exist ✅
- SC-6: Z3 keywords present in contract.md ✅
- SC-7: Fallback patterns present in fallback.md ✅

### Phase 3 — Behavioral tests
`tests/behaviors/1107-sc8-solve-prove-valid.sh`, `1107-sc9-solve-prove-invalid.sh`
- SC-8, SC-9: Behavioral tests for solve prove ✅

### Phase 4 — Integration
Updated cross-references in researcher, implementation-pipeline, adversarial-audit
- SC-10: N/A (skills auto-discovered)
- SC-11: Inline tool references reduced ✅

### Checkpoints
Every gate verified with Z3 solve check. Every phase tagged: phase-1-green, phase-2, phase-3, phase-4.

Closes #1107