### PR TITLE
fix: replace stale GitHub Issue plan references with local .issues/{N}/plan.md

### DIFF
--- a/guidelines/140-planning-spec-creation.md
+++ b/guidelines/140-planning-spec-creation.md
@@ -11,7 +11,7 @@ load_when: sub-agent
 AI agents MUST follow the **Spec-Driven Development** (Gated Workflow) approach with the **Plan-Bridge Hierarchy**:
 
 1. **Specify Phase**: Define **What & Why**. Kick off with a high-level vision (product brief), then expand it into a detailed specification focusing on user journeys, experiences, and success criteria.
-2. **Plan Phase** (Bridge): Define **How**. Create a local plan file at `*/.issues/{N}/plan.md` that references the spec via body linked reference. The plan bridges spec → tasks. **Spec approval authorizes plan creation; plan approval authorizes implementation.**
+2. **Plan Phase** (Bridge): Define **How**. Create a local plan file at `.issues/{N}/plan.md` or `*/.issues/{N}/plan.md` that references the spec via body linked reference. The plan bridges spec → tasks. **Spec approval authorizes plan creation; plan approval authorizes implementation.**
 3. **Tasks Phase**: Break the plan into **small, reviewable chunks** (sub-issues under the plan, not the spec) that can be implemented and tested in isolation.
 4. **Implement Phase**: **Execute** tasks and **verify** results.
 
@@ -33,10 +33,10 @@ ______________________________________________________________________
 ## Terminology: Spec vs. Plan vs. Guideline Files
 
 - **"Create a new spec"** = Create a GitHub Issue with `[SPEC]` prefix (Mandatory when GitHub MCP available)
-- **"Create a plan"** = Create a local plan file at `*/.issues/{N}/plan.md`, referencing the spec via body linked reference
+- **"Create a plan"** = Create a local plan file at `.issues/{N}/plan.md` or `*/.issues/{N}/plan.md`, referencing the spec via body linked reference
 - **"Create a guideline file"** = Create/modify files in `.opencode/guidelines/` (Implementation task)
 - **SPEC = GitHub Issue** — Specs are planning/tracking artifacts, not file system artifacts
-- **PLAN = local file** — Plans are local artifacts at `*/.issues/{N}/plan.md` that bridge specs to implementation sub-issues; sub-issues are children of the plan's spec issue, not the spec itself
+- **PLAN = local file** — Plans are local artifacts at `.issues/{N}/plan.md` or `*/.issues/{N}/plan.md` that bridge specs to implementation sub-issues; sub-issues are children of the plan's spec issue, not the spec itself
 
 ______________________________________________________________________
 

--- a/guidelines/140-planning-spec-creation.md
+++ b/guidelines/140-planning-spec-creation.md
@@ -11,7 +11,7 @@ load_when: sub-agent
 AI agents MUST follow the **Spec-Driven Development** (Gated Workflow) approach with the **Plan-Bridge Hierarchy**:
 
 1. **Specify Phase**: Define **What & Why**. Kick off with a high-level vision (product brief), then expand it into a detailed specification focusing on user journeys, experiences, and success criteria.
-2. **Plan Phase** (Bridge): Define **How**. Create a plan issue (`[PLAN]` prefix, `plan` label) that references the spec via body linked reference. The plan bridges spec → tasks. **Spec approval authorizes plan creation; plan approval authorizes implementation.**
+2. **Plan Phase** (Bridge): Define **How**. Create a local plan file at `*/.issues/{N}/plan.md` that references the spec via body linked reference. The plan bridges spec → tasks. **Spec approval authorizes plan creation; plan approval authorizes implementation.**
 3. **Tasks Phase**: Break the plan into **small, reviewable chunks** (sub-issues under the plan, not the spec) that can be implemented and tested in isolation.
 4. **Implement Phase**: **Execute** tasks and **verify** results.
 
@@ -33,10 +33,10 @@ ______________________________________________________________________
 ## Terminology: Spec vs. Plan vs. Guideline Files
 
 - **"Create a new spec"** = Create a GitHub Issue with `[SPEC]` prefix (Mandatory when GitHub MCP available)
-- **"Create a plan"** = Create a GitHub Issue with `[PLAN]` prefix and `plan` label, referencing the spec via body linked reference
+- **"Create a plan"** = Create a local plan file at `*/.issues/{N}/plan.md`, referencing the spec via body linked reference
 - **"Create a guideline file"** = Create/modify files in `.opencode/guidelines/` (Implementation task)
 - **SPEC = GitHub Issue** — Specs are planning/tracking artifacts, not file system artifacts
-- **PLAN = GitHub Issue** — Plans are separate issues that bridge specs to implementation sub-issues; sub-issues are children of the plan, not the spec
+- **PLAN = local file** — Plans are local artifacts at `*/.issues/{N}/plan.md` that bridge specs to implementation sub-issues; sub-issues are children of the plan's spec issue, not the spec itself
 
 ______________________________________________________________________
 

--- a/skills/approval-gate/tasks/reconcile-issue-graph.md
+++ b/skills/approval-gate/tasks/reconcile-issue-graph.md
@@ -38,10 +38,10 @@ For each finding from the traversal list, classify into one of six categories:
 
 For each sub-issue finding in the traversal list:
 
-- [ ] 1. **Identify the parent plan** — call `issue-operations -> read-sub-issues (github_issue_read(method=get_sub_issues, owner=<github.owner>, repo=<github.repo>, issue_number=<N>)` on each finding's parent to confirm the plan relationship. Record the parent plan issue number. <!-- Routes through issue-operations per SPEC #683 -->
-- [ ] 2. **Read the parent plan body** — call `issue-operations -> read-issue (github_issue_read(method=get, owner=<github.owner>, repo=<github.repo>, issue_number=<plan_N>)` and extract the spec reference using the pattern `Spec: #N`. <!-- Routes through issue-operations per SPEC #683 -->
-- [ ] 3. **Search for other plans referencing the same spec** — call `issue-operations -> search-issues (github_search_issues(query="label:plan \"Spec: #<spec_N>\" in:body repo:<github.owner>/<github.repo>", owner=<github.owner>, repo=<github.repo>)`. Collect all plan issue numbers returned. <!-- Routes through issue-operations per SPEC #683 -->
-- [ ] 4. **Compare plan scopes for overlap** — for each additional plan found, call `issue-operations -> read-issue (github_issue_read(method=get)` to read its body. Extract phase titles and compare with the current plan's phases. Record overlapping phase titles. <!-- Routes through issue-operations per SPEC #683 -->
+- [ ] 1. **Identify the parent plan** — read the local plan file at `*/.issues/{N}/plan.md` to confirm the plan relationship. Record the parent plan number. Plans are local artifacts, not GitHub Issues.
+- [ ] 2. **Read the parent plan body** — read the local plan file at `*/.issues/{plan_N}/plan.md` and extract the spec reference using the pattern `Spec: #N`.
+- [ ] 3. **Search for other plans referencing the same spec** — glob `*/.issues/*/plan.md` and grep for `"Spec: #<spec_N>"` in each file. Collect all plan numbers found.
+- [ ] 4. **Compare plan scopes for overlap** — for each additional plan found, read its local plan file. Extract phase titles and compare with the current plan's phases. Record overlapping phase titles.
 - [ ] 5. **If overlap exists**: Add a finding to the `uncertain` classification with reason `"duplicate plan track — requires dev action to determine which plan owns deliverables"`. Record: spec number, all plan numbers referencing that spec, and the overlapping phase titles.
 
 ### Step 2: Verify Auto-Close Candidates
