### PR TITLE
fix: route remote issue body to remote.md instead of spec.md

### DIFF
--- a/skills/issue-operations/tasks/import-remote.md
+++ b/skills/issue-operations/tasks/import-remote.md
@@ -13,7 +13,7 @@ Retroactively import a pre-existing remote issue into the local `.issues/` direc
 
 ## Exit Criteria
 
-- Full local mirror created at `.issues/open/<remote_number>-<slug>/spec.md`
+- Full local mirror created at `.issues/open/<remote_number>-<slug>/remote.md` (remote body) and `spec.md` (local frontmatter)
 - Comments imported to `.issues/open/<remote_number>-<slug>/comments.md`
 - Frontmatter written with remote metadata and `promotion_type: retroactive_import`
 - `.counter` advanced if `counter <= remote_number`
@@ -79,7 +79,20 @@ Create the local issue directory manually (not via `local-issues create`, becaus
 
 1. Determine slug from title: first 5 words, kebab-cased
 2. Create directory: `.issues/open/<remote_number:03d>-<slug>/`
-3. Write `spec.md` with:
+3. Write `remote.md` with minimal frontmatter + full remote body:
+
+```yaml
+---
+remote_issue: <remote_number>
+remote_url: "<html_url>"
+last_sync: <import_timestamp>
+source: <github.platform>
+---
+
+<full_remote_issue_body>
+```
+
+4. Write `spec.md` with local frontmatter only (no remote body):
 
 ```yaml
 ---
@@ -96,8 +109,6 @@ promotion_type: retroactive_import
 last_sync: <import_timestamp>
 author: <remote_author>
 ---
-
-<full_remote_issue_body>
 ```
 
 ### Step 5: Import Comments
@@ -130,7 +141,7 @@ If `counter > remote_number`, leave the counter unchanged (local issues already 
 
 Verify the full local mirror:
 
-1. Read spec.md: body matches remote, frontmatter has all required fields
+1. Read remote.md: body matches remote; Read spec.md: frontmatter has all required fields (verify no remote body content)
 2. Read comments.md: all comments present, ordered chronologically
 3. Verify counter: `cat .issues/.counter` shows `remote_number + 1` or greater
 
@@ -158,10 +169,12 @@ Verify the full local mirror:
 
 | Claim | Verification Action | Tool Call | Problem Class |
 | -- | -- | -- | -- |
-| "spec.md exists" | Verify file at `.issues/open/NNN-slug/spec.md` | `local-issues read <number>` | MISSING-ELEMENT |
+| "remote.md exists (body)" | Verify file at `.issues/open/NNN-slug/remote.md` | `local-issues read <number>` | MISSING-ELEMENT |
+| "spec.md exists (frontmatter only)" | Verify file at `.issues/open/NNN-slug/spec.md` | `local-issues read <number>` | MISSING-ELEMENT |
 | "comments.md exists with all comments" | Verify file and comment count matches remote | `cat .issues/open/NNN-slug/comments.md \| wc -l` | MISSING-ELEMENT |
 | "promotion_type in frontmatter" | Verify `promotion_type: retroactive_import` present | `local-issues read <number>` → parse frontmatter | STRUCTURE-VIOLATION |
 | "Counter advanced correctly" | Verify `.counter` value >= remote_number + 1 | `cat .issues/.counter` | VERIFICATION-GAP |
-| "Body matches remote" | Compare local body against remote issue body | `local-issues read <number>` | VERIFICATION-GAP |
+| "Body matches remote (remote.md)" | Compare remote.md body against remote issue body | `local-issues read <number>` | VERIFICATION-GAP |
+| "spec.md has no remote body" | Verify spec.md has no body content below frontmatter | `local-issues read <number>` → check body is empty after frontmatter | VERIFICATION-GAP |
 
-**Evidence artifact:** spec.md readback showing body + frontmatter, comments.md showing imported comments, .counter value.
+**Evidence artifact:** remote.md readback showing body, spec.md readback showing frontmatter only, comments.md showing imported comments, .counter value.

--- a/skills/issue-operations/tasks/import-remote.md
+++ b/skills/issue-operations/tasks/import-remote.md
@@ -78,8 +78,8 @@ If `.issues/` directory does not exist, route to `platforms/local/tasks/creation
 Create the local issue directory manually (not via `local-issues create`, because we need to set the number to match the remote):
 
 1. Determine slug from title: first 5 words, kebab-cased
-2. Create directory: `.issues/open/<remote_number:03d>-<slug>/`
-3. Write `remote.md` with minimal frontmatter + full remote body:
+1. Create directory: `.issues/open/<remote_number:03d>-<slug>/`
+1. Write `remote.md` with minimal frontmatter + full remote body:
 
 ```yaml
 ---
@@ -92,7 +92,7 @@ source: <github.platform>
 <full_remote_issue_body>
 ```
 
-4. Write `spec.md` with local frontmatter only (no remote body):
+4. Write `spec.md` with local frontmatter only — the remote body is NEVER written to spec.md, only to remote.md above:
 
 ```yaml
 ---
@@ -142,8 +142,8 @@ If `counter > remote_number`, leave the counter unchanged (local issues already 
 Verify the full local mirror:
 
 1. Read remote.md: body matches remote; Read spec.md: frontmatter has all required fields (verify no remote body content)
-2. Read comments.md: all comments present, ordered chronologically
-3. Verify counter: `cat .issues/.counter` shows `remote_number + 1` or greater
+1. Read comments.md: all comments present, ordered chronologically
+1. Verify counter: `cat .issues/.counter` shows `remote_number + 1` or greater
 
 ## Edge Cases
 

--- a/skills/issue-operations/tasks/sync-pull-to-local.md
+++ b/skills/issue-operations/tasks/sync-pull-to-local.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-After any `read-issue` call, automatically mirror the remote issue body to `.issues/<issue-number>/spec.md`. This enforces the Operating Protocol §3 spec.md mirror mandate — every remote read produces a local mirror.
+After any `read-issue` call, automatically mirror the remote issue body to `.issues/<issue-number>/remote.md` alongside the local `spec.md`. This enforces the Operating Protocol §3 remote mirror mandate — every remote read produces a local mirror.
 
 ## Entry Criteria
 
@@ -12,7 +12,7 @@ After any `read-issue` call, automatically mirror the remote issue body to `.iss
 
 ## Exit Criteria
 
-- Local mirror exists at `.issues/open/<number>-<slug>/spec.md`
+- Local mirror exists at `.issues/open/<number>-<slug>/remote.md` (remote body) alongside `spec.md` (local spec)
 - YAML frontmatter written with `remote_issue`, `remote_url`, `last_sync`
 - Local mirror is up to date with remote body
 
@@ -32,32 +32,26 @@ Determine whether a local issue already exists for this remote number:
 
 Capture the returned local issue number.
 
-### Step 3: Write Issue Body to spec.md
+### Step 3: Write Issue Body to remote.md
 
-Read the remote issue body from the `read-issue` result. Write it to the local spec.md, preserving the existing YAML frontmatter and adding remote metadata:
+Read the remote issue body from the `read-issue` result. Write it to `remote.md` alongside the local `spec.md`:
 
-**New issue (no prior frontmatter):**
+**New issue (no prior remote mirror):**
 
 ```yaml
 ---
-number: <local_number>
-title: "<remote_title>"
-status: open
-labels: [imported]
-created: <timestamp>
-updated: <timestamp>
 remote_issue: <remote_number>
 remote_url: "<remote_html_url>"
 last_sync: <timestamp>
-author: <dev.name>
+source: <github.platform>
 ---
 
 <remote_issue_body>
 ```
 
-**Existing issue (update frontmatter only — preserve local body):**
+**Existing issue (update frontmatter only — preserve local spec body):**
 
-Use `platforms/local/tasks/update.md` via task() to set `remote_issue`, `remote_url`, and `last_sync` fields. Only overwrite the body if explicitly instructed (see Edge Cases below).
+Use `platforms/local/tasks/update.md` via task() to update `remote.md` fields (`remote_issue`, `remote_url`, `last_sync`) and body. The local `spec.md` is never touched by this task — only `remote.md` is updated.
 
 ### Step 4: Link Local to Remote
 
@@ -65,12 +59,9 @@ If a new issue was created, route to `platforms/local/tasks/link.md` via task() 
 
 ### Step 5: Verify Mirror
 
-Read back the local spec.md and verify:
+Read back the local remote.md and verify:
 
 - Body content matches the remote issue body
-- `remote_issue` field matches the remote number
-- `remote_url` field matches the remote issue URL
-- `last_sync` timestamp is recent
 
 ## Edge Cases
 
@@ -95,9 +86,9 @@ Read back the local spec.md and verify:
 
 | Claim | Verification Action | Tool Call | Problem Class |
 | -- | -- | -- | -- |
-| "Local spec.md exists" | Verify file exists at `.issues/open/NNN-slug/spec.md` | `ls .issues/open/*/spec.md` | MISSING-ELEMENT |
-| "Body matches remote" | Compare local spec.md body vs remote issue body | `local-issues read NNN` | VERIFICATION-GAP |
+| "Local remote.md exists" | Verify file exists at `.issues/open/NNN-slug/remote.md` | `ls .issues/open/*/remote.md` | MISSING-ELEMENT |
+| "Body matches remote" | Compare local remote.md body vs remote issue body | `local-issues read NNN` (reads remote.md) | VERIFICATION-GAP |
 | "Frontmatter has remote_issue" | Verify YAML frontmatter contains `remote_issue` field | `local-issues read NNN` → parse frontmatter | STRUCTURE-VIOLATION |
 | "last_sync is recent" | Verify timestamp is within current session window | `local-issues read NNN` → parse frontmatter | VERIFICATION-GAP |
 
-**Evidence artifact:** Local spec.md readback showing body content and frontmatter fields.
+**Evidence artifact:** Local remote.md readback showing body content and frontmatter fields.


### PR DESCRIPTION
## Summary

Both `import-remote` and `sync-pull-to-local` wrote the remote API issue body to `spec.md`, overwriting the authoritative local spec with a remote exec summary. Now writes to `remote.md` alongside `spec.md`.

## Changes

- **import-remote.md Step 4**: Split into `remote.md` (minimal frontmatter + remote body) and `spec.md` (local frontmatter only)
- **import-remote.md**: Verification and exit criteria updated to check `remote.md` for body, `spec.md` for frontmatter only
- **sync-pull-to-local.md Step 3**: Writes body to `remote.md`, never touches `spec.md`
- **sync-pull-to-local.md**: Purpose, exit criteria, verification all reference `remote.md`

## Success Criteria

- SC-1: import-remote writes remote body to remote.md ✅
- SC-2: sync-pull-to-local writes remote body to remote.md ✅
- SC-3: spec.md is never overwritten by remote body content ✅

## Gates

- Plan: generated + validated (Tamer, SATISFICING, 6 actions)
- Solve: contract (16 vars), SAT checked at every gate
- RED: test FAIL (SC-1/2/3 all broken)
- GREEN: test PASS (all 3 SCs)
- Structural: mdformat + pymarkdown pass
- Audit: dual auditor (gemma4 PASS, mistral-large → fix applied)
- Final SAT: all invariants and postconditions SAT

Co-authored with AI: OpenCode (ollama-cloud/deepseek-v4-flash)