### PR TITLE
skildeck frontmatter validation + all linters advisory-only

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,8 +89,8 @@ Guidelines are pruned to the absolute minimum. See `.opencode/guidelines/` for:
 | Run all tests | `uv run pytest test/` | - |
 | Run one test file | `uv run pytest test/test_filename.py` | - |
 | Run one test | `uv run pytest test/test_filename.py::test_function_name` | - |
-| Lint + auto-fix | `uvx ruff check --fix src/ test/` | Python ONLY |
-| Format | `uvx ruff format src/ test/` | Python ONLY |
+| Lint (advisory) | `uvx ruff check src/ test/` | Python ONLY |
+| Format check (advisory) | `uvx ruff format --check src/ test/` | Python ONLY |
 | Type check | `uvx pyright src/` | Python ONLY |
 | Coverage | `uv run coverage run -m pytest test/ && uv run coverage report` | - |
 | Dead code scan | `uvx vulture src/` | Python ONLY |

--- a/guidelines/000-critical-rules.md
+++ b/guidelines/000-critical-rules.md
@@ -743,6 +743,17 @@ The uplift is automatic. Declaring an SC as `structural` or `string` does not ex
 Authority sources: `080-code-standards.md` §Evidence Type Taxonomy, `080-code-standards.md` §Test Integrity Mandate, `020-go-prohibitions.md` §1 ALWAYS DO — Cost-blind verification. See `065-verification-honesty.md` §Cost Model for the death-spiral cost rationale underlying this classification gate — automatic uplift from structural→behavioral prevents the death spiral at the earliest possible gate.
 
 
+### [critical-rules-linters-advisory] All linters are advisory only — no auto-modify
+
+All linters (current and future) MUST run in read-only/report-only mode. No linter may auto-modify files. A linter that modifies files is not advisory — it is destructive.
+
+| Linter | Forbidden | Required |
+|--------|-----------|----------|
+| `ruff check` | `ruff check --fix` (auto-fixes) | `ruff check` (report only) |
+| `ruff format` | `ruff format` (auto-formats) | `ruff format --check` (report what would change) |
+| `mdformat` | `mdformat` (without `--check`) | `mdformat --check` (report what would change) |
+| Any future linter | Auto-modify mode | Read-only/report-only mode |
+
 ### [critical-rules-063] Orchestrator Context Lean — orchestrator holds routing metadata only
 The orchestrator's context is the most expensive resource in the pipeline. Every byte held costs `byte × remaining_dispatches²` — and context is monotonic, never shrinking. Professional orchestrators hold routing metadata only (worktree.path, github.owner, github.repo, authorization_scope, halt_at, pr_strategy, pipeline_phase, pipeline_history). See `020-go-prohibitions.md` §1.1.
 

--- a/guidelines/080-code-standards.md
+++ b/guidelines/080-code-standards.md
@@ -106,17 +106,17 @@ Running `ruff check` or `ruff format` on `.md` files is prohibited — Python to
 **Python files (`.py`):**
 
 ```bash
-uvx ruff check --fix src/ test/   # Lint + auto-fix
-uvx ruff format src/ test/        # Format
-uvx pyright src/                  # Type check
-uvx vulture src/                  # Dead code scan
+uvx ruff check src/ test/              # Lint (advisory)
+uvx ruff format --check src/ test/     # Format check (advisory)
+uvx pyright src/                       # Type check
+uvx vulture src/                       # Dead code scan
 ```
 
 **Markdown files (`.md`):**
 
 ```bash
 uvx pymarkdownlnt scan -r .opencode/guidelines/ docs/   # Lint
-uvx mdformat .opencode/guidelines/ docs/                # Format
+uvx mdformat --check .opencode/guidelines/ docs/        # Format check (advisory)
 ```
 
 **Rationale:** Python linters (`ruff`, `pyright`, `vulture`) are designed for Python syntax and will produce incorrect or useless results when run on markdown files. Use markdown-specific tools (`pymarkdownlnt`, `mdformat`) for markdown files.

--- a/skills/executing-plans/tasks/progress.md
+++ b/skills/executing-plans/tasks/progress.md
@@ -8,8 +8,8 @@ Report current progress and track execution state.
 
 - [ ] 1. **Code verification:**
    ```bash
-   uv run ruff check --fix src/ test/
-   uv run ruff format src/ test/
+   uv run ruff check src/ test/
+   uv run ruff format --check src/ test/
    uv run pyright src/
    ```
 

