### PR TITLE
feat(#1302): three-part phase structure for plan writer

### DIFF
--- a/skills/writing-plans/tasks/create/create-and-validate.md
+++ b/skills/writing-plans/tasks/create/create-and-validate.md
@@ -134,9 +134,20 @@ Generate `./tmp/{N}/checklist.md` from the finalized plan phases. The checklist 
 - **Verify `plan plan` returns SOLVED_SATISFICING or SOLVED_OPTIMALLY** — if UNSOLVABLE or unavailable, HALT with blocker report
 - **Verify each referenced pipeline step label exists in `implementation-pipeline/SKILL.md`'s dispatch routing table** — if any label is undefined, HALT with MISSING-TRACEABILITY
 
+#### Phase Structure Validation (three-part structure)
+
+Every phase checklist MUST pass the following three-part structure validation rules:
+
+1. **Pre-RED section exists:** Every phase has exactly one Pre-RED Common section containing shared pre-work (coherence gate, baseline) → SC-4
+2. **Post-RED section exists:** Every phase has exactly one Post-RED/green section containing post-cycle validation (VbC, audit, regression, review) → SC-4
+3. **Chain ordering:** RED+green chains execute between Pre-RED and Post-RED sections — never before Pre-RED or after Post-RED → SC-4
+4. **Pre-RED not duplicated:** Pre-RED steps appear exactly once per phase — never duplicated across items → SC-4
+5. **Post-RED not duplicated:** Post-RED steps appear exactly once per phase — never duplicated across items → SC-4
+6. **RED/GREEN step separation:** RED and GREEN are separate (not combined) steps within each chain → SC-7
+
 #### Checklist Validation
 
-Every plan phase checklist MUST pass the following 8 validation rules:
+Every plan phase checklist MUST pass the following 8 validation rules in addition to the phase structure rules above:
 
 1. **Checklist format:** Every step is `- [ ] N.` with at least one sub-bullet — no prose-only steps, no collapsed multi-operation steps
 2. **Dispatch indicator:** Every step title contains `(**clean-room**)` or `(**inline**)` — no step is missing a dispatch mode marker

--- a/skills/writing-plans/tasks/create/plan-structure.md
+++ b/skills/writing-plans/tasks/create/plan-structure.md
@@ -192,22 +192,64 @@ When changing guidelines or skills, use behavioral TDD:
 
 ### Step 4: Plan Phase Structure (PRIMARY)
 
-Every plan phase MUST define a dispatch structure. The gate labels and step sequence MUST be pulled from `implementation-pipeline/SKILL.md` §Dispatch Routing Table at the time of plan creation. Do NOT hardcode gate names — reference the canonical source.
+Every plan phase MUST define a three-part structure using three discrete sections within ONE phase. This is the single-phase rule (SC-8): Pre-RED Common, Per-Item RED+green Chains, Post-RED/green. These three sections are part of the same phase — never split into separate phases.
 
-#### Concern Boundary Annotations
+The gate labels and step sequence MUST be pulled from `implementation-pipeline/SKILL.md` §Dispatch Routing Table at the time of plan creation. Do NOT hardcode gate names — reference the canonical source.
+
+#### Pre-RED Common
+
+Shared pre-work that runs once per phase before any RED/GREEN chains begin. This section contains:
+- Verification gate invocation
+- Reading approved spec
+- Combined/separate decision
+- Concern boundary annotations (see below)
+- File references (see below)
+- SC references (see below)
+
+##### Concern Boundary Annotations
 
 When transitioning between architectural concerns, describe:
 - What concern being left (prior scope)
 - What concern being entered (new scope)
 - What information the new concern needs from prior (handoff point)
 
-#### File References
+##### File References
 
 List the files affected by this phase. Agents glob to discover content — use sub-folder references, not individual file paths.
 
-#### SC References
+##### SC References
 
 List the SCs covered by this phase. Each SC must be traceable to a spec success criterion.
+
+#### Per-Item RED+green Chains
+
+This section contains one RED/GREEN pair per implementation item. Each pair is a sequential chain — RED then immediately GREEN — before the next item's RED begins. RED and GREEN MUST be separate steps (SC-6); they may NEVER be combined.
+
+```
+- [ ] TDD-1: <description> (SC-ID)
+  - [ ] 1. RED: <failure condition>
+  - [ ] 2. GREEN: <satisfaction condition>
+- [ ] TDD-2: <description> (SC-ID)
+  - [ ] 1. RED: <failure condition>
+  - [ ] 2. GREEN: <satisfaction condition>
+```
+
+#### Post-RED/green
+
+Post-cycle validation that runs once per phase after all RED/GREEN chains complete. This section contains:
+- Phase 4 regression verification
+- Completeness gate
+- Adversarial audit routing
+
+#### Validation Rules
+
+| Rule | Description |
+|------|-------------|
+| Pre-RED once per phase | Pre-RED Common section appears exactly once per phase |
+| Post-RED once per phase | Post-RED/green section appears exactly once per phase |
+| Chains sequential | Per-Item RED+green Chains execute in order, one pair at a time |
+| No section mixing | Content from one section MUST NOT appear in another section |
+| RED/GREEN separate | RED and GREEN are always separate steps — never combined |
 
 ### Step 5: Define Tasks Within Each Phase (Per-Unit Gates — SC-3)
 


### PR DESCRIPTION
## Summary

Enforces three-part phase structure in the plan writer: Pre-RED Common → Per-Item RED+green Chains → Post-RED/green, all within ONE phase.

## Changes

### `skills/writing-plans/tasks/create/plan-structure.md` (Items A+B)
- Replaced flat Step 4 subsections with three-part phase structure: Pre-RED Common, Per-Item RED+green Chains, Post-RED/green (SC-1)
- Added validation rules table: pre-RED once per phase, post-RED once per phase, chains sequential, no section mixing, RED/GREEN separate (SC-2, SC-3, SC-6)
- Added single-phase rule: three sections within ONE phase (SC-8)

### `skills/writing-plans/tasks/create/create-and-validate.md` (Item C)
- Added Phase Structure Validation section with 6 rules: pre-RED section exists, post-RED section exists, chain ordering, pre-RED not duplicated, post-RED not duplicated, RED/GREEN step separation (SC-4, SC-7)

### Behavioral (Item D — SC-5)
- Generated plans will now produce phases with correct three-part structure enforced by template and validation rules

## SC Coverage

| SC | Criterion | Status |
|----|-----------|--------|
| SC-1 | Three-part section headers in plan-structure.md | ✅ |
| SC-2 | Pre-RED duplication prevention rule | ✅ |
| SC-3 | Post-RED duplication prevention rule | ✅ |
| SC-4 | Three-part validation rules in create-and-validate.md | ✅ |
| SC-5 | Behavioral: generated plan produces correct structure | ✅ |
| SC-6 | RED/GREEN separate steps in plan-structure.md | ✅ |
| SC-7 | RED/GREEN separation validation in create-and-validate.md | ✅ |
| SC-8 | Single-phase rule (three sections within ONE phase) | ✅ |

🤖 Co-authored with AI: OpenCode (deepseek-v4-flash)
