### PR TITLE
fix(#1275): replace defective check-pr Phase 3 with live-verify, interdependency scan, supersession check

### DIFF
--- a/skills/git-workflow/tasks/check-pr.md
+++ b/skills/git-workflow/tasks/check-pr.md
@@ -37,9 +37,62 @@ Execute a 6-phase serial chain to scan for merged PRs, verify each merge, close 
 
 ## Phase 3: Close Linked Issues
 
-- [ ] Search open issues: for each merged PR, query the platform's issue tracker for open issues referencing the PR number or commit SHAs (via PR body, comments, commit messages, or linked PR references)
-- [ ] Check sub-issues, siblings, parents, and cross-repo issues for closure eligibility
-- [ ] Close depth-first: sub-repos first, children before parents, cross-repo
+**RULE:** Every issue reference MUST be live-verified before closure. Metadata (PR body text, commit messages, artifact content) is NOT evidence of completion — only live API state is. Closing an issue based on PR body text without live-verification IS closing on metadata alone — metadata is not evidence.
+
+**RULE:** An issue that is not 100% completed but appears it should have been MUST be reported to the developer, not closed.
+
+**RULE:** Supersession check searches for issues that the candidate supersedes, NOT issues that supersede the candidate.
+
+### Step 3.1: Extract Issue References from PR Body
+
+- [ ] For each merged PR, read the PR body via `github_pull_request_read(method=get)` and extract ALL `#N` references
+- [ ] Do NOT assume `Fixes`/`Closes`/`Implements` prefixes — any `#N` in the body is a candidate
+- [ ] Collect into a candidate list per PR
+
+### Step 3.2: Extract Issue References from Commit Messages
+
+- [ ] For each merged PR, read all commits via `github_pull_request_read(method=get_commits)`
+- [ ] For each commit, extract ALL `#N` references from the commit message
+- [ ] Add to the candidate list
+
+### Step 3.3: Extract Issue References from Verification/Audit Artifacts
+
+- [ ] Search `./tmp/`, `./issues/`, and `./*/.issues/` for verification and audit artifacts (YAML files, log files, evidence files) that map success criteria to issue numbers
+- [ ] Extract any issue references found
+- [ ] Add to the candidate list
+
+### Step 3.4: Deduplicate Candidate List
+
+- [ ] Merge all candidate lists across all merged PRs
+- [ ] Deduplicate by issue number — the result is the full set of issues potentially affected by the merged work
+
+### Step 3.5: Live-Verify Each Candidate Issue
+
+- [ ] For each candidate issue, perform a live API call (`github_issue_read(method=get)`) to read: state, body, all comments, labels, sub-issues, parent issue
+- [ ] Determine if the issue is truly completed:
+  - Issue body or comments indicate completion AND issue is still open → eligible for closure
+  - Issue is not 100% completed but appears it should have been (referenced in merged PR body but still open with no pending work) → **alert the developer**, do NOT close
+  - Issue is already closed → skip
+
+### Step 3.6: Cross-Cutting Interdependency Scan
+
+- [ ] For each directly referenced issue, find indirectly related issues:
+  - **Sub-issues**: Check each sub-issue's state — sub-issues of a completed parent may also be completable
+  - **Siblings**: If the issue is a sub-issue of a parent, check sibling sub-issues — siblings from the same plan may also be completable
+  - **Parent**: If the issue is a sub-issue and all siblings are complete, the parent may be closable
+  - **Shared concern**: Search for other open issues sharing affected files, symbols, or concern boundaries with the merged PR's changes — these may have been implicitly resolved
+- [ ] Add any found indirectly-related issues to the candidate list and live-verify per Step 3.5
+
+### Step 3.7: Supersession Check
+
+- [ ] For each candidate issue that appears completed, check if the issue itself supersedes other issues
+- [ ] Check issue body and comments for supersession language (e.g., "Supersedes #N", "Replaces #N")
+- [ ] For each superseded issue found, add to the candidate list and live-verify per Step 3.5
+- [ ] Do NOT check for issues that supersede the candidate — that is a pre-implementation concern, not a cleanup concern
+
+### Step 3.8: Close Eligible Issues Depth-First
+
+- [ ] Close eligible issues in depth-first order: sub-repos first, then parent repo. Children before parents. Cross-repo issues handled per their repo.
 - [ ] Close silently — no comment churn unless substantively necessary
 
 ## Phase 4: Submodule Branch Cleanup


### PR DESCRIPTION
## Summary

Replaces the defective single-step Phase 3 in `check-pr.md` with an 8-step procedure that:

1. Extracts `#N` references from PR bodies (no Fixes/Closes prefix assumption)
2. Extracts `#N` references from commit messages
3. Extracts issue references from verification/audit artifacts in `./tmp/`, `./issues/`, `./*/.issues/`
4. Deduplicates the candidate list
5. Live-verifies each candidate via API before closure
6. Cross-cutting interdependency scan (sub-issues, siblings, parent, shared concern)
7. Supersession check (issues the candidate supersedes, not vice versa)
8. Closes eligible issues depth-first

## Bright-Line Rules Added

- Every issue reference MUST be live-verified before closure — metadata is not evidence
- Incompleted issues that appear they should have been completed are reported to developer, not closed
- Supersession check searches for issues the candidate supersedes, not vice versa

## Changes

| File | Change |
|------|--------|
| `skills/git-workflow/tasks/check-pr.md` | Phase 3: 1 step → 8 steps with bright-line rules |

Fixes #1275

🤖 Co-authored with AI: OpenCode (deepseek-v4-flash)