### PR TITLE
fix #1246: update adversarial-audit dispatch routing in implementation-pipeline SKILL.md

### DIFF
--- a/skills/implementation-pipeline/SKILL.md
+++ b/skills/implementation-pipeline/SKILL.md
@@ -57,25 +57,31 @@ The orchestrator is a pure router — never reads task file content, never perfo
 | `structural-checks` | `finishing-a-development-branch --task checklist` | lint/typecheck/format results |
 | `green-doublecheck` | `verification-before-completion --task verify` (semantic-intent verification) | GREEN-side SC evidence + intent verdict |
 | `green-vbc` | `verification-before-completion --task completion` | VbC completion artifact |
-| `adversarial-audit` | `adversarial-audit --task verification-audit` | dual-auditor YAML verdicts |
-| `cross-validate` | `adversarial-audit --task cross-validate` | cross-validate findings YAML |
+| `adversarial-audit` | Resolve models → dispatch audit task (phase-appropriate: verification-audit/spec-audit/plan-fidelity/etc.) with auditor_1 (remediate + restart on non-clean-pass) → same audit task with auditor_2 (remediate + restart on non-clean-pass) | dual-auditor YAML verdicts per auditor |
+| `cross-validate` | `adversarial-audit --task cross-validate` (receives `auditor_artifact_paths` from adversarial-audit step) | cross-validate findings YAML |
 | `regression-check` | `test-driven-development --task patterns` (regression) | regression test results |
 | `review-prep` | `git-workflow --task review-prep` | review-prep status |
 | `exec-summary` | `completion-core --task completion` | push status + issue comment |
+
+**Note:** The `adversarial-audit` step is a multi-dispatch sequence with remediation loop-back. The audit task dispatched depends on pipeline phase (e.g., `verification-audit` for post-implementation, `spec-audit` for pre-implementation, `plan-fidelity` for plan validation):
+- [ ] 1. Run `.opencode/tools/resolve-models` to select cross-family auditors
+- [ ] 2. Dispatch the appropriate audit task with `subagent_type` from `auditor_1`
+- [ ] 3. If auditor 1 returned non-clean-pass (FAIL or DONE_WITH_CONCERNS): remediate the root cause, then restart from step 1 (re-run resolve-models). Do NOT dispatch auditor 2.
+- [ ] 4. Dispatch the same audit task with `subagent_type` from `auditor_2`
+- [ ] 5. If auditor 2 returned non-clean-pass: remediate the root cause, then restart from step 1 (re-run resolve-models).
+- [ ] 6. Both auditors clean PASS. Collect both `artifact_path` values and pass as `auditor_artifact_paths` context to `cross-validate`.
 
 ## Pre-Flight
 
 Before the pipeline dispatches to `sc-coherence-gate`, the orchestrator MUST run plan-to-pipeline handoff verification:
 
-1. **Plan-to-pipeline handoff:** Execute `implementation-pipeline --task pre-flight-handoff` — validates RED checkpoints, SC-ID traceability, approval cascade state, verification gate preservation, and manifest writes at `./tmp/{issue-N}/artifacts/plan-to-pipeline-handoff-*.yaml`
-
-2. **Handoff-consistency check:** Reads both `spec-to-plan-handoff-*.yaml` and `plan-to-pipeline-handoff-*.yaml` manifests and compares shared variables (SC coverage total, decomposition classification, phase count). BLOCKs on mismatch.
-
-3. **Pre-flight PASS required:** The pipeline MUST NOT proceed to `sc-coherence-gate` (step 1) if pre-flight returns BLOCKED. This is a hard gate — no bypass path.
+- [ ] 1. **Plan-to-pipeline handoff:** Execute `implementation-pipeline --task pre-flight-handoff` — validates RED checkpoints, SC-ID traceability, approval cascade state, verification gate preservation, and manifest writes at `./tmp/{issue-N}/artifacts/plan-to-pipeline-handoff-*.yaml`
+- [ ] 2. **Handoff-consistency check:** Reads both `spec-to-plan-handoff-*.yaml` and `plan-to-pipeline-handoff-*.yaml` manifests and compares shared variables (SC coverage total, decomposition classification, phase count). BLOCKs on mismatch.
+- [ ] 3. **Pre-flight PASS required:** The pipeline MUST NOT proceed to `sc-coherence-gate` (step 1) if pre-flight returns BLOCKED. This is a hard gate — no bypass path.
 
 ## Step Labels (for #932 naming convention)
 
