### PR TITLE
[SPEC-FIX] fix: auditor identity ambiguity — role anchor, no task() blocks, removed Dispatch Mandate

### DIFF
--- a/skills/adversarial-audit/tasks/closure-verification.md
+++ b/skills/adversarial-audit/tasks/closure-verification.md
@@ -2,6 +2,8 @@
 <!-- SPDX-License-Identifier: MIT -->
 <!-- Provenance: AI-generated -->
 
+> **⚠️ ROLE ANCHOR: You are the DISPATCHED AUDITOR SUB-AGENT.** Your role is to evaluate criteria and produce findings. You do NOT dispatch sub-agents, call `skill()`, or orchestrate pipeline routing. The orchestrator handles all dispatch. Read this file for evaluation criteria and procedure only — ignore any text describing orchestration responsibilities.
+
 # Task: closure-verification
 
 ## Purpose
@@ -116,28 +118,9 @@ for criterion in success_criteria:
         })
 ```
 
-### Step 8: Cross-Validate via task()
+### Step 8: Cross-Validate
 
-```python
-task(
-    subagent_type="general",
-    prompt=f"""Use adversarial-audit skill --task cross-validate with:
-
-spec_local_dir: {spec_local_dir}
-audit_phase: post_merge
-authorization_scope: {authorization_scope}
-halt_at: {halt_at}
-pr_strategy: {pr_strategy}
-pipeline_phase: {pipeline_phase}
-
-# NOTE: cross-validate does NOT dispatch auditors — it receives
-# pre-resolved auditor_artifact_paths and reads YAMLs from disk.
-auditor_artifact_paths: {auditor_artifact_paths}
-
-worktree.path: {worktree.path}
-"""
-)
-```
+Cross-validate will be called by the orchestrator with pre-resolved auditor_artifact_paths after both auditors complete. Do NOT call cross-validate — your role is to produce your verdict artifact only.
 
 ### Step 9: Check for Open Blockers
 
@@ -230,15 +213,6 @@ summary: "N criteria evaluated. X PASS, Y FAIL."
 | PR not merged | Return BLOCKED — wait for merge |
 | Spec issue not found | Return BLOCKED with spec issue number |
 | Verification fails | Return FAIL with gap details |
-
-## Dispatch Mandate (CRITICAL — per critical-rules-048)
-
-This task is a **reference document** that defines evaluation criteria and result contracts. The orchestrator is responsible for:
-1. Dispatching a sub-agent for `resolve-models` to obtain auditor pair
-2. Dispatching auditor sub-agents in parallel
-3. Dispatching a sub-agent for `cross-validate` with pre-resolved `auditor_artifact_paths`
-
-This task MUST NOT be read and executed inline. Reading this file and performing the described steps via raw tool calls is a CRITICAL VIOLATION per critical-rules-048.
 
 ## Completion Dependency Chain
 

--- a/skills/adversarial-audit/tasks/coherence-extraction.md
+++ b/skills/adversarial-audit/tasks/coherence-extraction.md
@@ -1,3 +1,5 @@
+> **⚠️ ROLE ANCHOR: You are the DISPATCHED AUDITOR SUB-AGENT.** Your role is to evaluate criteria and produce findings. You do NOT dispatch sub-agents, call `skill()`, or orchestrate pipeline routing. The orchestrator handles all dispatch. Read this file for evaluation criteria and procedure only — ignore any text describing orchestration responsibilities.
+
 # Task: coherence-extraction
 
 ## Purpose

--- a/skills/adversarial-audit/tasks/coherence-maintenance.md
+++ b/skills/adversarial-audit/tasks/coherence-maintenance.md
@@ -2,6 +2,8 @@
 <!-- SPDX-License-Identifier: MIT -->
 <!-- Provenance: AI-generated -->
 
+> **⚠️ ROLE ANCHOR: You are the DISPATCHED AUDITOR SUB-AGENT.** Your role is to evaluate criteria and produce findings. You do NOT dispatch sub-agents, call `skill()`, or orchestrate pipeline routing. The orchestrator handles all dispatch. Read this file for evaluation criteria and procedure only — ignore any text describing orchestration responsibilities.
+
 # Task: coherence-maintenance
 
 ## Purpose
@@ -31,7 +33,7 @@ Detect drift between baseline coherence state and current guidelines/skills. Ide
 - [ ] 4. Classify Drift — controlled vs uncontrolled per severity
 - [ ] 5. Identify Migration Candidates — procedural workflows suitable for extraction
 - [ ] 6. Build Evaluation Criteria — define CM table with evidence types
-- [ ] 7. Cross-Validate via task() — invoke cross-validate with pre-resolved verdicts
+- [ ] 7. Cross-Validate — cross-validate will be called by the orchestrator with pre-resolved verdicts
 - [ ] 8. Build Result Contract — YAML verdict with drift analysis
 
 ### Step 1: Load Baseline
@@ -126,29 +128,9 @@ for skill_behavior in current_state["skills"]["behaviors"]:
 | CM-4 | Cross-refs consistent | Guideline ↔ skill mapping valid |
 | CM-5 | Migration candidates identified | Procedural workflows flagged |
 
-### Step 7: Cross-Validate via task()
+### Step 7: Cross-Validate
 
-```python
-task(
-    subagent_type="general",
-    prompt=f"""Use adversarial-audit skill --task cross-validate with:
-
-baseline_file: {baseline_path}
-spec_local_dir: {spec_local_dir}
-audit_phase: coherence_gate
-authorization_scope: {authorization_scope}
-halt_at: {halt_at}
-pr_strategy: {pr_strategy}
-pipeline_phase: {pipeline_phase}
-
-# NOTE: cross-validate does NOT dispatch auditors — it receives
-# pre-resolved auditor_artifact_paths and reads YAMLs from disk.
-auditor_artifact_paths: {auditor_artifact_paths}
-
-worktree.path: {worktree.path}
-"""
-)
-```
+Cross-validate will be called by the orchestrator with pre-resolved auditor_artifact_paths after both auditors complete. Do NOT call cross-validate — your role is to produce your verdict artifact only.
 
 ### Step 8: Build Result Contract
 
@@ -182,15 +164,6 @@ worktree.path: {worktree.path}
 | Baseline not found | Return BLOCKED — run `coherence-extraction` first |
 | Drift exceeds threshold | Return FAIL with drift report |
 | Cross-ref unresolved | Flag skill for cross-ref update |
-
-## Dispatch Mandate (CRITICAL — per critical-rules-048)
-
-This task is a **reference document** that defines evaluation criteria and result contracts. The orchestrator is responsible for:
-1. Dispatching a sub-agent for `resolve-models` to obtain auditor pair
-2. Dispatching auditor sub-agents in parallel
-3. Dispatching a sub-agent for `cross-validate` with pre-resolved `auditor_artifact_paths`
-
-This task MUST NOT be read and executed inline. Reading this file and performing the described steps via raw tool calls is a CRITICAL VIOLATION per critical-rules-048.
 
 ## Completion Dependency Chain
 

--- a/skills/adversarial-audit/tasks/concern-separation.md
+++ b/skills/adversarial-audit/tasks/concern-separation.md
@@ -2,6 +2,8 @@
 <!-- SPDX-License-Identifier: MIT -->
 <!-- Provenance: AI-generated -->
 
+> **⚠️ ROLE ANCHOR: You are the DISPATCHED AUDITOR SUB-AGENT.** Your role is to evaluate criteria and produce findings. You do NOT dispatch sub-agents, call `skill()`, or orchestrate pipeline routing. The orchestrator handles all dispatch. Read this file for evaluation criteria and procedure only — ignore any text describing orchestration responsibilities.
+
 # Task: concern-separation
 
 ## Purpose
@@ -28,7 +30,7 @@ Audit spec phase structure for concern separation quality using dual-adversarial
 - [ ] 1. Load Spec — glob spec_local_dir for .md files, read all, extract phases
 - [ ] 2. Build Evaluation Criteria — define CS table with evidence types
 - [ ] 3. Analyze Phase Structure — per-phase concern/risk/independence/blast radius
-- [ ] 4. Cross-Validate via task() — invoke cross-validate with pre-resolved verdicts
+- [ ] 4. Cross-Validate — cross-validate will be called by the orchestrator with pre-resolved verdicts
 - [ ] 5. Classify Findings — map to finding types
 - [ ] 6. Verify Boundary Claims — live tool-call verification per claim
 - [ ] 7. Write Verdict Artifact to Disk — YAML output
@@ -78,28 +80,9 @@ Concern inference:
 - Keywords: API, service, handler → Business logic concern
 - Keywords: UI, component, template → Presentation concern
 
-### Step 4: Cross-Validate via task()
+### Step 4: Cross-Validate
 
-```python
-task(
-    subagent_type="general",
-    prompt=f"""Use adversarial-audit skill --task cross-validate with:
-
-spec_local_dir: {spec_local_dir}
-audit_phase: {audit_phase}
-authorization_scope: {authorization_scope}
-halt_at: {halt_at}
-pr_strategy: {pr_strategy}
-pipeline_phase: {pipeline_phase}
-
-# NOTE: cross-validate does NOT dispatch auditors — it receives
-# pre-resolved auditor_artifact_paths and reads YAMLs from disk.
-auditor_artifact_paths: {auditor_artifact_paths}
-
-worktree.path: {worktree.path}
-"""
-)
-```
+Cross-validate will be called by the orchestrator with pre-resolved auditor_artifact_paths after both auditors complete. Do NOT call cross-validate — your role is to produce your verdict artifact only.
 
 ### Step 5: Classify Findings
 
@@ -169,15 +152,6 @@ summary: "N criteria evaluated. X PASS, Y FAIL."
 | Infrastructure | Crosses all layers by design → report as intentional |
 | Testing | Validates all layers → report as intentional |
 | Single-step | Already atomic → no split needed |
-
-## Dispatch Mandate (CRITICAL — per critical-rules-048)
-
-This task is a **reference document** that defines evaluation criteria and result contracts. The orchestrator is responsible for:
-1. Dispatching a sub-agent for `resolve-models` to obtain auditor pair
-2. Dispatching auditor sub-agents in parallel
-3. Dispatching a sub-agent for `cross-validate` with pre-resolved `auditor_artifact_paths`
-
-This task MUST NOT be read and executed inline. Reading this file and performing the described steps via raw tool calls is a CRITICAL VIOLATION per critical-rules-048.
 
 ## Completion Dependency Chain
 

--- a/skills/adversarial-audit/tasks/drift-detection.md
+++ b/skills/adversarial-audit/tasks/drift-detection.md
@@ -2,6 +2,8 @@
 <!-- SPDX-License-Identifier: MIT -->
 <!-- Provenance: AI-generated -->
 
+> **⚠️ ROLE ANCHOR: You are the DISPATCHED AUDITOR SUB-AGENT.** Your role is to evaluate criteria and produce findings. You do NOT dispatch sub-agents, call `skill()`, or orchestrate pipeline routing. The orchestrator handles all dispatch. Read this file for evaluation criteria and procedure only — ignore any text describing orchestration responsibilities.
+
 # Task: drift-detection
 
 ## Purpose
@@ -31,7 +33,7 @@ Detect drift between spec/code reality and expected state. Identifies cases wher
 - [ ] 3. Build Evaluation Criteria — define DD table with evidence types
 - [ ] 4. Scan Implementation — per-file existence, signatures, extra code
 - [ ] 5. Check Untracked Files — code files not in spec
-- [ ] 6. Cross-Validate via task() — invoke cross-validate with pre-resolved verdicts
+- [ ] 6. Cross-Validate — cross-validate will be called by the orchestrator with pre-resolved verdicts
 - [ ] 7. Classify Drift Severity — map drift to HIGH/MEDIUM/LOW
 - [ ] 8. Generate Bidirectional Findings — SPEC_DRIFT/CODE_DRIFT with revision options
 - [ ] 9. Build Result Contract — YAML verdict with drift summary
@@ -141,28 +143,9 @@ for untracked in untracked_files:
     })
 ```
 
