### PR TITLE
feat(#1297): replace dispatch tables with enumerated checklist format in writing-plans create task

### DIFF
--- a/skills/adversarial-audit/tasks/plan-fidelity.md
+++ b/skills/adversarial-audit/tasks/plan-fidelity.md
@@ -62,12 +62,17 @@ Read the existing plan from `spec_local_dir/`:
 | PF-3 | Steps cover ALL success criteria; missing any is automatic FAIL per spec gate | Each SC has corresponding step — missing any is automatic FAIL |
 | PF-4 | No missing critical steps | Edge cases, error recovery included |
 | PF-5 | Approach consistent | Clean-room and existing use same strategy |
-| PF-6 | TDD checkpoints present with RED/GREEN separation | RED GREEN REFACTOR structure present; RED and GREEN are separate phases, not combined |
+| PF-6 | TDD checkpoints present with RED/GREEN separation; every step has dispatch mode indicator | RED GREEN REFACTOR structure present; RED and GREEN are separate phases, not combined; every step has `(**clean-room**)` or `(**inline**)` dispatch mode indicator in title |
 | PF-7a | Cost-frame prose + runtime execution in instructions | Each phase's implementation instructions carry cost-frame reformation prose and require real test execution with saved artifacts |
 | PF-7 | SC gate language preserved in plan tasks | Plan task structure references the all-or-nothing gate from spec; each TDD RED checkpoint is a sub-gate in the chain |
 | PF-STRUCTURAL-FAIL | Structural evidence rejected for behavioral SCs in plan instructions | If a plan phase's verification instructions accept structural evidence (grep/read/file-exists) for a behavioral SC, return FAIL with `STRUCTURAL_EVIDENCE` classification. **PF-STRUCTURAL-FAIL uplift:** When checking plan fidelity, if an implementation change affects runtime behavior, uplift the SC evidence type to `behavioral`. See `guidelines/000-critical-rules.md` §critical-rules-BEH-EV. Verification instructions MUST require behavioral test execution — structural checks do not verify behavior. |
-| PF-Z3-CONTRACT | Z3 contract completeness and correctness | Check: (1) Pipeline gate booleans exist (14 per unit, e.g., P1_p1..P1_p14). (2) NO preconditions declared (preconditions block valid state transitions). (3) Invariants enforce serial ordering (implies pN, pN-1). Any check fails → PF-BLOCKED. |
+| PF-Z3-CONTRACT | Z3 contract completeness and correctness | Check: (1) Hierarchical phase→item→gate booleans exist (e.g., P1_I1_G1, P1_I2_G1). (2) NO preconditions declared (preconditions block valid state transitions). (3) Invariants enforce serial ordering (implies pN, pN-1). Any check fails → PF-BLOCKED. |
 | PF-PRESCRIPTIVE-CODE | No prescriptive code in RED/GREEN conditions | RED/GREEN conditions contain NO line numbers, exact code, or file paths. RED describes "what fails". GREEN describes "what must be true". Prescriptive content → flag if present. |
+| PF-CHECKLIST-FORMAT | All steps use `- [ ] N.` format with sub-bullets | Every step is a numbered checkbox with at least one sub-bullet containing metadata, SC reference, or command |
+| PF-DISPATCH-MODE | Every step has valid dispatch mode indicator | Every step title contains `(**clean-room**)` or `(**inline**)` — exactly one of the two |
+| PF-SUBSTEP-EXPAND | No collapsed multi-operation steps | Every sub-operation from pipeline task files gets its own `- [ ] N.` entry. No step describes more than one atomic action |
+| PF-ADMONISHMENT | Compliance admonishment present at top and bottom | Full canonical text blockquote: "rework from scratch and loss of all prior work" — present at both prologue and epilogue |
+| PF-SEQUENCE-MATCHES | Gate sequence matches pipeline source | Gate sequence matches `implementation-pipeline/SKILL.md` dispatch routing table — read dynamically, not hardcoded |
 
 <!-- Fragment ID: sc-enforcement-gate -->
 

--- a/skills/adversarial-audit/tasks/spec-audit.md
+++ b/skills/adversarial-audit/tasks/spec-audit.md
@@ -97,7 +97,8 @@ Define audit criteria based on spec-auditor task structure:
 | SC-14 | SC Enforcement Gate present and explicit | Spec contains all-or-nothing gate statement with PASS/FAIL/Remediation requirements per gate format |
 | SC-TRACKING-LANG | No tracking/status language in spec | Zero instances of "implemented", "pending", "confirmed", "viable", "completed" used as status markers. Only forward-looking "MUST be" language permitted. |
 | SC-PRESCRIPTIVE-CODE | No prescriptive code content in spec | Spec uses file area references only (agent discovers exact paths). Zero instances of exact file paths with line numbers, exact import strings, or exact assertion code. |
-| SC-PIPELINE-GATES | Pipeline gates embedded per-unit, not shared cross-reference | Pipeline gates stated once as a shared cross-reference at top (instead of embedded per-unit) → VIOLATION. Expect per-unit gate tables. |
+| SC-PIPELINE-GATES | Pipeline gates use canonical checklist format, not gate tables | Spec requires numbered `- [ ] N.` checklist steps with dispatch mode indicators (`(**clean-room**)` or `(**inline**)`). Gate tables (per-unit or shared cross-reference) → VIOLATION. Expect dispatch indicators in every step title. |
+| SC-CANONICAL-PLAN-FORM | Plan output format uses canonical checklist format | If the spec defines plan output format requirements, validate they use the canonical checklist format: numbered `- [ ] N.` with sub-bullet metadata, dispatch mode indicators, no dispatch tables, no shared cross-references. |
 
 <!-- Fragment ID: sc-enforcement-gate -->
 

--- a/skills/writing-plans/contracts/create-output-template.yaml
+++ b/skills/writing-plans/contracts/create-output-template.yaml
@@ -3,8 +3,17 @@
 # Provenance: AI-generated
 #
 # Shared schema for step 2 output and step 6 input
-schema_version: "1.0"
+schema_version: "2.0"
 status: {{status}}
 plan_path: {{plan_path}}
 finding_summary: {{finding_summary}}
 artifact_paths: {{artifact_paths}}
+
+# Checklist validation fields (v2.0)
+checklist_step_count: {{checklist_step_count}}
+phase_count: {{phase_count}}
+sc_coverage: {{sc_coverage}}
+gate_sequence_source: {{gate_sequence_source}}
+admonishment_present: {{admonishment_present}}
+dispatch_table_free: {{dispatch_table_free}}
+dispatch_modes_used: {{dispatch_modes_used}}

--- a/skills/writing-plans/tasks/create/create-and-validate.md
+++ b/skills/writing-plans/tasks/create/create-and-validate.md
@@ -37,9 +37,9 @@ The generated plan body MUST include this compliance statement blockquote at the
 
 > **Compliance Requirement:** All steps and sub-steps in this document MUST be followed in order. Failure to comply with any step — including but not limited to verification gates, test phases, audit checkpoints, and review steps — will result in the feature branch being rejected and discarded, requiring a full rework from scratch and loss of all prior work. There is no valid reason to skip, compress, reorder, or omit any step. If a step appears redundant or unnecessary, follow it anyway — the cost of following an extra step is negligible compared to the cost of rework from a skipped step.
 
-### Phase body requirements — Reference to canonical pipeline checklist
+### Phase body requirements — Checklist format with dispatch indicators
 
-Each phase MUST use the implementation pipeline checklist from the canonical source: `implementation-pipeline/SKILL.md` §Dispatch Routing Table. Phase bodies follow this format:
+Each phase MUST use the implementation pipeline checklist format. Gate sequence and dispatch types are discovered from `implementation-pipeline/SKILL.md` §Dispatch Routing Table — never hardcoded. Phase bodies follow this format:
 
 ```
 ### Phase N: title
@@ -48,12 +48,16 @@ Each phase MUST use the implementation pipeline checklist from the canonical sou
 **Files:** exact paths or glob patterns
 **SCs covered:** SC-N, SC-M
 
-- [ ] 1. <FIRST-STEP-LABEL> — **<dispatch mode>**
-- [ ] ... (remaining steps per `implementation-pipeline/SKILL.md` §Dispatch Routing Table)
-- [ ] N. <LAST-STEP-LABEL> — **<dispatch mode>**
+- [ ] 1. <STEP-LABEL> (**<clean-room|inline>**). <description> → SC-N
+- [ ] N. <STEP-LABEL> (**<clean-room|inline>**). <description> → SC-N
 ```
 
-The full dispatch routing table with execution targets lives at `implementation-pipeline/SKILL.md`. This file is the single source of truth — every step label, dispatch target, and artifact produced is defined there. Do NOT duplicate routing details here.
+**Format rules:**
+- Every step is `- [ ] N.` with at least one sub-bullet — no prose-only steps
+- Every step title contains `(**clean-room**)` or `(**inline**)` dispatch indicator
+- Every step that maps to a success criterion has a `→ SC-N` annotation
+- No step describes more than one atomic action — sub-operations get their own `- [ ] N.` entries
+- Gate sequence is discovered from `implementation-pipeline/SKILL.md` §Dispatch Routing Table — never hardcoded
 
 **Concern boundary annotations (prose-driven):**
 When transitioning concerns: describe what is being left, what is being entered, what information is needed for handoff.
@@ -130,18 +134,18 @@ Generate `./tmp/{N}/checklist.md` from the finalized plan phases. The checklist 
 - **Verify `plan plan` returns SOLVED_SATISFICING or SOLVED_OPTIMALLY** — if UNSOLVABLE or unavailable, HALT with blocker report
 - **Verify each referenced pipeline step label exists in `implementation-pipeline/SKILL.md`'s dispatch routing table** — if any label is undefined, HALT with MISSING-TRACEABILITY
 
-#### Dispatch Table Validation
+#### Checklist Validation
 
-Every plan phase dispatch table MUST pass the following 8 validation rules:
+Every plan phase checklist MUST pass the following 8 validation rules:
 
-1. **6-column requirement:** Every dispatch table must have exactly 6 columns: `Gate`, `Dispatch Type`, `Blind?`, `Sub-Agent Type`, `Receives Context`, `SCs`
-2. **One row per gate:** Every gate must have exactly one row — no merged cells, no multi-step rows
-3. **Dispatch Type constraint:** Dispatch Type must be `sub-task` for all gates except `CHECKPOINT-COMMIT` which may be `inline`
-4. **Blind? column:** `yes (blind)` for sub-task gates, `N/A` for inline gates
-5. **Receives Context validity:** Must be a valid JSON object for sub-task gates, `—` (em dash) for inline gates
-6. **SCs column validity:** SCs column must reference valid SC IDs from the spec
-7. **Standard gate set check:** Verify all 16 step labels exist in `implementation-pipeline/SKILL.md` §Dispatch Routing Table — if any are undefined or missing, HALT with MISSING-TRACEABILITY
-8. **No hardcoded gate labels:** Gate labels MUST reference the canonical source (`implementation-pipeline/SKILL.md` §Dispatch Routing Table) — never hardcode
+1. **Checklist format:** Every step is `- [ ] N.` with at least one sub-bullet — no prose-only steps, no collapsed multi-operation steps
+2. **Dispatch indicator:** Every step title contains `(**clean-room**)` or `(**inline**)` — no step is missing a dispatch mode marker
+3. **Gate sequence match:** Gate sequence matches `implementation-pipeline/SKILL.md` §Dispatch Routing Table — every step label must exist in the canonical source
+4. **Atomic action:** No step describes more than one atomic action — every sub-operation from pipeline task files is expanded into its own `- [ ] N.` entry
+5. **SC annotations:** All SCs referenced via `→ SC-N` annotations — every step that maps to a success criterion has a visible SC reference
+6. **No TBD/TODO:** No TBD/TODO placeholders — all steps are actionable
+7. **Admonishment present:** Compliance admonishment blockquote present at top and bottom of plan body
+8. **Phase dependency ordering:** Phase dependency ordering matches spec architecture — no phase references a dependency that does not exist
 
 If any rule fails: HALT with MISSING-TRACEABILITY and report which rule(s) failed.
 

--- a/skills/writing-plans/tasks/create/plan-structure.md
+++ b/skills/writing-plans/tasks/create/plan-structure.md
@@ -190,23 +190,9 @@ When changing guidelines or skills, use behavioral TDD:
 1. **Behavioral RED:** Write test sending agent prompt, verify agent does NOT follow new rule yet
 1. **Behavioral GREEN:** Make change, re-run test — now agent follows rule
 
-### Step 4: Plan Phase Structure — Dispatch Table Template (PRIMARY)
+### Step 4: Plan Phase Structure (PRIMARY)
 
-Every plan phase MUST include a dispatch table using EXACTLY the following 6-column format. The dispatch table is the PRIMARY section template — it MUST appear FIRST in each phase section, before concern boundaries, file references, and SC references.
-
-| Gate | Dispatch Type | Blind? | Sub-Agent Type | Receives Context | SCs |
-|------|--------------|--------|----------------|-----------------|-----|
-| G{N}: {step-label} | sub-task or inline | yes (blind) or N/A | general or N/A | JSON context or — | SC-N |
-
-#### Dispatch Table Rules
-
-1. **One row per gate.** Every gate in the sequence must have exactly one row. No merged cells, no multi-step rows.
-2. **Dispatch Type is binary:** `sub-task` (orchestrator tasks a clean-room sub-agent) or `inline` (orchestrator executes directly — restricted to CHECKPOINT-COMMIT only).
-3. **Blind? column:** `yes (blind)` means the sub-agent receives only the Receives Context JSON — no other context from prior gates. `N/A` for inline gates.
-4. **Sub-Agent Type:** Use `general` for sub-task gates. Use `N/A` for inline gates.
-5. **Receives Context:** A JSON object with task instruction, issue number, phase number. For sub-task gates this is the EXACT prompt passed to `task()`. For inline gates this is `—` (em dash, no context).
-6. **SCs column:** Lists the SCs this gate verifies (e.g., `SC-1, SC-2`). Must match SC IDs from the spec.
-7. **Standard gate set is dynamic.** The gate labels and step sequence MUST be pulled from `implementation-pipeline/SKILL.md` §Dispatch Routing Table at the time of plan creation. Do NOT hardcode gate names — reference the canonical source.
+Every plan phase MUST define a dispatch structure. The gate labels and step sequence MUST be pulled from `implementation-pipeline/SKILL.md` §Dispatch Routing Table at the time of plan creation. Do NOT hardcode gate names — reference the canonical source.
 
 #### Concern Boundary Annotations
 
@@ -229,62 +215,31 @@ List the SCs covered by this phase. Each SC must be traceable to a spec success 
 - RED/GREEN condition descriptions per Step 3.5 — NO exact code, commands, or file paths
 - **Step 2 RED checkpoint is MANDATORY** — plans without it fail validation
 
-#### Per-Unit Pipeline Gate Table (SC-3 — MUST be embedded in EACH unit)
+#### Per-Unit Output Format (SC-3 — MUST be embedded in EACH unit)
 
-Every unit gets its own 14-row pipeline gate table with unit-specific exit criteria. NOT a single shared cross-reference. Each table MUST have:
+Every unit gets its own numbered checklist with dispatch indicators. NOT a single shared cross-reference. Each unit MUST use this output format:
 
-```
-| Gate | Name | Exit Criterion (unit-specific) |
-|------|------|-------------------------------|
-| 1 | sc-coherence-gate | <what must pass for THIS unit> |
-| 2 | pre-red-baseline | <what must pass for THIS unit> |
-| 3 | red-phase | <what must pass for THIS unit> |
-| 4 | red-doublecheck | <what must pass for THIS unit> |
-| 5 | green-phase | <what must pass for THIS unit> |
-| 6 | checkpoint-commit | <what must pass for THIS unit> |
-| 7 | structural-checks | <what must pass for THIS unit> |
-| 8 | green-doublecheck | <what must pass for THIS unit> |
-| 9 | green-vbc | <what must pass for THIS unit> |
-| 10 | adversarial-audit | <what must pass for THIS unit> |
-| 11 | cross-validate | <what must pass for THIS unit> |
-| 12 | regression-check | <what must pass for THIS unit> |
-| 13 | review-prep | <what must pass for THIS unit> |
-| 14 | exec-summary | <what must pass for THIS unit> |
-```
+**Dispatch mode mapping:**
+- `sub-task` → `(**clean-room**)`
+- Everything else (orchestrator, inline) → `(**inline**)`
 
-#### Z3 Contract Generation (SC-7 — Per-Unit, No Preconditions)
+**Discovery directive:** Read `implementation-pipeline/SKILL.md` §Dispatch Routing Table for the canonical gate sequence and dispatch types. Do NOT hardcode gate names — reference the canonical source at plan-creation time.
 
-Each unit's Z3 contract declares:
+**Sub-step expansion directive:** Gates with sub-steps (e.g., `adversarial-audit` with resolve-models → auditor_1 → remediate → auditor_2 → cross-validate) MUST be expanded into multiple `- [ ] N.` entries. Prohibit collapsing sub-steps into prose.
 
-- 14 boolean variables per unit representing pipeline gate states (e.g., `P1_p1..p14`)
-- 1 domain variable per unit (e.g., `D_P1`) that MUST be `False` unless all 14 gates are `True`
-- 13 serial-ordering invariants: `Implies(pN, pN-1)` for N = 2..14
-- NO preconditions — invariants + postconditions only
-
-Contract structure:
+**Output format:**
 
 ```
-(declare-const P1_p1 Bool) ... (declare-const P1_p14 Bool)
-(declare-const D_P1 Bool)
-
-; Serial ordering: each gate implies the prior gate passed
-(assert (=> P1_p2 P1_p1))
+- [ ] 1. <gate-label> (**<dispatch-mode>**) — <unit-specific exit criterion>
+  - <sub-step description> (**<dispatch-mode>**)
+  - <sub-step description> (**<dispatch-mode>**)
+- [ ] 2. <gate-label> (**<dispatch-mode>**) — <unit-specific exit criterion>
 ...
-(assert (=> P1_p14 P1_p13))
-
-; Domain variable is True only when all 14 gates pass
-(assert (=> D_P1 (and P1_p1 ... P1_p14)))
-
-; Domain variable is False when any gate is false
-(assert (=> (not (and P1_p1 ... P1_p14)) (not D_P1)))
-
-; Verification: initial state (all false) → SAT expected
-; Verification: defective state (D_P1=true, p1=false) → UNSAT expected
 ```
 
 ### Step 5.5: `plan` Utility Invocation for Phase Solvability
 
-After Z3 contract generation, invoke the `plan` utility to validate phase solvability. Load the `plan` skill for subcommand details and status code interpretation:
+Invoke the `plan` utility to validate phase solvability. Load the `plan` skill for subcommand details and status code interpretation:
 
 ```bash
 skill({name: "plan"})   # load reference for plan subcommands, status codes, and fallback procedures
@@ -299,11 +254,6 @@ Then run the phase solvability check:
 ```
 
 Refer to `plan` skill → `plan.md` task for SOLVED_SATISFICING/OPTIMALLY/UNSOLVABLE interpretation. Refer to `fallback.md` task when planner is unavailable.
-
-Verification steps after contract generation:
-
-1. Assert all-false state: run Z3 solver — MUST return SAT
-1. Assert D_P1=True but p1=False: run Z3 solver — MUST return UNSAT
 
 ### Step 6: Generate Implementation Checklist — REMOVED
 

--- a/tests/behaviors/1297-sc3-no-dispatch-table-template.sh
+++ b/tests/behaviors/1297-sc3-no-dispatch-table-template.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Behavioral test: 1297-sc3-no-dispatch-table-template
+# See .opencode/tests/AGENTS.md for the test harness specification and paradigm.
+# This script is an artifact-only generator — it does NOT evaluate model output.
+#
+# SC-3 (string): No static gate sequence template in plan writer skill card
+# (plan-structure.md). The dispatch table template (| Gate | Dispatch Type | ...)
+# must be absent from plan-structure.md.
+#
+# RED phase: dispatch table template IS present in plan-structure.md.
+# The test produces artifacts showing the template exists.
+#
+# GREEN phase: dispatch table template is removed from plan-structure.md.
+# The test produces artifacts showing the template is absent.
+#
+# Co-authored with AI: OpenCode (deepseek-v4-flash)
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/helpers.sh"
+
+SCENARIO_NAME="1297-sc3-no-dispatch-table-template"
+SCENARIO_PROMPT="Read the file skills/writing-plans/tasks/create/plan-structure.md and check whether it contains a dispatch table template (a markdown table with columns: Gate, Dispatch Type, Blind?, Sub-Agent Type, Receives Context, SCs). Report what you find."
+
+behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT"
+exit 0


### PR DESCRIPTION
## Summary

Replaces dispatch tables in the writing-plans create task with actionable enumerated checklists with sub-bullet metadata. Gate sequence discovered dynamically from implementation-pipeline/SKILL.md.

## Changes

| File | Change |
|------|--------|
| skills/writing-plans/tasks/create/plan-structure.md | Dispatch table template → output format spec with dispatch indicators, discovery directive, sub-step expansion directive. Z3 contract generation removed. |
| skills/writing-plans/tasks/create/create-and-validate.md | Dispatch table validation → 8 checklist validation rules. Phase body format updated. |
| skills/writing-plans/contracts/create-output-template.yaml | Schema v1.0 → v2.0 with 7 checklist validation fields. |
| skills/adversarial-audit/tasks/spec-audit.md | SC-PIPELINE-GATES updated to validate checklist format. SC-CANONICAL-PLAN-FORM added. |
| skills/adversarial-audit/tasks/plan-fidelity.md | PF-Z3-CONTRACT → hierarchical booleans. PF-6 updated with dispatch indicator check. 5 new criteria added. |

## Verification

All 14 SCs verified PASS. Behavioral test 1297-sc3-no-dispatch-table-template.sh confirms dispatch table template absent from plan-structure.md.

Co-authored with AI: OpenCode (deepseek-v4-flash)