@@ -157,7 +157,7 @@ Every action MUST produce a live tool-call artifact:
 | Uncertain | Conflicting tool-call results that prevent confident classification |
 | Evidence gate | `read`/`grep`/`srclight_get_symbol` output for auto-close candidates (mandatory — candidates without artifacts reclassified as `uncertain`) |
 | Comment conflict scan | `issue-operations -> read-comments (github_issue_read(method=get_comments)` output confirming no contradicting comments within 24-hour window | <!-- Routes through issue-operations per SPEC #683 -->
-| Cross-reference check | `issue-operations -> search-issues (github_search_issues` output showing plans referencing the same spec + `github_issue_read` output confirming scope overlap | <!-- Routes through issue-operations per SPEC #683 -->
+| Cross-reference check | `glob */.issues/*/plan.md` + grep for `Spec: #N` showing plans referencing the same spec + local file read confirming scope overlap |
 
 ## Context Required
 

--- a/skills/approval-gate/tasks/reconcile-issue-graph.md
+++ b/skills/approval-gate/tasks/reconcile-issue-graph.md
@@ -38,9 +38,9 @@ For each finding from the traversal list, classify into one of six categories:
 
 For each sub-issue finding in the traversal list:
 
-- [ ] 1. **Identify the parent plan** — read the local plan file at `*/.issues/{N}/plan.md` to confirm the plan relationship. Record the parent plan number. Plans are local artifacts, not GitHub Issues.
-- [ ] 2. **Read the parent plan body** — read the local plan file at `*/.issues/{plan_N}/plan.md` and extract the spec reference using the pattern `Spec: #N`.
-- [ ] 3. **Search for other plans referencing the same spec** — glob `*/.issues/*/plan.md` and grep for `"Spec: #<spec_N>"` in each file. Collect all plan numbers found.
+- [ ] 1. **Identify the parent plan** — read the local plan file at `.issues/{N}/plan.md` or `*/.issues/{N}/plan.md` to confirm the plan relationship. Record the parent plan number. Plans are local artifacts, not GitHub Issues.
+- [ ] 2. **Read the parent plan body** — read the local plan file at `.issues/{plan_N}/plan.md` or `*/.issues/{plan_N}/plan.md` and extract the spec reference using the pattern `Spec: #N`.
+- [ ] 3. **Search for other plans referencing the same spec** — glob `.issues/*/plan.md` and `*/.issues/*/plan.md`, grep for `"Spec: #<spec_N>"` in each file. Collect all plan numbers found.
 - [ ] 4. **Compare plan scopes for overlap** — for each additional plan found, read its local plan file. Extract phase titles and compare with the current plan's phases. Record overlapping phase titles.
 - [ ] 5. **If overlap exists**: Add a finding to the `uncertain` classification with reason `"duplicate plan track — requires dev action to determine which plan owns deliverables"`. Record: spec number, all plan numbers referencing that spec, and the overlapping phase titles.
 
@@ -157,7 +157,7 @@ Every action MUST produce a live tool-call artifact:
 | Uncertain | Conflicting tool-call results that prevent confident classification |
 | Evidence gate | `read`/`grep`/`srclight_get_symbol` output for auto-close candidates (mandatory — candidates without artifacts reclassified as `uncertain`) |
 | Comment conflict scan | `issue-operations -> read-comments (github_issue_read(method=get_comments)` output confirming no contradicting comments within 24-hour window | <!-- Routes through issue-operations per SPEC #683 -->
-| Cross-reference check | `glob */.issues/*/plan.md` + grep for `Spec: #N` showing plans referencing the same spec + local file read confirming scope overlap |
+| Cross-reference check | `glob .issues/*/plan.md */.issues/*/plan.md` + grep for `Spec: #N` showing plans referencing the same spec + local file read confirming scope overlap |
 
 ## Context Required
 

--- a/skills/approval-gate/tasks/verify-already-implemented.md
+++ b/skills/approval-gate/tasks/verify-already-implemented.md
@@ -115,23 +115,23 @@ When ALL success criteria are verified as already met:
 
 ### Step 6: Parent Plan Closure Check
 
-After autoclosing the current issue (Step 5), check if the parent plan issue should also be closed:
+After autoclosing the current issue (Step 5), check if the parent plan's sub-issues are all complete:
 
-- [ ] 1. **Determine parent issue context:**
-   - If this issue is a sub-issue of a plan, retrieve the parent plan issue via `issue-operations -> read-sub-issues (github_issue_read(method="get_sub_issues")` on the plan <!-- Routes through issue-operations per SPEC #683 -->
+- [ ] 1. **Determine parent plan context:**
+   - If this issue is a sub-issue of a plan, identify the plan number from the sub-issue relationship
    - If this issue references a plan via body text (`Plan: #N`), use that reference
    - If no parent plan exists, Skip Step 6 — this is a standalone issue
 
 - [ ] 2. **Check if ALL sub-issues of the plan are closed:**
    - Use `issue-operations -> read-sub-issues (github_issue_read(method="get_sub_issues", issue_number=<plan_number>)` to list all sub-issues <!-- Routes through issue-operations per SPEC #683 -->
    - Verify each sub-issue has `state == "closed"` with `state_reason == "completed"` (not `"not_planned"` or `"duplicate"` without merged PR evidence)
-   - If ANY sub-issue is still open or closed without legitimate completion evidence → do NOT close the parent plan
+   - If ANY sub-issue is still open or closed without legitimate completion evidence → do NOT close the parent spec
 
 - [ ] 3. **If ALL sub-issues are legitimately closed:**