-`sc-coherence-gate`, `pre-red-baseline`, `red-phase`, `red-doublecheck`, `post-red-enforcement`, `green-phase`, `post-green-enforcement`, `checkpoint-commit`, `structural-checks`, `green-doublecheck`, `green-vbc`, `adversarial-audit`, `cross-validate`, `regression-check`, `review-prep`, `exec-summary`
+`sc-coherence-gate`, `pre-red-baseline`, `red-phase`, `red-doublecheck`, `post-red-enforcement`, `green-phase`, `post-green-enforcement`, `checkpoint-commit`, `structural-checks`, `green-doublecheck`, `green-vbc`, `resolve-models`, `adversarial-audit`, `cross-validate`, `regression-check`, `review-prep`, `exec-summary`
 
 ## Invocation
 
@@ -169,10 +175,10 @@ Step results go to YAML disk artifact — never into solve state. Solve state tr
 ## Remediation Routing
 
 When a step returns FAIL, the orchestrator:
-1. Reads the FAIL artifact's YAML frontmatter from disk
-2. Dispatches the `researcher` skill to determine remediation scope
-3. Routes to `remediation_steps[0].target_step` based on researcher findings
-4. Re-runs the pipeline from the target remediation step
+- [ ] 1. Reads the FAIL artifact's YAML frontmatter from disk
+- [ ] 2. Dispatches the `researcher` skill to determine remediation scope
+- [ ] 3. Routes to `remediation_steps[0].target_step` based on researcher findings
+- [ ] 4. Re-runs the pipeline from the target remediation step
 
 ## Enforcement Reference
 

--- a/skills/implementation-pipeline/enforcement/context-passing.md
+++ b/skills/implementation-pipeline/enforcement/context-passing.md
@@ -73,9 +73,9 @@ exec_summary: string (markdown, human-readable)
 When the orchestrator task()s a sub-agent for a phase that follows a prior phase, the task context MUST carry phase progress information composed from prior sub-agent results and the work state file at `./tmp/{N}/work.md`. This information ensures each phase knows what has already been accomplished and can act accordingly.
 
 The orchestrator builds phase_progress incrementally. Before each sub-agent task():
-1. Read the work state file (`./tmp/{N}/work.md`) to identify which phases are already complete
-2. Accumulate `completed_phases`, `concern_boundaries_crossed`, and `verification_evidence` from each prior sub-agent's result
-3. If this sub-agent's work crosses a concern boundary, note the transition in `concern_boundaries_crossed`
+- [ ] 1. Read the work state file (`./tmp/{N}/work.md`) to identify which phases are already complete
+- [ ] 2. Accumulate `completed_phases`, `concern_boundaries_crossed`, and `verification_evidence` from each prior sub-agent's result
+- [ ] 3. If this sub-agent's work crosses a concern boundary, note the transition in `concern_boundaries_crossed`
 
 **How it is NOT composed:**
 
@@ -103,9 +103,9 @@ Decision log entries are classified as `internal` content per the content classi
 
 If a yield-back produces empty or missing fields:
 
-1. HALT orchestration
-2. Report which context field is missing
-3. Wait for manual intervention
+- [ ] 1. HALT orchestration
+- [ ] 2. Report which context field is missing
+- [ ] 3. Wait for manual intervention
 
 ### Phase Progress with No Prior Phases
 

--- a/skills/implementation-pipeline/enforcement/overflow-signal.md
+++ b/skills/implementation-pipeline/enforcement/overflow-signal.md
@@ -17,10 +17,10 @@ suggested_split: <proposed-split-strategy>
 
 When `assemble-work` receives an OVERFLOW result:
 
-1. Record completed items in work state file
-2. Create new sub-agent task(s) for remaining items using suggested split strategy
-3. Re-dispatch new sub-agent(s) with reduced scope
-4. Continue orchestration with accumulated results
+- [ ] 1. Record completed items in work state file
+- [ ] 2. Create new sub-agent task(s) for remaining items using suggested split strategy
+- [ ] 3. Re-dispatch new sub-agent(s) with reduced scope
+- [ ] 4. Continue orchestration with accumulated results
 
 ### Split Strategies
 

