### PR TITLE
fix(#201): remove unconditional per-turn diagnostic from session-enforcement.ts

### DIFF
--- a/plugins/session-enforcement.ts
+++ b/plugins/session-enforcement.ts
@@ -1005,18 +1005,14 @@ export default async function sessionEnforcementPlugin(input: PluginInput): Prom
         // REQ-4: Graceful degradation — if sessionID is unavailable, assume
         // primary session (isSubAgent = false) so full injections are applied.
         const sessionID = firstUser?.info?.sessionID;
-        let detectionSource = "none";
         let isSubAgent = false;
         if (sessionID) {
           if (sessionParentCache.has(sessionID)) {
             isSubAgent = true;
-            detectionSource = "event-cache";
           } else if (subAgentSessions.has(sessionID)) {
             isSubAgent = true;
-            detectionSource = "api-fallback";
           }
         }
-        console.error(`[session-enforcement-diag] isSubAgent=${isSubAgent} detectionSource=${detectionSource} sessionID=${sessionID}`);
 
         // --- First-turn-only PRIMARY sessions: Skip all first-turn injections
         //     for sub-agent sessions (isFirstTurn && !isSubAgent required) ---


### PR DESCRIPTION
## Summary

- Removes `console.error` diagnostic that printed `[session-enforcement-diag]` on every session turn
- Removes now-unused `detectionSource` variable
- Sub-agent detection logic (`isSubAgent` boolean) is unchanged

## Fixes

michael-conrad/opencode-config#201

🤖 Co-authored with AI: OpenCode (deepseek-v4-flash)