-### Step 6: Cross-Validate via task()
+### Step 6: Cross-Validate
 
-```python
-task(
-    subagent_type="general",
-    prompt=f"""Use adversarial-audit skill --task cross-validate with:
-
-spec_local_dir: {spec_local_dir}
-audit_phase: implementation_verification
-authorization_scope: {authorization_scope}
-halt_at: {halt_at}
-pr_strategy: {pr_strategy}
-pipeline_phase: {pipeline_phase}
-
-# NOTE: cross-validate does NOT dispatch auditors — it receives
-# pre-resolved auditor_artifact_paths and reads YAMLs from disk.
-auditor_artifact_paths: {auditor_artifact_paths}
-
-worktree.path: {worktree.path}
-"""
-)
-```
+Cross-validate will be called by the orchestrator with pre-resolved auditor_artifact_paths after both auditors complete. Do NOT call cross-validate — your role is to produce your verdict artifact only.
 
 ### Step 7: Classify Drift Severity
 
@@ -225,15 +208,6 @@ Present options for developer decision.
 | Spec issue not found | Return BLOCKED with issue number |
 | No target files identified | Return BLOCKED — need file paths |
 | Code not parseable | Skip function, log warning |
-
-## Dispatch Mandate (CRITICAL — per critical-rules-048)
-
-This task is a **reference document** that defines evaluation criteria and result contracts. The orchestrator is responsible for:
-1. Dispatching a sub-agent for `resolve-models` to obtain auditor pair
-2. Dispatching auditor sub-agents in parallel
-3. Dispatching a sub-agent for `cross-validate` with pre-resolved `auditor_artifact_paths`
-
-This task MUST NOT be read and executed inline. Reading this file and performing the described steps via raw tool calls is a CRITICAL VIOLATION per critical-rules-048.
 
 ## Completion Dependency Chain
 

