### PR TITLE
fix(#1300): skip worktree git refs in local-issues repo discovery

### DIFF
--- a/tools/local-issues
+++ b/tools/local-issues
@@ -284,6 +284,10 @@ def _discover_all_repos() -> list[Path]:
             continue
         git_ref = entry / ".git"
         if git_ref.exists():
+            if git_ref.is_file():
+                content = git_ref.read_text(encoding="utf-8")
+                if "worktrees" in content:
+                    continue
             resolved = entry.resolve()
             if resolved not in repos:
                 result = subprocess.run(


### PR DESCRIPTION
## Summary

`_discover_all_repos()` in `local-issues` was including the root repo's `.issues/` git worktree as a "child repo" because it found a `.git` file there with no filter to distinguish worktrees from submodules.

## Root Cause

The function scanned all immediate child directories for `.git` files/dirs and included any that passed `git rev-parse --is-bare-repository`. It had no filter to distinguish worktrees (`.issues/`) from submodules (`.opencode/`).

## Fix

Added a guard clause at `.opencode/tools/local-issues:287-290` that reads the `.git` file content and skips entries containing `worktrees/`. Submodule `.git` files contain `modules/` and pass through.

## Outcome

- SC-1: `_discover_all_repos()` no longer returns `.issues/` as a child repo — verified via live `local-issues init` execution
- SC-2: `.opencode/` submodule still discovered correctly — verified via live tool execution
- SC-3: `_sync_repo()` no longer probes `.issues/.issues/.git` — verified via behavioral test

## Verification

- 2 cross-family adversarial auditors (gemma4, qwen3.5) — all 3 SCs PASS
- Cross-validate consensus: PASS
- All 7 existing local-issues behavioral tests: PASS
- Lint (ruff check): PASS

🤖 Co-authored with AI: OpenCode (deepseek-v4-flash)