--- a/tests/behaviors/1246-sc1-adversarial-audit-dispatch-row.sh
+++ b/tests/behaviors/1246-sc1-adversarial-audit-dispatch-row.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+# Behavioral test: 1246-sc1-adversarial-audit-dispatch-row
+# See .opencode/tests/AGENTS.md for the test harness specification and paradigm.
+# This script is an artifact-only generator — it does NOT evaluate model output.
+# SC-1 (string): Dispatch routing table's adversarial-audit row documents
+# resolve-models + dual-dispatch sequence instead of single --task verification-audit call.
+#
+# RED phase: greps for the NEW text pattern — should FAIL because old text is still there.
+#
+# Co-authored with AI: OpenCode (deepseek-v4-flash)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/helpers.sh"
+
+SCENARIO_NAME="1246-sc1-adversarial-audit-dispatch-row"
+SKILL_FILE="$SCRIPT_DIR/../../skills/implementation-pipeline/SKILL.md"
+
+echo "=== Content-Verification Test: $SCENARIO_NAME ==="
+echo "Checking for new dispatch row pattern in $SKILL_FILE"
+echo ""
+
+OVERALL_RESULT=0
+
+# SC-1: The new adversarial-audit row should document resolve-models + dual-dispatch
+# Scope to Dispatch Routing Table section (lines 46-64)
+# Pattern: "resolve-models" in the adversarial-audit row (line 60)
+DISPATCH_TABLE=$(sed -n '46,64p' "$SKILL_FILE")
+if echo "$DISPATCH_TABLE" | grep -qi "resolve.m*models\|resolve-models"; then
+    echo "PASS: adversarial-audit row in Dispatch Routing Table documents resolve-models"
+else
+    echo "FAIL: adversarial-audit row in Dispatch Routing Table does NOT document resolve-models (expected RED — change not yet made)"
+    OVERALL_RESULT=1
+fi
+
+# Also check for dual-dispatch or multi-dispatch pattern in the dispatch table
+if echo "$DISPATCH_TABLE" | grep -q "dispatch.*auditor_1\|dispatch.*auditor_2\|dual.*dispatch\|multi.*dispatch"; then
+    echo "PASS: adversarial-audit row in Dispatch Routing Table documents dual/multi-dispatch"
+else
+    echo "FAIL: adversarial-audit row in Dispatch Routing Table does NOT document dual/multi-dispatch (expected RED — change not yet made)"
+    OVERALL_RESULT=1
+fi
+
+echo ""
+if [ "$OVERALL_RESULT" -eq 0 ]; then
+    echo "PASS: $SCENARIO_NAME"
+else
+    echo "FAIL: $SCENARIO_NAME (RED phase — expected to fail until GREEN implementation)"
+fi
+
+exit $OVERALL_RESULT

--- a/tests/behaviors/1246-sc2-cross-validate-artifact-paths.sh
+++ b/tests/behaviors/1246-sc2-cross-validate-artifact-paths.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# Behavioral test: 1246-sc2-cross-validate-artifact-paths
+# See .opencode/tests/AGENTS.md for the test harness specification and paradigm.
+# This script is an artifact-only generator — it does NOT evaluate model output.
+# SC-2 (string): cross-validate row documents receiving auditor_artifact_paths
+# from the adversarial-audit step.
+#
+# RED phase: greps for the NEW text pattern — should FAIL because old text is still there.
+#
+# Co-authored with AI: OpenCode (deepseek-v4-flash)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/helpers.sh"
+
+SCENARIO_NAME="1246-sc2-cross-validate-artifact-paths"
+SKILL_FILE="$SCRIPT_DIR/../../skills/implementation-pipeline/SKILL.md"
+
+echo "=== Content-Verification Test: $SCENARIO_NAME ==="
+echo "Checking for auditor_artifact_paths in cross-validate row of $SKILL_FILE"
+echo ""
+
+OVERALL_RESULT=0
+
+# SC-2: The cross-validate row should document receiving auditor_artifact_paths
+if grep -q "auditor_artifact_paths" "$SKILL_FILE" 2>/dev/null; then
+    echo "PASS: cross-validate row documents auditor_artifact_paths"
+else
+    echo "FAIL: cross-validate row does NOT document auditor_artifact_paths (expected RED — change not yet made)"
+    OVERALL_RESULT=1
+fi
+
+echo ""
+if [ "$OVERALL_RESULT" -eq 0 ]; then
+    echo "PASS: $SCENARIO_NAME"
+else
+    echo "FAIL: $SCENARIO_NAME (RED phase — expected to fail until GREEN implementation)"
+fi
+
+exit $OVERALL_RESULT