--- a/skills/executing-plans/tasks/verify.md
+++ b/skills/executing-plans/tasks/verify.md
@@ -10,8 +10,8 @@ Run appropriate verifications based on step type:
 
 **Code verification:**
 ```bash
-uv run ruff check --fix src/ test/
-uv run ruff format src/ test/
+uv run ruff check src/ test/
+uv run ruff format --check src/ test/
 uv run pyright src/
 ```
 

--- a/skills/finishing-a-development-branch/tasks/checklist.md
+++ b/skills/finishing-a-development-branch/tasks/checklist.md
@@ -23,7 +23,7 @@ Run the completion checklist to verify a branch is fully ready for PR creation.
 
 ### Code Quality
 - [ ] `ruff check` passes (zero errors)
-- [ ] `ruff format` applied
+- [ ] `ruff format --check` passes (advisory)
 - [ ] `pyright` passes (zero errors)
 - [ ] No dead code detected
 

--- a/skills/finishing-a-development-branch/tasks/prepare.md
+++ b/skills/finishing-a-development-branch/tasks/prepare.md
@@ -69,11 +69,11 @@ git status --porcelain
 ### Step 2: Run Code Quality Checks
 
 ```bash
-# Lint
-uv run ruff check --fix src/ test/
+# Lint (advisory)
+uv run ruff check src/ test/
 
-# Format
-uv run ruff format src/ test/
+# Format check (advisory)
+uv run ruff format --check src/ test/
 
 # Type check
 uv run pyright src/

--- a/skills/implementation-pipeline/tasks/pipeline-executor.md
+++ b/skills/implementation-pipeline/tasks/pipeline-executor.md
@@ -33,7 +33,7 @@ This is the core dispatch routing table for the 14-step serial implementation pi
 | 4 | `red-doublecheck` | `verification-before-completion --task verify` | `./tmp/{issue-N}/artifacts/pipeline-red-doublecheck-{STATUS}-{timestamp}.yaml` | `per_criterion[]` |
 | 5 | `green-phase` | `test-driven-development --task green` | `./tmp/{issue-N}/artifacts/pipeline-green-phase-{STATUS}-{timestamp}.yaml` | `per_criterion[]` |
 | 6 | `checkpoint-commit` | `git-workflow --task commit-prep` | `./tmp/{issue-N}/artifacts/pipeline-checkpoint-commit-{STATUS}-{timestamp}.yaml` | single-criterion |
-| 7 | `structural-checks` | `finishing-a-development-branch --task checklist` | `./tmp/{issue-N}/artifacts/pipeline-structural-checks-{STATUS}-{timestamp}.yaml` | single-criterion |
+| 7 | `structural-checks` | `finishing-a-development-branch --task checklist` (enforces advisory-only mode: all linters run with `--check`/report-only flags, never auto-modify) | `./tmp/{issue-N}/artifacts/pipeline-structural-checks-{STATUS}-{timestamp}.yaml` | single-criterion |
 | 8 | `green-doublecheck` | `verification-before-completion --task verify` | `./tmp/{issue-N}/artifacts/pipeline-green-doublecheck-{STATUS}-{timestamp}.yaml` | `per_criterion[]` |
 | 9 | `green-vbc` | `verification-before-completion --task completion` | `./tmp/{issue-N}/artifacts/pipeline-green-vbc-{STATUS}-{timestamp}.yaml` | single-criterion |
 | 10 | `adversarial-audit` | `adversarial-audit --task verification-audit` | `./tmp/{issue-N}/artifacts/pipeline-audit-{auditor_type}-{STATUS}-{timestamp}.yaml` | `per_criterion[]` (#932 schema) |

--- a/skills/requesting-code-review/tasks/prepare.md
+++ b/skills/requesting-code-review/tasks/prepare.md
@@ -77,7 +77,7 @@ For each reviewer, ensure:
 
 ```bash
 uv run pytest test/test_module.py -v
-uv run ruff check --fix src/
+uv run ruff check src/
 uv run pyright src/
 ```
 

--- a/skills/verification-before-completion/tasks/collect.md
+++ b/skills/verification-before-completion/tasks/collect.md
@@ -69,11 +69,11 @@ uv run pytest --cov=src/module test/
 ### Code Quality
 
 ```bash
-# Lint check
-uv run ruff check --fix src/ test/
+# Lint check (advisory)
+uv run ruff check src/ test/
 
-# Format check
-uv run ruff format src/ test/
+# Format check (advisory)
+uv run ruff format --check src/ test/
 
 # Type check
 uv run pyright src/

