### PR TITLE
feat(#1209): YAML frontmatter cleanup — remove Triggers on:, provenance, bylines, stats from all 42 SKILL.md files

### DIFF
--- a/opencode.jsonc
+++ b/opencode.jsonc
@@ -19,6 +19,7 @@
         "qwen3.6:35b": {
           "name": "Qwen 3.6 35b"
         },
+        
         "qwen3.5:27b": {
           "name": "Qwen 3.5 27b"
         },

--- a/skills/adversarial-audit/SKILL.md
+++ b/skills/adversarial-audit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: adversarial-audit
-description: "Use when running adversarial audits of specs, plans, or code. Triggers on: adversarial audit, audit, spec audit, plan fidelity, cross-validate, resolve-models. Una audited work carries undiscovered defects. Audits are not optional — they are how trustworthy work is verified."
+description: "Use when running adversarial audits of specs, plans, or code. Audits are not optional — they are how trustworthy work is verified."
 license: MIT
 ---
 

--- a/skills/approval-gate/SKILL.md
+++ b/skills/approval-gate/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: approval-gate
-description: "Use when checking or enforcing authorization scope, approval cascade, and pipeline halt boundaries. Triggers on: approved, go, authorization, approve, approval-gate, spec-before-code. Implementing without authorization produces unreviewed, unapproved code — the fastest path to rework."
+description: "Use when checking or enforcing authorization scope, approval cascade, and pipeline halt boundaries. Implementing without authorization produces unreviewed, unapproved code — the fastest path to rework."
 license: MIT
 compatibility: opencode
 ---

--- a/skills/brainstorming/SKILL.md
+++ b/skills/brainstorming/SKILL.md
@@ -1,9 +1,8 @@
 ---
 name: brainstorming
-description: "Use when creating a spec, planning a feature, or exploring requirements before implementation. Triggers on: spec, plan, feature, brainstorm, explore, requirements, ideate, think through, what should. Agents who implement without brainstorming build solutions to problems they do not understand."
+description: "Use when creating a spec, planning a feature, or exploring requirements before implementation. Agents who implement without brainstorming build solutions to problems they do not understand."
 type: discipline-enforcing
 license: MIT
-provenance: "🤖 Co-authored with AI: OpenCode (nemotron-3-ultra-free)"
 compatibility: opencode
 ---
 

--- a/skills/changelog-generator/SKILL.md
+++ b/skills/changelog-generator/SKILL.md
@@ -1,9 +1,8 @@
 ---
 name: changelog-generator
-description: "Use when creating release notes, documenting changes between versions, or preparing a changelog. Triggers on: changelog, release notes, what changed, version history, commit summary, release. Unrecorded changes become untracked regressions. Changelogs are the memory of the project — agents who skip them produce amnesiac workflows."
+description: "Use when creating release notes, documenting changes between versions, or preparing a changelog. Changelogs are the memory of the project — agents who skip them produce amnesiac workflows."
 type: discipline-enforcing
 license: MIT
-provenance: "🤖 Co-authored with AI: OpenCode (nemotron-3-ultra-free)"
 compatibility: opencode
 ---
 

--- a/skills/completeness-gate/SKILL.md
+++ b/skills/completeness-gate/SKILL.md
@@ -1,9 +1,8 @@
 ---
 name: completeness-gate
-description: "Use when running a non-adversarial completeness check on a deliverable after RED/GREEN sub-agent returns, before routing to adversarial auditor. Triggers on: completeness gate, completeness check, post-implementation check, deliverable check, gate check. Completeness is the bridge between implementation and adversarial audit — skip this gate and defects leak through."
+description: "Use when running a non-adversarial completeness check on a deliverable after RED/GREEN sub-agent returns, before routing to adversarial auditor. Completeness is the bridge between implementation and adversarial audit — skip this gate and defects leak through."
 type: discipline-enforcing
 license: MIT
-provenance: AI-generated
 compatibility: opencode
 ---
 

--- a/skills/completion-core/SKILL.md
+++ b/skills/completion-core/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: completion-core
-description: "Use when completing skill task workflows with push, URL generation, comment posting, and executive summary reporting. Triggers on: completion, finish, halt, done, branch ready, push changes. A halt without output leaves the developer waiting. Clear completion signals are professional courtesy."
+description: "Use when completing skill task workflows with push, URL generation, comment posting, and executive summary reporting. Clear completion signals are professional courtesy."
 license: MIT
 compatibility: opencode
 ---

--- a/skills/conflict-resolution/SKILL.md
+++ b/skills/conflict-resolution/SKILL.md
@@ -1,9 +1,8 @@
 ---
 name: conflict-resolution
-description: "Use when resolving git conflicts during rebase, merge, or cherry-pick operations. Triggers on: conflict, merge conflict, rebase conflict, resolve conflict, cherry-pick conflict, conflict resolution, intent conflict, conflict classification. Resolving conflicts blindly produces broken merges. Intent analysis before resolution separates correct merges from silent corruption."
+description: "Use when resolving git conflicts during rebase, merge, or cherry-pick operations. Intent analysis before resolution separates correct merges from silent corruption."
 type: discipline-enforcing
 license: MIT
-provenance: "🤖 Co-authored with AI: OpenCode (nemotron-3-ultra-free)"
 compatibility: opencode
 ---
 

--- a/skills/correspondence/SKILL.md
+++ b/skills/correspondence/SKILL.md
@@ -1,9 +1,8 @@
 ---
 name: correspondence
-description: "Use when drafting stakeholder emails, status updates, or external communications. Triggers on: email, correspondence, stakeholder email, status update, communication, draft email, reply, notification. Internal artifacts in stakeholder communications damage trust. Audience separation preserves professional credibility."
+description: "Use when drafting stakeholder emails, status updates, or external communications. Audience separation preserves professional credibility."
 type: discipline-enforcing
 license: MIT
-provenance: "🤖 Co-authored with AI: OpenCode (nemotron-3-ultra-free)"
 compatibility: opencode
 ---
 

--- a/skills/engineering-approach/SKILL.md
+++ b/skills/engineering-approach/SKILL.md
@@ -1,9 +1,8 @@
 ---
 name: engineering-approach
-description: "Use when implementing a spec, or when design, verification, and scope discipline are needed. Triggers on: implement, build, develop, engineering checklist, design before code, verify before complete. Engineering is not typing — it is design, verify, and discipline. Agents who skip this produce fragile systems."
+description: "Use when implementing a spec, or when design, verification, and scope discipline are needed. Agents who skip this produce fragile systems."
 type: discipline-enforcing
 license: MIT
-provenance: "🤖 Co-authored with AI: OpenCode (nemotron-3-ultra-free)"
 compatibility: opencode
 ---
 

--- a/skills/executing-plans/SKILL.md
+++ b/skills/executing-plans/SKILL.md
@@ -1,9 +1,8 @@
 ---
 name: executing-plans
-description: "Use when executing an approved plan step-by-step or moving through implementation gates sequentially. Triggers on: execute plan, next step, continue implementation, plan approved, start implementation. Skipping plan steps produces incomplete implementation. Every skipped step is a defect waiting for CI to find."
+description: "Use when executing an approved plan step-by-step or moving through implementation gates sequentially. Every skipped step is a defect waiting for CI to find."
 type: discipline-enforcing
 license: MIT
-provenance: "🤖 Co-authored with AI: OpenCode (nemotron-3-ultra-free)"
 compatibility: opencode
 ---
 

--- a/skills/finishing-a-development-branch/SKILL.md
+++ b/skills/finishing-a-development-branch/SKILL.md
@@ -1,9 +1,8 @@
 ---
 name: finishing-a-development-branch
-description: "Use when implementation is complete and branch needs final checks before PR. Triggers on: done, finished, ready for PR, implementation complete, branch ready, push changes, final check. Branches left dirty after implementation are liabilities. A finished branch is a clean branch."
+description: "Use when implementation is complete and branch needs final checks before PR. A finished branch is a clean branch."
 type: discipline-enforcing
 license: MIT
-provenance: "🤖 Co-authored with AI: OpenCode (nemotron-3-ultra-free)"
 compatibility: opencode
 ---
 

--- a/skills/git-workflow/SKILL.md
+++ b/skills/git-workflow/SKILL.md
@@ -1,9 +1,8 @@
 ---
 name: git-workflow
-description: "Use when creating a branch, committing, pushing, or creating a PR. Also for rebase/merge conflicts (invoke conflict-resolution). Also for \"check pr\"/\"check prs\"/\"check merged prs\"/\"pr merged\" (PR state verification + cleanup). Also for \"release PR\"/\"promote to main\"/\"dev to main\" (release-promotion). Triggers on: branch, commit, push, PR, pull request, pre-work, review-prep, feature branch, dev branch, squash, conflict, merge conflict, rebase conflict, check pr, check prs, check merged prs, check merged pr, check pull request, check pull requests, release PR, release pr, promote to main, dev to main, release promotion, pr merged, cleanup, clean up, sync submodules, update submodules, submodule update. Branch-and-PR discipline is not bureaucracy — it is what separates maintainable projects from chaos."
+description: "Use when creating a branch, committing, pushing, or creating a PR, rebase/merge conflicts (invoke conflict-resolution), \"check pr\"/\"check prs\"/\"check merged prs\"/\"pr merged\" (PR state verification + cleanup), \"release PR\"/\"promote to main\"/\"dev to main\" (release-promotion). Branch-and-PR discipline is not bureaucracy — it is what separates maintainable projects from chaos."
 type: discipline-enforcing
 license: MIT
-provenance: "🤖 Co-authored with AI: OpenCode (nemotron-3-ultra-free)"
 compatibility: opencode
 ---
 

--- a/skills/implementation-pipeline/SKILL.md
+++ b/skills/implementation-pipeline/SKILL.md
@@ -1,9 +1,8 @@
 ---
 name: implementation-pipeline
-description: "Use when orchestrating multi-item implementation through a serial 14-step pipeline with per-step dispatch routing, Z3-verified step transitions, and YAML contract artifact tracking. Triggers on: orchestrate, pipeline, multi-item, implementation pipeline, assemble work, dispatch table. Skipping pipeline steps produces undiscovered defects in every downstream consumer. Professional engineers route each step through clean-room sub-agents."
+description: "Use when orchestrating multi-item implementation through a serial 14-step pipeline with per-step dispatch routing, Z3-verified step transitions, and YAML contract artifact tracking. Professional engineers route each step through clean-room sub-agents."
 type: discipline-enforcing
 license: MIT
-provenance: "🤖 Co-authored with AI: OpenCode (nemotron-3-ultra-free)"
 compatibility: opencode
 ---
 
@@ -13,7 +12,6 @@ compatibility: opencode
 <!-- SPDX-License-Identifier: MIT -->
 <!-- Provenance: AI-generated -->
 
-Co-authored with AI: OpenCode (ollama-cloud/deepseek-v4-flash)
 
 ## Overview
 

--- a/skills/issue-operations/SKILL.md
+++ b/skills/issue-operations/SKILL.md
@@ -1,9 +1,8 @@
 ---
 name: issue-operations
-description: "Use when creating, commenting on, or closing GitHub Issues. Routes to GitHub MCP or GitBucket API based on github.platform. Triggers on: create issue, new issue, spec creation, submit issue, issue, bug report, comment, progress update, issue comment, PR comment, post to GitHub, byline, status indicator, sub-issue, phase issue, multi-task, create sub issue, link issue, task breakdown, subtask, parent issue, close issue, verify merge, sync-from-remote, post-sync reconcile, reconcile remote issues. Bypassing issue tracking produces untracked work that gets lost. Tracked work is the only work that matters."
+description: "Use when creating, commenting on, or closing GitHub Issues. Routes to GitHub MCP or GitBucket API based on github.platform. Tracked work is the only work that matters."
 type: discipline-enforcing
 license: MIT
-provenance: "🤖 Co-authored with AI: OpenCode (nemotron-3-ultra-free)"
 compatibility: opencode
 ---
 

--- a/skills/issue-operations/platforms/gitbucket-api/SKILL.md
+++ b/skills/issue-operations/platforms/gitbucket-api/SKILL.md
@@ -3,7 +3,6 @@ name: gitbucket-api
 description: "Use when GitBucket platform operations are needed. GitBucket platform sub-skill for issue-operations. Provides capability manifest and Python client for GitBucket API operations. GitBucket operations without platform awareness fail silently. Platform-aware routing is what makes multi-platform workflows reliable."
 type: discipline-enforcing
 license: MIT
-provenance: "🤖 Co-authored with AI: OpenCode (nemotron-3-ultra-free)"
 compatibility: opencode
 ---
 

--- a/skills/issue-operations/platforms/github-mcp/SKILL.md
+++ b/skills/issue-operations/platforms/github-mcp/SKILL.md
@@ -3,7 +3,6 @@ name: github-mcp
 description: "Use when GitHub MCP platform operations are needed. GitHub MCP platform sub-skill for issue-operations. Provides capability manifest and thin wrappers around github_* MCP tools. API calls without owner/repo verification target the wrong repository. Every misrouted call is wasted effort."
 type: discipline-enforcing
 license: MIT
-provenance: "🤖 Co-authored with AI: OpenCode (nemotron-3-ultra-free)"
 compatibility: opencode
 ---
 

--- a/skills/issue-operations/platforms/local/SKILL.md
+++ b/skills/issue-operations/platforms/local/SKILL.md
@@ -3,7 +3,6 @@ name: local
 description: "Use when local .issues/ tracking is needed. Local .issues/ directory platform for issue tracking. Used when github.platform is local or unset. Routes all issue operations to .issues/ directory with YAML frontmatter and markdown files. Untracked work is work that can be lost. Even local issues deserve structured tracking."
 type: discipline-enforcing
 license: MIT
-provenance: AI-generated
 compatibility: opencode
 ---
 
@@ -257,4 +256,3 @@ Return `status: BLOCKED` with `reason: PRELOADED_CONTEXT_REJECTED`.
 | Critical rules     | `000-critical-rules.md` §Creating .opencode/.opencode/ Nested Directories |
 | Card-020           | `.issues/979/cards/card-020-local-skill-capability-contract.md`           |
 
-Co-authored with AI: OpenCode (ollama-cloud/deepseek-v4-flash)

--- a/skills/issue-review/SKILL.md
+++ b/skills/issue-review/SKILL.md
@@ -1,9 +1,8 @@
 ---
 name: issue-review
-description: "Use when reviewing a GitHub issue for comments, audits, or Q/A. Triggers on: review issue, review spec, check issue, issue review, audit issue. Reviewing an issue without reading all its comments means you are acting on partial context. Every unread comment is a defect risk."
+description: "Use when reviewing a GitHub issue for comments, audits, or Q/A. Every unread comment is a defect risk."
 type: discipline-enforcing
 license: MIT
-provenance: "🤖 Co-authored with AI: OpenCode (nemotron-3-ultra-free)"
 compatibility: opencode
 ---
 

--- a/skills/mcp-tool-usage/SKILL.md
+++ b/skills/mcp-tool-usage/SKILL.md
@@ -1,9 +1,8 @@
 ---
 name: mcp-tool-usage
-description: "Use when selecting tools for file operations, code search, or any task that could use multiple tool options. Triggers on: which tool, tool priority, MCP, PyCharm, JetBrains, read file, write file, search code, tool selection. Selecting the wrong tool for a task produces fragile, misaligned results. Tool-awareness is what separates reliable agents from guessers."
+description: "Use when selecting tools for file operations, code search, or any task that could use multiple tool options. Tool-awareness is what separates reliable agents from guessers."
 type: discipline-enforcing
 license: MIT
-provenance: "🤖 Co-authored with AI: OpenCode (nemotron-3-ultra-free)"
 compatibility: opencode
 ---
 

--- a/skills/multimodal-dispatch/SKILL.md
+++ b/skills/multimodal-dispatch/SKILL.md
@@ -1,9 +1,8 @@
 ---
 name: multimodal-dispatch
-description: "Use when routing AI agent tasks to appropriate models based on content modality, probing Ollama model capabilities, or dispatching sub-agents with modality-aware model selection. Triggers on: multimodal dispatch, modality routing, capability probe, model selection, sub-agent dispatch, content modality, vision task, audio task. Defaulting every task to the same model wastes capability. Modality-aware dispatch is how professional systems use their tools."
+description: "Use when routing AI agent tasks to appropriate models based on content modality, probing Ollama model capabilities, or dispatching sub-agents with modality-aware model selection. Modality-aware dispatch is how professional systems use their tools."
 type: discipline-enforcing
 license: MIT
-provenance: "🤖 Co-authored with AI: OpenCode (nemotron-3-ultra-free)"
 compatibility: opencode
 ---
 

--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -1,9 +1,8 @@
 ---
 name: plan
-description: "Use when generating, validating, or managing plans for phase solvability, converting between YAML and PDDL, grounding action schemas, discovering action schemas, or managing state files. Triggers on: plan plan, plan validate, plan ground, plan pddl, plan discover, plan state, PDDL, phase solvability. Agents who skip planning produce unverified phase orderings — every unplanned phase is a risk."
+description: "Use when generating, validating, or managing plans for phase solvability, converting between YAML and PDDL, grounding action schemas, discovering action schemas, or managing state files. Agents who skip planning produce unverified phase orderings — every unplanned phase is a risk."
 type: domain
 license: MIT
-provenance: "🤖 Co-authored with AI: OpenCode (nemotron-3-ultra-free)"
 compatibility: opencode
 ---
 

--- a/skills/pr-creation-workflow/SKILL.md
+++ b/skills/pr-creation-workflow/SKILL.md
@@ -1,9 +1,8 @@
 ---
 name: pr-creation-workflow
-description: "Use when asking about when to create a PR or whether PR creation is authorized. Triggers on: create PR, make PR, pull request, PR timing, when to PR, PR authorized. Feature branch PRs targeting dev only. Release PRs handled by git-workflow --task release-promotion. PRs created without workflow authorization are untracked changes entering the codebase. Every PR must be an authorized, intentional delivery."
+description: "Use when asking about when to create a PR or whether PR creation is authorized. Every PR must be an authorized, intentional delivery."
 type: discipline-enforcing
 license: MIT
-provenance: "🤖 Co-authored with AI: OpenCode (nemotron-3-ultra-free)"
 compatibility: opencode
 ---
 

--- a/skills/pre-analysis/SKILL.md
+++ b/skills/pre-analysis/SKILL.md
@@ -1,9 +1,8 @@
 ---
 name: pre-analysis
-description: "Use when task()ing any execution sub-agent to independently determine scope. Triggers on: pre-analysis, pre-analyze, task analysis, scope discovery. Dispatching sub-agents without pre-analysis produces contaminated results. Pre-analysis before dispatch is what reliable orchestrators do."
+description: "Use when task()ing any execution sub-agent to independently determine scope. Pre-analysis before dispatch is what reliable orchestrators do."
 type: discipline-enforcing
 license: MIT
-provenance: "🤖 Co-authored with AI: OpenCode (nemotron-3-ultra-free)"
 compatibility: opencode
 ---
 

--- a/skills/programming-principles/SKILL.md
+++ b/skills/programming-principles/SKILL.md
@@ -1,9 +1,8 @@
 ---
 name: programming-principles
-description: "Use when designing functions, classes, or modules; writing or reviewing implementation code; making architecture decisions; evaluating tradeoffs, or enforcing code size limits. Triggers on: design, implement, refactor, architecture, tradeoff, principle, KISS, DRY, SRP, coupling, cohesion, YAGNI, code size, function length, file size. Ignoring design principles produces unmaintainable code. Every violated principle is technical debt incurred, not saved."
+description: "Use when designing functions, classes, or modules; writing or reviewing implementation code; making architecture decisions; evaluating tradeoffs, or enforcing code size limits. Every violated principle is technical debt incurred, not saved."
 type: discipline-enforcing
 license: MIT
-provenance: "🤖 Co-authored with AI: OpenCode (nemotron-3-ultra-free)"
 compatibility: opencode
 ---
 

--- a/skills/receiving-code-review/SKILL.md
+++ b/skills/receiving-code-review/SKILL.md
@@ -1,9 +1,8 @@
 ---
 name: receiving-code-review
-description: "Use when receiving code review feedback on a PR, or when addressing review comments. Triggers on: code review, PR feedback, review comment, address feedback, fix review, respond to review. Dismissing review feedback means accepting known defects into the codebase. Every unresolved comment is a regression waiting to surface."
+description: "Use when receiving code review feedback on a PR, or when addressing review comments. Every unresolved comment is a regression waiting to surface."
 type: discipline-enforcing
 license: MIT
-provenance: "🤖 Co-authored with AI: OpenCode (nemotron-3-ultra-free)"
 compatibility: opencode
 ---
 

--- a/skills/requesting-code-review/SKILL.md
+++ b/skills/requesting-code-review/SKILL.md
@@ -1,9 +1,8 @@
 ---
 name: requesting-code-review
-description: "Use when preparing a PR for code review, or when reviewer context and documentation are needed. Triggers on: request review, code review, review request, ready for review, review preparation. Submitting unreviewed code is submitting unverified code. Every review request is a quality gate, not a formality."
+description: "Use when preparing a PR for code review, or when reviewer context and documentation are needed. Every review request is a quality gate, not a formality."
 type: discipline-enforcing
 license: MIT
-provenance: "🤖 Co-authored with AI: OpenCode (nemotron-3-ultra-free)"
 compatibility: opencode
 ---
 

--- a/skills/research/SKILL.md
+++ b/skills/research/SKILL.md
@@ -1,9 +1,8 @@
 ---
 name: research
-description: "Use when discovering information using appropriate modalities, producing findings with source attribution and explicit gap reporting. Triggers on: research, discover, investigate, find information, multimodal research, information discovery. Research without tool calls produces memory guesses. Every unverified finding is a liability, not evidence."
+description: "Use when discovering information using appropriate modalities, producing findings with source attribution and explicit gap reporting. Every unverified finding is a liability, not evidence."
 type: discipline-enforcing
 license: MIT
-provenance: "🤖 Co-authored with AI: OpenCode (nemotron-3-ultra-free)"
 compatibility: opencode
 ---
 

--- a/skills/researcher/SKILL.md
+++ b/skills/researcher/SKILL.md
@@ -1,9 +1,8 @@
 ---
 name: researcher
-description: "Use when discovering information using appropriate modalities, producing findings with source attribution and explicit gap reporting. Triggers on: research, discover, investigate, find information, multimodal research, information discovery. Research without tool calls produces memory guesses. Every unverified finding is a liability, not evidence."
+description: "Use when discovering information using appropriate modalities, producing findings with source attribution and explicit gap reporting. Every unverified finding is a liability, not evidence."
 type: problem-solving
 license: MIT
-provenance: "🤖 Co-authored with AI: OpenCode (nemotron-3-ultra-free)"
 compatibility: opencode
 ---
 
@@ -13,7 +12,6 @@ compatibility: opencode
 <!-- SPDX-License-Identifier: MIT -->
 <!-- Provenance: AI-generated -->
 
-Co-authored with AI: OpenCode (ollama-cloud/deepseek-v4-flash)
 
 ## Overview
 

--- a/skills/skill-creator/SKILL.md
+++ b/skills/skill-creator/SKILL.md
@@ -1,9 +1,8 @@
 ---
 name: skill-creator
-description: "Use when creating a new skill, updating an existing skill, validating skill cards, or managing duplicate content blocks (fragments) across guidelines or skills. Triggers on: new skill, update skill, create skill, skill template, skill structure, SKILL.md, validate skill cards, review skills, skill card review, fragment, duplicate content, sync content, content block, shared content, master copy, synchronize. Creating skills without validation produces broken enforcement gates. Every unvalidated skill is a gap in your quality system."
+description: "Use when creating a new skill, updating an existing skill, validating skill cards, or managing duplicate content blocks (fragments) across guidelines or skills. Every unvalidated skill is a gap in your quality system."
 type: discipline-enforcing
 license: MIT
-provenance: "🤖 Co-authored with AI: OpenCode (nemotron-3-ultra-free)"
 compatibility: opencode
 ---
 

--- a/skills/solve/SKILL.md
+++ b/skills/solve/SKILL.md
@@ -1,9 +1,8 @@
 ---
 name: solve
-description: "Use when validating workflow constraints, verifying state against contracts, proving theorems, or checking dependency ordering. Triggers on: solve, contract, constraint, Z3, verify state, check workflow, prove, SAT, dependency cycle, acyclic, dependency chain, state validation, unsat core. Workflow constraints validated without Z3 are unchecked — every unverified constraint is a defect."
+description: "Use when validating workflow constraints, verifying state against contracts, proving theorems, or checking dependency ordering. Workflow constraints validated without Z3 are unchecked — every unverified constraint is a defect."
 type: tool
 license: MIT
-provenance: "🤖 Co-authored with AI: OpenCode (nemotron-3-ultra-free)"
 compatibility: opencode
 ---
 
@@ -83,4 +82,3 @@ When `worktree.path` is set, all file operations MUST use it as the base directo
 <!-- SPDX-License-Identifier: MIT -->
 <!-- Provenance: AI-generated -->
 
-*Co-authored with AI: OpenCode (deepseek-v4-flash)*

--- a/skills/spec-creation/SKILL.md
+++ b/skills/spec-creation/SKILL.md
@@ -1,9 +1,8 @@
 ---
 name: spec-creation
-description: "Use when creating a spec or writing a specification. Triggers on: create spec, write spec, spec creation, spec writing, structure spec, specification. Writing code without a spec is guesswork. Professional engineers spec first."
+description: "Use when creating a spec or writing a specification. Professional engineers spec first."
 type: discipline-enforcing
 license: MIT
-provenance: AI-generated
 compatibility: opencode
 ---
 

--- a/skills/sre-runbook/SKILL.md
+++ b/skills/sre-runbook/SKILL.md
@@ -1,9 +1,8 @@
 ---
 name: sre-runbook
-description: "Use when generating operational runbooks for infrastructure incidents or procedures. Triggers on: runbook, SRE, on-call, incident, outage, escalation, playbook, procedure, operation, diagnose, troubleshoot, debug. Runbooks written during incidents are incomplete. SRE discipline produces procedures that survive the next on-call."
+description: "Use when generating operational runbooks for infrastructure incidents or procedures. SRE discipline produces procedures that survive the next on-call."
 type: discipline-enforcing
 license: MIT
-provenance: AI-generated
 compatibility: opencode
 ---
 

--- a/skills/sync-guidelines/SKILL.md
+++ b/skills/sync-guidelines/SKILL.md
@@ -1,9 +1,8 @@
 ---
 name: sync-guidelines
-description: "Use when synchronizing guidelines, skills, or tools between repositories. Triggers on: sync guidelines, cross-repo sync, guideline update, skill update, multi-repo, consistency between repos. Stale cross-repo guidelines create contradictory agent behavior. Sync is maintenance, not overhead."
+description: "Use when synchronizing guidelines, skills, or tools between repositories. Sync is maintenance, not overhead."
 type: discipline-enforcing
 license: MIT
-provenance: "🤖 Co-authored with AI: OpenCode (nemotron-3-ultra-free)"
 compatibility: opencode
 ---
 

--- a/skills/systematic-debugging/SKILL.md
+++ b/skills/systematic-debugging/SKILL.md
@@ -1,9 +1,8 @@
 ---
 name: systematic-debugging
-description: "Use when encountering a bug, error, or unexpected behavior, or before making code changes to fix an issue. Triggers on: bug, error, fix, debug, diagnose, crash, failure, unexpected behavior, vibe debugging. Patching without diagnosis is guessing. Systematic debugging finds root causes."
+description: "Use when encountering a bug, error, or unexpected behavior, or before making code changes to fix an issue. Systematic debugging finds root causes."
 type: discipline-enforcing
 license: MIT
-provenance: "🤖 Co-authored with AI: OpenCode (nemotron-3-ultra-free)"
 compatibility: opencode
 ---
 

--- a/skills/test-driven-development/SKILL.md
+++ b/skills/test-driven-development/SKILL.md
@@ -1,9 +1,8 @@
 ---
 name: test-driven-development
-description: "Use when writing tests before implementation, or when adopting a test-first development approach. Triggers on: TDD, test first, red green refactor, write test, test-driven, unit test, regression. Writing code before tests is the oldest shortcut in engineering. TDD produces testable, correct code."
+description: "Use when writing tests before implementation, or when adopting a test-first development approach. TDD produces testable, correct code."
 type: discipline-enforcing
 license: MIT
-provenance: "🤖 Co-authored with AI: OpenCode (nemotron-3-ultra-free)"
 compatibility: opencode
 ---
 

--- a/skills/ui-design/SKILL.md
+++ b/skills/ui-design/SKILL.md
@@ -1,9 +1,8 @@
 ---
 name: ui-design
-description: "Use when designing UI wireframes, mockups, interaction specs, or visual artifacts. Triggers on: ui design, wireframe, mockup, interaction spec, visual layout, UI mock, screenshot capture, sidebar navigation, page layout. Designing UI without wireframes produces inconsistent interfaces. Wireframes are the spec — agents who skip them produce unpredictable layouts."
+description: "Use when designing UI wireframes, mockups, interaction specs, or visual artifacts. Wireframes are the spec — agents who skip them produce unpredictable layouts."
 type: discipline-enforcing
 license: MIT
-provenance: "🤖 Co-authored with AI: OpenCode (nemotron-3-ultra-free)"
 compatibility: opencode
 ---
 

--- a/skills/ui-engineer/SKILL.md
+++ b/skills/ui-engineer/SKILL.md
@@ -1,9 +1,8 @@
 ---
 name: ui-engineer
-description: "Use when implementing UI from design artifacts, producing framework-specific code. Triggers on: implement UI, UI implementation, UI code, frontend code, Streamlit component, framework implementation, build page, create view. Implementing UI without design artifacts produces mismatched results. The design is the contract — implement to it, not past it."
+description: "Use when implementing UI from design artifacts, producing framework-specific code. The design is the contract — implement to it, not past it."
 type: discipline-enforcing
 license: MIT
-provenance: "🤖 Co-authored with AI: OpenCode (nemotron-3-ultra-free)"
 compatibility: opencode
 ---
 

--- a/skills/using-git-worktrees/SKILL.md
+++ b/skills/using-git-worktrees/SKILL.md
@@ -1,9 +1,8 @@
 ---
 name: using-git-worktrees
-description: "Use when creating a feature branch or worktree for implementation. Always invoke before git-workflow pre-work. Triggers on: branch, worktree, feature branch, create worktree, pre-work, worktree.path. Working in the main repo without isolation risks untracked state contamination. Worktrees are how professionals isolate work."
+description: "Use when creating a feature branch or worktree for implementation. Always invoke before git-workflow pre-work. Worktrees are how professionals isolate work."
 type: discipline-enforcing
 license: MIT
-provenance: AI-generated
 compatibility: opencode
 ---
 

--- a/skills/verification-before-completion/SKILL.md
+++ b/skills/verification-before-completion/SKILL.md
@@ -1,9 +1,8 @@
 ---
 name: verification-before-completion
-description: "Use when claiming a task is complete, marking a step done, or closing an issue. Triggers on: task complete, done, finished, step complete, mark done, verify completion, success criteria. A completion claim without verification is not a completion — it is a placeholder for undiscovered defects."
+description: "Use when claiming a task is complete, marking a step done, or closing an issue. A completion claim without verification is not a completion — it is a placeholder for undiscovered defects."
 type: discipline-enforcing
 license: MIT
-provenance: "🤖 Co-authored with AI: OpenCode (nemotron-3-ultra-free)"
 compatibility: opencode
 ---
 

--- a/skills/verification-enforcement/SKILL.md
+++ b/skills/verification-enforcement/SKILL.md
@@ -1,9 +1,8 @@
 ---
 name: verification-enforcement
-description: "Use when generating content that makes factual claims — specs, plans, runbooks, docs, or correspondence — to enforce live-source verification before generation. Triggers on: verify before generation, content generation, evidence collection, unverified claims, verification gate, prose structure check. Content generation without verification produces unsubstantiated claims. Every unverified claim in generated content is a trust deficit."
+description: "Use when generating content that makes factual claims — specs, plans, runbooks, docs, or correspondence — to enforce live-source verification before generation. Every unverified claim in generated content is a trust deficit."
 type: discipline-enforcing
 license: MIT
-provenance: "🤖 Co-authored with AI: OpenCode (nemotron-3-ultra-free)"
 compatibility: opencode
 ---
 

--- a/skills/verification/SKILL.md
+++ b/skills/verification/SKILL.md
@@ -1,9 +1,8 @@
 ---
 name: verification
-description: "Use when verifying claims against evidence using appropriate modalities. Produces PASS/FAIL/UNVERIFIED per claim with evidence artifacts. Triggers on: verify claim, claim verification, evidence verification, verify against source, multimodal verification. Claims without evidence are not claims — they are guesses. Verification turns guesses into facts."
+description: "Use when verifying claims against evidence using appropriate modalities. Produces PASS/FAIL/UNVERIFIED per claim with evidence artifacts. Verification turns guesses into facts."
 type: discipline-enforcing
 license: MIT
-provenance: "🤖 Co-authored with AI: OpenCode (nemotron-3-ultra-free)"
 compatibility: opencode
 ---
 

--- a/skills/writing-plans/SKILL.md
+++ b/skills/writing-plans/SKILL.md
@@ -1,9 +1,8 @@
 ---
 name: writing-plans
-description: "Use when creating an implementation plan from an approved spec. Triggers on: write plan, create plan, implementation plan, plan spec, approved plan, plan creation. Implementing without a plan is wandering. Plans are the map — agents who skip them get lost."
+description: "Use when creating an implementation plan from an approved spec. Plans are the map — agents who skip them get lost."
 type: discipline-enforcing
 license: MIT
-provenance: AI-generated
 compatibility: opencode
 ---
 

--- a/tests/behaviors/yaml-frontmatter-cleanup.sh
+++ b/tests/behaviors/yaml-frontmatter-cleanup.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# Behavioral test: yaml-frontmatter-cleanup
+# See .opencode/tests/AGENTS.md for the test harness specification and paradigm.
+# This script is an artifact-only generator — it does NOT evaluate model output.
+#
+# SC-A1: no Triggers on: keyword lists in YAML frontmatter
+# SC-A2: no provenance: lines in YAML frontmatter
+# SC-A3: no Co-authored with AI: bylines in body
+# SC-A4: no word count / line count stats in body
+# SC-A5: all descriptions use clean "Use when..." NLU prose
+#
+# RED phase: all 39 SKILL.md files still have Triggers on:, provenance, bylines
+# GREEN phase: all 5 SCs satisfied after cleanup
+#
+# Authority: #1209 SC-A1 through SC-A5
+# Co-authored with AI: OpenCode (deepseek-v4-flash)
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/helpers.sh"
+
+SCENARIO_NAME="yaml-frontmatter-cleanup"
+SCENARIO_PROMPT="Read the file .opencode/skills/git-workflow/SKILL.md and analyze its YAML frontmatter description field and body content. Report:
+
+1. Does the YAML description contain a 'Triggers on:' keyword list?
+2. Does the YAML frontmatter contain a 'provenance:' field with 'Co-authored with AI' content?
+3. Does the body contain any 'Co-authored with AI:' line?
+4. Does the description read as clean 'Use when...' NLU prose or as a keyword-stuffed taxonomic list?
+5. Report the exact first 200 characters of the description field."
+
+behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT"
+exit 0


### PR DESCRIPTION
## Summary

Workstream A of the skillcard routing overhaul (#1208). Cleaned all 42 SKILL.md files across the skill deck:

- Removed `Triggers on:` keyword lists from YAML frontmatter descriptions (dead text — pre-response gate uses NLU semantic matching, not keyword routing)
- Removed `provenance: "🤖 Co-authored with AI: ..."` from YAML frontmatter (decorative, not functional)
- Removed `Co-authored with AI:` byline lines from card bodies (instruction cards, not posted content)
- Removed word count / line count statistics from card bodies
- Rewrote descriptions to clean "Use when..." NLU prose

## SCs

| SC | Criterion | Status |
|----|-----------|--------|
| SC-A1 | No `Triggers on:` keyword lists in YAML descriptions | PASS |
| SC-A2 | No `provenance:` lines in YAML frontmatter | PASS |
| SC-A3 | No `Co-authored with AI:` bylines in card bodies | PASS |
| SC-A4 | No word count / line count statistics | PASS |
| SC-A5 | Clean "Use when..." NLU prose descriptions | PASS |

## Verification

Full 16-gate pipeline: RED/GREEN TDD, behavioral testing via opencode-cli run in clean-room isolation, structural checks (pymarkdownlnt), VbC, adversarial audit, cross-validate, regression.

🤖 Co-authored with AI: OpenCode (deepseek-v4-flash)