### PR TITLE
feat(#1191): add dispatch table mandate to writing-plans create task

### DIFF
--- a/skills/writing-plans/tasks/create.md
+++ b/skills/writing-plans/tasks/create.md
@@ -54,34 +54,48 @@ Writes plan header, stores at `.issues/{N}/plan.md`, runs self-review and valida
 | `create/plan-structure` | Verification, combined/separate decision, file mapping, TDD definition | ≈750 |
 | `create/create-and-validate` | Document writing, local storage, validation, approval cascade | ≈650 |
 
-## Plan Phase Structure Requirements — Mandatory Enumerated Checklist with Routing Annotations
+## Orchestrator Execution Protocol
 
-Every plan phase MUST use EXACTLY the following 14-item enumerated checklist with routing annotations. No free-form prose outside the Concern/Files/SCs header block. No deviations.
+1. Read the dispatch tables in the plan to determine the gate sequence for the current phase
+2. Execute every gate in every phase in numeric order (G1, G2, G3, ...)
+3. Do NOT skip any gate — every row is mandatory
+4. Do NOT reorder gates — the sequence is defined by the plan
+5. For `sub-task` gates: call `task()` with the exact `Receives Context` JSON object as the prompt, using the specified `Sub-Agent Type`
+6. For `inline` gates: execute the described operation directly (no sub-agent)
+7. After each gate completes, verify the SCs listed in that gate's SCs column
+8. Report progress via chat output only — zero GitHub Issue comments during implementation unless absolutely warranted
+9. After each phase completes, run the Inter-Phase Handoff steps before advancing to the next phase
+10. Do NOT modify the plan — it is a static definitional artifact. Only mutate for remediation or scope revision
 
-Each checklist item MUST include a routing annotation specifying which agent role executes it:
-- **orchestrator routes to [sub-agent-type]** — orchestrator tasks a clean-room sub-agent
-- **orchestrator inline** — orchestrator performs the action directly (only for git commits, file reads, artifact verification)
+## Dispatch Table
 
-The 14 gates with routing annotations:
+Every plan phase MUST include a dispatch table using EXACTLY the following 6-column format. No deviations.
 
-- [ ] 1. SC-COHERENCE-GATE — **orchestrator routes to pre-analysis**: verify spec SCs are internally consistent and complete for this phase
-- [ ] 2. PRE-RED-BASELINE — **orchestrator routes to exploration**: run full test suite, confirm all existing tests PASS before any changes
-- [ ] 3. RED-PHASE — **orchestrator routes to RED sub-agent**: write enforcement test at permanent path → run → capture output to `./tmp/{issue-N}/artifacts/{phase}-test-output.log` → expected FAIL (exit non-zero)
-- [ ] 4. RED-DOUBLECHECK — **orchestrator inline**: confirm RED evidence artifact exists and shows non-zero exit
-- [ ] 5. GREEN-PHASE — **orchestrator routes to GREEN sub-agent (clean-room, receives spec + test path only)**: implement change → run test → capture output → expected PASS (exit 0)
-- [ ] 6. CHECKPOINT-COMMIT — **orchestrator inline**: git commit -m "phase N checkpoint" with test + change
-- [ ] 7. STRUCTURAL-CHECKS — **orchestrator routes to structural sub-agent**: lint, format, typecheck on changed files
-- [ ] 8. GREEN-DOUBLECHECK — **orchestrator inline**: confirm GREEN evidence artifact exists and shows exit 0
-- [ ] 9. GREEN-VBC — **orchestrator routes to VbC sub-agent**: verification-before-completion against this phase's SCs
-- [ ] 10. ADVERSARIAL-AUDIT — **orchestrator routes to resolve-models**: dispatches 2 auditors for plan-fidelity + concern-separation
-- [ ] 11. CROSS-VALIDATE — **orchestrator inline**: verify dual-auditor consensus on all phase SCs
-- [ ] 12. REGRESSION-CHECK — **orchestrator routes to regression sub-agent**: full test suite, confirm nothing previously passing is now broken
-- [ ] 13. REVIEW-PREP — **orchestrator routes to review-prep sub-agent**: compare URL (verified from session-init), PR body draft for the phase
-- [ ] 14. EXEC-SUMMARY — **orchestrator inline**: read all sub-agent result contracts, produce phase completion report with SC status, artifact paths, byline
+| Gate | Dispatch Type | Blind? | Sub-Agent Type | Receives Context | SCs |
+|------|--------------|--------|----------------|-----------------|-----|
+| G{N}: {step-label} | sub-task or inline | yes (blind) or N/A | general or N/A | JSON context or — | SC-N |
+
+### Dispatch Table Rules
+
+1. **One row per gate.** Every gate in the sequence must have exactly one row. No merged cells, no multi-step rows.
+2. **Dispatch Type is binary:** `sub-task` (orchestrator tasks a clean-room sub-agent) or `inline` (orchestrator executes directly — restricted to CHECKPOINT-COMMIT only).
+3. **Blind? column:** `yes (blind)` means the sub-agent receives only the Receives Context JSON — no other context from prior gates. `N/A` for inline gates.
+4. **Sub-Agent Type:** Use `general` for sub-task gates. Use `N/A` for inline gates.
+5. **Receives Context:** A JSON object with task instruction, issue number, phase number. For sub-task gates this is the EXACT prompt passed to `task()`. For inline gates this is `—` (em dash, no context).
+6. **SCs column:** Lists the SCs this gate verifies (e.g., `SC-1, SC-2`). Must match SC IDs from the spec.
+7. **Standard gate set is dynamic.** The gate labels and step sequence MUST be pulled from `implementation-pipeline/SKILL.md` §Dispatch Routing Table at the time of plan creation. Do NOT hardcode gate names — reference the canonical source. The current standard set is: `sc-coherence-gate`, `pre-red-baseline`, `red-phase`, `red-doublecheck`, `post-red-enforcement`, `green-phase`, `post-green-enforcement`, `checkpoint-commit`, `structural-checks`, `green-doublecheck`, `green-vbc`, `adversarial-audit`, `cross-validate`, `regression-check`, `review-prep`, `exec-summary`. Any deviation from this set must be justified.
+
+### Dynamic Standard Gate Set Mandate
+
+The dispatch table for every phase MUST pull the list of gate step labels from `implementation-pipeline/SKILL.md` §Dispatch Routing Table. This is a MANDATORY dynamic reference — gate names are NOT hardcoded in `create.md`. The gate labels, their dispatch targets, and artifact requirements are defined in the implementation-pipeline skill and may evolve independently. If a gate is added or removed from the implementation-pipeline Dispatch Routing Table, plans follow automatically without updating `create.md`.
+
+### Inline Gates Restriction
+
+Only `checkpoint-commit` may be an inline gate. All other gates MUST be `sub-task`. This restriction ensures every pipeline step is executed by a clean-room sub-agent except the git commit, which is a mechanical operation.
 
 ### Inter-Phase Handoff
 
-Between gate 14 of phase N and gate 1 of phase N+1:
+Between the last gate of phase N and gate 1 of phase N+1:
 
 - Update Z3 state file: `solve state update` with phase N's gate states
 - Run `solve check`: confirm phase N dependency contract still SAT
@@ -90,17 +104,11 @@ Between gate 14 of phase N and gate 1 of phase N+1:
 
 ### Post-All-Phases Sweep
 
-After the last phase's gate 14:
+After the last phase's final gate:
 
 - [ ] FINISHING CHECKLIST — **orchestrator routes to finishing sub-agent**: git status clean, lint/typecheck from scratch, coverage sweep
 - [ ] PR CREATION — **orchestrator routes to git-workflow pr-creation**: via `github_create_pull_request`, extract `html_url` from response
 - [ ] POST-MERGE CLEANUP — **orchestrator routes to git-workflow cleanup**: delete merged branches, close issues, sync dev
-
-### Solve and Plan Mandatory
-
-- `solve check` on dependency contract: MUST return SAT. If UNSAT, HALT.
-- `plan plan` on phase problem: MUST return SOLVED_SATISFICING or SOLVED_OPTIMALLY. If UNSOLVABLE, HALT.
-- No fallback paths. No "If utility unavailable, validate manually." HALT on unavailability.
 
 ### Concern Boundary Annotations
 

--- a/skills/writing-plans/tasks/create/create-and-validate.md
+++ b/skills/writing-plans/tasks/create/create-and-validate.md
@@ -103,6 +103,21 @@ Before finalizing the plan, verify spec-to-plan handoff artifacts:
 - **Verify `plan plan` returns SOLVED_SATISFICING or SOLVED_OPTIMALLY** — if UNSOLVABLE or unavailable, HALT with blocker report
 - **Verify each referenced pipeline step label exists in `implementation-pipeline/SKILL.md`'s dispatch routing table** — if any label is undefined, HALT with MISSING-TRACEABILITY
 
+#### Dispatch Table Validation
+
+Every plan phase dispatch table MUST pass the following 8 validation rules:
+
+1. **6-column requirement:** Every dispatch table must have exactly 6 columns: `Gate`, `Dispatch Type`, `Blind?`, `Sub-Agent Type`, `Receives Context`, `SCs`
+2. **One row per gate:** Every gate must have exactly one row — no merged cells, no multi-step rows
+3. **Dispatch Type constraint:** Dispatch Type must be `sub-task` for all gates except `CHECKPOINT-COMMIT` which may be `inline`
+4. **Blind? column:** `yes (blind)` for sub-task gates, `N/A` for inline gates
+5. **Receives Context validity:** Must be a valid JSON object for sub-task gates, `—` (em dash) for inline gates
+6. **SCs column validity:** SCs column must reference valid SC IDs from the spec
+7. **Standard gate set check:** Verify all 16 step labels exist in `implementation-pipeline/SKILL.md` §Dispatch Routing Table — if any are undefined or missing, HALT with MISSING-TRACEABILITY
+8. **No hardcoded gate labels:** Gate labels MUST reference the canonical source (`implementation-pipeline/SKILL.md` §Dispatch Routing Table) — never hardcode
+
+If any rule fails: HALT with MISSING-TRACEABILITY and report which rule(s) failed.
+
 ### Step 10: Verification Revisit (MANDATORY)
 
 Invoke: `/skill verification-enforcement --task revisit`
@@ -161,6 +176,17 @@ if scope_level >= SCOPE_LEVELS["for_plan"]:
 ```
 
 **If `halt_at == plan_created`:** HALT after plan creation. Do NOT proceed to implementation.
+
+### Step 14: Plan-Reference Sync
+
+After the plan is approved and before the procedure exits, sync a cross-reference from the spec issue to the plan:
+
+1. Read the plan file from `.issues/{N}/plan.md` to confirm it exists
+2. Call `github_issue_write(method='update', owner='<owner>', repo='<repo>', issue_number=<N>)` with the existing issue body preserved and a plan cross-reference appended:
+   - If the issue body does not already contain a plan reference, append:
+     `---\n**Plan:** See [plan.md](.issues/{N}/plan.md) for the implementation plan.\n`
+   - If the issue body already contains a plan reference, skip (no duplicate)
+3. Verify the update succeeded by reading back the issue body
 
 ## Acceptance Criteria
 

--- a/skills/writing-plans/tasks/create/plan-structure.md
+++ b/skills/writing-plans/tasks/create/plan-structure.md
@@ -190,13 +190,38 @@ When changing guidelines or skills, use behavioral TDD:
 1. **Behavioral RED:** Write test sending agent prompt, verify agent does NOT follow new rule yet
 1. **Behavioral GREEN:** Make change, re-run test — now agent follows rule
 
-### Step 4: Plan Phase Structure
+### Step 4: Plan Phase Structure — Dispatch Table Template (PRIMARY)
 
-Organize by concern flow:
+Every plan phase MUST include a dispatch table using EXACTLY the following 6-column format. The dispatch table is the PRIMARY section template — it MUST appear FIRST in each phase section, before concern boundaries, file references, and SC references.
 
-- Determine phases needed
-- Write prose for phase descriptions
-- Prose-driven, not template-driven
+| Gate | Dispatch Type | Blind? | Sub-Agent Type | Receives Context | SCs |
+|------|--------------|--------|----------------|-----------------|-----|
+| G{N}: {step-label} | sub-task or inline | yes (blind) or N/A | general or N/A | JSON context or — | SC-N |
+
+#### Dispatch Table Rules
+
+1. **One row per gate.** Every gate in the sequence must have exactly one row. No merged cells, no multi-step rows.
+2. **Dispatch Type is binary:** `sub-task` (orchestrator tasks a clean-room sub-agent) or `inline` (orchestrator executes directly — restricted to CHECKPOINT-COMMIT only).
+3. **Blind? column:** `yes (blind)` means the sub-agent receives only the Receives Context JSON — no other context from prior gates. `N/A` for inline gates.
+4. **Sub-Agent Type:** Use `general` for sub-task gates. Use `N/A` for inline gates.
+5. **Receives Context:** A JSON object with task instruction, issue number, phase number. For sub-task gates this is the EXACT prompt passed to `task()`. For inline gates this is `—` (em dash, no context).
+6. **SCs column:** Lists the SCs this gate verifies (e.g., `SC-1, SC-2`). Must match SC IDs from the spec.
+7. **Standard gate set is dynamic.** The gate labels and step sequence MUST be pulled from `implementation-pipeline/SKILL.md` §Dispatch Routing Table at the time of plan creation. Do NOT hardcode gate names — reference the canonical source.
+
+#### Concern Boundary Annotations
+
+When transitioning between architectural concerns, describe:
+- What concern being left (prior scope)
+- What concern being entered (new scope)
+- What information the new concern needs from prior (handoff point)
+
+#### File References
+
+List the files affected by this phase. Agents glob to discover content — use sub-folder references, not individual file paths.
+
+#### SC References
+
+List the SCs covered by this phase. Each SC must be traceable to a spec success criterion.
 
 ### Step 5: Define Tasks Within Each Phase (Per-Unit Gates — SC-3)
 
@@ -280,24 +305,9 @@ Verification steps after contract generation:
 1. Assert all-false state: run Z3 solver — MUST return SAT
 1. Assert D_P1=True but p1=False: run Z3 solver — MUST return UNSAT
 
-### Step 6: Generate Implementation Checklist (MANDATORY)
+### Step 6: Generate Implementation Checklist — REMOVED
 
-After plan content is finalized, generate `implementation-checklist.md` as a sibling of `plan.md`:
-
-1. Read plan phases, SC-ID traceability table, and pipeline gate tables from plan.md
-1. For each phase, emit the 14-gate checklist with sub-steps:
-   - Pre-cleanup (remove stale artifacts per Rule 3)
-   - Dispatch via task()
-   - Post-step Z3 state update (3 sequential calls to `solve state update`)
-   - Checkpoint tag creation and verification (`git tag -l` confirmation)
-   - Lifecycle manifest event append
-1. Emit remediation routing section (R.1-R.10) — rollback procedure, researcher dispatch, max 3 attempts
-1. Emit phase completion section (PC.1-PC.6) — all gates PASS, all SCs verified, manifest complete
-1. Emit overall completion section (OC.1-OC.7) — all phases complete, full regression suite, final push
-1. Emit key constraints section referencing implementation-pipeline-\* rules
-1. Verify the checklist covers every SC from the SC-ID traceability table — flag any uncovered SCs
-
-The checklist generation is a mechanical transformation of plan structure — no creative decisions. Reference the pipeline-readiness `sc_summary` from sc-pipeline-readiness.yaml for SC count verification.
+Implementation checklist generation has been removed. The dispatch table template (Step 4) and per-unit pipeline gate tables (Step 5) provide sufficient execution guidance. No separate checklist artifact is needed.
 
 ## Context Required
 

--- a/tests/behaviors/writing-plans-dispatch-table.sh
+++ b/tests/behaviors/writing-plans-dispatch-table.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# Behavioral test: writing-plans-dispatch-table
+# See .opencode/tests/AGENTS.md for the test harness specification and paradigm.
+# This script is an artifact-only generator — it does NOT evaluate model output.
+#
+# SC-1: create.md has dispatch table template section with 6 columns
+#   (Gate/Dispatch Type/Blind?/Sub-Agent Type/Receives Context/SCs) and 7 rules
+# SC-2: create.md has orchestrator execution protocol section with all 10 rules
+# SC-3: plan-structure.md has dispatch table as primary phase section template
+#   before concern boundaries/files/SCs
+# SC-4: create-and-validate.md Step 9 has dispatch table validation subsection
+#   with 8 rules (inline=CHECKPOINT-COMMIT only, standard gate set check against
+#   implementation-pipeline/SKILL.md §Dispatch Routing Table)
+# SC-5: create-and-validate.md no longer generates implementation-checklist.md
+# SC-6: create-and-validate.md has plan-reference sync step after Step 13
+#   referencing github_issue_write
+#
+# RED phases: Phase 1 (no dispatch table/protocol in create.md),
+#   Phase 2 (prose-driven Step 4 in plan-structure.md),
+#   Phase 3 (no dispatch table validation in Step 9, no plan-ref sync step)
+#
+# GREEN phases: All 3 phases implemented, all 6 SCs satisfied.
+#
+# Authority: #1191 Phases 1-3 (SC-1 through SC-6)
+# Co-authored with AI: OpenCode (deepseek-v4-flash)
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/helpers.sh"
+
+SCENARIO_NAME="writing-plans-dispatch-table"
+SCENARIO_PROMPT="Read the files .opencode/skills/writing-plans/tasks/create.md, .opencode/skills/writing-plans/tasks/create/plan-structure.md, and .opencode/skills/writing-plans/tasks/create/create-and-validate.md. Analyze the phase structure and validation content across all three files. Report what structures you find. Specifically:
+
+1. In create.md: Does the section contain a dispatch table template with at least 6 columns (Gate, Dispatch Type, Blind?, Sub-Agent Type, Receives Context, SCs)?
+2. In create.md: Does the section contain an orchestrator execution protocol with numbered rules?
+3. In plan-structure.md Step 4: Does the Plan Phase Structure section contain a dispatch table as the primary section template, appearing before concern boundaries, file references, and SC references?
+4. In create-and-validate.md Step 9 (Validate Plan): Does the section contain a dispatch table validation subsection with specific validation rules (e.g., inline=CHECKPOINT-COMMIT only, standard gate set check against implementation-pipeline/SKILL.md)?
+5. In create-and-validate.md: Does the file contain any reference to 'implementation-checklist' or 'checklist.md' generation?
+6. In create-and-validate.md: After Step 13 (Plan Approval), is there a plan-reference sync step that references github_issue_write?
+7. Describe the current content of Step 9 in create-and-validate.md in detail."
+
+# RED phase: BEHAVIOR_PHASE=RED will be set when running for RED
+behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT"
+exit 0


### PR DESCRIPTION
## Summary

- **Phase 1 (create.md):** Orchestrator Execution Protocol (10 rules) + Dispatch Table template (6 columns, 7 rules, dynamic-pull mandate from `implementation-pipeline/SKILL.md`)
- **Phase 2 (plan-structure.md):** Dispatch table as PRIMARY phase section template before concern boundaries/files/SCs. Step 6 implementation checklist generation removed.
- **Phase 3 (create-and-validate.md):** Dispatch table validation subsection (8 rules) in Step 9. Plan-reference sync Step 14 with `github_issue_write`.

## SCs

| SC | Status | File |
|----|--------|------|
| SC-1: Dispatch table template (6 columns, 7 rules) | PASS | `create.md` |
| SC-2: Orchestrator execution protocol (10 rules) | PASS | `create.md` |
| SC-3: Dispatch table as primary phase section | PASS | `plan-structure.md` |
| SC-4: Dispatch table validation (8 rules) in Step 9 | PASS | `create-and-validate.md` |
| SC-5: No implementation-checklist.md generation | PASS | `create-and-validate.md` |
| SC-6: Plan-reference sync step | PASS | `create-and-validate.md` |

## Verification

All 16 gates per phase executed: RED/GREEN TDD cycle, behavioral testing via clean-room `opencode-cli run`, structural checks (pymarkdownlnt), VbC, adversarial audit, cross-validate, regression check, review-prep.

🤖 Co-authored with AI: OpenCode (deepseek-v4-flash)