--- a/tests/behaviors/linters-advisory-only.sh
+++ b/tests/behaviors/linters-advisory-only.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# Behavioral test: linters-advisory-only
+# See .opencode/tests/AGENTS.md for the test harness specification and paradigm.
+# This script is an artifact-only generator — it does NOT evaluate model output.
+# SC-5: No linter runs in auto-modify mode — all linters use read-only/report-only flags
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/helpers.sh"
+
+SCENARIO_NAME="linters-advisory-only"
+SCENARIO_PROMPT="Run the standard code quality checks on the project. Include linting, formatting checks, and type checking. Report what commands you ran and what the results were."
+
+behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT"
+exit 0

--- a/tests/behaviors/skildeck-frontmatter-validation.sh
+++ b/tests/behaviors/skildeck-frontmatter-validation.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# Behavioral test: skildeck-frontmatter-validation
+# See .opencode/tests/AGENTS.md for the test harness specification and paradigm.
+# This script is an artifact-only generator — it does NOT evaluate model output.
+# SC-1, SC-2, SC-3, SC-4, SC-6: skildeck lint validates SKILL.md YAML frontmatter
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/helpers.sh"
+
+SCENARIO_NAME="skildeck-frontmatter-validation"
+SCENARIO_PROMPT="Run skildeck lint on the skills directory and report any errors found in SKILL.md YAML frontmatter. Specifically check for: unquoted description values, name/directory mismatches, missing required fields, and YAML parse failures."
+
+behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT"
+exit 0

--- a/tools/impl/skildeck/skildeck-lint
+++ b/tools/impl/skildeck/skildeck-lint
@@ -86,6 +86,155 @@ def _extract_yaml_frontmatter(text: str) -> dict | None:
     except yaml.YAMLError:
         return None
 
+def lint_skill_frontmatter(base_dir: Path) -> list[LintFinding]:
+    """Validate SKILL.md YAML frontmatter against opencode schema."""
+    import yaml
+    findings: list[LintFinding] = []
+
+    skills_dir = base_dir / "skills"
+    if not skills_dir.exists():
+        return findings
+
+    recognized_fields = {"name", "description", "license", "compatibility", "metadata", "type"}
+    name_re = __import__("re").compile(r"^[a-z0-9]+(-[a-z0-9]+)*$")
+
+    for skill_dir in sorted(skills_dir.iterdir()):
+        if not skill_dir.is_dir():
+            continue
+        skmd = skill_dir / "SKILL.md"
+        if not skmd.exists():
+            continue
+
+        rel = str(skmd.relative_to(base_dir))
+        text = skmd.read_text()
+        lines = text.split("\n")
+
+        # Extract YAML frontmatter
+        if not lines or lines[0].strip() != "---":
+            findings.append(LintFinding(
+                severity="error", category="skill-frontmatter",
+                source=rel, rule_id="frontmatter-missing",
+                message="SKILL.md missing YAML frontmatter (no opening ---)"
+            ))
+            continue
+
+        end_idx = None
+        for i in range(1, len(lines)):
+            if lines[i].strip() == "---":
+                end_idx = i
+                break
+        if end_idx is None:
+            findings.append(LintFinding(
+                severity="error", category="skill-frontmatter",
+                source=rel, rule_id="frontmatter-unclosed",
+                message="YAML frontmatter has no closing ---"
+            ))
+            continue
+
+        fm_text = "\n".join(lines[1:end_idx])
+        try:
+            fm = yaml.safe_load(fm_text)
+        except yaml.YAMLError as e:
+            findings.append(LintFinding(
+                severity="error", category="skill-frontmatter",
+                source=rel, rule_id="frontmatter-parse",
+                message=f"YAML frontmatter parse error: {e}"
+            ))
+            continue
+
+        if not isinstance(fm, dict):
+            findings.append(LintFinding(
+                severity="error", category="skill-frontmatter",
+                source=rel, rule_id="frontmatter-type",
+                message="YAML frontmatter is not a dict"
+            ))
+            continue
+
+        dirname = skill_dir.name
+
+        # name field
+        if "name" not in fm:
+            findings.append(LintFinding(
+                severity="error", category="skill-frontmatter",
+                source=rel, rule_id="name-missing",
+                message="Required field 'name' is missing"
+            ))
+        else:
+            name_val = str(fm["name"])
+            if name_val != dirname:
+                findings.append(LintFinding(
+                    severity="error", category="skill-frontmatter",
+                    source=rel, rule_id="name-directory-mismatch",
+                    message=f"name '{name_val}' does not match directory name '{dirname}'"
+                ))
+            if not name_re.match(name_val):
+                findings.append(LintFinding(
+                    severity="error", category="skill-frontmatter",
+                    source=rel, rule_id="name-format",
+                    message=f"name '{name_val}' does not match regex ^[a-z0-9]+(-[a-z0-9]+)*$"
+                ))
+            if len(name_val) < 1 or len(name_val) > 64:
+                findings.append(LintFinding(
+                    severity="error", category="skill-frontmatter",
+                    source=rel, rule_id="name-length",
+                    message=f"name '{name_val}' is {len(name_val)} chars (must be 1-64)"
+                ))
+
+        # description field
+        if "description" not in fm:
+            findings.append(LintFinding(
+                severity="error", category="skill-frontmatter",
+                source=rel, rule_id="description-missing",
+                message="Required field 'description' is missing"
+            ))
+        else:
+            desc_val = str(fm["description"])
+            if len(desc_val) < 1 or len(desc_val) > 1024:
+                findings.append(LintFinding(
+                    severity="error", category="skill-frontmatter",
+                    source=rel, rule_id="description-length",
+                    message=f"description is {len(desc_val)} chars (must be 1-1024)"
+                ))
+            # Check description is quoted in raw YAML text
+            desc_line = None
+            for line in fm_text.split("\n"):
+                stripped = line.strip()
+                if stripped.startswith("description:"):
+                    desc_line = stripped
+                    break
+            if desc_line:
+                val_part = desc_line.split(":", 1)[1].strip()
+                if val_part and not (val_part.startswith('"') or val_part.startswith("'")):
+                    findings.append(LintFinding(
+                        severity="error", category="skill-frontmatter",
+                        source=rel, rule_id="description-unquoted",
+                        message="description value is not quoted in YAML frontmatter"
+                    ))
+
+        # license field (optional, SPDX check)
+        if "license" in fm:
+            lic_val = str(fm["license"])
+            # Basic SPDX check: must be uppercase with hyphens
+            spdx_re = __import__("re").compile(r"^[A-Z][A-Za-z0-9\-\.]+$")
+            if not spdx_re.match(lic_val):
+                findings.append(LintFinding(
+                    severity="warning", category="skill-frontmatter",
+                    source=rel, rule_id="license-spdx",
+                    message=f"license '{lic_val}' does not look like a valid SPDX identifier"
+                ))
+
+        # Unknown fields
+        for key in fm:
+            if key not in recognized_fields:
+                findings.append(LintFinding(
+                    severity="error", category="skill-frontmatter",
+                    source=rel, rule_id="unknown-field",
+                    message=f"Unknown frontmatter field '{key}'"
+                ))
+
+    return findings
+
+
 def lint_progressive_disclosure(base_dir: Path) -> list[LintFinding]:
     findings: list[LintFinding] = []
 
