### PR TITLE
fix(#1187): restore pre-implementation readiness checks to verify-authorization chain

### DIFF
--- a/skills/approval-gate/tasks/verify-already-implemented.md
+++ b/skills/approval-gate/tasks/verify-already-implemented.md
@@ -21,6 +21,21 @@ Check whether a spec is already fully implemented before starting work. When all
 
 ## Procedure
 
+### Step 0: Main Issue Closure Check
+
+Before extracting success criteria, check the main issue's own closure state:
+
+1. Read the main issue via `github_issue_read(method=get, issue_number=N)`
+2. If issue is closed with `state_reason: "completed"`:
+   - Search for merged PR referencing the issue via `github_search_pull_requests`
+   - Verify PR merge via `github_pull_request_read(method=get)` confirming `merged == true`
+   - If merged PR found AND all SCs pass → auto-close (existing Step 5 handles this)
+   - If merged PR found AND some SCs fail → downgrade to PARTIALLY_IMPLEMENTED
+3. If issue is open:
+   - Check for merged PRs referencing the issue (issue may be open but work already done)
+   - If merged PR found → proceed to Step 1 with PARTIALLY_IMPLEMENTED flag
+   - If no merged PR → proceed to standard SC verification (existing Steps 1-4)
+
 ### Step 1: Extract Success Criteria
 
 From the spec issue, extract every success criterion:

--- a/skills/approval-gate/tasks/verify-authorization.md
+++ b/skills/approval-gate/tasks/verify-authorization.md
@@ -32,6 +32,10 @@ This task delegates to atomic sub-tasks. Each sub-task reads inputs from the wor
 | 5 | `verify-authorization/sub-issue-verification` | Sub-issue phase count, adversarial verification, closed-issue check |
 | 5b | `verify-authorization/spec-to-plan-cascade` | Spec-to-plan approval cascade |
 | 5b.5+5c | `verify-authorization/gap-fill-cascade` | Gap-fill precedence and cascade execution |
+| 5d.1 | `verify-authorization/verify-codebase` | Staleness detection, superseding issue check |
+| 5d.2 | `verify-authorization/verify-blockers` | Blocking dependency check |
+| 5d.3 | `verify-authorization/verify-closed-issue-main` | Main issue prior-closure verification |
+| 5d.4 | `verify-authorization/verify-already-implemented` | Terminal gate: auto-close or proceed |
 | 6 | `verify-authorization/auto-dispatch` | Scope-aware auto-dispatch + output lineage |
 
 
@@ -40,9 +44,9 @@ This task delegates to atomic sub-tasks. Each sub-task reads inputs from the wor
 | Condition | Path |
 |-----------|------|
 | 1 issue + `for_review_prep` scope + 0 sub-issues + explicit auth | fast-path (skip 2, 4.5, 4.6, 5, 5b, 5b.5+5c) |
-| 1 issue + scope ∈ {for_pr, for_implementation, for_plan, for_analysis} + 0 sub-issues | gap-fill-path (0.5, 1, 5b.5+5c, then 6) |
-| 1 issue + sub-issues OR plan with phases | medium-path (0.5, 1, 4.5, 4.6, 5, then 6) |
-| Multi-issue authorization set | full-path (all steps) |
+| 1 issue + scope ∈ {for_pr, for_implementation, for_plan, for_analysis} + 0 sub-issues | gap-fill-path (0.5, 1, 5b.5+5c, 5d, then 6) |
+| 1 issue + sub-issues OR plan with phases | medium-path (0.5, 1, 4.5, 4.6, 5, 5d, then 6) |
+| Multi-issue authorization set | full-path (all steps + 5d) |
 
 ## Sub-Agent Result Guard
 

--- a/skills/approval-gate/tasks/verify-authorization/auto-dispatch.md
+++ b/skills/approval-gate/tasks/verify-authorization/auto-dispatch.md
@@ -37,7 +37,7 @@ authorization_source: "User approved #N on YYYY-MM-DD"
 | -- | -- | -- |
 | **Spec approval** | Issue title contains `[SPEC` or has `spec` label | `writing-plans --task create` (or `brainstorming --task explore` if gap-fill) |
 | **Plan approval** | Issue has `plan` label or `[PLAN]` prefix in title | `executing-plans --task start` |
-| **Already implemented** | `verify-already-implemented` returns positive (after closed-issue verification in Step 5.4 confirms legitimate closure) | No dispatch — auto-close instead |
+| **Already implemented** | Step 5d.4 (`verify-already-implemented`) returns positive | No dispatch — auto-close instead (execution path: Step 0 of auto-route procedure) |
 | **Reconciled during verification** | reconcile-issue-graph returned auto-closed or reopened tickets | Include reconciled tickets in chat output; proceed with dispatch |
 | **Closed but NOT verified** | Step 5.4 closed-issue verification finds closure without merged PR evidence | flag-for-review — do NOT autoclose |
 
@@ -60,6 +60,13 @@ When `authorization_scope == "for_analysis"`:
 - HALT after `analysis_complete`
 
 ## Auto-Route Procedure
+
+0. Check pre-implementation readiness results from Step 5d:
+   - If verify-already-implemented returned positive → auto-close issue, check parent plan, HALT
+   - If verify-codebase found staleness → HALT, report staleness
+   - If verify-blockers found blockers → HALT, report blockers
+   - If verify-closed-issue-main found VERIFICATION_GAP → flag-for-review, HALT
+   - Otherwise → proceed to spec/plan routing
 
 1. Determine approval context (spec vs plan) by checking:
    - Issue title format: `[SPEC` prefix = spec approval

--- a/skills/approval-gate/tasks/verify-authorization/verify-already-implemented.md
+++ b/skills/approval-gate/tasks/verify-authorization/verify-already-implemented.md
@@ -1,0 +1,25 @@
+# Task: verify-authorization — Step 5d.4: Verify Already Implemented
+
+## Purpose
+
+Thin wrapper dispatching `tasks/verify-already-implemented.md` for terminal gate: auto-close or proceed.
+
+## Entry Criteria
+
+- Authorization verified (from Step 1)
+- Codebase checked (from Step 5d.1)
+- No blockers (from Step 5d.2)
+- Main issue closure verified (from Step 5d.3)
+
+## Exit Criteria
+
+- Auto-close or proceed to implementation
+
+## Procedure
+
+Dispatch `tasks/verify-already-implemented.md` with the current issue context. Reads from work state `## verify-closed-issue-main`, writes to `## verify-already-implemented`.
+
+## Work State I/O
+
+- **Reads from:** `## verify-closed-issue-main`
+- **Writes to:** `## verify-already-implemented`

--- a/skills/approval-gate/tasks/verify-authorization/verify-blockers.md
+++ b/skills/approval-gate/tasks/verify-authorization/verify-blockers.md
@@ -1,0 +1,24 @@
+# Task: verify-authorization — Step 5d.2: Verify Blockers
+
+## Purpose
+
+Thin wrapper dispatching `tasks/verify-blockers.md` for blocking dependency check.
+
+## Entry Criteria
+
+- Authorization verified (from Step 1)
+- Sub-issues verified (from Step 5)
+- Codebase verified (from Step 5d.1)
+
+## Exit Criteria
+
+- No blocking issues, no unresolved dependencies
+
+## Procedure
+
+Dispatch `tasks/verify-blockers.md` with the current issue context. Reads from work state `## verify-codebase`, writes to `## verify-blockers`.
+
+## Work State I/O
+
+- **Reads from:** `## verify-codebase`
+- **Writes to:** `## verify-blockers`

--- a/skills/approval-gate/tasks/verify-authorization/verify-closed-issue-main.md
+++ b/skills/approval-gate/tasks/verify-authorization/verify-closed-issue-main.md
@@ -1,0 +1,32 @@
+# Task: verify-authorization — Step 5d.3: Verify Closed Issue (Main)
+
+## Purpose
+
+Check the main approved issue for prior closure via merged PR. This is NOT a wrapper — it implements new logic that was never in the pre-image.
+
+## Entry Criteria
+
+- Authorization verified (from Step 1)
+- Codebase checked (from Step 5d.1)
+- No blockers (from Step 5d.2)
+
+## Exit Criteria
+
+- Main issue closure verified
+- `reconcile-issue-graph` dispatched for main issue's cross-reference graph
+
+## Procedure
+
+1. Check if the main issue is already closed via `github_issue_read(method=get)`
+2. If closed with `state_reason: "completed"`:
+   - Search for merged PR referencing the issue via `github_search_pull_requests`
+   - Verify PR merge via `github_pull_request_read(method=get)` confirming `merged == true`
+   - If merged PR found → mark as `VERIFIED_CLOSED`
+   - If no merged PR found → mark as `VERIFICATION_GAP`
+3. If open → check for merged PRs referencing the issue (issue may be open but work already done)
+4. After verification, dispatch `reconcile-issue-graph` to act on findings for the main issue's cross-reference graph
+
+## Work State I/O
+
+- **Reads from:** `## verify-blockers`
+- **Writes to:** `## verify-closed-issue-main`

--- a/skills/approval-gate/tasks/verify-authorization/verify-codebase.md
+++ b/skills/approval-gate/tasks/verify-authorization/verify-codebase.md
@@ -1,0 +1,23 @@
+# Task: verify-authorization — Step 5d.1: Verify Codebase
+
+## Purpose
+
+Thin wrapper dispatching `tasks/verify-codebase.md` for staleness detection and superseding issue check.
+
+## Entry Criteria
+
+- Authorization verified (from Step 1)
+- Sub-issues verified (from Step 5)
+
+## Exit Criteria
+
+- Files exist, code valid, no superseding issues, no staleness
+
+## Procedure
+
+Dispatch `tasks/verify-codebase.md` with the current issue context. Reads from work state `## sub-issue-verification`, writes to `## verify-codebase`.
+
+## Work State I/O
+
+- **Reads from:** `## sub-issue-verification`
+- **Writes to:** `## verify-codebase`

--- a/tests/behaviors/1187-sc10-stale-spec-halt.sh
+++ b/tests/behaviors/1187-sc10-stale-spec-halt.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Behavioral test: 1187-sc10-stale-spec-halt
+# See .opencode/tests/AGENTS.md for the test harness specification and paradigm.
+# This script is an artifact-only generator — it does NOT evaluate model output.
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/helpers.sh"
+
+SCENARIO_NAME="1187-sc10-stale-spec-halt"
+# SC-10: agent approves a stale spec (superseded by later issue) -> agent halts with superseding report
+SCENARIO_PROMPT="approved for implementation: .opencode#9997
+
+The spec #9997 describes changes to verify-authorization.md but issue #9998 (created after #9997) already modified the same file with overlapping changes. Run the verify-authorization chain including verify-codebase."
+
+behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT"
+exit 0

--- a/tests/behaviors/1187-sc11-blocker-halt.sh
+++ b/tests/behaviors/1187-sc11-blocker-halt.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Behavioral test: 1187-sc11-blocker-halt
+# See .opencode/tests/AGENTS.md for the test harness specification and paradigm.
+# This script is an artifact-only generator — it does NOT evaluate model output.
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/helpers.sh"
+
+SCENARIO_NAME="1187-sc11-blocker-halt"
+# SC-11: agent approves an issue with blocking dependencies -> agent halts with blocker report
+SCENARIO_PROMPT="approved for implementation: .opencode#9996
+
+The spec #9996 depends on issue #9995 which is still open and has a 'needs-approval' label. Run the verify-authorization chain including verify-blockers."
+
+behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT"
+exit 0

--- a/tests/behaviors/1187-sc9-auto-close-completed.sh
+++ b/tests/behaviors/1187-sc9-auto-close-completed.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Behavioral test: 1187-sc9-auto-close-completed
+# See .opencode/tests/AGENTS.md for the test harness specification and paradigm.
+# This script is an artifact-only generator — it does NOT evaluate model output.
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/helpers.sh"
+
+SCENARIO_NAME="1187-sc9-auto-close-completed"
+# SC-9: agent approves an already-completed issue (merged PR exists) -> agent auto-closes instead of proceeding to implementation
+SCENARIO_PROMPT="approved for implementation: .opencode#9999
+
+The issue #9999 was already implemented and merged via PR #9998. The spec describes changes that are already in the codebase. Run the verify-authorization chain."
+
+behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT"
+exit 0


### PR DESCRIPTION
## Summary

Restores three readiness checks (verify-codebase, verify-blockers, verify-already-implemented) that were dropped during the `d188b375` decomposition of `verify-authorization.md`, plus adds a main-issue closure check that was never present in the pre-image.

## Changes

- **Phase 1:** Added Step 5d.1-5d.4 rows to verify-authorization.md sub-task table between Step 5c and Step 6. Updated path selection for gap-fill, medium, and full paths.
- **Phase 2:** Created 4 new sub-task wrapper files (verify-codebase.md, verify-blockers.md, verify-closed-issue-main.md, verify-already-implemented.md) and 3 behavioral test scripts (SC-9, SC-10, SC-11).
- **Phase 3:** Added Step 0 pre-check to auto-dispatch.md auto-route procedure that reads Step 5d results before spec/plan routing.
- **Phase 4:** Added Step 0 main issue closure check to verify-already-implemented.md before SC verification.

## SC Coverage

| ID | Criterion | Status |
|----|-----------|--------|
| SC-1 | Sub-task table includes Step 5d rows | ✅ |
| SC-2 | Path selection table updated | ✅ |
| SC-3 | verify-codebase.md exists | ✅ |
| SC-4 | verify-blockers.md exists | ✅ |
| SC-5 | verify-closed-issue-main.md exists | ✅ |
| SC-6 | verify-already-implemented.md exists | ✅ |
| SC-7 | auto-dispatch.md Step 0 pre-check | ✅ |
| SC-8 | verify-already-implemented.md Step 0 | ✅ |
| SC-9 | Behavioral test: auto-close on completed | ✅ (test script) |
| SC-10 | Behavioral test: halt on stale spec | ✅ (test script) |
| SC-11 | Behavioral test: halt on blockers | ✅ (test script) |

Fixes #1187