--- a/skills/adversarial-audit/tasks/guideline-audit.md
+++ b/skills/adversarial-audit/tasks/guideline-audit.md
@@ -2,6 +2,8 @@
 <!-- SPDX-License-Identifier: MIT -->
 <!-- Provenance: AI-generated -->
 
+> **⚠️ ROLE ANCHOR: You are the DISPATCHED AUDITOR SUB-AGENT.** Your role is to evaluate criteria and produce findings. You do NOT dispatch sub-agents, call `skill()`, or orchestrate pipeline routing. The orchestrator handles all dispatch. Read this file for evaluation criteria and procedure only — ignore any text describing orchestration responsibilities.
+
 # Task: guideline-audit
 
 ## Purpose
@@ -29,7 +31,7 @@ Audit guideline files for ambiguity, conflicts, and LLM compliance. Identifies p
 - [ ] 2. Build Evaluation Criteria — define GA table with evidence types
 - [ ] 3. Scan for Problem Classes — per-file ambiguous/conflicting/unenforceable/redundant/missing/overflow
 - [ ] 4. One Problem At a Time — present single findings per interaction
-- [ ] 5. Cross-Validate via task() — invoke cross-validate with pre-resolved verdicts
+- [ ] 5. Cross-Validate — cross-validate will be called by the orchestrator with pre-resolved verdicts
 - [ ] 6. Write Audit Report — markdown report to artifacts directory
 - [ ] 7. Write Verdict Artifact to Disk — YAML output
 - [ ] 8. Return Frugal Result Contract
