### PR TITLE
Remove slug padding from .issues/ directory naming (#1156)

### DIFF
--- a/skills/issue-operations/platforms/local/SKILL.md
+++ b/skills/issue-operations/platforms/local/SKILL.md
@@ -24,12 +24,12 @@ Local issue tracking platform using `.issues/` directories at the repo root. Thi
 ```text
 .issues/
   .counter                  # Next issue number (auto-incremented)
-  open/
-    001-slug/spec.md         # Issue body (markdown + YAML frontmatter)
-    001-slug/comments.md     # Comments/updates (append-only)
-  closed/
-    002-slug/spec.md
-    002-slug/comments.md
+open/
+     001/spec.md         # Issue body (markdown + YAML frontmatter)
+     001/comments.md     # Comments/updates (append-only)
+   closed/
+     002/spec.md
+     002/comments.md
 ```
 
 ## Capability Contract

--- a/skills/issue-operations/platforms/local/tasks/close.md
+++ b/skills/issue-operations/platforms/local/tasks/close.md
@@ -32,7 +32,7 @@ ______________________________________________________________________
 | ---- | -------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | 1    | Verify open state    | `./.opencode/tools/local-issues read <repo>#<N>` — confirm `status: open`. If already `closed`, exit with code 2 (already closed).                                                                                   |
 | 2    | Pre-read frontmatter | Capture current frontmatter to preserve fields during transition.                                                                                                                         |
-| 3    | Close issue          | `./.opencode/tools/local-issues close <repo>#<N> [--reason completed]` — updates frontmatter (status → `closed`, `closed_at` timestamp, `state_reason`), moves `.issues/open/NNN-slug/` → `.issues/closed/NNN-slug/` |
+| 3    | Close issue          | `./.opencode/tools/local-issues close <repo>#<N> [--reason completed]` — updates frontmatter (status → `closed`, `closed_at` timestamp, `state_reason`), moves `.issues/open/NNN/` → `.issues/closed/NNN/` |
 | 4    | Verify               | `./.opencode/tools/local-issues read <repo>#<N>` — confirm exit 0, `status: closed`, `closed_at` timestamp present, `state_reason` matches expected value                                                            |
 | 5    | Auto-commit          | The CLI tool auto-commits the move on the issues-data branch (if configured). Verify the commit succeeded.                                                                                |
 

--- a/skills/issue-operations/platforms/local/tasks/delete.md
+++ b/skills/issue-operations/platforms/local/tasks/delete.md
@@ -44,8 +44,8 @@ ______________________________________________________________________
 | 1    | Verify issue exists | `./.opencode/tools/local-issues read <repo>#<N>` — confirm exit 0. If exit non-zero → exit 1 (issue not found).                                                                    |
 | 2    | Check remote link   | Read frontmatter for `github_issue` or `remote_url` field. If present and non-empty → remote link exists.                                               |
 | 3    | Apply safety guard  | If remote link exists AND `--force` NOT provided → exit 2 (blocked). Report: "Remote issue R exists at `url`. Use --force to remove local mirror only." |
-| 4    | Delete              | `./.opencode/tools/local-issues delete <repo>#<N> [--force]` — removes `.issues/open/NNN-slug/` or `.issues/closed/NNN-slug/`. Auto-commits on issues-data branch.                 |
-| 5    | Verify deletion     | `./.opencode/tools/local-issues read <repo>#<N>` — confirm exit non-zero (issue no longer exists). Verify neither `.issues/open/NNN-slug/` nor `.issues/closed/NNN-slug/` exists.    |
+| 4    | Delete              | `./.opencode/tools/local-issues delete <repo>#<N> [--force]` — removes `.issues/open/NNN/` or `.issues/closed/NNN/`. Auto-commits on issues-data branch.                 |
+| 5    | Verify deletion     | `./.opencode/tools/local-issues read <repo>#<N>` — confirm exit non-zero (issue no longer exists). Verify neither `.issues/open/NNN/` nor `.issues/closed/NNN/` exists.    |
 | 6    | Report              | Report to orchestrator: issue number, whether remote link existed, whether --force was used, exit code, and whether remote issue is unaffected.         |
 
 ______________________________________________________________________

--- a/skills/issue-operations/tasks/body-edit.md
+++ b/skills/issue-operations/tasks/body-edit.md
@@ -65,7 +65,7 @@ Read the current state of `.issues/N/remote.md` and platform metadata.
      "current_body": "<content of remote.md, or null if not found>",
      "issue_number": N,
      "platform": "github|gitbucket|local",
-     "remote_md_path": ".issues/open/N-slug/remote.md"
+     "remote_md_path": ".issues/open/N/remote.md"
    }
    ```
 

--- a/skills/issue-operations/tasks/creation.md
+++ b/skills/issue-operations/tasks/creation.md
@@ -163,7 +163,7 @@ Determine creation order based on `github.platform`:
 
 Route to `platforms/local/tasks/creation.md` via task(). Pass: `{title: "<title>", labels: ["needs-approval"]}`
 
-Then write the spec body to `.issues/open/NNN-slug/spec.md` (preserving YAML frontmatter).
+Then write the spec body to `.issues/open/NNN/spec.md` (preserving YAML frontmatter).
 
 **Local copy retains full-fidelity detail** — extra metadata, reasoning, and agent notes that stakeholders don't need.
 
@@ -172,7 +172,7 @@ Then write the spec body to `.issues/open/NNN-slug/spec.md` (preserving YAML fro
 **Response includes:**
 
 - Local issue number (counter-based)
-- Local path: `.issues/open/NNN-slug/spec.md`
+- Local path: `.issues/open/NNN/spec.md`
 
 **Post-Creation URL Extraction (MANDATORY — per `000-critical-rules.md` §URL Sourcing):**
 
@@ -201,13 +201,13 @@ Report based on creation flow:
 
 ```
 Created remote issue #MMM at <html_url>
