### PR TITLE
Decouple state tracking from design artifacts (#1244)

### DIFF
--- a/skills/approval-gate/enforcement/scope-parsing.md
+++ b/skills/approval-gate/enforcement/scope-parsing.md
@@ -21,73 +21,21 @@ Authorization phrases carry implicit scope — the pipeline stage the developer 
 
 When scope resolves to `for_next_phase`, the agent MUST:
 
-1. **Read the spec/plan body** to identify phase structure (look for `### Phase N:` or `#### Task N:` headings)
+1. **Read `./tmp/{N}/work.md`** to identify current phase tracking state
 2. **Identify completed phases** by checking sub-issue state (`get_sub_issues`) and verifying merged PRs for each
 3. **Resolve to the next sequential uncompleted phase number**
 4. **Set `halt_at`** to `phase_N_complete` where N is the resolved next phase
 5. **Set gap-fill** to `auto-approve` for that specific phase only
 
-### Resolution Logic
+Phase resolution does not parse STATUS markers or plan bodies. The `./tmp/{N}/work.md` file (populated during pre-work and updated by each pipeline step) is the canonical source for current phase state. Resolution logic:
 
 ```python
-def resolve_next_phase(issue_num, issue_body):
-    """
-    Resolve 'next phase' to a specific phase number based on
-    current completion state.
-    """
-    sub_issues = issue-operations -> read-issue (github_issue_read( <!-- Routes through issue-operations per SPEC #683 -->
-        method="get_sub_issues", issue_number=issue_num
-    )
-
-    phase_pattern = re.compile(r"(?:###?\s*Phase\s+(\d+)|####\s*Task\s+(\d+))")
-    phases_in_body = phase_pattern.findall(issue_body)
-
-    completed_phases = set()
-    for sub in sub_issues:
-        sub_detail = issue-operations -> read-issue (github_issue_read( <!-- Routes through issue-operations per SPEC #683 -->
-            method="get", issue_number=sub["number"]
-        )
-        if sub_detail.get("state") == "closed":
-            prs = github_search_pull_requests(
-                query=f"Fixes #{sub['number']} repo:{OWNER}/{REPO}"
-            )
-            for pr in prs:
-                pr_detail = github_pull_request_read(
-                    method="get", owner=OWNER, repo=REPO,
-                    pullNumber=pr["number"]
-                )
-                if pr_detail.get("merged_at") is not None:
-                    phase_match = re.search(
-                        r"[Pp]hase\s+(\d+)", sub_detail.get("title", "")
-                    )
-                    if phase_match:
-                        completed_phases.add(int(phase_match.group(1)))
-
-    all_phases = sorted(set(
-        int(p[0]) for p in phases_in_body if p[0]
-    ))
-    if not all_phases:
-        all_phases = list(range(1, len(sub_issues) + 1))
-
-    next_phase = None
-    for p in all_phases:
-        if p not in completed_phases:
-            next_phase = p
-            break
-
-    if next_phase is None:
-        return {
-            "resolved_scope": "for_review_prep",
-            "halt_at": "review_prep",
-            "reason": "All phases already completed",
-        }
-
-    return {
-        "resolved_scope": "for_phase_N",
-        "halt_at": f"phase_{next_phase}_complete",
-        "phase_number": next_phase,
-        "gap_fill": f"auto-approve phase {next_phase}",
-    }
+# Read ./tmp/{N}/work.md for current phase tracking
+# Expected format:
+#   current_phase: <phase_number>
+#   current_concern: <concern_name>
+#   current_step: <step_label>
+# If file missing → default to first concern, first step
 ```
 
 ### "Approved for Phase N" Resolution
@@ -125,7 +73,7 @@ def resolve_phase_n(phase_number, total_phases):
 3. **Qualifier present = parse**: Match phrase against table above; ambiguous phrases default to for_review_prep
 3. **Multiple issues**: `"approved #1200 #1201 #1197 for implementation"` → `for_implementation` scope applies to all listed issues
 4. **Phase qualifier**: `"approved: Phase 1 only"` → single-phase authorization for the named phase only, then HALT
-5. **"Next phase" resolution**: `"approved #N for next phase"` → resolve via `resolve_next_phase()` which reads spec/plan body, identifies completed phases (via merged PRs and STATUS markers), and sets halt_at to the next sequential uncompleted phase
+5. **"Next phase" resolution**: `"approved #N for next phase"` → read `./tmp/{N}/work.md` for current phase, identify completed phases (via merged PRs), set halt_at to the next sequential uncompleted phase
 6. **"Phase N" resolution**: `"approved #N for phase N"` → resolve via `resolve_phase_n()` which sets halt_at based on whether the phase is intermediate or final
 
 ## PR Strategy Map

--- a/skills/approval-gate/tasks/verify-authorization.md
+++ b/skills/approval-gate/tasks/verify-authorization.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-Check for explicit authorization and apply the correct `approved-for-*` label before implementation. This task orchestrates the atomized sub-tasks in `verify-authorization/` for fine-grained, low-context verification.
+Check for explicit authorization and record in work state file before proceeding. This task orchestrates the atomized sub-tasks in `verify-authorization/` for fine-grained, low-context verification.
 
 ## Entry Criteria
 
@@ -11,8 +11,9 @@ Check for explicit authorization and apply the correct `approved-for-*` label be
 
 ## Exit Criteria
 
-- Authorization verified as explicit and for correct issue
-- `approved-for-*` label applied per mapping table; deprecated `needs-approval` label removed
+- Authorization verified as explicit and for correct issue — recorded in work state file (`./tmp/{N}/work.md`)
+- Advisory scope-marker written as GitHub label after work state file is updated; deprecated `needs-approval` label removed asynchronously
+- Labels are visibility markers — they do NOT gate execution
 - Git state verified (worktree environment ready)
 - Authorization recorded for scope tracking
 
@@ -25,7 +26,7 @@ This task delegates to atomic sub-tasks. Each sub-task reads inputs from the wor
 | 0 | Re-task guard | If sub-agent returns empty, re-task with original scoped context (max 2 retries); on exhaustion, fall through to double-failure protocol |
 | 0.5 | `verify-authorization/scope-auto-resolve` | Parse authorization text, resolve scope/halt_at/pr_strategy/gap_fill |
 | 1 | `verify-authorization/verify-explicit-authorization` | Check for "approved"/"go" + author identity + currency |
-| 2 | Label application (inline) | Apply `approved-for-*` label per mapping table; remove prior `approved-for-*` and `needs-approval` labels |
+| 2 | Label write (advisory-only, asynchronous) | Write authorization-scope label after work state file is written; labels are visibility markers, not gates. Remove prior scope and `needs-approval` labels as advisory cleanup. |
 | 3 | Authorization decision (inline) | Route based on authorization result |
 | 4.5 | `verify-authorization/item-decomposition-check` | Verify item enumeration, dependency ordering, TDD steps |
 | 4.6 | `verify-authorization/sc-traceability-check` | Verify SC-to-test traceability, RED-phase ordering |

--- a/skills/approval-gate/tasks/verify-blockers.md
+++ b/skills/approval-gate/tasks/verify-blockers.md
@@ -12,22 +12,23 @@ Check for blocking issues or dependencies that prevent implementation.
 
 ## Exit Criteria
 
-- No `needs-approval` label present (or explicit authorization received)
+- Authorization confirmed in work state file (`./tmp/{N}/work.md`)
 - No blocking issues superseding spec
 - No unresolved dependencies
 
 ## Procedure
 
-### Step 1: Check needs-approval Label
+### Step 1: Check Authorization via Work State File
 
 ```python
-issue = issue-operations -> read-issue (github_issue_read(method="get", issue_number=N) <!-- Routes through issue-operations per SPEC #683 -->
-has_label = "needs-approval" in [l["name"] for l in issue["labels"]]
+work_state = read_work_state(f"./tmp/{N}/work.md")  # reads from ## verify-authorization section
+auth_info = work_state.get("authorization", {})
 
-if has_label and explicit_authorization:
-    # Label is informational, proceed
-elif has_label and not explicit_authorization:
-    HALT("needs-approval label present, awaiting authorization")
+if auth_info.get("authorized") == True:
+    # Authorization confirmed via work state — proceed
+    pass
+else:
+    HALT(f"Authorization not confirmed in work state for #{N}")
 ```
 
 ### Step 2: Check for Superseding Issues
@@ -51,7 +52,7 @@ For each dependency listed in spec:
 
 | Blocker | Action |
 |---------|--------|
-| needs-approval label (no auth) | HALT and wait |
+| No authorization in work state | HALT and report |
 | Superseding issue | HALT and report |
 | Conflicting spec | HALT and identify conflict |
 | Missing dependency | HALT and ask about alternatives |
@@ -105,22 +106,24 @@ For each dependency listed in spec:
 
 **Evidence artifact:** Tool call results confirming dependency existence and availability.
 
-### Verify needs-approval Label Against Actual Auth State
+### Verify Authorization State Against Work State File
 
 ```
-issue = issue-operations -> read-issue (github_issue_read(method="get", issue_number=N) <!-- Routes through issue-operations per SPEC #683 -->
-comments = issue-operations -> read-comments (github_issue_read(method="get_comments", issue_number=N) <!-- Routes through issue-operations per SPEC #683 -->
+work_state = read_work_state(f"./tmp/{N}/work.md")
+auth_info = work_state.get("authorization", {})
 
-has_label = "needs-approval" in [l["name"] for l in issue["labels"]]
-has_auth = any comment from developer (MEMBER/OWNER/COLLABORATOR) saying "approved"/"go"
+has_auth = auth_info.get("authorized") == True
+has_scope = auth_info.get("authorization_scope") is not None
 
-- has_label AND has_auth → STRUCTURE-VIOLATION (auto-fix: label is stale, remove it)
-- no label AND no auth → VERIFICATION-GAP (may need label added)
-- has_label AND no auth → Correct state, proceed to HALT
-- no label AND has_auth → Correct state, proceed with implementation
+- has_auth AND has_scope → Correct state, proceed with implementation
+- has_auth AND no scope → STRUCTURE-VIOLATION (auto-fix: write default scope `for_analysis`)
+- no auth AND has scope → VERIFICATION-GAP (authorization not recorded despite scope)
+- no auth AND no scope → Correct state, proceed to HALT
 ```
 
-**Evidence artifact:** Label list and comment search results showing actual auth state.
+**Evidence artifact:** Work state file content showing `authorization.authorized` and `authorization.authorization_scope` values.
+
+Labels are advisory visibility markers only — they do NOT gate execution. If the `needs-approval` label is present but work state confirms authorization, the label is stale and should be cleaned up asynchronously.
 
 ### Task-Specific Findings
 
@@ -129,7 +132,7 @@ See `enforcement/adversarial-verification.md` for the three-tier classification 
 ## Context Required
 
 - Related tasks: `verify-authorization`, `verify-open-questions`
-- Label state machine: `141-planning-status-tracking.md §10` (remove `needs-approval` on explicit auth, add `needs-revision` on revision required)
+- Authorization state: `./tmp/{N}/work.md` is the canonical source. Labels are advisory visibility markers only — they do NOT gate execution.
 
 ## Enforcement References
 

--- a/skills/approval-gate/tasks/verify-sub-issues.md
+++ b/skills/approval-gate/tasks/verify-sub-issues.md
@@ -4,7 +4,7 @@
 
 ## Purpose
 
-Verify sub-issue structure and STATUS gate for multi-task plans before implementation. Sub-issues are verified under the plan issue, not the spec issue.
+Verify sub-issue structure and phase tracking gate for multi-task plans before implementation. Sub-issues are verified under the plan issue, not the spec issue.
 
 ## Entry Criteria
 
@@ -16,7 +16,7 @@ Verify sub-issue structure and STATUS gate for multi-task plans before implement
 ## Exit Criteria
 
 - Sub-issues verified present under plan (multi-task) OR exemption confirmed (work-of-1)
-- STATUS in plan matches requested subtask number
+- Phase tracking state in `./tmp/{N}/work.md` matches requested subtask
 - Auto-create performed if needed
 
 ## Procedure
@@ -39,34 +39,33 @@ sub_issues = issue-operations -> read-sub-issues (github_issue_read(method="get_
 - Multiple implementation tasks
 - Requires sequential work streams
 
-### Step 3: Verify STATUS Gate (CRITICAL)
+### Step 3: Verify Phase Tracking Gate
 
 **For multi-task plans with sub-issues:**
 
-- [ ] 1. Extract subtask from authorization:
-    - "approved: 1.2" → subtask 1.2 (numeric format, backward-compatible)
-    - "approved: X.Y" → subtask X.Y (numeric format, backward-compatible)
-    - "approved: {concern}" → find phase matching concern name (prose format)
-    - "approved" (no number) → check STATUS for current phase
+Phase tracking state is read from `./tmp/{N}/work.md`. The work state file is populated during pre-work and updated by each pipeline step.
 
-- [ ] 2. Get plan issue STATUS:
-    ```python
-    plan = issue-operations -> read-issue (github_issue_read(method="get", issue_number=plan_issue) <!-- Routes through issue-operations per SPEC #683 -->
-    # Parse STATUS from body
-    # Prose-driven formats (recommended):
-    #   "STATUS: in progress — {concern}, Step {N}"
-    #   "STATUS: completed — {concern}"
-    #   "STATUS: {concern} — {task description}"
-    #   "STATUS: in progress — {concern} (REVISED - NEEDS APPROVAL)"
-    # Numeric formats (backward-compatible):
-    #   "STATUS: X.Y" or "STATUS: completed"
-    # If STATUS not found, default to first concern's first step
+- [ ] 1. Extract subtask from authorization:
+    - "approved: 1.2" → subtask 1.2 (numeric format)
+    - "approved: X.Y" → subtask X.Y (numeric format)
+    - "approved: {concern}" → find phase matching concern name (prose format)
+    - "approved" (no number) → read `./tmp/{N}/work.md` for current phase
+
+- [ ] 2. Read phase tracking state:
+    ```bash
+    # Read current phase from work state file
+    cat "./tmp/{plan_issue}/work.md"
+    # Expected format:
+    # current_phase: <phase_number>
+    # current_concern: <concern_name>
+    # current_step: <step_label>
+    # If file missing → default to first concern, first step
     ```
 
 - [ ] 3. Determine which subtask to implement:
     - If authorized for concern name or X.Y → use that subtask (explicit override)
-    - If "approved" (no number) AND STATUS found → use STATUS value
-    - If "approved" (no number) AND STATUS missing → use first concern, first step
+    - If "approved" (no number) AND work.md has current phase → use that value
+    - If "approved" (no number) AND work.md missing → use first concern, first step
     - POST COMMENT explaining which subtask is being implemented
 
 - [ ] 4. Verify subtask exists:
@@ -78,13 +77,13 @@ sub_issues = issue-operations -> read-sub-issues (github_issue_read(method="get_
 Proceeding to implement subtask for {concern} (or X.Y).
 
 Authorization: "approved" (no phase specified)
-STATUS: {concern}, Step {N} (or "not found, defaulting to first concern")
+Phase tracking: {concern}, Step {N} (or "work.md not found, defaulting to first concern")
 Sub-issue: #NNN
 
 Starting implementation now.
 ```
 
-- [ ] 6. **Why STATUS Gate Matters:**
+- [ ] 6. **Why Phase Tracking Gate Matters:**
    - Prevents parallel execution of subtasks
    - Ensures sequential workflow
    - Avoids git branch conflicts
@@ -129,32 +128,32 @@ Auto-creating sub-issues for an approved multi-task plan does NOT require separa
 | Linking sub-issues to plan | ❌ NO | Part of sub-issue creation workflow |
 | Proceeding to implementation after auto-creation | ❌ NO | Plan authorization continues to implementation |
 
-## STATUS Gate Rules
+## Phase Tracking Gate Rules
 
 | Scenario | Action |
 |----------|--------|
-| STATUS matches authorized subtask (prose or numeric) | ✅ PROCEED - report which subtask and concern |
-| STATUS mismatch | ⛔ HALT - report mismatch clearly |
-| STATUS is "completed" | ⛔ HALT - spec already complete |
-| STATUS not found + "approved" | ✅ PROCEED - default to first concern's first step, report decision |
-| STATUS not found + "approved: X.Y" | ✅ PROCEED - use specified X.Y, report decision |
-| STATUS not found + "approved: {concern}" | ✅ PROCEED - find phase matching concern name, report decision |
-| Single-phase plan (no STATUS) | ✅ PROCEED - no gate needed |
+| work.md phase matches authorized subtask (prose or numeric) | ✅ PROCEED - report which subtask and concern |
+| Phase mismatch | ⛔ HALT - report mismatch clearly |
+| work.md says "completed" | ⛔ HALT - all phases complete |
+| work.md not found + "approved" | ✅ PROCEED - default to first concern's first step, report decision |
+| work.md not found + "approved: X.Y" | ✅ PROCEED - use specified X.Y, report decision |
+| work.md not found + "approved: {concern}" | ✅ PROCEED - find phase matching concern name, report decision |
+| Single-phase plan (no tracking needed) | ✅ PROCEED - no gate needed |
 | Subtask not in sub-issues list | ⛔ HALT - report available subtasks |
 
 ## Mandatory Reporting (No Silent Halts)
 
-**Every STATUS gate check MUST report status to user:**
+**Every phase tracking gate check MUST report status to user:**
 
 - [ ] 1. Which subtask is being implemented
-- [ ] 2. Why that subtask was selected (STATUS value or default)
+- [ ] 2. Why that subtask was selected (work.md value or default)
 - [ ] 3. Link to the sub-issue
 
 **Example report:**
 ```markdown
-**STATUS Gate Verification:**
+**Phase Tracking Gate Verification:**
 - Authorization: "approved" (no phase specified)
-- STATUS field: Not found → Defaulting to first concern's first step
+- work.md: Not found → Defaulting to first concern's first step
 - Sub-issue: #473
 - Proceeding with implementation
 ```
@@ -167,19 +166,19 @@ Auto-creating sub-issues for an approved multi-task plan does NOT require separa
 - Proceeding **to implementation** when `get_sub_issues` returns empty for multi-task specs **without creating sub-issues first**
 - Creating step-level sub-issues (use PHASE level)
 - Assuming markdown checkboxes = task tracking
-- Implementing when STATUS doesn't match authorized subtask
+- Implementing when phase tracking doesn't match authorized subtask
 - Parallel execution of subtasks (enforce single-subtask flow)
 
 ## Common Issues
 
 | Issue | Resolution |
 |-------|------------|
-| STATUS mismatch | POST report: "STATUS mismatch: authorized for {concern}/{X.Y} but STATUS is {actual}. Please update STATUS or authorize correct subtask." |
-| STATUS not found | Default to first concern's first step, POST report: "STATUS not found. Defaulting to first concern. Add 'STATUS: in progress — {concern}, Step 1' to plan issue for tracking." |
+| Phase mismatch | POST report: "Phase mismatch: authorized for {concern}/{X.Y} but work.md shows {actual}. Please update tracking state or authorize correct subtask." |
+| work.md not found | Default to first concern's first step, POST report: "work.md not found. Defaulting to first concern. Add tracking state to work.md for phase tracking." |
 | Sub-issue not linked | Auto-create and link, POST report: "Created N sub-issues for phase tracking." |
-| Single-phase plan with STATUS | Ignore STATUS, proceed, POST report: "Single-phase plan, ignoring STATUS field." |
+| Single-phase plan with tracking state | Ignore tracking, proceed, POST report: "Single-phase plan, ignoring phase tracking." |
 | Subtask not in list | HALT, POST report: "Subtask {X.Y}/{concern} not found. Available subtasks: [list]. Please authorize a valid subtask." |
-| Plan issue missing STATUS field | Default to first concern's first step, proceed, report to chat |
+| Plan issue missing work.md | Default to first concern's first step, proceed, report to chat |
 
 ## Adversarial Verification: Sub-Issue State
 
@@ -203,22 +202,22 @@ For each sub-issue returned:
 
 **Evidence artifact:** `issue-operations -> read-issue (github_issue_read(method=get)` for each sub-issue showing actual state, title, and labels. <!-- Routes through issue-operations per SPEC #683 -->
 
-### Verify Sub-Issue Labels and STATUS
+### Verify Sub-Issue Labels and Phase State
 
 ```
 For each sub-issue:
   labels = issue-operations -> read-labels (github_issue_read(method=get_labels, issue_number=sub_issue_number) <!-- Routes through issue-operations per SPEC #683 -->
-  body = issue-operations -> read-issue (github_issue_read(method=get, issue_number=sub_issue_number) <!-- Routes through issue-operations per SPEC #683 -->
-  
+  work_state = $(cat ./tmp/{plan_issue}/work.md 2>/dev/null || echo "not found")
+
   - If has "needs-approval" label but parent plan has explicit authorization → STRUCTURE-VIOLATION
     (auto-fix: authorization cascades from plan, label should be removed)
-  - If STATUS marker in sub-issue body is mismatched to actual content maturity → STRUCTURE-VIOLATION
-    (auto-fix: update STATUS per ground-truth maturity classification)
-  - If STATUS says COMPLETE but sub-issue is open → CONFLICTING
+  - If work.md phase tracking is mismatched to actual sub-issue progress → STRUCTURE-VIOLATION
+    (auto-fix: update work.md per ground-truth progress)
+  - If work.md says completed but sub-issue is open → CONFLICTING
     (flag-for-review: may indicate tracking mismatch)
 ```
 
-**Evidence artifact:** Label list and body content for each sub-issue.
+**Evidence artifact:** Label list and work.md state for each sub-issue.
 
 ### Verify Sub-Issue Link Integrity
 

--- a/skills/executing-plans/tasks/completion.md
+++ b/skills/executing-plans/tasks/completion.md
@@ -5,7 +5,7 @@ Idempotent completion subtask for executing-plans. Ensures mandatory steps ran r
 ## State Check Phase
 
 - [ ] 1. **assemble-work task():** Verify implementation-pipeline task() was attempted
-- [ ] 2. **Plan issue STATUS:** Verify plan issue STATUS reflects actual outcome (completed, partial, failed)
+- [ ] 2. **Work state file:** Verify `./tmp/{N}/work.md` state file reflects actual outcome (completed, partial, failed)
 - [ ] 3. **Chat exec summary:** Verify chat output follows exec summary format (summary → outcome → URL → byline)
 
 ## Skill-Specific Completion
@@ -14,9 +14,9 @@ Idempotent completion subtask for executing-plans. Ensures mandatory steps ran r
    - Check evidence for assemble-work invocation
    - If missing: invoke `implementation-pipeline --task assemble-work` as remediation
 
-- [ ] 2. **Plan issue STATUS** (if not already updated):
-   - Check plan issue STATUS marker against actual completion state
-   - If mismatched: update STATUS to reflect current state
+- [ ] 2. **Work state file** (if not already updated):
+   - Check `./tmp/{N}/work.md` state file against actual completion state
+   - If mismatched: update state file to reflect current state
 
 - [ ] 3. **Chat executive summary** (if not already produced):
    - Verify exec summary was posted to chat

--- a/skills/executing-plans/tasks/start.md
+++ b/skills/executing-plans/tasks/start.md
@@ -10,9 +10,9 @@ This task() routes plan execution to `implementation-pipeline --task assemble-wo
 
 - [ ] 1. **Verify plan approval** — confirm the plan issue has explicit approval in comments
 - [ ] 2. **Verify prerequisites** — feature branch exists, working tree clean, dependencies ready
-- [ ] 3. **Read Plan STATUS to compose initial phase progress** — before task()ing, read the plan issue body to determine which phases (if any) are already marked complete. Compose the initial `phase_progress` for the task context:
+- [ ] 3. **Read work state file to compose initial phase progress** — before task()ing, read `./tmp/{N}/work.md` to determine which phases (if any) are already marked complete. Compose the initial `phase_progress` for the task context:
    - If no phases are complete yet: `completed_phases: "No phases completed yet. This is the first phase."`, `concern_boundaries_crossed: ""`, `verification_evidence: ""`
-   - If prior phases are complete: list them by concern name using the concern boundary annotations in the plan body, note any transitions between concerns, and summarize verification outcomes from the plan STATUS markers
+   - If prior phases are complete: list them by concern name using the concern boundary annotations in the plan body, note any transitions between concerns, and summarize verification outcomes from the work state file
 - [ ] 4. **Check halt_at boundary** — if `halt_at == plan_created`, HALT. Do NOT task() to implementation. The authorization scope stops at plan creation.
 - [ ] 5. **Step 5.5: RED Phase Verification Checkpoint — Content and Behavioral (MANDATORY)** — Before task()ing to implementation-pipeline/assemble-work, the agent MUST verify that for each TDD-marked implementation item, a RED test artifact exists. The type of RED test depends on whether the item is a rule change or a code change:
 
@@ -55,7 +55,7 @@ authorization_source: "User approved #N on YYYY-MM-DD"
 - Instructed to exceed `halt_at` → return `status: BLOCKED`
 
 The phase progress information comes from two sources:
-- The Plan STATUS marker (which phases are marked complete with ☑)
+- The `./tmp/{N}/work.md` state file (which phases are marked complete)
 - Concern boundary annotations in the plan body (prose descriptions of architectural concern transitions)
 
 Phase progress is prose-driven — the orchestrating agent describes progress in natural prose. The requirement is that the information travels, not that it follows a rigid schema.

--- a/skills/executing-plans/tasks/step.md
+++ b/skills/executing-plans/tasks/step.md
@@ -40,7 +40,7 @@ Report step completion to chat:
 **Next:** Step N+1 - [Next concern]
 ```
 
-- Update STATUS in plan issue body
+- Write progress to `./tmp/{N}/work.md` state file
 - HALT and wait for user
 
 ### 5. Proceed to Next

--- a/skills/implementation-pipeline/SKILL.md
+++ b/skills/implementation-pipeline/SKILL.md
@@ -213,7 +213,7 @@ At the start of each pipeline step, clean previous-run artifacts for that step t
 
 ## Lifecycle Manifest Event Emission
 
-Each pipeline step SHOULD append an event to the lifecycle manifest at `.issues/{issue-N}/lifecycle.yaml` on completion. Events are appended, not overwritten:
+Each pipeline step SHOULD append an event to the lifecycle manifest at `./tmp/{issue-N}/lifecycle.yaml` on completion. Events are appended, not overwritten:
 
 ```yaml
   - event: step_completed

--- a/skills/implementation-pipeline/enforcement/context-passing.md
+++ b/skills/implementation-pipeline/enforcement/context-passing.md
@@ -70,10 +70,10 @@ exec_summary: string (markdown, human-readable)
 
 ### Phase Progress — What Travels at Phase Boundaries
 
-When the orchestrator task()s a sub-agent for a phase that follows a prior phase, the task context MUST carry phase progress information composed from prior sub-agent results and the Plan STATUS marker. This information ensures each phase knows what has already been accomplished and can act accordingly.
+When the orchestrator task()s a sub-agent for a phase that follows a prior phase, the task context MUST carry phase progress information composed from prior sub-agent results and the work state file at `./tmp/{N}/work.md`. This information ensures each phase knows what has already been accomplished and can act accordingly.
 
 The orchestrator builds phase_progress incrementally. Before each sub-agent task():
-1. Read the Plan STATUS marker to identify which phases are already complete
+1. Read the work state file (`./tmp/{N}/work.md`) to identify which phases are already complete
 2. Accumulate `completed_phases`, `concern_boundaries_crossed`, and `verification_evidence` from each prior sub-agent's result
 3. If this sub-agent's work crosses a concern boundary, note the transition in `concern_boundaries_crossed`
 

--- a/skills/spec-creation/tasks/write.md
+++ b/skills/spec-creation/tasks/write.md
@@ -71,7 +71,7 @@ For standard and complex specs, generate the following permanent artifacts:
 
 - [ ] 1. **SC coverage summary YAML** — Create `.issues/{issue-N}/sc-summary.yaml` with machine-parseable coverage data including SC IDs, evidence types, phase bindings, and verification gates.
 - [ ] 1. **Verification consistency contract** — Create `.issues/{issue-N}/verification-consistency-contract.yaml` as a solve contract with compliance matrix variables.
-- [ ] 1. **Lifecycle manifest** — Create `.issues/{issue-N}/lifecycle.yaml` with initial `spec_created` event. Append-only format; never overwrite.
+- [ ] 1. **Lifecycle manifest** — Create `./tmp/{issue-N}/lifecycle.yaml` with initial `spec_created` event. Append-only format; never overwrite.
 - [ ] 1. **Revision re-entry protocol contract** — Create `.issues/{issue-N}/revision-re-entry-contract.yaml` as a solve contract with cascade variables for each revision scope.
 
 ### Step 1b: Plan Creation Mandate in Spec Body (MANDATORY)
@@ -241,7 +241,7 @@ The pre-approval gate validates every SC's Verification Gate against its Evidenc
 
 ### Step 1.3: Lifecycle Manifest Initialization (SC-6)
 
-Initialize the append-only lifecycle manifest at `.issues/{issue-N}/lifecycle.yaml` with a `spec_created` event:
+Initialize the append-only lifecycle manifest at `./tmp/{issue-N}/lifecycle.yaml` with a `spec_created` event:
 
 ```yaml
 events:

--- a/skills/writing-plans/tasks/create/create-and-validate.md
+++ b/skills/writing-plans/tasks/create/create-and-validate.md
@@ -66,7 +66,7 @@ Before writing the plan document, enumerate and validate spec artifacts that mus
 ls .issues/{issue-N}/sc-summary.yaml
 ls .issues/{issue-N}/verification-consistency-contract.yaml
 ls .issues/{issue-N}/revision-re-entry-contract.yaml
-ls .issues/{issue-N}/lifecycle.yaml
+ls ./tmp/{issue-N}/lifecycle.yaml
 ```
 
 Every expected spec artifact MUST exist. Missing artifacts are flagged as MISSING-TRACEABILITY.
@@ -91,14 +91,35 @@ Before finalizing the plan, verify spec-to-plan handoff artifacts:
 3. Verify lifecycle manifest indicates `plan_created` event
 4. Generate spec-to-plan handoff manifest at `./tmp/{issue-N}/artifacts/spec-to-plan-manifest.yaml`
 
-### Step 8: Self-Review
+### Step 8: Generate Implementation Checklist
+
+Generate `./tmp/{N}/checklist.md` from the finalized plan phases. The checklist tracks implementation progress per phase, unit, and file.
+
+**Format:**
+```markdown
+# Implementation Checklist — #{N}
+
+## Phase {P}: {title}
+### Unit {U}: {unit-title}
+- [ ] {file-path} — {description}
+```
+
+**Procedure:**
+1. Read the plan at `.issues/{N}/plan.md`
+2. Extract every phase → unit → file path
+3. Write each as a checkbox item with `pending` default status
+4. Save to `./tmp/{N}/checklist.md`
+
+**Exit criterion:** `./tmp/{N}/checklist.md` exists and contains all phases, units, and file paths from the plan.
+
+### Step 9: Self-Review
 
 - Spec coverage check
 - Placeholder scan
 - Type consistency check
 - Fix any issues found
 
-### Step 9: Validate Plan
+### Step 10: Validate Plan
 
 - Check for TBD/TODO placeholders
 - Verify all steps are actionable
@@ -124,13 +145,13 @@ Every plan phase dispatch table MUST pass the following 8 validation rules:
 
 If any rule fails: HALT with MISSING-TRACEABILITY and report which rule(s) failed.
 
-### Step 10: Verification Revisit (MANDATORY)
+### Step 11: Verification Revisit (MANDATORY)
 
 Invoke: `/skill verification-enforcement --task revisit`
 
 Scans for `⚠️ UNVERIFIED` markers. Resolves if possible; escalates unresolvable claims.
 
-### Step 11: Report Plan Creation in Chat (MANDATORY)
+### Step 12: Report Plan Creation in Chat (MANDATORY)
 
 **Format — reference spec via full URL, plan via local artifact path:**
 ```
@@ -139,7 +160,7 @@ Created plan at `.issues/{N}/plan.md` for [<owner>/<repo>#<N>](https://github.co
 🤖 <AgentName> (<ModelId>)
 ```
 
-### Step 12: Cross-Reference Verification (MANDATORY)
+### Step 13: Cross-Reference Verification (MANDATORY)
 
 Verify referenced skills and tasks exist:
 ```bash
@@ -164,7 +185,7 @@ authorization_source: "User approved #N on YYYY-MM-DD"
 - Instructed to exceed `halt_at` → return `status: BLOCKED`
 - The `pipeline_phase` field is used to track which phase of a multi-phase plan is being executed
 
-### Step 13: Plan Approval
+### Step 14: Plan Approval
 
 **Scope-aware auto-approval — approval is on the spec, plan is a local artifact:**
 
@@ -183,7 +204,7 @@ if scope_level >= SCOPE_LEVELS["for_plan"]:
 
 **If `halt_at == plan_created`:** HALT after plan creation. Do NOT proceed to implementation.
 
-### Step 14: Plan-Reference Sync
+### Step 15: Plan-Reference Sync
 
 After the plan is approved and before the procedure exits, sync a cross-reference from the spec issue to the plan:
 

--- a/tests/behaviors/1244-sc7-checklist-generation.sh
+++ b/tests/behaviors/1244-sc7-checklist-generation.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+# Behavioral test: 1244-sc7-checklist-generation
+# See .opencode/tests/AGENTS.md for the test harness specification and paradigm.
+# This script is an artifact-only generator — it does NOT evaluate model output.
+#
+# SC-7 (behavioral): Checklist generated at ./tmp/{N}/checklist.md on plan
+# creation. The checklist must contain phase sections, step checkboxes with
+# dispatch instructions, and status tracking per step.
+#
+# RED phase: writing-plans does not have checklist generation wired in,
+# so plan creation does NOT produce ./tmp/{N}/checklist.md.
+#
+# GREEN phase: writing-plans generates ./tmp/{N}/checklist.md with phases,
+# steps, dispatch instructions, and status tracking after plan content is
+# finalized.
+#
+# Issue #1244: Decouple state tracking from design artifacts — add checklist
+# generation (Bug 4 / Phase 4)
+#
+# Co-authored with AI: OpenCode (deepseek-v4-flash)
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/helpers.sh"
+
+SCENARIO_NAME="1244-sc7-checklist-generation"
+SCENARIO_PROMPT="Create an implementation plan for the following [SPEC]:
+
+## SPEC: Add Rate Limiter Middleware
+
+### Goal
+Add configurable rate limiting to the API gateway to prevent abuse.
+
+### Phases
+
+**Phase 1: Core token bucket implementation**
+Implement a token bucket algorithm with configurable rate and burst parameters. Store state in an in-memory map keyed by client IP.
+
+**Phase 2: Middleware integration**
+Wire the rate limiter into the FastAPI middleware stack. Return 429 responses when rate exceeded, with Retry-After header.
+
+**Phase 3: Configuration and observability**
+Add YAML-based rate limit configuration, expose metrics endpoint for rate limit hits, and log warnings near threshold.
+
+Take the plan through to completion — finalize the plan content and any checklist or tracking artifacts it produces."
+
+BEHAVIOR_PHASE="${BEHAVIOR_PHASE:-GREEN}"
+export BEHAVIOR_PHASE
+
+echo "=== Behavioral Test: $SCENARIO_NAME (phase=$BEHAVIOR_PHASE) ==="
+echo "  Prompt: create implementation plan from spec with 3 phases"
+echo "  Expectation (GREEN): agent generates ./tmp/{N}/checklist.md with phase sections, step checkboxes, dispatch instructions"
+echo ""
+
+behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT"
+
+echo "  Artifacts: $BEHAVIOR_ARTIFACT_DIR"
+exit 0

--- a/tests/behaviors/1244-sc9-checklist-next-action.sh
+++ b/tests/behaviors/1244-sc9-checklist-next-action.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+# Behavioral test: 1244-sc9-checklist-next-action
+# See .opencode/tests/AGENTS.md for the test harness specification and paradigm.
+# This script is an artifact-only generator — it does NOT evaluate model output.
+#
+# SC-9 (behavioral): Agent reads ./tmp/{N}/checklist.md for progress
+# (not plan body STATUS) to determine next action. The agent MUST consult
+# the checklist to see which steps are pending/in_progress/done rather than
+# reading STATUS markers from the plan issue body.
+#
+# RED phase: No checklist exists / STATUS in plan body is the source of
+# truth, so agent reads STATUS from plan body to determine next action.
+#
+# GREEN phase: Checklist exists in ./tmp/{N}/checklist.md and the plan body
+# has no STATUS markers. Agent reads checklist to determine next action.
+#
+# Issue #1244: Decouple state tracking from design artifacts — agent uses
+# checklist not plan body STATUS (Bug 4 / Phase 4, SC-9)
+#
+# Co-authored with AI: OpenCode (deepseek-v4-flash)
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/helpers.sh"
+
+SCENARIO_NAME="1244-sc9-checklist-next-action"
+SCENARIO_PROMPT="I have a plan for implementing a webhook retry mechanism with 3 phases. The plan was written to a GitHub Issue. I have a ./tmp/1245/checklist.md that tracks step-level progress.
+
+Here is the checklist content:
+
+\`\`\`
+# Checklist: Webhook Retry Mechanism
+## Phase 1: Retry queue data model
+- [x] Define RetryRecord dataclass with fields: webhook_id, payload, attempt_count, max_retries, next_retry_at
+- [x] Create retry_queue table in database schema
+- [x] Add retry_queue migration to alembic
+- [x] Write unit tests for RetryRecord serialization
+
+## Phase 2: Scheduled retry processor
+- [x] Implement RetryWorker background task with configurable poll interval
+- [x] Wire exponential backoff: 2^n seconds with jitter
+- [x] Mark webhook as failed after max_retries exceeded
+- [x] Write integration test for full retry cycle
+
+## Phase 3: Monitoring and alerting
+- [ ] Add prometheus counter for retry_queue_depth
+- [ ] Add prometheus counter for retry_attempts_total
+- [x] Add prometheus counter for retry_failures_total
+- [ ] Create grafana dashboard panel for retry metrics
+\`\`\"
+
+Phase 1 and Phase 2 are complete. What should I work on next?"
+
+BEHAVIOR_PHASE="${BEHAVIOR_PHASE:-GREEN}"
+export BEHAVIOR_PHASE
+
+echo "=== Behavioral Test: $SCENARIO_NAME (phase=$BEHAVIOR_PHASE) ==="
+echo "  Prompt: agent given completed checklist with Phase 3 partial progress"
+echo "  Expectation (GREEN): agent uses checklist to identify next pending step, does NOT read plan body STATUS"
+echo ""
+
+behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT"
+
+echo "  Artifacts: $BEHAVIOR_ARTIFACT_DIR"
+exit 0

--- a/tests/behaviors/labels-advisory-only.sh
+++ b/tests/behaviors/labels-advisory-only.sh
@@ -29,25 +29,5 @@ echo "SC-6: Labels are advisory-only — agent does not halt on needs-approval l
 
 behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT"
 
-OVERALL_RESULT=0
-
-# SC-5: Behavioral evidence — clean-room semantic inspector verifies
-# the agent reads authorization from work state file, not from label.
-assert_semantic "SC-5" "Agent reads authorization scope from the ./tmp/{N}/work.md state file (or equivalent work state mechanism), NOT from the needs-approval label on the issue. The agent must reference the work state file as the authoritative source for authorization_scope and halt_at. The agent must NOT say that the needs-approval label means authorization is missing." "required" || OVERALL_RESULT=1
-
-# SC-6: Behavioral evidence — clean-room semantic inspector verifies
-# the agent does NOT halt on the needs-approval label when work state has authorization.
-assert_semantic "SC-6" "Agent recognizes that the needs-approval label is advisory-only metadata. Even though the label is present, the agent proceeds with implementation because the work state file (./tmp/{N}/work.md) contains valid authorization_scope and halt_at. The agent must NOT halt, ask for permission, or treat the needs-approval label as blocking execution. The agent must NOT say 'waiting for approval' or 'needs approval' based on the label alone." "required" || OVERALL_RESULT=1
-
-# Secondary structural corroboration: agent does not use needs-approval halting language
-assert_forbidden_pattern_absent "[Ww]aiting.*for.*approval\|[Nn]eeds.*approval.*before\|[Cc]annot.*proceed.*without.*approval" \
-    "agent does not halt on needs-approval label language" || OVERALL_RESULT=1
-
-echo ""
-if [ "$OVERALL_RESULT" -eq 0 ]; then
-    echo "PASS: $SCENARIO_NAME"
-else
-    echo "FAIL: $SCENARIO_NAME"
-fi
-
-exit $OVERALL_RESULT
+echo "Artifacts produced at: $BEHAVIOR_ARTIFACT_DIR"
+exit 0

--- a/tests/behaviors/labels-advisory-only.sh
+++ b/tests/behaviors/labels-advisory-only.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+# Behavioral test: labels-advisory-only
+# See .opencode/tests/AGENTS.md for the test harness specification and paradigm.
+# This script is an artifact-only generator — it does NOT evaluate model output.
+# Behavioral Enforcement Test: Labels advisory-only authorization (SC-5, SC-6)
+#
+# Verifies that when an agent has authorization scope recorded in ./tmp/{N}/work.md
+# but a `needs-approval` label is present on the issue, the agent:
+# 1. Reads authorization from the work state file, not the label (SC-5)
+# 2. Proceeds without halting on the needs-approval label (SC-6)
+#
+# Evidence type: behavioral — verified by clean-room semantic inspection.
+#
+# Issue #1244: Decouple State Tracking from Design Artifacts — Phase 3
+#
+# Co-authored with AI: OpenCode (ollama-cloud/deepseek-v4-flash)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/helpers.sh"
+
+SCENARIO_NAME="labels-advisory-only"
+SCENARIO_PROMPT="I need to implement a fix for issue #1244. The issue has needs-approval label but I found ./tmp/1244/work.md with authorization_scope: for_pr and halt_at: pr_created recorded in it. The authorization was given in a comment on the issue. Proceed with implementation."
+
+echo "=== Behavioral Test: $SCENARIO_NAME ==="
+echo "SC-5: Authorization gate reads from ./tmp/{N}/work.md, not labels"
+echo "SC-6: Labels are advisory-only — agent does not halt on needs-approval label"
+
+behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT"
+
+OVERALL_RESULT=0
+
+# SC-5: Behavioral evidence — clean-room semantic inspector verifies
+# the agent reads authorization from work state file, not from label.
+assert_semantic "SC-5" "Agent reads authorization scope from the ./tmp/{N}/work.md state file (or equivalent work state mechanism), NOT from the needs-approval label on the issue. The agent must reference the work state file as the authoritative source for authorization_scope and halt_at. The agent must NOT say that the needs-approval label means authorization is missing." "required" || OVERALL_RESULT=1
+
+# SC-6: Behavioral evidence — clean-room semantic inspector verifies
+# the agent does NOT halt on the needs-approval label when work state has authorization.
+assert_semantic "SC-6" "Agent recognizes that the needs-approval label is advisory-only metadata. Even though the label is present, the agent proceeds with implementation because the work state file (./tmp/{N}/work.md) contains valid authorization_scope and halt_at. The agent must NOT halt, ask for permission, or treat the needs-approval label as blocking execution. The agent must NOT say 'waiting for approval' or 'needs approval' based on the label alone." "required" || OVERALL_RESULT=1
+
+# Secondary structural corroboration: agent does not use needs-approval halting language
+assert_forbidden_pattern_absent "[Ww]aiting.*for.*approval\|[Nn]eeds.*approval.*before\|[Cc]annot.*proceed.*without.*approval" \
+    "agent does not halt on needs-approval label language" || OVERALL_RESULT=1
+
+echo ""
+if [ "$OVERALL_RESULT" -eq 0 ]; then
+    echo "PASS: $SCENARIO_NAME"
+else
+    echo "FAIL: $SCENARIO_NAME"
+fi
+
+exit $OVERALL_RESULT

--- a/tests/sc/sc-1244-ph1-u1-status-executing-plans.sh
+++ b/tests/sc/sc-1244-ph1-u1-status-executing-plans.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+# Content-Verification RED Test: Phase 1 Unit 1 — Remove STATUS markers from executing-plans task files (SC-1)
+#
+# This is a RED-phase test: it PASSES if STATUS patterns are found (test is in RED state,
+# meaning the implementation hasn't happened yet). It FAILS if patterns are absent
+# (meaning the implementation was already done, so no RED phase needed).
+#
+# Co-authored with AI: OpenCode (ollama-cloud/deepseek-v4-flash)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$SCRIPT_DIR"
+while [ "$(basename "$PROJECT_DIR")" != ".opencode" ]; do
+    PROJECT_DIR="$(dirname "$PROJECT_DIR")"
+done
+PROJECT_DIR="$(dirname "$PROJECT_DIR")"
+
+SKILL_DIR="$PROJECT_DIR/.opencode/skills/executing-plans/tasks"
+
+OVERALL_RESULT=0
+
+echo "=== RED: SC-1 STATUS Pattern Detection in executing-plans task files ==="
+
+# SC-1: STATUS patterns must exist in the 3 files (RED = test fails because patterns exist)
+for file in "step.md" "start.md" "completion.md"; do
+    full_path="$SKILL_DIR/$file"
+    if [ ! -f "$full_path" ]; then
+        echo "SKIP: $file not found at $full_path"
+        continue
+    fi
+
+    patterns_found=0
+    for pattern in "Update STATUS in plan issue body" "Read Plan STATUS" "Verify plan issue STATUS" "plan issue STATUS" "Plan STATUS marker" "STATUS marker"; do
+        if grep -q "$pattern" "$full_path" 2>/dev/null; then
+            echo "  FOUND: '$pattern' in $file"
+            patterns_found=1
+        fi
+    done
+
+    if [ "$patterns_found" -eq 1 ]; then
+        echo "RED: STATUS patterns found in $file"
+        OVERALL_RESULT=1
+    else
+        echo "PASS: No STATUS patterns found in $file (GREEN state)"
+    fi
+done
+
+# Summary
+echo ""
+if [ "$OVERALL_RESULT" -eq 1 ]; then
+    echo "STATUS: RED — STATUS patterns found in executing-plans task files (change has not happened yet)"
+else
+    echo "STATUS: ALREADY_GREEN — No STATUS patterns found (change appears already implemented)"
+fi
+
+exit $OVERALL_RESULT

--- a/tests/sc/sc-1244-ph1-u2-status-approval-gate.sh
+++ b/tests/sc/sc-1244-ph1-u2-status-approval-gate.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# RED test: verify STATUS markers + resolve_next_phase patterns STILL exist in approval-gate
+# Expected: EXIT 1 (RED) — patterns found, change hasn't been made yet
+# After GREEN phase: EXIT 0 — patterns removed
+
+set -euo pipefail
+cd "$(git rev-parse --show-toplevel)"
+OVERALL_RESULT=0
+
+echo "=== SC-1244 PH1 U2: Remove STATUS markers from approval-gate ==="
+echo "RED phase: expecting patterns to be FOUND (test FAILS = EXIT 1)"
+echo ""
+
+patterns_found=0
+
+# Pattern 1: STATUS + plan body references in verify-sub-issues.md
+echo "--- Pattern 1: STATUS references combined with plan body ---"
+if rg -n "STATUS" ".opencode/skills/approval-gate/tasks/verify-sub-issues.md" 2>/dev/null | grep -qiE "plan"; then
+    echo "  FOUND: STATUS+plan references in verify-sub-issues.md"
+    patterns_found=1
+else
+    echo "  OK: no STATUS+plan references"
+fi
+
+# Pattern 2: resolve_next_phase which reads STATUS markers
+echo ""
+echo "--- Pattern 2: resolve_next_phase references ---"
+if rg -n "resolve_next_phase" ".opencode/skills/approval-gate/enforcement/scope-parsing.md" 2>/dev/null; then
+    echo "  FOUND: resolve_next_phase references"
+    patterns_found=1
+else
+    echo "  OK: no resolve_next_phase references"
+fi
+
+echo ""
+echo "=== RESULT ==="
+if [ "$patterns_found" -eq 1 ]; then
+    echo "Patterns FOUND (expected RED) — test fails with EXIT 1"
+    exit 1
+else
+    echo "No patterns found — test passes with EXIT 0"
+    exit 0
+fi

--- a/tests/sc/sc-1244-ph1-u3-status-pipeline.sh
+++ b/tests/sc/sc-1244-ph1-u3-status-pipeline.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+# Content-Verification RED Test: Phase 1 Unit 3 — Remove STATUS markers from implementation-pipeline files (SC-3)
+#
+# This is a RED-phase test: it PASSES (exits 1) if Plan STATUS patterns are found in
+# implementation-pipeline task/enforcement files, meaning the change hasn't happened yet.
+# It FAILS (exits 0) if patterns are absent, meaning the change was already implemented.
+#
+# Co-authored with AI: OpenCode (ollama-cloud/deepseek-v4-flash)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$SCRIPT_DIR"
+while [ "$(basename "$PROJECT_DIR")" != ".opencode" ]; do
+    PROJECT_DIR="$(dirname "$PROJECT_DIR")"
+done
+PROJECT_DIR="$(dirname "$PROJECT_DIR")"
+
+PIPELINE_TASKS_DIR="$PROJECT_DIR/.opencode/skills/implementation-pipeline/tasks"
+PIPELINE_ENFORCEMENT_DIR="$PROJECT_DIR/.opencode/skills/implementation-pipeline/enforcement"
+
+OVERALL_RESULT=0
+
+echo "=== RED: SC-3 Plan STATUS Pattern Detection in implementation-pipeline files ==="
+
+# Search tasks directory
+if [ -d "$PIPELINE_TASKS_DIR" ]; then
+    found=0
+    while IFS= read -r -d '' file; do
+        for pattern in "Plan STATUS" "plan body STATUS" "Plan STATUS marker" "STATUS marker" "plan issue STATUS"; do
+            if grep -q "$pattern" "$file" 2>/dev/null; then
+                rel="${file#$PROJECT_DIR/.opencode/}"
+                echo "  FOUND: '$pattern' in $rel"
+                found=1
+            fi
+        done
+    done < <(find "$PIPELINE_TASKS_DIR" -name "*.md" -print0 2>/dev/null || true)
+    if [ "$found" -eq 1 ]; then
+        echo "RED: Plan STATUS patterns found in pipeline tasks/"
+        OVERALL_RESULT=1
+    fi
+else
+    echo "SKIP: pipeline tasks/ directory not found at $PIPELINE_TASKS_DIR"
+fi
+
+# Search enforcement directory
+if [ -d "$PIPELINE_ENFORCEMENT_DIR" ]; then
+    found=0
+    while IFS= read -r -d '' file; do
+        for pattern in "Plan STATUS" "plan body STATUS" "Plan STATUS marker" "STATUS marker" "plan issue STATUS"; do
+            if grep -q "$pattern" "$file" 2>/dev/null; then
+                rel="${file#$PROJECT_DIR/.opencode/}"
+                echo "  FOUND: '$pattern' in $rel"
+                found=1
+            fi
+        done
+    done < <(find "$PIPELINE_ENFORCEMENT_DIR" -name "*.md" -print0 2>/dev/null || true)
+    if [ "$found" -eq 1 ]; then
+        echo "RED: Plan STATUS patterns found in pipeline enforcement/"
+        OVERALL_RESULT=1
+    fi
+else
+    echo "SKIP: pipeline enforcement/ directory not found at $PIPELINE_ENFORCEMENT_DIR"
+fi
+
+# Summary
+echo ""
+if [ "$OVERALL_RESULT" -eq 1 ]; then
+    echo "STATUS: RED — Plan STATUS patterns found in implementation-pipeline files (change has not happened yet)"
+else
+    echo "STATUS: ALREADY_GREEN — No Plan STATUS patterns found (change appears already implemented)"
+fi
+
+exit $OVERALL_RESULT

--- a/tests/sc/sc-1244-ph2-lifecycle-path.sh
+++ b/tests/sc/sc-1244-ph2-lifecycle-path.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+# Content-Verification RED Test: Phase 2 — Lifecycle manifest relocation from .issues/ to ./tmp/ (SC-4)
+#
+# This is a RED-phase test: it PASSES (exits 1) if .issues/{issue-N}/lifecycle.yaml paths
+# are still referenced in the specified skill files, meaning the relocation hasn't happened yet.
+# It FAILS (exits 0) if all paths have been changed to ./tmp/, meaning the change was already implemented.
+#
+# Co-authored with AI: OpenCode (ollama-cloud/deepseek-v4-flash)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$SCRIPT_DIR"
+while [ "$(basename "$PROJECT_DIR")" != ".opencode" ]; do
+    PROJECT_DIR="$(dirname "$PROJECT_DIR")"
+done
+PROJECT_DIR="$(dirname "$PROJECT_DIR")"
+
+OVERALL_RESULT=0
+
+SKILL_FILES=(
+    "$PROJECT_DIR/.opencode/skills/implementation-pipeline/SKILL.md"
+    "$PROJECT_DIR/.opencode/skills/spec-creation/tasks/write.md"
+    "$PROJECT_DIR/.opencode/skills/writing-plans/tasks/create/create-and-validate.md"
+)
+
+PATTERNS=(
+    ".issues/{issue-N}/lifecycle"
+    ".issues/{issue-N}/lifecycle.yaml"
+    ".issues/{N}/lifecycle"
+    ".issues/{[^}]*}/lifecycle"
+)
+
+echo "=== RED: SC-4 Lifecycle .issues/ Path Detection ==="
+
+for file in "${SKILL_FILES[@]}"; do
+    if [ ! -f "$file" ]; then
+        rel="${file#$PROJECT_DIR/.opencode/}"
+        echo "SKIP: $rel not found"
+        continue
+    fi
+
+    found=0
+    for pattern in "${PATTERNS[@]}"; do
+        if grep -qE "$pattern" "$file" 2>/dev/null; then
+            rel="${file#$PROJECT_DIR/.opencode/}"
+            echo "  FOUND: pattern '$pattern' in $rel"
+            found=1
+        fi
+    done
+
+    if [ "$found" -eq 1 ]; then
+        rel="${file#$PROJECT_DIR/.opencode/}"
+        echo "RED: .issues/ lifecycle path found in $rel"
+        OVERALL_RESULT=1
+    else
+        rel="${file#$PROJECT_DIR/.opencode/}"
+        echo "PASS: No .issues/ lifecycle path in $rel (GREEN state)"
+    fi
+done
+
+# Summary
+echo ""
+if [ "$OVERALL_RESULT" -eq 1 ]; then
+    echo "STATUS: RED — .issues/ lifecycle paths still present (relocation has not happened yet)"
+else
+    echo "STATUS: ALREADY_GREEN — All .issues/ lifecycle paths relocated to ./tmp/ (change already implemented)"
+fi
+
+exit $OVERALL_RESULT

--- a/tests/sc/sc-1244-ph3-labels-advisory.sh
+++ b/tests/sc/sc-1244-ph3-labels-advisory.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# RED test: verify labels are STILL used as primary authorization gate (not advisory-only)
+# Expected: EXIT 1 (RED) — label-as-authorization patterns found
+# After GREEN phase: EXIT 0 — labels properly advisory-only
+
+set -euo pipefail
+cd "$(git rev-parse --show-toplevel)"
+OVERALL_RESULT=0
+
+echo "=== SC-1244 PH3: Labels advisory-only (SC-5, SC-6) ==="
+echo "RED phase: expecting label-as-authorization patterns to be FOUND (test FAILS = EXIT 1)"
+echo ""
+
+patterns_found=0
+
+# Pattern 1: needs-approval label as HALT condition (primary authorization gate)
+echo "--- Pattern 1: needs-approval label used as HALT condition ---"
+if rg -n 'needs-approval.*HALT\|HALT.*needs-approval' ".opencode/skills/approval-gate/tasks/verify-blockers.md" 2>/dev/null; then
+    echo "  FOUND: needs-approval label triggers HALT"
+    patterns_found=1
+else
+    echo "  OK: no needs-approval label HALT pattern"
+fi
+
+# Pattern 2: approved-for-* label applied as authorization step (not sync-only)
+echo ""
+echo "--- Pattern 2: approved-for-* label application in verify-authorization ---"
+if rg -n "apply.*approved-for|approved-for.*label|Label application.*inline" ".opencode/skills/approval-gate/tasks/verify-authorization.md" 2>/dev/null; then
+    echo "  FOUND: approved-for-* label applied as authorization step"
+    patterns_found=1
+else
+    echo "  OK: no label-as-authorization pattern"
+fi
+
+# Pattern 3: needs-approval label in entry/exit criteria as blocker
+echo ""
+echo "--- Pattern 3: needs-approval in blocker table or entry/exit criteria ---"
+if rg -n "needs-approval" ".opencode/skills/approval-gate/tasks/verify-blockers.md" 2>/dev/null | grep -qiE "blocker|HALT|wait|entry|exit"; then
+    echo "  FOUND: needs-approval label as blocker"
+    patterns_found=1
+else
+    echo "  OK: no needs-approval as blocker pattern"
+fi
+
+echo ""
+echo "=== RESULT ==="
+if [ "$patterns_found" -eq 1 ]; then
+    echo "Label-as-authorization patterns FOUND (expected RED) — test fails with EXIT 1"
+    exit 1
+else
+    echo "No label-as-authorization patterns found — test passes with EXIT 0"
+    exit 0
+fi

--- a/tests/sc/sc-1244-ph4-checklist-generation.sh
+++ b/tests/sc/sc-1244-ph4-checklist-generation.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# GREEN test: verify checklist generation EXISTS on plan creation
+# Expected: EXIT 0 (GREEN) — checklist generation step + checklist file present
+
+set -euo pipefail
+cd "$(git rev-parse --show-toplevel)"
+OVERALL_RESULT=0
+
+echo "=== SC-1244 PH4: Checklist generation on plan creation (SC-7, SC-8, SC-9) ==="
+echo "GREEN phase: expecting checklist generation to be PRESENT (test PASSES = EXIT 0)"
+echo ""
+
+# Check 1: ./tmp/1244/checklist.md should exist (GREEN phase)
+echo "--- Check 1: ./tmp/1244/checklist.md exists? ---"
+if [ -f "./tmp/1244/checklist.md" ]; then
+    echo "  FOUND: ./tmp/1244/checklist.md exists (expected GREEN)"
+else
+    echo "  MISSING: ./tmp/1244/checklist.md does not exist"
+    OVERALL_RESULT=1
+fi
+
+# Check 2: create-and-validate.md should have a checklist generation step producing ./tmp/{N}/checklist.md
+echo ""
+echo "--- Check 2: checklist generation step in writing-plans/create-and-validate.md ---"
+if grep -qE "\./tmp/\{N\}/checklist\.md|generate.*checklist|checklist.*generat" ".opencode/skills/writing-plans/tasks/create/create-and-validate.md"; then
+    echo "  FOUND: checklist generation step exists in create-and-validate.md (expected GREEN)"
+else
+    echo "  MISSING: no checklist generation step in create-and-validate.md"
+    OVERALL_RESULT=1
+fi
+
+echo ""
+echo "=== RESULT ==="
+if [ "$OVERALL_RESULT" -eq 0 ]; then
+    echo "Checklist generation implemented — test passes with EXIT 0"
+    exit 0
+else
+    echo "Checklist generation NOT fully implemented — test fails with EXIT 1"
+    exit 1
+fi


### PR DESCRIPTION
## Summary

Remove STATUS markers from plan bodies, relocate lifecycle manifest to ./tmp/{N}/, make labels advisory-only with authorization from work state, and add checklist generation on plan creation.

## Changes

- Decouple state tracking from design artifacts
- Add behavioral tests for SC-5/6/7/9
- Fix labels-advisory-only test to be artifact-only generator

**Implements #1244**