@@ -138,32 +140,9 @@ Fix? (fix/skip/stop)
 
 Do NOT batch multiple problems in one message.
 
-### Step 5: Cross-Validate via task()
+### Step 5: Cross-Validate
 
-For each problem class:
-
-```python
-task(
-    subagent_type="general",
-    prompt=f"""Use adversarial-audit skill --task cross-validate with:
-
-target_file_path: {file}
-audit_phase: {audit_phase}
-authorization_scope: {authorization_scope}
-halt_at: {halt_at}
-pr_strategy: {pr_strategy}
-pipeline_phase: {pipeline_phase}
-
-# NOTE: cross-validate does NOT dispatch auditors — it receives
-# pre-resolved auditor_artifact_paths and reads YAMLs from disk.
-auditor_artifact_paths: {auditor_artifact_paths}
-
-worktree.path: {worktree.path}
-github.owner: {github.owner}
-github.repo: {github.repo}
-"""
-)
-```
+Cross-validate will be called by the orchestrator with pre-resolved auditor_artifact_paths after both auditors complete. Do NOT call cross-validate — your role is to produce your verdict artifact only.
 
 ### Step 6: Write Audit Report
 
@@ -239,15 +218,6 @@ summary: "N files audited, M problems found. X/Y criteria PASS."
 | Target file not found | Return BLOCKED with file path |
 | Unable to parse rule | Skip rule, log warning |
 | Token limit exceeded | Report as CONTEXT-OVERFLOW |
-
-## Dispatch Mandate (CRITICAL — per critical-rules-048)
-
-This task is a **reference document** that defines evaluation criteria and result contracts. The orchestrator is responsible for:
-1. Dispatching a sub-agent for `resolve-models` to obtain auditor pair
-2. Dispatching auditor sub-agents in parallel
-3. Dispatching a sub-agent for `cross-validate` with pre-resolved `auditor_artifact_paths`
-
-This task MUST NOT be read and executed inline. Reading this file and performing the described steps via raw tool calls is a CRITICAL VIOLATION per critical-rules-048.
 
 ## Completion Dependency Chain
 

--- a/skills/adversarial-audit/tasks/plan-fidelity.md
+++ b/skills/adversarial-audit/tasks/plan-fidelity.md
@@ -2,6 +2,8 @@
 <!-- SPDX-License-Identifier: MIT -->
 <!-- Provenance: AI-generated -->
 
+> **⚠️ ROLE ANCHOR: You are the DISPATCHED AUDITOR SUB-AGENT.** Your role is to evaluate criteria and produce findings. You do NOT dispatch sub-agents, call `skill()`, or orchestrate pipeline routing. The orchestrator handles all dispatch. Read this file for evaluation criteria and procedure only — ignore any text describing orchestration responsibilities.
+
 # Task: plan-fidelity
 
 ## Purpose
@@ -33,7 +35,7 @@ Audit a plan for fidelity against its spec using clean-room comparison and dual-
 - [ ] 1. Validate Clean-Room Plan Source — confirm sub-agent dispatch origin
 - [ ] 2. Fetch Existing Plan — read from spec_local_dir or spec body
 - [ ] 3. Build Evaluation Criteria — define PF table with evidence types
-- [ ] 4. Cross-Validate with Pre-Resolved Verdicts — invoke cross-validate task
+- [ ] 4. Cross-Validate with Pre-Resolved Verdicts — cross-validate will be called by the orchestrator
 - [ ] 5. Classify Discrepancies — map findings to classification types
 - [ ] 6. Generate Bidirectional Findings — FAIL/DISAGREE with revision options
 - [ ] 7. Write Verdict Artifact to Disk — YAML output
@@ -71,27 +73,7 @@ Read the existing plan from `spec_local_dir/`:
 
 ### Step 4: Cross-Validate with Pre-Resolved Verdicts
 
-This task does NOT dispatch auditors. The orchestrator dispatches auditors and passes pre-resolved `auditor_artifact_paths` to this task. Invoke `cross-validate` with the artifact paths already available:
-
-```python
-task(
-    subagent_type="general",
-    prompt=f"""Use adversarial-audit skill --task cross-validate with:
-
-plan_issue_number: {plan_issue}
-audit_phase: plan_creation
-auditor_artifact_paths: {auditor_artifact_paths}
-authorization_scope: {authorization_scope}
-halt_at: {halt_at}
-pr_strategy: {pr_strategy}
-pipeline_phase: {pipeline_phase}
-
-worktree.path: {worktree.path}
-github.owner: {github.owner}
-github.repo: {github.repo}
-"""
-)
-```
+Cross-validate will be called by the orchestrator with pre-resolved auditor_artifact_paths after both auditors complete. Do NOT call cross-validate — your role is to produce your verdict artifact only.
 
 ### Step 5: Classify Discrepancies
 