-   - Close the parent plan issue with `issue-operations -> update-issue (github_issue_write(method="update", state="closed", state_reason="completed")` <!-- Routes through issue-operations per SPEC #683 -->
-   - Route verification results through `issue-operations -> comment` substantive gate. Gate decides whether to post to the plan issue.
+   - Plans are local artifacts — no GitHub Issue closure needed. The plan file remains as a record.
+   - Route verification results through `issue-operations -> comment` substantive gate. Gate decides whether to post to the parent spec issue.
      ```
-     All sub-issues verified complete. Closing parent plan.
+     All sub-issues verified complete.
 
      Sub-issue closure evidence:
      - #<N1>: Verified via [merged PR / already-implemented autoclose] — <brief evidence>

--- a/skills/approval-gate/tasks/verify-authorization/auto-dispatch.md
+++ b/skills/approval-gate/tasks/verify-authorization/auto-dispatch.md
@@ -36,7 +36,7 @@ authorization_source: "User approved #N on YYYY-MM-DD"
 | Approval Context | How to Detect | Auto-Dispatch Target |
 | -- | -- | -- |
 | **Spec approval** | Issue title contains `[SPEC` or has `spec` label | `writing-plans --task create` (or `brainstorming --task explore` if gap-fill) |
-| **Plan approval** | Local plan file exists at `*/.issues/{N}/plan.md` | `executing-plans --task start` |
+| **Plan approval** | Local plan file exists at `.issues/{N}/plan.md` or `*/.issues/{N}/plan.md` | `executing-plans --task start` |
 | **Already implemented** | Step 5d.4 (`verify-already-implemented`) returns positive | No dispatch — auto-close instead (execution path: Step 0 of auto-route procedure) |
 | **Reconciled during verification** | reconcile-issue-graph returned auto-closed or reopened tickets | Include reconciled tickets in chat output; proceed with dispatch |
 | **Closed but NOT verified** | Step 5.4 closed-issue verification finds closure without merged PR evidence | flag-for-review — do NOT autoclose |
@@ -71,7 +71,7 @@ When `authorization_scope == "for_analysis"`:
 1. Determine approval context (spec vs plan) by checking:
    - Issue title format: `[SPEC` prefix = spec approval
    - Labels: presence of `spec` label
-   - Plan detection is via local file existence at `*/.issues/{N}/plan.md` (NOT via GitHub Issue labels or title prefixes)
+   - Plan detection is via local file existence at `.issues/{N}/plan.md` or `*/.issues/{N}/plan.md` (NOT via GitHub Issue labels or title prefixes)
 2. Determine scope from Step 2.0 result (`authorization_scope`, `halt_at`, `pr_strategy`)
 3. Execute gap-fill from Step 5c if scope >= `for_plan`
 5. **If spec approval:** Invoke `writing-plans --task create` with context:
@@ -94,7 +94,7 @@ If a spec is revised (status contains `REVISED - NEEDS APPROVAL` — in either p
 Prose format: `STATUS: in progress — {concern} (REVISED - NEEDS APPROVAL)`
 Numeric format: `STATUS: 1.1 (REVISED - NEEDS APPROVAL)`
 
-1. Check for local plan files at `*/.issues/{N}/plan.md` that reference the spec number
+1. Check for local plan files at `.issues/{N}/plan.md` or `*/.issues/{N}/plan.md` that reference the spec number
 2. Mark found plans for audit (their authorization is revoked by the spec revision)
 3. Report affected plans in chat output
 

--- a/skills/approval-gate/tasks/verify-authorization/auto-dispatch.md
+++ b/skills/approval-gate/tasks/verify-authorization/auto-dispatch.md
@@ -36,7 +36,7 @@ authorization_source: "User approved #N on YYYY-MM-DD"
 | Approval Context | How to Detect | Auto-Dispatch Target |
 | -- | -- | -- |
 | **Spec approval** | Issue title contains `[SPEC` or has `spec` label | `writing-plans --task create` (or `brainstorming --task explore` if gap-fill) |
-| **Plan approval** | Issue has `plan` label or `[PLAN]` prefix in title | `executing-plans --task start` |
+| **Plan approval** | Local plan file exists at `*/.issues/{N}/plan.md` | `executing-plans --task start` |
 | **Already implemented** | Step 5d.4 (`verify-already-implemented`) returns positive | No dispatch — auto-close instead (execution path: Step 0 of auto-route procedure) |
 | **Reconciled during verification** | reconcile-issue-graph returned auto-closed or reopened tickets | Include reconciled tickets in chat output; proceed with dispatch |
 | **Closed but NOT verified** | Step 5.4 closed-issue verification finds closure without merged PR evidence | flag-for-review — do NOT autoclose |
@@ -70,9 +70,8 @@ When `authorization_scope == "for_analysis"`:
 
 1. Determine approval context (spec vs plan) by checking:
    - Issue title format: `[SPEC` prefix = spec approval
-   - Issue title format: `[PLAN]` prefix = plan approval
-   - Labels: presence of `spec` or `plan` labels
-   - Plan detection is via `plan` label or `[PLAN]` prefix in title (NOT via sub-issue relationship to spec)
+   - Labels: presence of `spec` label
+   - Plan detection is via local file existence at `*/.issues/{N}/plan.md` (NOT via GitHub Issue labels or title prefixes)
 2. Determine scope from Step 2.0 result (`authorization_scope`, `halt_at`, `pr_strategy`)
 3. Execute gap-fill from Step 5c if scope >= `for_plan`
 5. **If spec approval:** Invoke `writing-plans --task create` with context:
@@ -95,7 +94,7 @@ If a spec is revised (status contains `REVISED - NEEDS APPROVAL` — in either p
 Prose format: `STATUS: in progress — {concern} (REVISED - NEEDS APPROVAL)`
 Numeric format: `STATUS: 1.1 (REVISED - NEEDS APPROVAL)`
 
-1. Search for `[PLAN]` issues that reference the spec number in their body
+1. Check for local plan files at `*/.issues/{N}/plan.md` that reference the spec number
 2. Mark found plans for audit (their authorization is revoked by the spec revision)
 3. Report affected plans in chat output
 

--- a/skills/approval-gate/tasks/verify-authorization/gap-fill-cascade.md
+++ b/skills/approval-gate/tasks/verify-authorization/gap-fill-cascade.md
@@ -58,7 +58,7 @@ def execute_gap_fill(scope, issue_number, issue_labels, issue_title):
     if "auto_create_plan" in actions:
         # Check if plan already exists as local file
         plan_paths = [f".issues/{issue_number}/plan.md", f"*/.issues/{issue_number}/plan.md"]
-        plan_exists = any(os.path.exists(p.replace("*", ".opencode")) for p in plan_paths)
+        plan_exists = any(glob.glob(p) for p in plan_paths)
         if not plan_exists:
             # Invoke writing-plans --task create to create plan
             results.append({"action": "auto_create_plan", "status": "dispatched", "target": "writing-plans"})

--- a/skills/approval-gate/tasks/verify-authorization/gap-fill-cascade.md
+++ b/skills/approval-gate/tasks/verify-authorization/gap-fill-cascade.md
@@ -56,9 +56,10 @@ def execute_gap_fill(scope, issue_number, issue_labels, issue_title):
             results.append({"action": "auto_create_spec", "status": "skipped", "reason": "spec_exists"})
 
     if "auto_create_plan" in actions:
-        # Check if plan already exists
-        is_plan = "plan" in [l["name"] for l in issue_labels] or issue_title.startswith("[PLAN]")
-        if not is_plan:
+        # Check if plan already exists as local file
+        plan_paths = [f".issues/{issue_number}/plan.md", f"*/.issues/{issue_number}/plan.md"]
+        plan_exists = any(os.path.exists(p.replace("*", ".opencode")) for p in plan_paths)
+        if not plan_exists:
             # Invoke writing-plans --task create to create plan
             results.append({"action": "auto_create_plan", "status": "dispatched", "target": "writing-plans"})
         else:

--- a/skills/approval-gate/tasks/verify-authorization/item-decomposition-check.md
+++ b/skills/approval-gate/tasks/verify-authorization/item-decomposition-check.md
@@ -14,8 +14,9 @@ Before implementation proceeds, verify that the plan includes item-level decompo
 ## Procedure
 
 ```
-plan_issue = issue-operations -> read-issue (github_issue_read(method="get", issue_number=plan_number) <!-- Routes through issue-operations per SPEC #683 -->
-plan_body = plan_issue["body"]
+# Read plan from local file (plans are local artifacts, not GitHub Issues)
+plan_paths = [f".issues/{plan_number}/plan.md", f"*/.issues/{plan_number}/plan.md"]
+plan_body = read_local_plan_file(plan_paths)
 
 # Check for item enumeration
 has_items = "Item" in plan_body and ("Dependencies" in plan_body or "Acceptance Criteria" in plan_body)

--- a/skills/approval-gate/tasks/verify-authorization/spec-to-plan-cascade.md
+++ b/skills/approval-gate/tasks/verify-authorization/spec-to-plan-cascade.md
@@ -22,7 +22,7 @@ if not is_spec:
 
 # Search for local plan files referencing this spec
 spec_number = issue["number"]
-plan_files = glob_plan_files_for_spec(spec_number)  # Searches */.issues/*/plan.md for "Spec: #N"
+plan_files = glob_plan_files_for_spec(spec_number)  # Searches .issues/*/plan.md and */.issues/*/plan.md for "Spec: #N"
 ```
 
 ## 5b.2 Process Cascade Approval
@@ -69,7 +69,7 @@ elif not plan_files:
 | No plan exists | Cascade does NOT apply; current flow (spec approval → writing-plans) is correct |
 | Plan already approved (no `needs-approval` label) | No action needed — plan is already approved |
 
-**Evidence artifact:** `glob */.issues/*/plan.md` + grep for `Spec: #N` showing plan files referencing the spec. Plans are local artifacts — no GitHub Issue mutation needed.
+**Evidence artifact:** `glob .issues/*/plan.md */.issues/*/plan.md` + grep for `Spec: #N` showing plan files referencing the spec. Plans are local artifacts — no GitHub Issue mutation needed.
 
 ## Work State I/O
 

--- a/skills/approval-gate/tasks/verify-authorization/spec-to-plan-cascade.md
+++ b/skills/approval-gate/tasks/verify-authorization/spec-to-plan-cascade.md
@@ -20,58 +20,31 @@ if not is_spec:
     # Skip cascade — only applies to spec approvals
     proceed to Step 6
 
-# Search for plans referencing this spec
+# Search for local plan files referencing this spec
 spec_number = issue["number"]
-plan_issues = issue-operations -> search-issues (github_search_issues( <!-- Routes through issue-operations per SPEC #683 -->
-    query=f"open label:plan Spec: #{spec_number} repo:{<github.owner>}/{<github.repo>}"
-)
+plan_files = glob_plan_files_for_spec(spec_number)  # Searches */.issues/*/plan.md for "Spec: #N"
 ```
 
 ## 5b.2 Process Cascade Approval
 
-If one or more plans reference the approved spec:
+If one or more plan files reference the approved spec:
 
 ```python
-if plan_issues:
-    # Multiple plans: approve the most recent, supersede the rest
-    if len(plan_issues) > 1:
-        # Sort by creation date, most recent first
-        plan_issues.sort(key=lambda p: p["created_at"], reverse=True)
-        most_recent = plan_issues[0]
-        older_plans = plan_issues[1:]
+if plan_files:
+    # Plans are local artifacts — cascade approval means the plan is considered approved
+    # No GitHub Issue labels or comments needed (plans are not GitHub Issues)
+    most_recent = plan_files[-1]  # Most recent by file modification time
+    older_plans = plan_files[:-1]
 
-        # Cascade-approve the most recent plan
-        issue-operations -> creation/update (github_issue_write( <!-- Routes through issue-operations per SPEC #683 -->
-            method="update",
-            issue_number=most_recent["number"],
-            labels=[l for l in most_recent["labels"] if l != "needs-approval"],
-        )
-        issue-operations -> comment (github_add_issue_comment( <!-- Routes through issue-operations per SPEC #683 -->
-            issue_number=most_recent["number"],
-            body="Approval cascaded from spec #{spec_number}. Plan approved automatically because spec is already approved and this is the most recent plan referencing it.",
-        )
+    # Cascade-approve the most recent plan
+    # (No GitHub Issue mutation — plans are local files)
+    log_cascade(spec_number, most_recent)
 
-        # Supersede older plans
-        for old_plan in older_plans:
-            issue-operations -> comment (github_add_issue_comment( <!-- Routes through issue-operations per SPEC #683 -->
-                issue_number=old_plan["number"],
-                body="Superseded by #{most_recent_number} — cascade approval applies to the most recent plan only.",
-            )
+    # Supersede older plans
+    for old_plan in older_plans:
+        log_supersede(old_plan, most_recent)
 
-    else:
-        # Single plan: cascade-approve it
-        plan_issue = plan_issues[0]
-        issue-operations -> creation/update (github_issue_write( <!-- Routes through issue-operations per SPEC #683 -->
-            method="update",
-            issue_number=plan_issue["number"],
-            labels=[l for l in plan_issue["labels"] if l != "needs-approval"],
-        )
-        issue-operations -> comment (github_add_issue_comment( <!-- Routes through issue-operations per SPEC #683 -->
-            issue_number=plan_issue["number"],
-            body="Approval cascaded from spec #{spec_number}. Plan approved automatically because spec is already approved.",
-        )
-
-elif not plan_issues:
+elif not plan_files:
     # No plan exists — cascade does NOT apply
     # Current flow is correct: spec approval → writing-plans create → plan needs approval
     proceed to Step 6 (auto-dispatch to writing-plans)
@@ -96,7 +69,7 @@ elif not plan_issues:
 | No plan exists | Cascade does NOT apply; current flow (spec approval → writing-plans) is correct |
 | Plan already approved (no `needs-approval` label) | No action needed — plan is already approved |
 
-**Evidence artifact:** `issue-operations -> search-issues (github_search_issues` response showing plan issues referencing the spec, and `github_issue_write` response confirming label removal and comment posting. <!-- Routes through issue-operations per SPEC #683 -->
+**Evidence artifact:** `glob */.issues/*/plan.md` + grep for `Spec: #N` showing plan files referencing the spec. Plans are local artifacts — no GitHub Issue mutation needed.
 
 ## Work State I/O
 

--- a/skills/approval-gate/tasks/verify-authorization/sub-issue-verification.md
+++ b/skills/approval-gate/tasks/verify-authorization/sub-issue-verification.md
@@ -9,14 +9,13 @@ This gate is the SINGLE AUTHORITATIVE verification point for sub-issue readiness
 ### 5.1 Determine Plan Type
 
 ```
-plan_issue = issue-operations -> read-issue (github_issue_read(method="get", issue_number=N) <!-- Routes through issue-operations per SPEC #683 -->
+# Read plan from local file (plans are local artifacts, not GitHub Issues)
+plan_paths = [f".issues/{N}/plan.md", f"*/.issues/{N}/plan.md"]
+plan_body = read_local_plan_file(plan_paths)
 
-# Check if this is a plan (has plan label or [PLAN] prefix)
-is_plan = "plan" in [l["name"] for l in plan_issue["labels"]] or plan_issue["title"].startswith("[PLAN]")
-
-if is_plan:
+if plan_body:
     # All plans use unified dispatch path (work-of-1)
-    phases = parse_phases_from_plan_body(plan_issue["body"])
+    phases = parse_phases_from_plan_body(plan_body)
 ```
 
 ### 5.2 Verify Sub-Issues Under Plan (All Plans)

--- a/skills/approval-gate/tasks/verify-qa-mode.md
+++ b/skills/approval-gate/tasks/verify-qa-mode.md
@@ -77,7 +77,7 @@ GATE 3: Is current branch a feature branch (not main/dev/master)?
 
 **Search Procedure:**
 
-- [ ] 1. **Label search:** Search GitHub Issues with labels `[SPEC]`, `[PLAN]`, `[SPEC-FIX]` in the repository
+- [ ] 1. **Label search:** Search GitHub Issues with labels `[SPEC]`, `[SPEC-FIX]` in the repository
 - [ ] 2. **Keyword search:** Search GitHub Issues using keywords from the implementation request (e.g., feature name, component, module, bug area)
 - [ ] 3. **Evaluate candidates:** For each result, assess relevance to the request target
 - [ ] 4. **Present candidates:** If candidates found, list them with:
@@ -127,7 +127,7 @@ I see you'd like me to implement [X], but I need clarification first.
 [If search found candidates:]
 I found the following existing specs/plans that may be relevant:
 1. #123 [SPEC] Feature X implementation — <URL>
-2. #456 [PLAN] Feature X rollout — <URL>
+2. #456 [SPEC] Feature X rollout — <URL>
 
 Would you like me to work with one of these, or create a new spec?
 

--- a/skills/approval-gate/tasks/verify-sub-issues.md
+++ b/skills/approval-gate/tasks/verify-sub-issues.md
@@ -8,7 +8,7 @@ Verify sub-issue structure and phase tracking gate for multi-task plans before i
 
 ## Entry Criteria
 
-- Plan exists as local file at `*/.issues/{N}/plan.md`
+- Plan exists as local file at `.issues/{N}/plan.md` or `*/.issues/{N}/plan.md`
 - Authorization received for specific subtask (e.g., "approved: 1.2")
 - Subtask number provided or extracted from authorization
 - Authorization received for plan (covers sub-issue creation)

--- a/skills/approval-gate/tasks/verify-sub-issues.md
+++ b/skills/approval-gate/tasks/verify-sub-issues.md
@@ -8,7 +8,7 @@ Verify sub-issue structure and phase tracking gate for multi-task plans before i
 
 ## Entry Criteria
 
-- Plan exists as GitHub Issue (with `plan` label or `[PLAN]` prefix)
+- Plan exists as local file at `*/.issues/{N}/plan.md`
 - Authorization received for specific subtask (e.g., "approved: 1.2")
 - Subtask number provided or extracted from authorization
 - Authorization received for plan (covers sub-issue creation)

--- a/skills/git-workflow/tasks/cleanup.md
+++ b/skills/git-workflow/tasks/cleanup.md
@@ -257,25 +257,16 @@ SPEC #100 (parent)
 └── Task #103: Phase 3 → PR merges → Close #103 AND #100
 ```
 
-**Parent issues MUST be closed after ALL child issues are verified complete.** Leaving a parent plan issue open after all sub-issues are closed and verified is a process gap that must be treated as a bug requiring a fix.
+**Parent spec issues MUST be closed after ALL child issues are verified complete.** Plans are local artifacts — they are not closed as GitHub Issues.
 
-Example:
+### Step 2.8: Parent Spec Closure After Sub-Issues
 
-```
-Plan #50 (parent)
-├── Task #51: Phase 1 → closed, verified complete → OK
-├── Task #52: Phase 2 → closed, verified complete → OK
-└── ALL children closed → Close #50 with verification comment
-```
+After closing sub-issues (Step 2), check whether the parent spec issue should be closed:
 
-### Step 2.8: Parent Plan Closure After Sub-Issues
+- [ ] 1. **Identify the parent spec issue:**
 
-After closing sub-issues (Step 2), check whether the parent plan issue should be closed:
-
-- [ ] 1. **Identify the parent plan issue:**
-
-   - Use `issue-operations -> read-sub-issues (github_issue_read(method="get_sub_issues")` on the plan to list all sub-issues <!-- Routes through issue-operations per SPEC #683 -->
-   - If the current closure context came from a PR body referencing a plan, use that plan issue number
+   - Use `issue-operations -> read-sub-issues (github_issue_read(method="get_sub_issues")` on the spec to list all sub-issues <!-- Routes through issue-operations per SPEC #683 -->
+   - If the current closure context came from a PR body referencing a spec, use that spec issue number
 
 - [ ] 2. **Verify ALL sub-issues are closed with legitimate completion evidence:**
 
@@ -285,23 +276,23 @@ After closing sub-issues (Step 2), check whether the parent plan issue should be
 
 - [ ] 3. **If ALL sub-issues are legitimately closed:**
 
-   - Close the parent plan issue with `issue-operations -> update-issue (github_issue_write(method="update", state="closed", state_reason="completed")` <!-- Routes through issue-operations per SPEC #683 -->
+   - Close the parent spec issue with `issue-operations -> update-issue (github_issue_write(method="update", state="closed", state_reason="completed")` <!-- Routes through issue-operations per SPEC #683 -->
    - Post a verification comment documenting per-sub-issue evidence:
      ```
-     All sub-issues verified complete. Closing parent plan.
+     All sub-issues verified complete. Closing parent spec.
 
      Sub-issue closure evidence:
      - #<N1>: Merged PR #<P1> — <brief description>
      - #<N2>: Verified already implemented via autoclose — <brief description>
      - ...
 
-     Parent plan closure is legitimate because all child issues are verified complete.
+     Parent spec closure is legitimate because all child issues are verified complete.
      ```
 
 - [ ] 4. **If ANY sub-issue is NOT closed or NOT legitimately completed:**
 
-   - Do NOT close the parent plan
-   - Report in cleanup output: "Parent plan #\<plan_number> remains open — sub-issue #\<open_num> is not yet complete"
+   - Do NOT close the parent spec
+   - Report in cleanup output: "Parent spec #\<spec_number> remains open — sub-issue #\<open_num> is not yet complete"
 
 ## Closing Summary (Conditional)
 

--- a/skills/git-workflow/tasks/cleanup/issue-closure.md
+++ b/skills/git-workflow/tasks/cleanup/issue-closure.md
@@ -61,13 +61,13 @@ for pattern_name, pattern in patterns.items():
 
 | Classification | Detection | Closure Path |
 | -- | -- | -- |
-| Plan | Local plan file at `*/.issues/{N}/plan.md` | Plan closure path (Step 3) |
+| Plan | Local plan file at `.issues/{N}/plan.md` or `*/.issues/{N}/plan.md` | Plan closure path (Step 3) |
 | Spec / Spec-Fix | Has `[SPEC]` or `[SPEC-FIX]` label or title prefix | Spec closure path (Step 4) |
 | Other | No plan/spec labels | Direct close |
 
 ### Step 3: Plan Closure Path
 
-1. Read plan body from local file at `*/.issues/{N}/plan.md` for spec reference: `Spec:\s*#(\d+)` or `For spec:\s*#(\d+)`
+1. Read plan body from local file at `.issues/{N}/plan.md` or `*/.issues/{N}/plan.md` for spec reference: `Spec:\s*#(\d+)` or `For spec:\s*#(\d+)`
 2. Add referenced spec to closure candidates
 3. Get sub-issues via `issue-operations -> read-sub-issues (github_issue_read(method="get_sub_issues")` <!-- Routes through issue-operations per SPEC #683 -->
 4. For each sub-issue:

--- a/skills/git-workflow/tasks/cleanup/issue-closure.md
+++ b/skills/git-workflow/tasks/cleanup/issue-closure.md
@@ -61,19 +61,19 @@ for pattern_name, pattern in patterns.items():
 
 | Classification | Detection | Closure Path |
 | -- | -- | -- |
-| Plan | Has `[PLAN]` label or `[PLAN]` title prefix | Plan closure path (Step 3) |
+| Plan | Local plan file at `*/.issues/{N}/plan.md` | Plan closure path (Step 3) |
 | Spec / Spec-Fix | Has `[SPEC]` or `[SPEC-FIX]` label or title prefix | Spec closure path (Step 4) |
 | Other | No plan/spec labels | Direct close |
 
 ### Step 3: Plan Closure Path
 
-1. Parse plan body for spec reference: `Spec:\s*#(\d+)` or `For spec:\s*#(\d+)`
+1. Read plan body from local file at `*/.issues/{N}/plan.md` for spec reference: `Spec:\s*#(\d+)` or `For spec:\s*#(\d+)`
 2. Add referenced spec to closure candidates
 3. Get sub-issues via `issue-operations -> read-sub-issues (github_issue_read(method="get_sub_issues")` <!-- Routes through issue-operations per SPEC #683 -->
 4. For each sub-issue:
    - If open and deliverables covered by PR files → close with evidence comment
    - If open and deliverables NOT in PR → flag for developer review, do NOT auto-close
-5. Close the plan issue after sub-issues are resolved
+5. Plans are local artifacts — no GitHub Issue closure needed. The plan file remains as a record.
 
 **Deliverable check:** Verify each sub-issue's deliverables (file paths, descriptions) against the merged PR's file list.
 

--- a/skills/git-workflow/tasks/cleanup/verify-merge.md
+++ b/skills/git-workflow/tasks/cleanup/verify-merge.md
@@ -128,7 +128,7 @@ Verify ALL phases/sub-issues have merged PRs before allowing closure of a multi-
 | `ALL_COMPLETE` | Proceed to close the issue |
 | `PARTIAL_COMPLETE` | Do NOT close. Add progress comment listing completed and remaining phases. |
 
-**Safety rule: NEVER close a multi-phase spec or plan until ALL sub-issues are closed with verified merged PRs.**
+**Safety rule: NEVER close a multi-phase spec until ALL sub-issues are closed with verified merged PRs. Plans are local artifacts and are not closed as GitHub Issues.**
 
 ### Finding Classification
 

--- a/skills/issue-operations/tasks/link-sub-issue.md
+++ b/skills/issue-operations/tasks/link-sub-issue.md
@@ -29,8 +29,10 @@ Route based on `github.platform`:
 
 **GitHub platform (sub-skill implementation):**
 ```python
-plan = github_issue_read(method="get", issue_number=M)
-phases = extract_phases(plan["body"])
+# Read plan from local file (plans are local artifacts, not GitHub Issues)
+plan_paths = [f".issues/{M}/plan.md", f"*/.issues/{M}/plan.md"]
+plan_body = read_local_plan_file(plan_paths)
+phases = extract_phases(plan_body)
 if len(phases) == 1:
     # Single-task exemption - no sub-issue needed
     return

--- a/skills/pre-analysis/tasks/analyze.md
+++ b/skills/pre-analysis/tasks/analyze.md
@@ -35,7 +35,7 @@ authorization_source: "User approved #N on YYYY-MM-DD"
 ### Step 1: Load Spec and Plan
 
 - [ ] 1. Read the spec issue via `issue-operations -> read-issue (github_issue_read(method="get", issue_number=<spec>)` <!-- Routes through issue-operations per SPEC #683 -->
-- [ ] 2. Read the plan issue via `issue-operations -> read-issue (github_issue_read(method="get", issue_number=<plan>)` <!-- Routes through issue-operations per SPEC #683 -->
+- [ ] 2. Read the plan file from local `*/.issues/{plan}/plan.md` (plans are local artifacts, not GitHub Issues)
 - [ ] 3. Read any sub-issue via `issue-operations -> read-issue (github_issue_read(method="get", issue_number=<sub_issue>)` <!-- Routes through issue-operations per SPEC #683 -->
 - [ ] 4. Read all comments on the sub-issue: `issue-operations -> read-comments (github_issue_read(method="get_comments", issue_number=<sub_issue>)` <!-- Routes through issue-operations per SPEC #683 -->
 

--- a/skills/pre-analysis/tasks/analyze.md
+++ b/skills/pre-analysis/tasks/analyze.md
@@ -35,7 +35,7 @@ authorization_source: "User approved #N on YYYY-MM-DD"
 ### Step 1: Load Spec and Plan
 
 - [ ] 1. Read the spec issue via `issue-operations -> read-issue (github_issue_read(method="get", issue_number=<spec>)` <!-- Routes through issue-operations per SPEC #683 -->
-- [ ] 2. Read the plan file from local `*/.issues/{plan}/plan.md` (plans are local artifacts, not GitHub Issues)
+- [ ] 2. Read the plan file from local `.issues/{plan}/plan.md` or `*/.issues/{plan}/plan.md` (plans are local artifacts, not GitHub Issues)
 - [ ] 3. Read any sub-issue via `issue-operations -> read-issue (github_issue_read(method="get", issue_number=<sub_issue>)` <!-- Routes through issue-operations per SPEC #683 -->
 - [ ] 4. Read all comments on the sub-issue: `issue-operations -> read-comments (github_issue_read(method="get_comments", issue_number=<sub_issue>)` <!-- Routes through issue-operations per SPEC #683 -->
 

--- a/skills/writing-plans/tasks/clean-room.md
+++ b/skills/writing-plans/tasks/clean-room.md
@@ -28,7 +28,7 @@ Generate a clean-room implementation plan from a problem statement only, using p
 | -- | -- | -- |
 | Input source | Approved spec issue | Problem statement only (from temp file) |
 | References existing plan | May reference spec phases | **NEVER references existing plan** |
-| Creates GitHub issue | No (plan is local `*/.issues/{N}/plan.md` artifact) | **No** — returned as markdown only |
+| Creates GitHub issue | No (plan is local `.issues/{N}/plan.md` or `*/.issues/{N}/plan.md` artifact) | **No** — returned as markdown only |
 | Requires approval | Yes (`needs-approval` label) | **No** — comparison artifact |
 | Skip approval gate | No | **Yes** — not an implementation plan |
 | Structure | Agent-chosen prose | Agent-chosen prose (no template) |

--- a/skills/writing-plans/tasks/clean-room.md
+++ b/skills/writing-plans/tasks/clean-room.md
@@ -28,7 +28,7 @@ Generate a clean-room implementation plan from a problem statement only, using p
 | -- | -- | -- |
 | Input source | Approved spec issue | Problem statement only (from temp file) |
 | References existing plan | May reference spec phases | **NEVER references existing plan** |
-| Creates GitHub issue | Yes (`[PLAN]` prefixed issue) | **No** — returned as markdown only |
+| Creates GitHub issue | No (plan is local `*/.issues/{N}/plan.md` artifact) | **No** — returned as markdown only |
 | Requires approval | Yes (`needs-approval` label) | **No** — comparison artifact |
 | Skip approval gate | No | **Yes** — not an implementation plan |
 | Structure | Agent-chosen prose | Agent-chosen prose (no template) |

--- a/skills/writing-plans/tasks/completion.md
+++ b/skills/writing-plans/tasks/completion.md
@@ -4,7 +4,7 @@ Idempotent completion subtask for writing-plans. Ensures mandatory steps ran reg
 
 ## State Check Phase
 
-- [ ] 1. **Plan issue created:** Verify plan issue exists with [PLAN] prefix and `needs-approval` label (separate), or combined spec+plan has `## Implementation Plan` section
+- [ ] 1. **Plan file created:** Verify plan file exists at `*/.issues/{N}/plan.md` (separate), or combined spec+plan has `## Implementation Plan` section
 - [ ] 2. **Sub-issues created:** For multi-task plans, verify sub-issues created under the plan
 - [ ] 3. **Self-review completed:** Verify self-review checklist was run (coverage, placeholders, type consistency)
 - [ ] 4. **Chat exec summary + URL:** Verify chat output includes exec summary format with plan URL

--- a/skills/writing-plans/tasks/completion.md
+++ b/skills/writing-plans/tasks/completion.md
@@ -4,7 +4,7 @@ Idempotent completion subtask for writing-plans. Ensures mandatory steps ran reg
 
 ## State Check Phase
 
-- [ ] 1. **Plan file created:** Verify plan file exists at `*/.issues/{N}/plan.md` (separate), or combined spec+plan has `## Implementation Plan` section
+- [ ] 1. **Plan file created:** Verify plan file exists at `.issues/{N}/plan.md` or `*/.issues/{N}/plan.md` (separate), or combined spec+plan has `## Implementation Plan` section
 - [ ] 2. **Sub-issues created:** For multi-task plans, verify sub-issues created under the plan
 - [ ] 3. **Self-review completed:** Verify self-review checklist was run (coverage, placeholders, type consistency)
 - [ ] 4. **Chat exec summary + URL:** Verify chat output includes exec summary format with plan URL

--- a/skills/writing-plans/tasks/retroactive.md
+++ b/skills/writing-plans/tasks/retroactive.md
@@ -9,11 +9,11 @@ Create a plan for an existing spec that does not yet have one.
 - [ ] 1. **Query existing spec:**
 
     - Get spec from GitHub Issue
-    - Search for existing plan files at `*/.issues/{N}/plan.md` that reference the spec
+    - Search for existing plan files at `.issues/{N}/plan.md` or `*/.issues/{N}/plan.md` that reference the spec
 
 - [ ] 2. **If no plan exists:**
 
-    - Create local plan file at `*/.issues/{N}/plan.md`
+    - Create local plan file at `.issues/{N}/plan.md` or `*/.issues/{N}/plan.md`
     - Include spec reference as prose in body (e.g., `Spec: #N`)
     - Plan content uses hybrid approach (phases + TDD steps)
     - Include header, file structure, self-review
@@ -32,7 +32,7 @@ Create a plan for an existing spec that does not yet have one.
 | Claim | Verification Action | Tool Call | Problem Class |
 |-------|-------------------|-----------|---------------|
 | "Spec #N exists" | Verify issue exists and has spec label | `issue-operations -> read-issue (github_issue_read(method="get", issue_number=N)` | MISSING-ELEMENT | <!-- Routes through issue-operations per SPEC #683 -->
-| "No plan exists for spec #N" | Check for local plan file | `ls */.issues/{N}/plan.md 2>/dev/null` | VERIFICATION-GAP |
+| "No plan exists for spec #N" | Check for local plan file | `ls .issues/{N}/plan.md */.issues/{N}/plan.md 2>/dev/null` | VERIFICATION-GAP |
 | "Plan is valid" | Run `validate` task checks | `validate` task inline | VERIFICATION-GAP |
 | "Plan has sub-issues" | Check sub-issue state | `issue-operations -> read-sub-issues (github_issue_read(method="get_sub_issues", issue_number=plan_number)` | MISSING-ELEMENT | <!-- Routes through issue-operations per SPEC #683 -->
 

--- a/skills/writing-plans/tasks/retroactive.md
+++ b/skills/writing-plans/tasks/retroactive.md
@@ -9,15 +9,14 @@ Create a plan for an existing spec that does not yet have one.
 - [ ] 1. **Query existing spec:**
 
     - Get spec from GitHub Issue
-    - Search for linked plans (GitHub Issues with `plan` label and body text matching `Spec: #N`)
+    - Search for existing plan files at `*/.issues/{N}/plan.md` that reference the spec
 
 - [ ] 2. **If no plan exists:**
 
-    - Create `[PLAN]` GitHub Issue with `plan` + `needs-approval` labels
+    - Create local plan file at `*/.issues/{N}/plan.md`
     - Include spec reference as prose in body (e.g., `Spec: #N`)
     - Plan content uses hybrid approach (phases + TDD steps)
     - Include header, file structure, self-review
-    - Create sub-issues under the plan (not the spec)
     - HALT and wait for plan approval
 
 - [ ] 3. **If plan exists:**
@@ -33,7 +32,7 @@ Create a plan for an existing spec that does not yet have one.
 | Claim | Verification Action | Tool Call | Problem Class |
 |-------|-------------------|-----------|---------------|
 | "Spec #N exists" | Verify issue exists and has spec label | `issue-operations -> read-issue (github_issue_read(method="get", issue_number=N)` | MISSING-ELEMENT | <!-- Routes through issue-operations per SPEC #683 -->
-| "No plan exists for spec #N" | Query for linked plans | `issue-operations -> search-issues (github_search_issues(query="label:plan Spec: #N")` or iterate recent issues | VERIFICATION-GAP | <!-- Routes through issue-operations per SPEC #683 -->
+| "No plan exists for spec #N" | Check for local plan file | `ls */.issues/{N}/plan.md 2>/dev/null` | VERIFICATION-GAP |
 | "Plan is valid" | Run `validate` task checks | `validate` task inline | VERIFICATION-GAP |
 | "Plan has sub-issues" | Check sub-issue state | `issue-operations -> read-sub-issues (github_issue_read(method="get_sub_issues", issue_number=plan_number)` | MISSING-ELEMENT | <!-- Routes through issue-operations per SPEC #683 -->
 

--- a/skills/writing-plans/tasks/validate.md
+++ b/skills/writing-plans/tasks/validate.md
@@ -15,7 +15,7 @@ Check an existing plan for placeholders and completeness.
 - [ ] 07. **Self-review evidence** — Agent has performed spec coverage, placeholder, and type consistency checks
 - [ ] 08. **Spec reference** — Plan body contains a spec reference (search for `Spec: #N` pattern)
 - [ ] 09. **Sub-issue parent** — If plan has sub-issues, they link to the plan (not the spec)
-- [ ] 10. **Plan label** — Plan issue has `plan` label
+- [ ] 10. **Plan file exists** — Plan file exists at `*/.issues/{N}/plan.md`
 
 ## No-Placeholders Rule
 
@@ -73,7 +73,7 @@ Does NOT enforce a specific section order. A plan without "Risks" is valid if ri
 | "No placeholders present" | Search for placeholder patterns in plan body | \`grep(pattern="TBD | TODO |
 | "Spec reference exists in plan" | Search for `Spec: #N` pattern | `grep(pattern="Spec: #")` on plan body | MISSING-ELEMENT |
 | "Sub-issues link to plan (not spec)" | Verify sub-issue parent | `issue-operations -> read-sub-issues (github_issue_read(method="get_sub_issues", issue_number=plan_number)` | STRUCTURE-VIOLATION | <!-- Routes through issue-operations per SPEC #683 -->
-| "Plan has `plan` label" | Verify label on plan issue | `issue-operations -> read-issue (github_issue_read(method="get", issue_number=plan_number)` → check labels | MISSING-ELEMENT | <!-- Routes through issue-operations per SPEC #683 -->
+| "Plan file exists" | Verify plan file at `*/.issues/{N}/plan.md` | `ls */.issues/{N}/plan.md 2>/dev/null` | MISSING-ELEMENT |
 | "Steps are actionable" | Verify each step has concrete action | Manual parse — flag abstract goals | VERIFICATION-GAP |
 
 **Evidence artifact:** Tool call results for automated checks; manual review log for actionable-step verification.

--- a/skills/writing-plans/tasks/validate.md
+++ b/skills/writing-plans/tasks/validate.md
@@ -15,7 +15,7 @@ Check an existing plan for placeholders and completeness.
 - [ ] 07. **Self-review evidence** — Agent has performed spec coverage, placeholder, and type consistency checks
 - [ ] 08. **Spec reference** — Plan body contains a spec reference (search for `Spec: #N` pattern)
 - [ ] 09. **Sub-issue parent** — If plan has sub-issues, they link to the plan (not the spec)
-- [ ] 10. **Plan file exists** — Plan file exists at `*/.issues/{N}/plan.md`
+- [ ] 10. **Plan file exists** — Plan file exists at `.issues/{N}/plan.md` or `*/.issues/{N}/plan.md`
 
 ## No-Placeholders Rule
 
@@ -73,7 +73,7 @@ Does NOT enforce a specific section order. A plan without "Risks" is valid if ri
 | "No placeholders present" | Search for placeholder patterns in plan body | \`grep(pattern="TBD | TODO |
 | "Spec reference exists in plan" | Search for `Spec: #N` pattern | `grep(pattern="Spec: #")` on plan body | MISSING-ELEMENT |
 | "Sub-issues link to plan (not spec)" | Verify sub-issue parent | `issue-operations -> read-sub-issues (github_issue_read(method="get_sub_issues", issue_number=plan_number)` | STRUCTURE-VIOLATION | <!-- Routes through issue-operations per SPEC #683 -->
-| "Plan file exists" | Verify plan file at `*/.issues/{N}/plan.md` | `ls */.issues/{N}/plan.md 2>/dev/null` | MISSING-ELEMENT |
+| "Plan file exists" | Verify plan file at `.issues/{N}/plan.md` or `*/.issues/{N}/plan.md` | `ls .issues/{N}/plan.md */.issues/{N}/plan.md 2>/dev/null` | MISSING-ELEMENT |
 | "Steps are actionable" | Verify each step has concrete action | Manual parse — flag abstract goals | VERIFICATION-GAP |
 
 **Evidence artifact:** Tool call results for automated checks; manual review log for actionable-step verification.


### PR DESCRIPTION
## Summary

Replaces all stale GitHub Issue plan references (`[PLAN]` prefix, `plan` label, `github_issue_read`/`github_search_issues` for plan reading) with local `*/.issues/{N}/plan.md` file operations. Plans are local artifacts only — not GitHub Issues.

## Changes

19 files modified across 6 directories:

- **approval-gate**: Plan detection via local file existence at `*/.issues/{N}/plan.md`, not labels/title prefixes. Spec-to-plan cascade reads local plan files. Gap-fill checks local file existence. Sub-issue verification reads plan from local file.
- **writing-plans**: Plan creation as local file, not GitHub Issue. Validation checks file existence, not labels. Clean-room docs updated.
- **git-workflow cleanup**: No "close parent plan" steps — plans are local artifacts. Plan closure path reads local file, does not close GitHub Issue.
- **issue-operations link-sub-issue**: Reads plan from local file instead of `github_issue_read`.
- **pre-analysis analyze**: Reads plan from local file instead of `github_issue_read`.
- **guidelines**: `[PLAN]` prefix and `plan` label references replaced with `*/.issues/{N}/plan.md`.

## Verification

All 4 success criteria verified PASS via grep:

- SC-1: Zero `github_issue_read`/`github_search_issues` calls for reading a plan artifact (sub-issue reads under a plan are still valid — those read sub-issues, not the plan itself)
- SC-2: Zero "close plan" execution steps in cleanup tasks
- SC-3: Zero `[PLAN]` prefix or `plan` label references as plan storage mechanism
- SC-4: All plan detection uses `*/.issues/{N}/plan.md` file existence check

Fixes #1284