### PR TITLE
fix(#1144): reject dict-format preconditions/postconditions/invariants in solve tool

### DIFF
--- a/tests/behaviors/1144-sc4-dict-format-rejected.sh
+++ b/tests/behaviors/1144-sc4-dict-format-rejected.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# Behavioral test: 1144-sc4-dict-format-rejected
+# See .opencode/tests/AGENTS.md for the test harness specification and paradigm.
+# This script is an artifact-only generator — it does NOT evaluate model output.
+# SC-4 (#1144): All 3 actions with dict-format precondition → clear die() error
+#
+# Co-authored with AI: OpenCode (ollama-cloud/deepseek-v4-flash)
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/helpers.sh"
+
+SCENARIO_NAME="1144-sc4-dict-format-rejected"
+SCENARIO_PROMPT="Create a dict-format contract YAML file and run solve prove with it. The solve tool is at .opencode/tools/solve. A dict-format precondition looks like this in YAML:
+
+\`\`\`yaml
+variables:
+  x:
+    type: bool
+preconditions:
+  - name: my_pre
+    expr: x == True
+\`\`\`
+
+Write this to a temp file and run \`solve prove --contract-path <file> --theorem 'x == True'\`."
+
+echo "=== Behavioral Test (RED): $SCENARIO_NAME ==="
+echo "  Task: agent runs solve prove with dict-format contract"
+echo "  RED phase: should show crash (eval on dict) before fix"
+echo ""
+
+behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT"
+
+echo "  Artifacts: ${BEHAVIOR_ARTIFACT_DIR:-<not set>}"
+echo "=== Done ==="
+exit 0

--- a/tools/solve
+++ b/tools/solve
@@ -51,6 +51,31 @@ def _die(msg: str, code: int = 2) -> None:
     sys.exit(code)
 
 
+def _normalize_exprs(items) -> list[str]:
+    """Normalize precondition/postcondition/invariant items to list of strings.
+
+    Accepts: None, a single string, a list of strings.
+    Dict items are rejected with _die() as schema violations.
+    """
+    if items is None:
+        return []
+    if not isinstance(items, list):
+        items = [items]
+    result = []
+    for item in items:
+        if isinstance(item, dict):
+            name = item.get("name", "<unnamed>")
+            _die(
+                f"contract expression must be a string, got dict "
+                f"(name={name!r}). "
+                f"Use flat format: '- <z3-expr>'"
+            )
+        if not isinstance(item, str):
+            _die(f"contract expression must be a string, got {type(item).__name__}")
+        result.append(item)
+    return result
+
+
 def _load_yaml(path: str) -> dict:
     p = Path(path)
     if not p.exists():
@@ -153,8 +178,7 @@ def _action_check(args: argparse.Namespace) -> None:
             solver.add(consts[name] == z3val)
 
     # Assert preconditions
-    pre = contract.get("preconditions", [])
-    for expr in pre if isinstance(pre, list) else [pre]:
+    for expr in _normalize_exprs(contract.get("preconditions")):
         solver.add(_eval_expr(expr, consts))
 
     # Check SAT after preconditions
@@ -171,12 +195,10 @@ def _action_check(args: argparse.Namespace) -> None:
         return
 
     # Add postconditions + invariants, re-check
-    post = contract.get("postconditions", [])
-    for expr in post if isinstance(post, list) else [post]:
+    for expr in _normalize_exprs(contract.get("postconditions")):
         solver.add(_eval_expr(expr, consts))
 
-    inv = contract.get("invariants", [])
-    for expr in inv if isinstance(inv, list) else [inv]:
+    for expr in _normalize_exprs(contract.get("invariants")):
         solver.add(_eval_expr(expr, consts))
 
     sat_post = solver.check()
@@ -205,12 +227,10 @@ def _action_model(args: argparse.Namespace) -> None:
     solver = z3.Solver()
 
     # Contract constraints: preconditions + invariants
-    pre = contract.get("preconditions", [])
-    for expr in pre if isinstance(pre, list) else [pre]:
+    for expr in _normalize_exprs(contract.get("preconditions")):
         solver.add(_eval_expr(expr, consts))
 
-    inv = contract.get("invariants", [])
-    for expr in inv if isinstance(inv, list) else [inv]:
+    for expr in _normalize_exprs(contract.get("invariants")):
         solver.add(_eval_expr(expr, consts))
 
     # Query constraint
@@ -238,12 +258,10 @@ def _action_prove(args: argparse.Namespace) -> None:
     solver = z3.Solver()
 
     # Assumptions = preconditions + invariants
-    pre = contract.get("preconditions", [])
-    for expr in pre if isinstance(pre, list) else [pre]:
+    for expr in _normalize_exprs(contract.get("preconditions")):
         solver.add(_eval_expr(expr, consts))
 
-    inv = contract.get("invariants", [])
-    for expr in inv if isinstance(inv, list) else [inv]:
+    for expr in _normalize_exprs(contract.get("invariants")):
         solver.add(_eval_expr(expr, consts))
 
     # Negate the theorem


### PR DESCRIPTION
## Summary

- Add `_normalize_exprs()` helper to consolidate 7 duplicated `isinstance(list)` guards and add type validation
- Dict-format `{name, expr}` items are rejected with `_die()`: `"contract expression must be a string, got dict"`
- All 3 actions (`check`, `model`, `prove`) now consistently validate all expression types (preconditions, postconditions, invariants)
- Single-string values (not wrapped in a list) also handled correctly
- No behavioral change for flat-format contracts — all 4 existing `./tmp/` contracts continue to work

## Root cause

The `{name, expr}` dict format was never a valid schema variant — it was unreviewed test fixture detritus. No external convention uses it, no spec defines it. The code assumed all YAML items were strings and crashed on dict input at all 7 iteration sites across 3 functions.

## Fixes

https://github.com/michael-conrad/.opencode/issues/1144

Co-authored with AI: OpenCode (ollama-cloud/deepseek-v4-flash)