@@ -155,16 +137,6 @@ status: DONE
 artifact_path: "./tmp/{issue-N}/artifacts/pipeline-audit-plan-fidelity-PASS-{timestamp}.yaml"
 summary: "N criteria evaluated. X PASS, Y FAIL. Z discrepancies found."
 ```
-
-## Dispatch Mandate (CRITICAL — per critical-rules-048)
-
-This task is a **reference document** that defines evaluation criteria and result contracts. The orchestrator is responsible for:
-1. Dispatching a sub-agent to generate the clean-room plan via `writing-plans`
-2. Dispatching a sub-agent for `resolve-models` to obtain auditor pair
-3. Dispatching auditor sub-agents in parallel
-4. Dispatching a sub-agent for `cross-validate` with pre-resolved `auditor_artifact_paths`
-
-This task MUST NOT be read and executed inline. Reading this file and performing the described steps via raw tool calls is a CRITICAL VIOLATION per critical-rules-048.
 
 ## Completion Dependency Chain
 

--- a/skills/adversarial-audit/tasks/spec-audit.md
+++ b/skills/adversarial-audit/tasks/spec-audit.md
@@ -2,6 +2,8 @@
 <!-- SPDX-License-Identifier: MIT -->
 <!-- Provenance: AI-generated -->
 
+> **⚠️ ROLE ANCHOR: You are the DISPATCHED AUDITOR SUB-AGENT.** Your role is to evaluate criteria and produce findings. You do NOT dispatch sub-agents, call `skill()`, or orchestrate pipeline routing. The orchestrator handles all dispatch. Read this file for evaluation criteria and procedure only — ignore any text describing orchestration responsibilities.
+
 # Task: spec-audit
 
 ## Purpose
@@ -30,7 +32,7 @@ Audit a spec for quality, structure, and completeness using dual-adversarial cro
 - [ ] 1. Load Spec Content — glob spec_local_dir for .md files, read all
 - [ ] 2. Verify Documentation Sources — research each cited URL, API reference, or documentation claim against live sources
 - [ ] 3. Build Evaluation Criteria — define SC table with evidence types
-- [ ] 4. Cross-Validate with Pre-Resolved Verdicts — invoke cross-validate task
+- [ ] 4. Cross-Validate with Pre-Resolved Verdicts — cross-validate will be called by the orchestrator
 - [ ] 5. Process Verdicts — per-criterion PASS/FAIL consensus
 - [ ] 6. Evaluate SC Determinism (SC-DET) — check each SC for determinism
 - [ ] 7. Generate Bidirectional Findings — FAIL/DISAGREE criteria with revision options
@@ -101,33 +103,11 @@ Define audit criteria based on spec-auditor task structure:
 
 ### Step 3: Cross-Validate with Pre-Resolved Verdicts
 
-This task does NOT dispatch auditors. The orchestrator dispatches auditors and passes pre-resolved `auditor_artifact_paths` to this task. Invoke `cross-validate` with artifact paths already available:
+This task does NOT dispatch auditors. The orchestrator dispatches auditors and passes pre-resolved `auditor_artifact_paths` to this task. Cross-validate will be called by the orchestrator.
 
 When dispatching auditors, the `evaluation_criteria` array MUST include each SC's `evidence_type` field. Auditors MUST use the declared evidence type to determine their verification method. For `behavioral` SCs, auditors MUST require execution evidence (test output, stderr) — not file existence. This is enforced by the cross-validate evidence type gate (per `cross-validate.md` §Evidence Type Gate). Each auditor writes its full YAML verdict to disk and returns a frugal contract. The orchestrator collects artifact paths and passes them to cross-validate.
 
-```python
-task(
-    subagent_type="general",
-    prompt="""Use adversarial-audit skill --task cross-validate with:
-
-spec_issue_number: <spec_issue_number>
-audit_phase: spec_creation
-auditor_artifact_paths: <auditor_artifact_paths>
-authorization_scope: <authorization_scope>
-halt_at: <halt_at>
-pr_strategy: <pr_strategy>
-pipeline_phase: <pipeline_phase>
-
-worktree.path: <worktree.path>
-github.owner: <github.owner>
-github.repo: <github.repo>
-
-failure_description: <failure_description>  # Optional — provided when routed from remediation loop
-
-Mandatory: cross-validate receives pre-resolved artifact paths and reads YAMLs from disk — it does NOT dispatch auditors.
-"""
-)
-```
+Cross-validate will be called by the orchestrator with pre-resolved auditor_artifact_paths after both auditors complete. Do NOT call cross-validate — your role is to produce your verdict artifact only.
 
 **When `failure_description` is provided:** The spec auditor must evaluate whether the SCs are deterministic and testable specifically in light of the failure evidence. The evaluation should answer: "Would this SC have prevented the observed failure if it were properly deterministic?" or "Is the failure attributable to a non-deterministic SC?" If yes, return SPEC_GAP with revision recommendation. If no (SCs are deterministic but the implementer failed), return confirmation that implementation failure is the root cause.
 
@@ -219,15 +199,6 @@ status: DONE
 artifact_path: "./tmp/{issue-N}/artifacts/pipeline-audit-spec-audit-PASS-{timestamp}.yaml"
 summary: "N criteria evaluated. X PASS, Y FAIL."
 ```