--- a/tests/behaviors/1246-sc3-resolve-models-preflight.sh
+++ b/tests/behaviors/1246-sc3-resolve-models-preflight.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# Behavioral test: 1246-sc3-resolve-models-preflight
+# See .opencode/tests/AGENTS.md for the test harness specification and paradigm.
+# This script is an artifact-only generator — it does NOT evaluate model output.
+# SC-3 (behavioral): Orchestrator runs resolve-models before dispatching auditors
+# SC-4 (behavioral): Orchestrator dispatches verification-audit with cross-family subagent_types (not general)
+# SC-5 (behavioral): Orchestrator dispatches two verification-audit sub-agents, not one
+#
+# Artifact-only generator: produces model-run artifacts for clean-room evaluation.
+#
+# Co-authored with AI: OpenCode (deepseek-v4-flash)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/helpers.sh"
+
+SCENARIO_NAME="1246-sc3-resolve-models-preflight"
+
+echo "=== Behavioral Test (Artifact-Only Generator): $SCENARIO_NAME ==="
+echo ""
+
+# Prompt: ask the agent to execute the adversarial-audit pipeline step
+# Include issue number context so the agent doesn't halt asking for clarification
+SCENARIO_PROMPT="Execute the adversarial-audit step from the implementation-pipeline for issue #1246. First run .opencode/tools/resolve-models to select two cross-family auditors, then dispatch verification-audit with subagent_type=auditor_1 and subagent_type=auditor_2. Use the implementation-pipeline SKILL.md dispatch routing table as your guide."
+
+behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT"
+
+echo ""
+echo "Artifacts produced at: $BEHAVIOR_ARTIFACT_DIR"
+echo ""
+
+exit 0

--- a/tests/behaviors/1246-sc6-step-labels.sh
+++ b/tests/behaviors/1246-sc6-step-labels.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# Behavioral test: 1246-sc6-step-labels
+# See .opencode/tests/AGENTS.md for the test harness specification and paradigm.
+# This script is an artifact-only generator — it does NOT evaluate model output.
+# SC-6 (string): Step Labels section includes resolve-models or references
+# the multi-dispatch pattern.
+#
+# RED phase: greps for the NEW text pattern — should FAIL because old text is still there.
+#
+# Co-authored with AI: OpenCode (deepseek-v4-flash)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/helpers.sh"
+
+SCENARIO_NAME="1246-sc6-step-labels"
+SKILL_FILE="$SCRIPT_DIR/../../skills/implementation-pipeline/SKILL.md"
+
+echo "=== Content-Verification Test: $SCENARIO_NAME ==="
+echo "Checking for resolve-models in Step Labels section of $SKILL_FILE"
+echo ""
+
+OVERALL_RESULT=0
+
+# SC-6: Step Labels section should include resolve-models as a standalone label
+# Scope to Step Labels section (lines 82-84)
+STEP_LABELS=$(sed -n '82,84p' "$SKILL_FILE")
+if echo "$STEP_LABELS" | grep -q "resolve-models"; then
+    echo "PASS: Step Labels section includes resolve-models as a standalone label"
+else
+    echo "FAIL: Step Labels section does NOT include resolve-models (expected RED — change not yet made)"
+    OVERALL_RESULT=1
+fi
+
+echo ""
+if [ "$OVERALL_RESULT" -eq 0 ]; then
+    echo "PASS: $SCENARIO_NAME"
+else
+    echo "FAIL: $SCENARIO_NAME (RED phase — expected to fail until GREEN implementation)"
+fi
+
+exit $OVERALL_RESULT


### PR DESCRIPTION
## Summary

Fixes the `adversarial-audit` dispatch routing in `implementation-pipeline/SKILL.md` to document the correct multi-dispatch sequence (resolve-models → dual auditor dispatch → remediation loop-back → cross-validate with artifact paths). Adds behavioral and content-verification enforcement tests for all 6 SCs.

## Changes

- Dispatch Routing Table — `adversarial-audit` row now documents `Resolve models → dispatch auditor_1 → dispatch auditor_2` instead of a single `--task verification-audit` call
- Cross-validate row — Documents receiving `auditor_artifact_paths` from the adversarial-audit step
- Multi-dispatch note — Added after the routing table explaining the 5-step sequence with remediation loop-back: non-clean-pass from either auditor restarts from resolve-models
- Step Labels — `resolve-models` added as a standalone step label
- Enforcement tests — 4 new test files (3 content-verification, 1 behavioral artifact generator)

## Fixes

Fixes #1246

---

🤖 Co-authored with AI: OpenCode (deepseek-v4-flash)