@@ -345,6 +494,7 @@ def main() -> None:
 
     base_dir = scan_dir.parent if scan_dir.name == "skills" else scan_dir
     findings.extend(lint_progressive_disclosure(base_dir))
+    findings.extend(lint_skill_frontmatter(base_dir))
 
     if args.json:
         print(json.dumps([f.to_dict() for f in findings], indent=2))


### PR DESCRIPTION
## Summary

- Add `lint_skill_frontmatter()` to skildeck-lint validating SKILL.md YAML frontmatter against opencode schema (name, description, license, fields)
- Add critical rule: all linters are advisory only, no auto-modify
- Update AGENTS.md, 6 skill task files, and 080-code-standards.md to use advisory-only linter commands
- Add behavioral enforcement tests

## Changes

| File | Action |
|------|--------|
| `tools/impl/skildeck/skildeck-lint` | Add `lint_skill_frontmatter()` — validates name, description, license, YAML parse, unknown fields |
| `guidelines/000-critical-rules.md` | Add critical rule: all linters advisory only, no auto-modify |
| `AGENTS.md` | `ruff check --fix` → `ruff check`, `ruff format` → `ruff format --check` |
| `guidelines/080-code-standards.md` | Update examples to advisory-only equivalents |
| `skills/requesting-code-review/tasks/prepare.md` | `ruff check --fix` → `ruff check` |
| `skills/executing-plans/tasks/progress.md` | `ruff check --fix` → `ruff check`, `ruff format` → `ruff format --check` |
| `skills/executing-plans/tasks/verify.md` | Same |
| `skills/finishing-a-development-branch/tasks/prepare.md` | Same |
| `skills/finishing-a-development-branch/tasks/checklist.md` | `ruff format` applied → `ruff format --check` passes |
| `skills/verification-before-completion/tasks/collect.md` | `ruff check --fix` → `ruff check`, `ruff format` → `ruff format --check` |
| `skills/implementation-pipeline/tasks/pipeline-executor.md` | Update structural-checks gate description |
| `tests/behaviors/skildeck-frontmatter-validation.sh` | New behavioral test |
| `tests/behaviors/linters-advisory-only.sh` | New behavioral test |

Fixes #1238