-
-## Dispatch Mandate (CRITICAL — per critical-rules-048)
-
-This task is a **reference document** that defines evaluation criteria and result contracts. The orchestrator is responsible for:
-1. Dispatching a sub-agent for `resolve-models` to obtain auditor pair
-2. Dispatching auditor sub-agents in parallel
-3. Dispatching a sub-agent for `cross-validate` with pre-resolved `auditor_artifact_paths`
-
-This task MUST NOT be read and executed inline. Reading this file and performing the described steps via raw tool calls is a CRITICAL VIOLATION per critical-rules-048.
 
 ## Completion Dependency Chain
 

--- a/skills/adversarial-audit/tasks/spec-summary.md
+++ b/skills/adversarial-audit/tasks/spec-summary.md
@@ -2,6 +2,8 @@
 <!-- SPDX-License-Identifier: MIT -->
 <!-- Provenance: AI-generated -->
 
+> **⚠️ ROLE ANCHOR: You are the DISPATCHED AUDITOR SUB-AGENT.** Your role is to evaluate criteria and produce findings. You do NOT dispatch sub-agents, call `skill()`, or orchestrate pipeline routing. The orchestrator handles all dispatch. Read this file for evaluation criteria and procedure only — ignore any text describing orchestration responsibilities.
+
 # Task: spec-summary
 
 ## Purpose
@@ -82,28 +84,9 @@ comparison = {
 }
 ```
 
-### Step 6: Cross-Validate via task()
+### Step 6: Cross-Validate
 
-```python
-task(
-    subagent_type="general",
-    prompt=f"""Use adversarial-audit skill --task cross-validate with:
-
-spec_local_dir: {spec_local_dir}
-audit_phase: pr_creation
-authorization_scope: {authorization_scope}
-halt_at: {halt_at}
-pr_strategy: {pr_strategy}
-pipeline_phase: {pipeline_phase}
-
-# NOTE: cross-validate does NOT dispatch auditors — it receives
-# pre-resolved auditor_artifact_paths and reads YAMLs from disk.
-auditor_artifact_paths: {auditor_artifact_paths}
-
-worktree.path: {worktree.path}
-"""
-)
-```
+Cross-validate will be called by the orchestrator with pre-resolved auditor_artifact_paths after both auditors complete. Do NOT call cross-validate — your role is to produce your verdict artifact only.
 
 ### Step 7: Verify Closing Keywords
 
@@ -181,15 +164,6 @@ else:
 | PR not found | Return BLOCKED with PR number |
 | Spec issue not found | Return BLOCKED with issue number |
 | Spec not linked from PR | Report as LINK_MISSING, continue |
-
-## Dispatch Mandate (CRITICAL — per critical-rules-048)
-
-This task is a **reference document** that defines evaluation criteria and result contracts. The orchestrator is responsible for:
-1. Dispatching a sub-agent for `resolve-models` to obtain auditor pair
-2. Dispatching auditor sub-agents in parallel
-3. Dispatching a sub-agent for `cross-validate` with pre-resolved `auditor_artifact_paths`
-
-This task MUST NOT be read and executed inline. Reading this file and performing the described steps via raw tool calls is a CRITICAL VIOLATION per critical-rules-048.
 
 ## Completion Dependency Chain
 

--- a/skills/adversarial-audit/tasks/verification-audit.md
+++ b/skills/adversarial-audit/tasks/verification-audit.md
@@ -2,6 +2,8 @@
 <!-- SPDX-License-Identifier: MIT -->
 <!-- Provenance: AI-generated -->
 
+> **⚠️ ROLE ANCHOR: You are the DISPATCHED AUDITOR SUB-AGENT.** Your role is to evaluate criteria and produce findings. You do NOT dispatch sub-agents, call `skill()`, or orchestrate pipeline routing. The orchestrator handles all dispatch. Read this file for evaluation criteria and procedure only — ignore any text describing orchestration responsibilities.
+
 # Task: verification-audit
 
 ## Purpose
@@ -30,7 +32,7 @@ Verify implementation against spec success criteria using dual-adversarial cross
 - [ ] 1. Load Spec Content — glob spec_local_dir, read spec SCs and evidence type declarations
 - [ ] 2. Load Behavioral Evidence — read artifact_evidence_dir for per-SC evidence files
 - [ ] 3. Build Evaluation Criteria — map spec SCs to evidence artifacts
-- [ ] 4. Cross-Validate with Pre-Resolved Verdicts — invoke cross-validate task
+- [ ] 4. Cross-Validate with Pre-Resolved Verdicts — cross-validate will be called by the orchestrator
 - [ ] 5. Verify Implementation Completeness — does implemented code satisfy each SC?
 - [ ] 6. Verify Evidence Type Compliance — each SC verified using minimum acceptable method per declared type
 - [ ] 7. Generate Findings — per-SC PASS/FAIL with evidence references
@@ -78,29 +80,9 @@ Map spec SCs to evidence artifacts. For each SC:
 
 ### Step 4: Cross-Validate with Pre-Resolved Verdicts
 
-Same pattern as spec-audit Step 3 — invoke `cross-validate` with pre-resolved auditor artifact paths:
+Same pattern as spec-audit Step 3 — cross-validate will be called by the orchestrator with pre-resolved auditor artifact paths:
 
-```python
-task(
-    subagent_type="general",
-    prompt="""Use adversarial-audit skill --task cross-validate with:
-
-spec_issue_number: <spec_issue_number>
-audit_phase: verification
-auditor_artifact_paths: <auditor_artifact_paths>
-authorization_scope: <authorization_scope>
-halt_at: <halt_at>
-pr_strategy: <pr_strategy>
-pipeline_phase: <pipeline_phase>
-
-worktree.path: <worktree.path>
-github.owner: <github.owner>
-github.repo: <github.repo>
-
-Mandatory: cross-validate receives pre-resolved artifact paths and reads YAMLs from disk — it does NOT dispatch auditors.
-"""
-)
-```
+Cross-validate will be called by the orchestrator with pre-resolved auditor_artifact_paths after both auditors complete. Do NOT call cross-validate — your role is to produce your verdict artifact only.
 
 ### Step 5: Verify Implementation Completeness
 
@@ -170,15 +152,6 @@ status: DONE
 artifact_path: "./tmp/{issue-N}/artifacts/pipeline-audit-verification-audit-PASS-{timestamp}.yaml"
 summary: "N criteria evaluated. X PASS, Y FAIL."
 ```