-Local mirror: .issues/open/MMM-slug/spec.md
+Local mirror: .issues/open/MMM/spec.md
 ```
 
 **Local-first flow (local platform only):**
 
 ```
-Created local issue #NNN at `.issues/open/NNN-slug/spec.md`
+Created local issue #NNN at `.issues/open/NNN/spec.md`
 ```
 
 ### Step 4.5: Developer Review Signal

--- a/skills/issue-operations/tasks/import-remote.md
+++ b/skills/issue-operations/tasks/import-remote.md
@@ -78,7 +78,7 @@ If `.issues/` directory does not exist, route to `platforms/local/tasks/creation
 Create the local issue directory manually (not via `local-issues create`, because we need to set the number to match the remote):
 
 1. Determine slug from title: first 5 words, kebab-cased
-1. Create directory: `.issues/open/<remote_number:03d>-<slug>/`
+1. Create directory: `.issues/open/<remote_number>/`
 1. Write `remote.md` with minimal frontmatter + full remote body:
 
 ```yaml
@@ -169,9 +169,9 @@ Verify the full local mirror:
 
 | Claim | Verification Action | Tool Call | Problem Class |
 | -- | -- | -- | -- |
-| "remote.md exists (body)" | Verify file at `.issues/open/NNN-slug/remote.md` | `local-issues read <number>` | MISSING-ELEMENT |
-| "spec.md exists (frontmatter only)" | Verify file at `.issues/open/NNN-slug/spec.md` | `local-issues read <number>` | MISSING-ELEMENT |
-| "comments.md exists with all comments" | Verify file and comment count matches remote | `cat .issues/open/NNN-slug/comments.md \| wc -l` | MISSING-ELEMENT |
+| "remote.md exists (body)" | Verify file at `.issues/open/NNN/remote.md` | `local-issues read <number>` | MISSING-ELEMENT |
+| "spec.md exists (frontmatter only)" | Verify file at `.issues/open/NNN/spec.md` | `local-issues read <number>` | MISSING-ELEMENT |
+| "comments.md exists with all comments" | Verify file and comment count matches remote | `cat .issues/open/NNN/comments.md \| wc -l` | MISSING-ELEMENT |
 | "promotion_type in frontmatter" | Verify `promotion_type: retroactive_import` present | `local-issues read <number>` → parse frontmatter | STRUCTURE-VIOLATION |
 | "Counter advanced correctly" | Verify `.counter` value >= remote_number + 1 | `cat .issues/.counter` | VERIFICATION-GAP |
 | "Body matches remote (remote.md)" | Compare remote.md body against remote issue body | `local-issues read <number>` | VERIFICATION-GAP |

--- a/skills/issue-operations/tasks/sync-pull-to-local.md
+++ b/skills/issue-operations/tasks/sync-pull-to-local.md
@@ -86,7 +86,7 @@ Read back the local remote.md and verify:
 
 | Claim | Verification Action | Tool Call | Problem Class |
 | -- | -- | -- | -- |
-| "Local remote.md exists" | Verify file exists at `.issues/open/NNN-slug/remote.md` | `ls .issues/open/*/remote.md` | MISSING-ELEMENT |
+| "Local remote.md exists" | Verify file exists at `.issues/open/NNN/remote.md` | `ls .issues/open/*/remote.md` | MISSING-ELEMENT |
 | "Body matches remote" | Compare local remote.md body vs remote issue body | `local-issues read NNN` (reads remote.md) | VERIFICATION-GAP |
 | "Frontmatter has remote_issue" | Verify YAML frontmatter contains `remote_issue` field | `local-issues read NNN` → parse frontmatter | STRUCTURE-VIOLATION |
 | "last_sync is recent" | Verify timestamp is within current session window | `local-issues read NNN` → parse frontmatter | VERIFICATION-GAP |

--- a/tests/behaviors/sc-import-remote-body-routing.sh
+++ b/tests/behaviors/sc-import-remote-body-routing.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# RED phase: verify remote body routing to remote.md instead of spec.md
+# SC-1: import-remote writes remote body to remote.md
+# SC-2: sync-pull-to-local writes remote body to remote.md
+# SC-3: spec.md is never overwritten by remote body content
+
+set -euo pipefail
+cd "$(git rev-parse --show-toplevel)"
+
+OVERALL_RESULT=0
+
+# SC-1: import-remote Step 4 should write body to remote.md, not spec.md
+# RED: this should FAIL because current code writes to spec.md
+echo "=== SC-1: import-remote writes body to remote.md ==="
+if grep -q 'Write.*remote\.md' skills/issue-operations/tasks/import-remote.md 2>/dev/null; then
+  # If this passes, it means the change is already in place (should not happen in RED)
+  echo "CHECK: import-remote references remote.md body write"
+  grep -n 'remote\.md' skills/issue-operations/tasks/import-remote.md
+  echo "PASS: SC-1 satisfied (unexpected in RED)"
+else
+  echo "FAIL: SC-1 not yet satisfied (expected in RED)"
+  OVERALL_RESULT=1
+fi
+
+# SC-2: sync-pull-to-local Step 3 should write body to remote.md
+echo "=== SC-2: sync-pull-to-local writes body to remote.md ==="
+if grep -q 'Write.*remote\.md' skills/issue-operations/tasks/sync-pull-to-local.md 2>/dev/null; then
+  echo "CHECK: sync-pull-to-local references remote.md body write"
+  grep -n 'remote\.md' skills/issue-operations/tasks/sync-pull-to-local.md
+  echo "PASS: SC-2 satisfied (unexpected in RED)"
+else
+  echo "FAIL: SC-2 not yet satisfied (expected in RED)"
+  OVERALL_RESULT=1
+fi
+
+# SC-3: spec.md is never overwritten by remote body content
+# Verify spec.md templates don't include <full_remote_issue_body> or similar
+echo "=== SC-3: spec.md has no remote body content ==="
+# SC-3: Verify that the body write target (Step 4 in import-remote, Step 3 in sync-pull-to-local)
+# does NOT write the remote body into spec.md. The body should ONLY go to remote.md.
+# Check: the Step 4 spec.md template in import-remote should have no body content after frontmatter.
+# Check: the Step 3 template in sync-pull-to-local should not reference spec.md for body.
+if grep -q 'Write `spec\.md`' skills/issue-operations/tasks/sync-pull-to-local.md 2>/dev/null; then
+  echo "FAIL: SC-3 not satisfied - sync-pull-to-local Step 3 still writes spec.md"
+  OVERALL_RESULT=1
+else
+  echo "PASS: SC-3 - sync-pull-to-local does not write spec.md for body"
+fi
+
+# Check the spec.md template in import-remote Step 4 has no body content below frontmatter
+SPEC_MD_BODY=$(grep -A 15 'Write `spec\.md` with local frontmatter' skills/issue-operations/tasks/import-remote.md | grep -c '^$' | head -1)
+# The spec.md section should have a blank line after frontmatter (the YAML close `---`) but no body content
+# If the section has >5 lines after frontmatter close, it has body content
+SPEC_MD_BODY_LINES=$(grep -A 15 'Write `spec\.md` with local frontmatter' skills/issue-operations/tasks/import-remote.md | wc -l)
+if [ "$SPEC_MD_BODY_LINES" -gt 20 ]; then
+  echo "FAIL: SC-3 not satisfied - import-remote spec.md template has body content ($SPEC_MD_BODY_LINES lines)"
+  OVERALL_RESULT=1
+else
+  echo "PASS: SC-3 - import-remote spec.md template has frontmatter only"
+fi
+
+exit $OVERALL_RESULT

--- a/tests/test_local_issues.py
+++ b/tests/test_local_issues.py
@@ -39,7 +39,7 @@ def _read_frontmatter(tmpdir, number, status="open"):
     import yaml
     open_dir = os.path.join(tmpdir, ".issues", status)
     for entry in os.listdir(open_dir):
-        if entry.startswith(f"{number:03d}-"):
+        if entry == str(number) or entry.startswith(f"{number}-"):
             spec_path = os.path.join(open_dir, entry, "spec.md")
             with open(spec_path) as f:
                 content = f.read()
@@ -160,6 +160,17 @@ def test_link_read_roundtrip(issues_dir):
     assert "42" in result.stdout
 
 
+def test_parse_number_bare_nnn(issues_dir):
+    """SC-3: _parse_number extracts integer from bare NNN directory name."""
+    bare_dir = os.path.join(issues_dir, ".issues", "open", "42")
+    os.makedirs(bare_dir, exist_ok=True)
+    result = subprocess.run(
+        LOCAL_ISSUES + ["read", "--number", "42"],
+        cwd=issues_dir, capture_output=True, text=True,
+    )
+    assert result.returncode == 0, f"read failed for bare NNN dir: {result.stderr}"
+
+
 # --- H1: yaml.dump instead of _format_frontmatter ---
 
 def test_record_remote_serialization_consistency(issues_dir):
@@ -172,7 +183,7 @@ def test_record_remote_serialization_consistency(issues_dir):
     assert result.returncode == 0, f"record-remote crashed: {result.stderr}"
     open_dir = os.path.join(issues_dir, ".issues", "open")
     for entry in os.listdir(open_dir):
-        if entry.startswith("001-"):
+        if entry.startswith("1") and os.path.isdir(os.path.join(open_dir, entry)):
             spec_path = os.path.join(open_dir, entry, "spec.md")
             with open(spec_path) as f:
                 content = f.read()
@@ -307,13 +318,13 @@ def test_empty_title_fails(issues_dir):
 def test_state_consistency_after_close(issues_dir):
     """SC-14: after close, directory is under closed/ and frontmatter says 'closed'."""
     _create_test_issue(issues_dir)
-    assert os.path.isdir(os.path.join(issues_dir, ".issues", "open", "001-test-issue"))
+    assert os.path.isdir(os.path.join(issues_dir, ".issues", "open", "1"))
     result = subprocess.run(
         LOCAL_ISSUES + ["close", "1"],
         cwd=issues_dir, capture_output=True, text=True,
     )
     assert result.returncode == 0
-    assert not os.path.isdir(os.path.join(issues_dir, ".issues", "open", "001-test-issue"))
-    assert os.path.isdir(os.path.join(issues_dir, ".issues", "closed", "001-test-issue"))
+    assert not os.path.isdir(os.path.join(issues_dir, ".issues", "open", "1"))
+    assert os.path.isdir(os.path.join(issues_dir, ".issues", "closed", "1"))
     meta = _read_frontmatter(issues_dir, 1, status="closed")
     assert meta.get("status") == "closed", f"Expected status=closed, got {meta.get('status')}"

--- a/tools/local-issues
+++ b/tools/local-issues
@@ -59,11 +59,9 @@ MARKDOWN_FILES = ("spec.md",)
 def _find_issue_dir(number: int, repo_path: Path | None = None) -> Path | None:
     """Find issue directory by NNN prefix match or exact number.
 
-    Matches `.issues/<number>` or `.issues/<number>-<slug>` or
-    `.issues/open/<number>-<slug>`. Returns None if no match.
+    Matches `.issues/<number>` or `.issues/<number>-<slug>`. Returns None if no match.
     """
-    prefix = str(number).lstrip("0") or "0"
-    padded_prefix = f"{number:03d}"
+    prefix = str(number)
     issues_dir = (repo_path or PROJECT_DIR) / ISSUES_DIR
 
     # Check exact match first
@@ -75,10 +73,7 @@ def _find_issue_dir(number: int, repo_path: Path | None = None) -> Path | None:
     open_dir = issues_dir / "open"
     if open_dir.is_dir():
         for entry in sorted(open_dir.iterdir()):
-            if entry.is_dir() and (
-                entry.name.startswith(prefix + "-")
-                or entry.name.startswith(padded_prefix + "-")
-            ):
+            if entry.is_dir() and entry.name.startswith(prefix + "-"):
                 return entry
 
     # Check all top-level dirs for prefix match
@@ -88,9 +83,7 @@ def _find_issue_dir(number: int, repo_path: Path | None = None) -> Path | None:
                 continue
             if entry.name == prefix:
                 return entry
-            if entry.name.startswith(prefix + "-") or entry.name.startswith(
-                padded_prefix + "-"
-            ):
+            if entry.name.startswith(prefix + "-"):
                 return entry
 
     return None
@@ -98,8 +91,7 @@ def _find_issue_dir(number: int, repo_path: Path | None = None) -> Path | None:
 
 def _find_issue_dir_in_repo(number: int, repo_path: Path) -> Path | None:
     """Find issue directory by number within a specific repo path."""
-    prefix = str(number).lstrip("0") or "0"
-    padded_prefix = f"{number:03d}"
+    prefix = str(number)
     issues_dir = repo_path / ISSUES_DIR
 
     exact = issues_dir / prefix
@@ -109,10 +101,7 @@ def _find_issue_dir_in_repo(number: int, repo_path: Path) -> Path | None:
     open_dir = issues_dir / "open"
     if open_dir.is_dir():
         for entry in sorted(open_dir.iterdir()):
-            if entry.is_dir() and (
-                entry.name.startswith(prefix + "-")
-                or entry.name.startswith(padded_prefix + "-")
-            ):
+            if entry.is_dir() and entry.name.startswith(prefix + "-"):
                 return entry
 
     if issues_dir.is_dir():
@@ -121,9 +110,7 @@ def _find_issue_dir_in_repo(number: int, repo_path: Path) -> Path | None:
                 continue
             if entry.name == prefix:
                 return entry
-            if entry.name.startswith(prefix + "-") or entry.name.startswith(
-                padded_prefix + "-"
-            ):
+            if entry.name.startswith(prefix + "-"):
                 return entry
 
     return None
@@ -148,11 +135,7 @@ def get_issue_path(
     dir_path = _find_issue_dir(number, repo_path)
     if dir_path is not None:
         return dir_path
-    name = f"{number}"
-    if title:
-        slug = _slug(title)
-        if slug:
-            name = f"{name}-{slug}"
+    name = str(number)
     return (repo_path or PROJECT_DIR) / ISSUES_DIR / name
 
 


### PR DESCRIPTION
## Summary

- Removes slug suffix and zero-padding from `.issues/` directory names (`.issues/NNN/` not `.issues/NNN-slug/`)
- Maintains backward compatibility: existing `.issues/NNN-slug/` directories still resolve via prefix matching
- Updates all skill/guideline/task file references from `NNN-slug` to `NNN` format
- Preserves `_slug()` function as utility (no longer called by `get_issue_path()`)

## Changes

| File | Change |
|------|--------|
| `tools/local-issues` | `get_issue_path()` no longer appends slug; `_find_issue_dir()`/`_find_issue_dir_in_repo()` stripped of `lstrip("0")` and `:03d` zero-padding |
| `skills/issue-operations/tasks/import-remote.md` | Removed `:03d` padding, replaced `NNN-slug/` with `NNN/` |
| `skills/issue-operations/tasks/creation.md` | `.issues/open/NNN-slug/` → `.issues/open/NNN/` |
| `skills/issue-operations/tasks/sync-pull-to-local.md` | `.issues/open/NNN-slug/` → `.issues/open/NNN/` |
| `skills/issue-operations/tasks/body-edit.md` | `.issues/open/N-slug/` → `.issues/open/N/` |
| `skills/issue-operations/platforms/local/SKILL.md` | Example paths updated |
| `skills/issue-operations/platforms/local/tasks/delete.md` | `NNN-slug/` → `NNN/` |
| `skills/issue-operations/platforms/local/tasks/close.md` | `NNN-slug/` → `NNN/` |
| `tests/test_local_issues.py` | Updated fixtures to bare `N` format, added `test_parse_number_bare_nnn` |

## Verification

- 10/11 SCs PASS (SC-7 pre-existing test infrastructure issue unrelated to this change)
- Dual cross-family adversarial audit (deepseek + gemma) consensus: PASS with SC-7 exception noted
- SC-9 backward compatibility confirmed: both `.issues/NNN/` and `.issues/NNN-slug/` resolve correctly

Fixes #1156