### PR TITLE
fix(#1301): remove dispatch table references from writing-plans, create plan-creation-pipeline skill

### DIFF
--- a/skills/plan-creation-pipeline/SKILL.md
+++ b/skills/plan-creation-pipeline/SKILL.md
@@ -1,0 +1,143 @@
+---
+name: plan-creation-pipeline
+description: "Use when creating a plan from an approved spec through a formal 6-step pipeline with Z3-verified state transitions. Plan creation without a structured pipeline produces inconsistent plans."
+type: discipline-enforcing
+license: MIT
+compatibility: opencode
+---
+
+# Skill: plan-creation-pipeline
+
+<!-- SPDX-FileCopyrightText: 2026 Michael Conrad -->
+<!-- SPDX-License-Identifier: MIT -->
+<!-- Provenance: AI-generated -->
+
+## Overview
+
+Pure orchestrator routing table with 6 serial dispatch steps for plan creation. The orchestrator holds only routing metadata — each step dispatches to an existing skill's task file via `task()`. Step transitions are validated by Z3 via `solve check` against `pipeline-state-machine.yaml`. YAML contract artifacts at `./tmp/{issue-N}/artifacts/plan-pipeline-{step_label}-{STATUS}-{timestamp}.yaml`.
+
+The orchestrator is a pure router — never reads task file content, never performs inline analysis. Sub-agents do the work.
+
+## Trigger Dispatch Table
+
+| User says / Context | Task | Dispatch | Context passed |
+|---------------------|------|----------|----------------|
+| "plan-creation" / "create plan pipeline" | `plan-creation` | `sub-task` | {issue_number} |
+| completion / workflow end | `completion` | `sub-task` | {workflow_state} |
+
+## Dispatch Routing Table
+
+| Step Label | Dispatches To | Artifact Produced |
+|------------|---------------|-------------------|
+| `spec-to-plan-handoff` | `approval-gate --task verify-authorization` | handoff artifact at `./tmp/{issue-N}/artifacts/plan-pipeline-handoff-{STATUS}-{timestamp}.yaml` |
+| `plan-create` | `writing-plans --task create` | plan artifact at `.issues/{N}/plan.md` |
+| `solve-model` | `solve model` | dependency-ordering constraints contract at `./tmp/{issue-N}/artifacts/plan-pipeline-solve-model-{STATUS}-{timestamp}.yaml` |
+| `solve-check` | `solve check` | SAT verification at `./tmp/{issue-N}/artifacts/plan-pipeline-solve-check-{STATUS}-{timestamp}.yaml` |
+| `plan-plan` | `plan plan` | phase solvability validation at `./tmp/{issue-N}/artifacts/plan-pipeline-plan-plan-{STATUS}-{timestamp}.yaml` |
+| `plan-completion` | `local-issues sync` | commits plan to `.issues/` worktree. Then produce chat output: detailed and formatted exec summary + URL to blob for spec folder on remote API (if remote API exists) + AI byline. No push, no issue comment, no approval cascade. |
+
+## Step Labels
+
+`spec-to-plan-handoff`, `plan-create`, `solve-model`, `solve-check`, `plan-plan`, `plan-completion`
+
+## Invocation
+
+`skill({name: "plan-creation-pipeline"})` — call the skill, then dispatch each step via task():
+
+| Step | Call via task() |
+|------|----------------|
+| Any dispatch step | `task(..., prompt: "execute <step_label> from plan-creation-pipeline")` |
+
+Every task context MUST include the authorization context block:
+
+```yaml
+authorization_scope: <for_analysis|for_spec|for_plan|for_implementation|for_review_prep|for_pr|for_pr_only|for_review_only>
+halt_at: <analysis_complete|spec_created|plan_created|verification_complete|review_prep|pr_created>
+pr_strategy: <none|stacked>
+pipeline_phase: <current_phase_name>
+authorization_source: "User approved #N on YYYY-MM-DD"
+```
+
+## Sub-Agent Routing
+
+All substantive work runs via `task(subagent_type="general")`. The orchestrator is a pure router — no creative work, no file edits, no inline analysis. Auditor tasks use subagent_type from resolve-models result contract (auditor_1/auditor_2) — NOT `general`. Include `audit_phase` in task context when routing auditors. `pre-analysis` receives only `{ issue_number, task_description, github.owner, github.repo }`.
+
+Exclusions: implementation context, agent memory, cached verification results.
+
+### DISPATCH_GATE — Orchestrator task() Prompt Protocol
+
+The orchestrator MUST NOT preload execution context into `task()` prompts.
+Every sub-agent MUST independently discover scope and produce its own result contract.
+
+#### Forbidden in task() Prompts
+
+| Violation | Forbidden Pattern | Correct Pattern |
+|-----------|-------------------|-----------------|
+| Preloaded file paths | "Read plan-structure.md then execute step 1" | "execute plan-create from plan-creation-pipeline" |
+| Preloaded step sequences | "Step 1: handoff. Step 2: create." | "execute plan-create from plan-creation-pipeline" |
+| Preloaded expected outcomes | "Return { plan_path, status }" | Let sub-agent define its own result contract |
+| Preloaded orchestrator reasoning | "The spec was just approved so we need to..." | Pure objective, no narrative |
+| Missing task file discovery directive | "execute plan-create from plan-creation-pipeline" without task file path | "execute plan-create from plan-creation-pipeline. Read `writing-plans/tasks/create.md` first" |
+
+## Required: Sub-agent Task File Discovery Directive
+
+Every `task()` prompt that dispatches a named task MUST include a discovery directive in the format:
+
+```
+execute <task> from <skill>. Read `<skill>/tasks/<task>.md` first
+```
+
+#### Dispatch Context Contract
+
+Every `task()` call MUST include only:
+
+- `worktree.path`
+- `github.owner`
+- `github.repo`
+- `authorization_scope`
+- `halt_at`
+- `pr_strategy`
+- `pipeline_phase`
+
+Plus skill-specific fields per the `## Sub-Agent Routing` section above.
+
+Exclusions (MUST NOT be in prompt):
+- `orchestrator_reasoning`
+- `expected_outcomes`
+- `inline_file_paths`
+- `agent_memory`
+- `cached_verification_results`
+
+#### Sub-Agent Entry Criteria
+
+A sub-agent receiving a `task()` prompt MUST reject it if the prompt contains:
+- Inline file paths to task files
+- Inline step or procedure definitions
+- Expected outcome structures or schema constraints
+- Pre-loaded evidence or orchestrator-derived conclusions
+
+Return `status: BLOCKED` with `reason: PRELOADED_CONTEXT_REJECTED`.
+
+#### Orchestrator Entry Criteria
+
+After loading this skill and reading the Trigger Dispatch Table, the orchestrator MUST:
+- Use the exact `task(..., prompt: "...")` string from the table
+- NOT write a custom prompt with preloaded context
+- NOT add orchestrator reasoning, file paths, step sequences, or expected outcomes
+- If the canonical dispatch produces an empty result: re-task clean-room with the same canonical string (max 2 retries)
+
+## Cross-References
+
+Skills: `writing-plans`, `approval-gate`, `completion-core`. Guidelines: `010-approval-gate.md`, `000-critical-rules.md`.
+
+```yaml+symbolic
+schema_version: "1.0"
+last_updated: "2026-06-19T00:00:00Z"
+rules:
+  - id: plan-creation-pipeline-001
+    title: "Plan creation requires approved spec"
+    conditions:
+      all: ["plan_creation_attempted == true", "spec_approved == false"]
+    actions: [HALT]
+    source: "plan-creation-pipeline/SKILL.md"
+```

--- a/skills/plan-creation-pipeline/pipeline-state-machine.yaml
+++ b/skills/plan-creation-pipeline/pipeline-state-machine.yaml
@@ -1,0 +1,45 @@
+# Pipeline State Machine Contract for Z3 Validation
+# SPDX-FileCopyrightText: 2026 Michael Conrad
+# SPDX-License-Identifier: MIT
+# Provenance: AI-generated
+# Co-authored with AI: OpenCode (deepseek-v4-flash)
+schema_version: "1.0"
+last_updated: "2026-06-19T00:00:00Z"
+
+variables:
+  current_step:
+    type: string
+    domain:
+      - spec-to-plan-handoff
+      - plan-create
+      - solve-model
+      - solve-check
+      - plan-plan
+      - plan-completion
+  previous_step:
+    type: string
+    domain:
+      - init
+      - spec-to-plan-handoff
+      - plan-create
+      - solve-model
+      - solve-check
+      - plan-plan
+  pipeline_state:
+    type: string
+    domain: [init, running, complete, failed]
+
+preconditions:
+  - "z3.Implies(previous_step == z3.StringVal('init'), current_step == z3.StringVal('spec-to-plan-handoff'))"
+  - "z3.Implies(previous_step == z3.StringVal('spec-to-plan-handoff'), current_step == z3.StringVal('plan-create'))"
+  - "z3.Implies(previous_step == z3.StringVal('plan-create'), current_step == z3.StringVal('solve-model'))"
+  - "z3.Implies(previous_step == z3.StringVal('solve-model'), current_step == z3.StringVal('solve-check'))"
+  - "z3.Implies(previous_step == z3.StringVal('solve-check'), current_step == z3.StringVal('plan-plan'))"
+  - "z3.Implies(previous_step == z3.StringVal('plan-plan'), current_step == z3.StringVal('plan-completion'))"
+  - "z3.Or(pipeline_state == z3.StringVal('init'), pipeline_state == z3.StringVal('running'), pipeline_state == z3.StringVal('failed'))"
+
+postconditions:
+  - "z3.Implies(current_step == z3.StringVal('plan-completion'), pipeline_state == z3.StringVal('complete'))"
+  - "z3.Not(previous_step == current_step)"
+  - "z3.Not(z3.And(pipeline_state == z3.StringVal('complete'), z3.Not(current_step == z3.StringVal('plan-completion'))))"
+  - "z3.Implies(z3.Not(previous_step == z3.StringVal('init')), pipeline_state == z3.StringVal('running'))"

--- a/skills/writing-plans/SKILL.md
+++ b/skills/writing-plans/SKILL.md
@@ -18,7 +18,7 @@ Transforms approved specs into actionable implementation plans using hybrid stru
 
 | User says / Context | Task | Dispatch | Context passed |
 |---------------------|------|----------|----------------|
-| "create plan" / "implementation plan" / "write plan" | `create` | `sub-task` | {spec_issue_number, spec_body} |
+| "create plan" / "implementation plan" / "write plan" / "plan" / "draft plan" | `create` | `sub-task` | {spec_issue_number, spec_body} |
 | completion / workflow end | `completion` | `sub-task` | {workflow_state} |
 
 ## Persona

--- a/skills/writing-plans/tasks/create.md
+++ b/skills/writing-plans/tasks/create.md
@@ -19,7 +19,7 @@ Create an implementation plan from an approved spec. Plans are stored at `.issue
 - [ ] 4. **RED checkpoint mandatory** — Procedure: every TDD task must include explicit Step 2 checkpoint
 - [ ] 5. **Approval cascade auto-approve** — Procedure: pipeline scope (`for_plan+`) auto-approves plan
 - [ ] 6. **Handoff verification pre-PASS** — **orchestrator routes to**: `handoffs/spec-to-plan` via sub-agent — Before any plan content is written, spec-to-plan handoff MUST return PASS. This is a non-waivable hard gate — no exceptions, no "proceed anyway."
-- [ ] 7. **16-gate dispatch table format mandatory** — Procedure: all plan phases MUST use the 16-gate implementation pipeline dispatch table format defined below in §Dispatch Table and §Dynamic Standard Gate Set Mandate. The gate labels, step sequence, and dispatch targets MUST reference the canonical source at `implementation-pipeline/SKILL.md` §Dispatch Routing Table. This is the default format for every phase — no exceptions, no simplified alternatives.
+- [ ] 7. **Checklist format mandatory** — Procedure: all plan phases MUST use the numbered checklist format with dispatch indicators. Steps are `- [ ] N.` with `(**clean-room**)` or `(**inline**)` dispatch mode indicators. The gate labels, step sequence, and dispatch targets MUST reference the canonical source at `implementation-pipeline/SKILL.md` §Dispatch Routing Table. This is the default format for every phase — no exceptions, no simplified alternatives.
 
 ## Entry Criteria
 
@@ -49,42 +49,43 @@ Create an implementation plan from an approved spec. Plans are stored at `.issue
 
 ## Orchestrator Execution Protocol
 
-- [ ] 1. Read the dispatch tables in the plan to determine the gate sequence for the current phase
-- [ ] 2. Execute every gate in every phase in numeric order (G1, G2, G3, ...)
-- [ ] 3. Do NOT skip any gate — every row is mandatory
-- [ ] 4. Do NOT reorder gates — the sequence is defined by the plan
-- [ ] 5. For `sub-task` gates: call `task()` with the exact `Receives Context` JSON object as the prompt, using the specified `Sub-Agent Type`
-- [ ] 6. For `inline` gates: execute the described operation directly (no sub-agent)
-- [ ] 7. After each gate completes, verify the SCs listed in that gate's SCs column
+- [ ] 1. Read the numbered checklist steps in the plan to determine the gate sequence for the current phase
+- [ ] 2. Execute every step in every phase in numeric order (1, 2, 3, ...)
+- [ ] 3. Do NOT skip any step — every entry is mandatory
+- [ ] 4. Do NOT reorder steps — the sequence is defined by the plan
+- [ ] 5. For `(**clean-room**)` steps: dispatch a clean-room sub-agent via `task()` with scoped context
+- [ ] 6. For `(**inline**)` steps: execute the described operation directly (no sub-agent)
+- [ ] 7. After each step completes, verify the SCs referenced in that step's `→ SC-N` annotation
 - [ ] 8. Report progress via chat output only — zero GitHub Issue comments during implementation unless absolutely warranted
 - [ ] 9. After each phase completes, run the Inter-Phase Handoff steps before advancing to the next phase
 - [ ] 10. Do NOT modify the plan — it is a static definitional artifact. Only mutate for remediation or scope revision
 
-## Dispatch Table
+## Checklist Format Specification
 
-Every plan phase MUST include a dispatch table using EXACTLY the following 6-column format. No deviations.
+Every plan phase MUST use the numbered checklist format with dispatch indicators. No deviations.
 
-| Gate | Dispatch Type | Blind? | Sub-Agent Type | Receives Context | SCs |
-|------|--------------|--------|----------------|-----------------|-----|
-| G{N}: {step-label} | sub-task or inline | yes (blind) or N/A | general or N/A | JSON context or — | SC-N |
+### Dispatch Mode Mapping
 
-### Dispatch Table Rules
+- `sub-task` → `(**clean-room**)`
+- Everything else (orchestrator, inline) → `(**inline**)`
 
-- [ ] 1. **One row per gate.** Every gate in the sequence must have exactly one row. No merged cells, no multi-step rows.
-- [ ] 2. **Dispatch Type is binary:** `sub-task` (orchestrator tasks a clean-room sub-agent) or `inline` (orchestrator executes directly — restricted to CHECKPOINT-COMMIT only).
-- [ ] 3. **Blind? column:** `yes (blind)` means the sub-agent receives only the Receives Context JSON — no other context from prior gates. `N/A` for inline gates.
-- [ ] 4. **Sub-Agent Type:** Use `general` for sub-task gates. Use `N/A` for inline gates.
-- [ ] 5. **Receives Context:** A JSON object with task instruction, issue number, phase number. For sub-task gates this is the EXACT prompt passed to `task()`. For inline gates this is `—` (em dash, no context).
-- [ ] 6. **SCs column:** Lists the SCs this gate verifies (e.g., `SC-1, SC-2`). Must match SC IDs from the spec.
-- [ ] 7. **Standard gate set is dynamic.** The gate labels and step sequence MUST be pulled from `implementation-pipeline/SKILL.md` §Dispatch Routing Table at the time of plan creation. Do NOT hardcode gate names — reference the canonical source. The current standard set is: `sc-coherence-gate`, `pre-red-baseline`, `red-phase`, `red-doublecheck`, `post-red-enforcement`, `green-phase`, `post-green-enforcement`, `checkpoint-commit`, `structural-checks`, `green-doublecheck`, `green-vbc`, `adversarial-audit`, `cross-validate`, `regression-check`, `review-prep`, `exec-summary`. Any deviation from this set must be justified.
+### Discovery Directive
 
-### Dynamic Standard Gate Set Mandate
+Read `implementation-pipeline/SKILL.md` §Dispatch Routing Table for the canonical gate sequence and dispatch types. Do NOT hardcode gate names — reference the canonical source at plan-creation time.
 
-The dispatch table for every phase MUST pull the list of gate step labels from `implementation-pipeline/SKILL.md` §Dispatch Routing Table. This is a MANDATORY dynamic reference — gate names are NOT hardcoded in `create.md`. The gate labels, their dispatch targets, and artifact requirements are defined in the implementation-pipeline skill and may evolve independently. If a gate is added or removed from the implementation-pipeline Dispatch Routing Table, plans follow automatically without updating `create.md`.
+### Sub-Step Expansion Directive
 
-### Inline Gates Restriction
+Gates with sub-steps (e.g., `adversarial-audit` with resolve-models → auditor_1 → remediate → auditor_2 → cross-validate) MUST be expanded into multiple `- [ ] N.` entries. Prohibit collapsing sub-steps into prose.
 
-Only `checkpoint-commit` may be an inline gate. All other gates MUST be `sub-task`. This restriction ensures every pipeline step is executed by a clean-room sub-agent except the git commit, which is a mechanical operation.
+### Output Format
+
+```
+- [ ] 1. <gate-label> (**<dispatch-mode>**) — <unit-specific exit criterion>
+  - <sub-step description> (**<dispatch-mode>**)
+  - <sub-step description> (**<dispatch-mode>**)
+- [ ] 2. <gate-label> (**<dispatch-mode>**) — <unit-specific exit criterion>
+...
+```
 
 ### Inter-Phase Handoff
 

--- a/skills/writing-plans/tasks/create/plan-structure.md
+++ b/skills/writing-plans/tasks/create/plan-structure.md
@@ -257,7 +257,7 @@ Refer to `plan` skill → `plan.md` task for SOLVED_SATISFICING/OPTIMALLY/UNSOLV
 
 ### Step 6: Generate Implementation Checklist — REMOVED
 
-Implementation checklist generation has been removed. The dispatch table template (Step 4) and per-unit pipeline gate tables (Step 5) provide sufficient execution guidance. No separate checklist artifact is needed.
+Implementation checklist generation has been removed. The checklist format (Step 4) and per-unit output format (Step 5) provide sufficient execution guidance. No separate checklist artifact is needed.
 
 ## Context Required
 


### PR DESCRIPTION
## Summary

Fixes `create.md` still containing old dispatch table format, and creates a formal plan-creation-pipeline skill with Z3-verified state transitions.

## Changes

| File | Change |
|------|--------|
| skills/writing-plans/SKILL.md | Add "plan" / "draft plan" trigger keywords |
| skills/writing-plans/tasks/create.md | Replace dispatch table section with checklist format spec. Fix Operating Protocol step 7 and Orchestrator Execution Protocol. |
| skills/writing-plans/tasks/create/plan-structure.md | Fix stale historical note to reference checklist format |
| skills/plan-creation-pipeline/SKILL.md | **New** — 6-step pipeline with Z3-verified transitions |
| skills/plan-creation-pipeline/pipeline-state-machine.yaml | **New** — state machine contract |

## Pipeline Steps

spec-to-plan-handoff → plan-create → solve-model → solve-check → plan-plan → plan-completion

plan-completion uses `local-issues sync` — no push, no URL, no comment, no approval cascade.

## Verification

All 12 SCs verified PASS. No dispatch table references remain in writing-plans task files.

Co-authored with AI: OpenCode (deepseek-v4-flash)