-
-## Dispatch Mandate (CRITICAL — per critical-rules-048)
-
-This task is a **reference document** that defines evaluation criteria and result contracts. The orchestrator is responsible for:
-1. Dispatching a sub-agent for `resolve-models` to obtain auditor pair
-2. Dispatching auditor sub-agents in parallel
-3. Dispatching a sub-agent for `cross-validate` with pre-resolved `auditor_artifact_paths`
-
-This task MUST NOT be read and executed inline. Reading this file and performing the described steps via raw tool calls is a CRITICAL VIOLATION per critical-rules-048.
 
 ## Completion Dependency Chain
 

--- a/tests/behaviors/1160-sc5-auditor-no-identity-deliberation.sh
+++ b/tests/behaviors/1160-sc5-auditor-no-identity-deliberation.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# Behavioral test: 1160-sc5-auditor-no-identity-deliberation
+# See .opencode/tests/AGENTS.md for the test harness specification and paradigm.
+# This script is an artifact-only generator — it does NOT evaluate model output.
+#
+# SC-5 from .opencode#1160: dispatched auditor sub-agent given a task file
+# with role header + no task() blocks + no Dispatch Mandate produces a verdict
+# without identity deliberation.
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/helpers.sh"
+
+SCENARIO_NAME="1160-sc5-auditor-no-identity-deliberation"
+
+# Simulate an auditor sub-agent dispatch: task the agent with evaluating
+# a spec criterion, which is the auditor's actual job. The prompt mimics
+# what the orchestrator would pass to an auditor sub-agent.
+SCENARIO_PROMPT="You are the DISPATCHED AUDITOR SUB-AGENT. Your role is to evaluate criteria and produce findings. You do NOT dispatch sub-agents, call skill(), or orchestrate pipeline routing.
+
+Evaluate this criterion:
+- criterion_id: SPEC-QUALITY-1
+- description: Spec has a clear Problem Statement section
+- evidence_type: string
+- verification_method: grep for '## Problem Statement'
+
+Task file at .opencode/skills/adversarial-audit/tasks/spec-audit.md contains evaluation criteria and procedure you should use.
+
+Proceed with the evaluation and return your verdict."
+
+behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT"
+exit 0

