### PR TITLE
feat(#1149): update viewport-editor MCP plugin to v0.3.3 with AGENTS.md activation stanza

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -218,3 +218,33 @@ When parent issue has sub-issues, authorization cascades to ALL sub-issues:
 - Assume cached values from previous sessions
 - HALT after each phase of multi-task spec (see Multi-Task Spec Workflow above)
 - Write spec/plan content directly to chat as the final deliverable — ALWAYS invoke brainstorming → spec-creation → issue-operations to persist specs as GitHub Issues
+
+---
+
+## viewport-editor MCP Plugin
+
+This repo uses [viewport-editor](https://github.com/michael-conrad/viewport-editor) as its editing MCP server.
+
+**11-tool surface** (see README for full action lists):
+
+| Tool | Purpose |
+|------|---------|
+| **viewport** | Open, navigate, and manage focused editing windows |
+| **edit** | Stage text changes into viewport buffers (replace, insert, delete, swap, move) |
+| **file** | Commit or discard staged changes to disk |
+| **diff** | Show unified diffs of pending edits before saving |
+| **clipboard** | Copy/cut/paste content across viewports with provenance tracking |
+| **search** | Find text with substring or regex matching |
+| **regex** | Test and escape regex patterns |
+| **read_file** | Composite: open + scroll — preferred over built-in `read` for single-call reading |
+| **write_file** | Composite: open + replace-all + save — preferred over built-in `write` for conflict-safe writing |
+| **edit_text** | Composite: open + replace + save — preferred over built-in `edit` for targeted changes with conflict detection |
+| **find_text** | Composite: search — preferred over built-in `grep` for structured results |
+
+**Recommended agent behavior:**
+
+- Use `read_file`, `write_file`, `edit_text`, `find_text` for single-call operations
+- Use `viewport` + `edit` + `file` for multi-step editing with diff review
+- Always call `diff:show` before `file:save` to verify staged changes
+- File paths are relative to project root (MCP resolver defaults to `os.getcwd()`)
+- Conflict detection: server tracks file mtime+size externally; stale-file soft warning on reads, hard block on `file:save` (use `force: true` override if change is intentional)

--- a/opencode.jsonc
+++ b/opencode.jsonc
@@ -129,7 +129,7 @@
     },
     "viewport-editor": {
       "type": "local",
-      "command": ["uvx", "--from", "git+https://github.com/michael-conrad/viewport-editor@v0.2.0", "viewport-editor"],
+      "command": ["uvx", "--from", "git+https://github.com/michael-conrad/viewport-editor@v0.3.3", "viewport-editor"],
       "enabled": true
     }
   }


### PR DESCRIPTION
## Summary

- Bump viewport-editor MCP tool from v0.2.0 → v0.3.3 in `opencode.jsonc`
- Add viewport-editor activation stanza to `AGENTS.md` per the project's "Consuming Repo Instructions" (11-tool table + recommended agent behavior)

## Outcome

Agents now have documented guidance for using viewport-editor's composite tools (`read_file`, `write_file`, `edit_text`, `find_text`) and the standard multi-step editing workflow.

## Fixes

https://github.com/michael-conrad/.opencode/issues/1149