--- a/tests/enforcement/enforce-1160-auditor-identity.sh
+++ b/tests/enforcement/enforce-1160-auditor-identity.sh
@@ -1,0 +1,121 @@
+#!/bin/bash
+# Content-Verification Test: Auditor Identity Fix — spec-fix for #1160
+#
+# Verifies SC-1 through SC-4 from .opencode#1160:
+#   SC-1: All 10 task files have role-anchoring header
+#   SC-2: Zero `task()` code blocks (cross-validate dispatch patterns)
+#   SC-3: Dispatch Mandate sections removed from all files
+#   SC-4: Zero "Invoke.*cross-validate" imperative language
+#
+# RED-phase test: MUST FAIL before implementation changes (all patterns absent/incorrect).
+#
+# Co-authored with AI: OpenCode (deepseek-v4-flash)
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+while [ "$(basename "$SCRIPT_DIR")" != ".opencode" ]; do
+    SCRIPT_DIR="$(dirname "$SCRIPT_DIR")"
+done
+TASKS_DIR="$SCRIPT_DIR/skills/adversarial-audit/tasks"
+
+AUDITOR_FILES=(
+    "spec-audit.md"
+    "verification-audit.md"
+    "guideline-audit.md"
+    "plan-fidelity.md"
+    "concern-separation.md"
+    "closure-verification.md"
+    "coherence-maintenance.md"
+    "coherence-extraction.md"
+    "spec-summary.md"
+    "drift-detection.md"
+)
+
+FAILURES=0
+FILE_COUNT=${#AUDITOR_FILES[@]}
+
+echo "=== Content-Verification: Auditor Identity Fix (SC-1 through SC-4) ==="
+echo "Target: $FILE_COUNT auditor task files"
+echo ""
+
+# --- SC-1: Role-anchoring header ---
+echo "--- SC-1: Role-anchoring header present in all $FILE_COUNT files ---"
+SC1_MATCHES=0
+for f in "${AUDITOR_FILES[@]}"; do
+    FILE="$TASKS_DIR/$f"
+    if grep -qai "DISPATCHED AUDITOR SUB-AGENT" "$FILE" 2>/dev/null; then
+        SC1_MATCHES=$((SC1_MATCHES + 1))
+    fi
+done
+if [ "$SC1_MATCHES" -eq "$FILE_COUNT" ]; then
+    echo "PASS: SC-1 — All $FILE_COUNT files have role-anchoring header"
+else
+    echo "FAIL: SC-1 — Expected $FILE_COUNT files with header, found $SC1_MATCHES"
+    FAILURES=1
+fi
+echo ""
+
+# --- SC-2: Zero task() code blocks ---
+echo "--- SC-2: Zero task() code blocks (cross-validate dispatch patterns) ---"
+SC2_BLOCKS=0
+for f in "${AUDITOR_FILES[@]}"; do
+    FILE="$TASKS_DIR/$f"
+    # Count task(` calls inside python code fences
+    IN_FENCE=0
+    while IFS= read -r line; do
+        if [[ "$line" == '```python' ]]; then
+            IN_FENCE=1
+        elif [[ "$line" == '```'* ]] && [ "$IN_FENCE" -eq 1 ]; then
+            IN_FENCE=0
+        elif [ "$IN_FENCE" -eq 1 ] && [[ "$line" =~ task\( ]]; then
+            SC2_BLOCKS=$((SC2_BLOCKS + 1))
+        fi
+    done < "$FILE"
+done
+if [ "$SC2_BLOCKS" -eq 0 ]; then
+    echo "PASS: SC-2 — Zero task() code blocks in auditor files"
+else
+    echo "FAIL: SC-2 — Found $SC2_BLOCKS task() code block(s) in auditor files"
+    FAILURES=1
+fi
+echo ""
+
+# --- SC-3: Dispatch Mandate sections removed from all files ---
+echo "--- SC-3: Dispatch Mandate sections removed from all $FILE_COUNT files ---"
+SC3_MATCHES=0
+for f in "${AUDITOR_FILES[@]}"; do
+    FILE="$TASKS_DIR/$f"
+    HAS_DM=$(grep -c "^## Dispatch Mandate" "$FILE" 2>/dev/null || true)
+    SC3_MATCHES=$((SC3_MATCHES + HAS_DM))
+done
+if [ "$SC3_MATCHES" -eq 0 ]; then
+    echo "PASS: SC-3 — Zero Dispatch Mandate sections in all $FILE_COUNT files"
+else
+    echo "FAIL: SC-3 — Found $SC3_MATCHES Dispatch Mandate section(s)"
+    FAILURES=1
+fi
+echo ""
+
+# --- SC-4: Zero "Invoke.*cross-validate" imperative language ---
+echo "--- SC-4: Zero \"Invoke.*cross-validate\" imperative language ---"
+SC4_MATCHES=0
+for f in "${AUDITOR_FILES[@]}"; do
+    FILE="$TASKS_DIR/$f"
+    COUNT=$(grep -ci "invoke.*cross-validate" "$FILE" 2>/dev/null || true)
+    SC4_MATCHES=$((SC4_MATCHES + COUNT))
+done
+if [ "$SC4_MATCHES" -eq 0 ]; then
+    echo "PASS: SC-4 — Zero \"Invoke.*cross-validate\" patterns found"
+else
+    echo "FAIL: SC-4 — Found $SC4_MATCHES \"Invoke.*cross-validate\" imperative pattern(s)"
+    FAILURES=1
+fi
+
+echo ""
+if [ "$FAILURES" -eq 0 ]; then
+    echo "=== RESULT: PASS ==="
+    exit 0
+else
+    echo "=== RESULT: FAIL ==="
+    exit 1
+fi


### PR DESCRIPTION
## Summary

- Added role-anchoring header to all 10 auditor task files: "You are the DISPATCHED AUDITOR SUB-AGENT"
- Removed `task()` code blocks from cross-validate step sections (replaced with declarative prose)
- Removed "Dispatch Mandate" sections from all task files
- Replaced "Invoke cross-validate" imperative language with declarative alternatives
- Added content-verification enforcement test (SC-1 through SC-4)
- Added behavioral test for SC-5: dispatched auditor produces verdict without identity deliberation

## Outcome

All 5 SCs verified PASS:

| SC | Evidence Type | Result | Method |
|----|--------------|--------|--------|
| SC-1 | string | PASS | grep for role anchor in all 10 files |
| SC-2 | string | PASS | zero task() code blocks in auditor files |
| SC-3 | string | PASS | zero Dispatch Mandate sections remaining |
| SC-4 | string | PASS | zero "Invoke.*cross-validate" patterns |
| SC-5 | behavioral | PASS | opencode-cli run → clean audit verdict, no deliberation spiral |

## Documentation

See `.opencode#1160` for full spec.

Fixes https://github.com/michael-conrad/.opencode/issues/1160