### PR TITLE
[SPEC] local-issues: detect legacy slug formats + strict {N} lookup + task file remediation

### DIFF
--- a/skills/issue-operations/platforms/local/SKILL.md
+++ b/skills/issue-operations/platforms/local/SKILL.md
@@ -17,12 +17,8 @@ Local issue tracking platform using `.issues/` directories at the repo root. Thi
 ```text
 .issues/
   .counter                  # Next issue number (auto-incremented)
-  open/
-    001-slug/spec.md         # Issue body (markdown + YAML frontmatter)
-    001-slug/comments.md     # Comments/updates (append-only)
-  closed/
-    002-slug/spec.md
-    002-slug/comments.md
+  {N}/spec.md               # Issue body (markdown + YAML frontmatter)
+  {N}/comments.md           # Comments/updates (append-only)
 ```
 
 ## Capability Contract

--- a/skills/issue-operations/platforms/local/tasks/close.md
+++ b/skills/issue-operations/platforms/local/tasks/close.md
@@ -8,7 +8,7 @@
 
 ## Overview
 
-Close a local issue by moving it from `.issues/open/` to `.issues/closed/`. Close is a local file mutation only — remote closure is handled by the sync-pull-to-local workflow. The agent that calls close must also dispatch `push-body` separately if remote sync is needed (see Remote Sync Note below).
+Close a local issue by updating its frontmatter `status` to `closed`. Close is a local file mutation only — remote closure is handled by the sync-pull-to-local workflow. The agent that calls close must also dispatch `push-body` separately if remote sync is needed (see Remote Sync Note below).
 
 **Primary tool:** `./.opencode/tools/local-issues`
 
@@ -19,7 +19,7 @@ ______________________________________________________________________
 ## Entry Criteria
 
 - \[ \] Issue identifier is known — bare `N` (integer) or qualified `{repo}#{N}` (e.g. `<repo>#<N>`)
-- \[ \] `.issues/open/<N>/` or `<child-repo>/.issues/open/<N>/` directory exists
+- \[ \] Issue directory `.issues/{N}/` or `<child-repo>/.issues/{N}/` exists
 - \[ \] `./.opencode/tools/local-issues` CLI tool is available
 - \[ \] Issue is currently open (`status: open` in frontmatter)
 - \[ \] Close reason is specified if known: `--reason completed|not_planned|duplicate`
@@ -32,7 +32,7 @@ ______________________________________________________________________
 | ---- | -------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | 1    | Verify open state    | `./.opencode/tools/local-issues read <repo>#<N>` — confirm `status: open`. If already `closed`, exit with code 2 (already closed).                                                                                   |
 | 2    | Pre-read frontmatter | Capture current frontmatter to preserve fields during transition.                                                                                                                         |
-| 3    | Close issue          | `./.opencode/tools/local-issues close <repo>#<N> [--reason completed]` — updates frontmatter (status → `closed`, `closed_at` timestamp, `state_reason`), moves `.issues/open/NNN-slug/` → `.issues/closed/NNN-slug/` |
+| 3    | Close issue          | `./.opencode/tools/local-issues close <repo>#<N> [--reason completed]` — updates frontmatter (status → `closed`, `closed_at` timestamp, `state_reason`) |
 | 4    | Verify               | `./.opencode/tools/local-issues read <repo>#<N>` — confirm exit 0, `status: closed`, `closed_at` timestamp present, `state_reason` matches expected value                                                            |
 | 5    | Auto-commit          | The CLI tool auto-commits the move on the issues-data branch (if configured). Verify the commit succeeded.                                                                                |
 
@@ -46,22 +46,17 @@ ______________________________________________________________________
 
 When no reason is specified, default is `completed`.
 
-### Directory Move
+### Flat Directory Close
 
-The CLI tool handles the physical move:
-
-- Source: `.issues/open/<N>-<slug>/`
-- Destination: `.issues/closed/<N>-<slug>/`
-
-The slug stays the same — only the parent directory changes. This preserves all files: `spec.md`, `comments.md`, `links.yaml`, `remote.md`, `state.md`.
+Close is a frontmatter-only mutation. The issue directory `.issues/{N}/` stays in place — no physical move. All files (`spec.md`, `comments.yaml`, `links.yaml`, `remote.md`) remain at the same path. The CLI tool updates `issue.yaml` frontmatter: `status: closed`, `closed_at`, `state_reason`.
 
 ______________________________________________________________________
 
 ## Exit Criteria
 
 - \[ \] CLI tool returned exit code 0
-- \[ \] `.issues/open/<N>/` directory no longer exists
-- \[ \] `.issues/closed/<N>/` directory exists with all files intact
+- \[ \] `.issues/{N}/issue.yaml` frontmatter `status` is `closed`
+- \[ \] `.issues/{N}/` directory exists with all files intact
 - \[ \] `./.opencode/tools/local-issues read N` returns exit 0
 - \[ \] Frontmatter `status` is `closed`
 - \[ \] `closed_at` timestamp is present (ISO 8601 format)
@@ -94,10 +89,10 @@ ______________________________________________________________________
 | Error                                         | Cause                                             | Resolution                                                                                        |
 | --------------------------------------------- | ------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
 | `./.opencode/tools/local-issues close N` exits code 2           | Issue is already closed                           | Report to orchestrator. No action needed — issue is in desired state.                             |
-| `./.opencode/tools/local-issues close N` exits non-zero (non-2) | Issue not found, move failed, frontmatter corrupt | Verify `.issues/open/<N>/` exists. Check frontmatter is valid YAML. Check filesystem permissions. |
-| Issue N not found                             | `.issues/open/<N>/` does not exist                | HALT. Verify issue number. Check if issue is already in `.issues/closed/`.                        |
+| `./.opencode/tools/local-issues close N` exits non-zero (non-2) | Issue not found, frontmatter corrupt | Verify `.issues/{N}/` exists. Check frontmatter is valid YAML. Check filesystem permissions. |
+| Issue N not found                             | `.issues/{N}/` does not exist                | HALT. Verify issue number. Check if issue exists.                        |
 | Frontmatter missing `status` field            | Corrupted spec.md                                 | HALT. Report corrupt issue data. Orchestrator must repair or delete.                              |
-| Move to closed fails                          | Filesystem error, permissions, destination exists | HALT. `.issues/closed/<N>/` may already exist. Orchestrator must resolve collision.               |
+| Close update fails                          | Filesystem error, permissions | HALT. Check filesystem.               |
 | CLI tool not found                            | `./.opencode/tools/local-issues` missing            | HALT. The tool must exist for local platform operations.                                          |
 | Push-body after close fails                   | Remote API error (auth, rate limit, 404)          | Report to orchestrator. Local close is already committed — push failure is a separate concern.    |
 

--- a/skills/issue-operations/platforms/local/tasks/delete.md
+++ b/skills/issue-operations/platforms/local/tasks/delete.md
@@ -19,7 +19,7 @@ ______________________________________________________________________
 ## Entry Criteria
 
 - \[ \] Issue identifier is known — bare `N` (integer) or qualified `{repo}#{N}` (e.g. `<repo>#<N>`)
-- \[ \] Issue N exists in `.issues/open/` or `.issues/closed/` (or `<child-repo>/.issues/` for qualified)
+- \[ \] Issue N exists in `.issues/{N}/` (or `<child-repo>/.issues/{N}/` for qualified)
 - \[ \] `./.opencode/tools/local-issues` CLI tool is available
 - \[ \] Intent is confirmed — delete is ONLY for cleanup (orphaned drafts, test artifacts, duplicates). Delete is NOT for closing issues in normal workflow. Use `close` instead.
 - \[ \] Orchestrator has explicitly requested deletion — delete is never self-initiated by a sub-agent
@@ -44,8 +44,8 @@ ______________________________________________________________________
 | 1    | Verify issue exists | `./.opencode/tools/local-issues read <repo>#<N>` — confirm exit 0. If exit non-zero → exit 1 (issue not found).                                                                    |
 | 2    | Check remote link   | Read frontmatter for `github_issue` or `remote_url` field. If present and non-empty → remote link exists.                                               |
 | 3    | Apply safety guard  | If remote link exists AND `--force` NOT provided → exit 2 (blocked). Report: "Remote issue R exists at `url`. Use --force to remove local mirror only." |
-| 4    | Delete              | `./.opencode/tools/local-issues delete <repo>#<N> [--force]` — removes `.issues/open/NNN-slug/` or `.issues/closed/NNN-slug/`. Auto-commits on issues-data branch.                 |
-| 5    | Verify deletion     | `./.opencode/tools/local-issues read <repo>#<N>` — confirm exit non-zero (issue no longer exists). Verify neither `.issues/open/NNN-slug/` nor `.issues/closed/NNN-slug/` exists.    |
+| 4    | Delete              | `./.opencode/tools/local-issues delete <repo>#<N> [--force]` — removes `.issues/{N}/` directory. Auto-commits on issues-data branch.                 |
+| 5    | Verify deletion     | `./.opencode/tools/local-issues read <repo>#<N>` — confirm exit non-zero (issue no longer exists). Verify `.issues/{N}/` no longer exists.    |
 | 6    | Report              | Report to orchestrator: issue number, whether remote link existed, whether --force was used, exit code, and whether remote issue is unaffected.         |
 
 ______________________________________________________________________
@@ -53,7 +53,7 @@ ______________________________________________________________________
 ## Exit Criteria
 
 - \[ \] CLI tool returned exit code 0
-- \[ \] `.issues/open/<N>/` and `.issues/closed/<N>/` both absent — issue fully removed
+- \[ \] `.issues/{N}/` absent — issue directory fully removed
 - \[ \] Remote issue is confirmed untouched (if remote link existed, `--force` removes only the local mirror)
 - \[ \] For exit 2: warning was printed, no files were modified
 - \[ \] For exit 1: issue was not found, no files were modified

--- a/skills/issue-operations/tasks/body-edit.md
+++ b/skills/issue-operations/tasks/body-edit.md
@@ -53,7 +53,7 @@ Read the current state of `.issues/N/remote.md` and platform metadata.
    ```bash
    git rev-parse --show-toplevel  # find repo root
    ```
-   Then locate `.issues/open/N-*` or `.issues/closed/N-*` matching the issue number.
+   Then locate `.issues/N/` matching the issue number.
 
 - [ ] 2. Read `.issues/N/remote.md` via `read` tool. If the file does not exist, report `remote_md_path: null` — the transform agent will create it.
 
@@ -65,11 +65,11 @@ Read the current state of `.issues/N/remote.md` and platform metadata.
      "current_body": "<content of remote.md, or null if not found>",
      "issue_number": N,
      "platform": "github|gitbucket|local",
-     "remote_md_path": ".issues/open/N-slug/remote.md"
+     "remote_md_path": ".issues/{N}/remote.md"
    }
    ```
 
-**Error handling:** If the issue directory does not exist (no `.issues/open/N-*` or `.issues/closed/N-*`), return `{ error: "issue_directory_not_found", issue_number: N }`. The orchestrator HALTs — do not create directories inline.
+**Error handling:** If the issue directory does not exist (no `.issues/N/`), return `{ error: "issue_directory_not_found", issue_number: N }`. The orchestrator HALTs — do not create directories inline.
 
 ### Phase 2: Transform Agent
 

--- a/skills/issue-operations/tasks/creation.md
+++ b/skills/issue-operations/tasks/creation.md
@@ -30,14 +30,14 @@ Create issue with proper title format, labels, and byline after validation passe
 
 **MANDATORY before proceeding to any creation step.**
 
-Verify that the `pre-creation` task's Step 0.5 title dedup gate was executed. This step MUST produce evidence that dedup was performed before the creation API call is allowed. **For both local and remote platforms, dedup checks MUST cover local `.issues/open/` directory AND the platform's remote issue search.**
+Verify that the `pre-creation` task's Step 0.5 title dedup gate was executed. This step MUST produce evidence that dedup was performed before the creation API call is allowed. **For both local and remote platforms, dedup checks MUST cover local `.issues/` directory AND the platform's remote issue search.**
 
 **Required evidence (from `pre-creation` Step 0.5 output):**
 
 ```
 Check: Title dedup gate for "<proposed title>"
 Tool: `issue-operations → search-issues` / `platforms/gitbucket-api/` / `platforms/local/tasks/search.md`
-Local: [N candidates found in .issues/open/]
+Local: [N candidates found in .issues/]
 Remote: [N candidates found, match levels classified]
 Classification: [EXACT-DUPLICATE|NEAR-DUPLICATE|CLOSED-IN-ERROR|RELATED-BUT-DISTINCT|FALSE-POSITIVE]
 Action: [auto-resolved strategy | proceed | HALT]
@@ -45,7 +45,7 @@ Action: [auto-resolved strategy | proceed | HALT]
 
 **Local dedup search (MANDATORY):**
 
-Before or alongside the remote dedup search, search `.issues/open/` for existing local specs:
+Before or alongside the remote dedup search, search `.issues/` for existing local specs:
 
 - [ ] 1. Route to `platforms/local/tasks/search.md` via task(). Pass: `{query: "<significant keywords>", status: "open"}`
 - [ ] 1. For each match, compare title keywords against proposed title
@@ -74,7 +74,7 @@ Cannot create issue: Step 0.5 dedup gate evidence missing. Run pre-creation task
 This fallback catches the scenario where `pre-creation` was not run or its output is not in the current session context.
 
 - [ ] 1. Extract significant keywords from the proposed title (remove stop words, prefixes like `[SPEC]`, `[SPEC-FIX]`, `[Task:]`)
-- [ ] 1. Search `.issues/open/` for local duplicates:
+- [ ] 1. Search `.issues/` for local duplicates:
    - **Local:** Route to `platforms/local/tasks/search.md` via task(). Pass: `{query: "<keywords>", status: "open"}`
    - Classify any local matches per `pre-creation.md` Step 0.5 Phase 2 classification table
 - [ ] 1. Search for existing issues via platform API:
@@ -90,7 +90,7 @@ This fallback catches the scenario where `pre-creation` was not run or its outpu
 ```
 Check: Runtime search fallback for "<proposed title>"
 Tool: `platforms/local/tasks/search.md` / `issue-operations → search-issues` / gitbucket-api issues
-Local: [N candidates found in .issues/open/]
+Local: [N candidates found in .issues/]
 Remote: [N candidates found, match levels classified]
 Classification: [EXACT-DUPLICATE|NEAR-DUPLICATE|CLOSED-IN-ERROR|RELATED-BUT-DISTINCT|FALSE-POSITIVE]
 Action: [HALT | proceed with runtime evidence]
@@ -141,9 +141,9 @@ Determine creation order based on `github.platform`:
 
 - [ ] 1. **Extract remote issue number** from API response `number` field
 
-- [ ] 1. **Create local `.issues/open/<remote-number>-<slug>/`** — the remote number IS the local directory name (no local counter needed)
+- [ ] 1. **Create local `.issues/{remote-number}/`** — the remote number IS the local directory name (no local counter needed)
 
-- [ ] 1. Write spec body to `.issues/open/<remote-number>-<slug>/spec.md` (preserving YAML frontmatter)
+- [ ] 1. Write spec body to `.issues/{remote-number}/spec.md` (preserving YAML frontmatter)
 
 - [ ] 1. Record remote metadata in YAML frontmatter:
 
@@ -163,16 +163,16 @@ Determine creation order based on `github.platform`:
 
 Route to `platforms/local/tasks/creation.md` via task(). Pass: `{title: "<title>", labels: ["needs-approval"]}`
 
-Then write the spec body to `.issues/open/NNN-slug/spec.md` (preserving YAML frontmatter).
+Then write the spec body to `.issues/{N}/spec.md` (preserving YAML frontmatter).
 
 **Local copy retains full-fidelity detail** — extra metadata, reasoning, and agent notes that stakeholders don't need.
 
-**No remote promotion possible.** Issue exists only in `.issues/open/`.
+**No remote promotion possible.** Issue exists only in `.issues/{N}/`.
 
 **Response includes:**
 
 - Local issue number (counter-based)
-- Local path: `.issues/open/NNN-slug/spec.md`
+- Local path: `.issues/{N}/spec.md`
 
 **Post-Creation URL Extraction (MANDATORY — per `000-critical-rules.md` §URL Sourcing):**
 
@@ -201,13 +201,13 @@ Report based on creation flow:
 
 ```
 Created remote issue #MMM at <html_url>
-Local mirror: .issues/open/MMM-slug/spec.md
+Local mirror: .issues/{N}/spec.md
 ```
 
 **Local-first flow (local platform only):**
 
 ```
-Created local issue #NNN at `.issues/open/NNN-slug/spec.md`
+Created local issue #NNN at `.issues/{N}/spec.md`
 ```
 
 ### Step 4.5: Developer Review Signal

--- a/skills/issue-operations/tasks/import-remote.md
+++ b/skills/issue-operations/tasks/import-remote.md
@@ -13,8 +13,8 @@ Retroactively import a pre-existing remote issue into the local `.issues/` direc
 
 ## Exit Criteria
 
-- Full local mirror created at `.issues/open/<remote_number>-<slug>/remote.md` (remote body) and `spec.md` (local frontmatter)
-- Comments imported to `.issues/open/<remote_number>-<slug>/comments.md`
+- Full local mirror created at `.issues/{remote_number}/remote.md` (remote body) and `spec.md` (local frontmatter)
+- Comments imported to `.issues/{remote_number}/comments.md`
 - Frontmatter written with remote metadata and `promotion_type: retroactive_import`
 - `.counter` advanced if `counter <= remote_number`
 
@@ -77,8 +77,7 @@ If `.issues/` directory does not exist, route to `platforms/local/tasks/creation
 
 Create the local issue directory manually (not via `local-issues create`, because we need to set the number to match the remote):
 
-- [ ] 1. Determine slug from title: first 5 words, kebab-cased
-- [ ] 1. Create directory: `.issues/open/<remote_number:03d>-<slug>/`
+- [ ] 1. Create directory: `.issues/{remote_number}/`
 - [ ] 1. Write `remote.md` with minimal frontmatter + full remote body:
 
 ```yaml
@@ -113,7 +112,7 @@ author: <remote_author>
 
 ### Step 5: Import Comments
 
-Write all fetched comments to `.issues/open/<remote_number>-<slug>/comments.md`:
+Write all fetched comments to `.issues/{remote_number}/comments.md`:
 
 ```markdown
 ---
@@ -151,7 +150,7 @@ Verify the full local mirror:
 | -- | -- |
 | Issue already imported (matching `remote_issue` found) | HALT — report already imported, provide path |
 | Issue number conflicts with existing local issue | Use next available number, record remote_number in frontmatter |
-| Remote issue is closed | Import as closed: create in `.issues/closed/` with `status: closed` |
+| Remote issue is closed | Import as closed: create at `.issues/{N}/` with `status: closed` |
 | Remote has zero comments | Write empty `comments.md` |
 | Remote body is empty | Write "*(No body content)*" placeholder |
 | Platform API returns error | HALT — report the error, do not create partial import |
@@ -169,9 +168,9 @@ Verify the full local mirror:
 
 | Claim | Verification Action | Tool Call | Problem Class |
 | -- | -- | -- | -- |
-| "remote.md exists (body)" | Verify file at `.issues/open/NNN-slug/remote.md` | `local-issues read <number>` | MISSING-ELEMENT |
-| "spec.md exists (frontmatter only)" | Verify file at `.issues/open/NNN-slug/spec.md` | `local-issues read <number>` | MISSING-ELEMENT |
-| "comments.md exists with all comments" | Verify file and comment count matches remote | `cat .issues/open/NNN-slug/comments.md \| wc -l` | MISSING-ELEMENT |
+| "remote.md exists (body)" | Verify file at `.issues/{N}/remote.md` | `local-issues read <number>` | MISSING-ELEMENT |
+| "spec.md exists (frontmatter only)" | Verify file at `.issues/{N}/spec.md` | `local-issues read <number>` | MISSING-ELEMENT |
+| "comments.md exists with all comments" | Verify file and comment count matches remote | `ls .issues/{N}/comments.md` | MISSING-ELEMENT |
 | "promotion_type in frontmatter" | Verify `promotion_type: retroactive_import` present | `local-issues read <number>` → parse frontmatter | STRUCTURE-VIOLATION |
 | "Counter advanced correctly" | Verify `.counter` value >= remote_number + 1 | `cat .issues/.counter` | VERIFICATION-GAP |
 | "Body matches remote (remote.md)" | Compare remote.md body against remote issue body | `local-issues read <number>` | VERIFICATION-GAP |

--- a/skills/issue-operations/tasks/sync-pull-to-local.md
+++ b/skills/issue-operations/tasks/sync-pull-to-local.md
@@ -12,7 +12,7 @@ After any `read-issue` call, automatically mirror the remote issue body to `.iss
 
 ## Exit Criteria
 
-- Local mirror exists at `.issues/open/<number>-<slug>/remote.md` (remote body) alongside `spec.md` (local spec)
+- Local mirror exists at `.issues/{number}/remote.md` (remote body) alongside `spec.md` (local spec)
 - YAML frontmatter written with `remote_issue`, `remote_url`, `last_sync`
 - Local mirror is up to date with remote body
 
@@ -26,7 +26,7 @@ If `.issues/` directory does not exist, route to `platforms/local/tasks/creation
 
 Determine whether a local issue already exists for this remote number:
 
-- [ ] 1. Search `.issues/open/` and `.issues/closed/` for an entry matching the remote number
+- [ ] 1. Search `.issues/` for an entry matching the remote number
 - [ ] 2. If found: the issue exists locally — proceed to Step 3 (update)
 - [ ] 3. If not found: create a new local issue via task() to `platforms/local/tasks/creation.md`: `{title: "<remote_title>"}`
 
@@ -86,7 +86,7 @@ Read back the local remote.md and verify:
 
 | Claim | Verification Action | Tool Call | Problem Class |
 | -- | -- | -- | -- |
-| "Local remote.md exists" | Verify file exists at `.issues/open/NNN-slug/remote.md` | `ls .issues/open/*/remote.md` | MISSING-ELEMENT |
+| "Local remote.md exists" | Verify file exists at `.issues/{N}/remote.md` | `ls .issues/{N}/remote.md` | MISSING-ELEMENT |
 | "Body matches remote" | Compare local remote.md body vs remote issue body | `local-issues read NNN` (reads remote.md) | VERIFICATION-GAP |
 | "Frontmatter has remote_issue" | Verify YAML frontmatter contains `remote_issue` field | `local-issues read NNN` → parse frontmatter | STRUCTURE-VIOLATION |
 | "last_sync is recent" | Verify timestamp is within current session window | `local-issues read NNN` → parse frontmatter | VERIFICATION-GAP |

--- a/tools/local-issues
+++ b/tools/local-issues
@@ -81,7 +81,7 @@ def _repo_has_issue(number: int, repo_path: Path) -> bool:
     path = _find_issue_dir_in_repo(number, repo_path)
     if not path or not path.is_dir():
         return False
-    return (path / "issue.yaml").exists() or (path / "spec.md").exists()
+    return True
 
 
 def _slug(text: str, max_len: int = 60) -> str:

--- a/tools/local-issues
+++ b/tools/local-issues
@@ -57,75 +57,23 @@ MARKDOWN_FILES = ("spec.md",)
 
 
 def _find_issue_dir(number: int, repo_path: Path | None = None) -> Path | None:
-    """Find issue directory by NNN prefix match or exact number.
+    """Find issue directory by exact number match.
 
-    Matches `.issues/<number>` or `.issues/<number>-<slug>` or
-    `.issues/open/<number>-<slug>`. Returns None if no match.
+    Matches `.issues/<number>` only. Returns None if no match.
     """
-    prefix = str(number).lstrip("0") or "0"
-    padded_prefix = f"{number:03d}"
     issues_dir = (repo_path or PROJECT_DIR) / ISSUES_DIR
-
-    # Check exact match first
-    exact = issues_dir / prefix
+    exact = issues_dir / str(number)
     if exact.is_dir():
         return exact
-
-    # Check open/ first (active issues)
-    open_dir = issues_dir / "open"
-    if open_dir.is_dir():
-        for entry in sorted(open_dir.iterdir()):
-            if entry.is_dir() and (
-                entry.name.startswith(prefix + "-")
-                or entry.name.startswith(padded_prefix + "-")
-            ):
-                return entry
-
-    # Check all top-level dirs for prefix match
-    if issues_dir.is_dir():
-        for entry in sorted(issues_dir.iterdir()):
-            if not entry.is_dir():
-                continue
-            if entry.name == prefix:
-                return entry
-            if entry.name.startswith(prefix + "-") or entry.name.startswith(
-                padded_prefix + "-"
-            ):
-                return entry
-
     return None
 
 
 def _find_issue_dir_in_repo(number: int, repo_path: Path) -> Path | None:
-    """Find issue directory by number within a specific repo path."""
-    prefix = str(number).lstrip("0") or "0"
-    padded_prefix = f"{number:03d}"
+    """Find issue directory by exact number within a specific repo path."""
     issues_dir = repo_path / ISSUES_DIR
-
-    exact = issues_dir / prefix
+    exact = issues_dir / str(number)
     if exact.is_dir():
         return exact
-
-    open_dir = issues_dir / "open"
-    if open_dir.is_dir():
-        for entry in sorted(open_dir.iterdir()):
-            if entry.is_dir() and (
-                entry.name.startswith(prefix + "-")
-                or entry.name.startswith(padded_prefix + "-")
-            ):
-                return entry
-
-    if issues_dir.is_dir():
-        for entry in sorted(issues_dir.iterdir()):
-            if not entry.is_dir():
-                continue
-            if entry.name == prefix:
-                return entry
-            if entry.name.startswith(prefix + "-") or entry.name.startswith(
-                padded_prefix + "-"
-            ):
-                return entry
-
     return None
 
 
@@ -725,13 +673,6 @@ def _count_issues(repo_path: Path) -> int:
         if num is not None and num not in seen:
             seen.add(num)
             count += 1
-    open_dir = issues_dir / "open"
-    if open_dir.is_dir():
-        for entry in sorted(open_dir.iterdir()):
-            num = _parse_number(entry)
-            if num is not None and num not in seen:
-                seen.add(num)
-                count += 1
     return count
 
 
@@ -1010,12 +951,6 @@ def _recent_issue_numbers(repo_path: Path | None = None) -> list[int]:
         num = _parse_number(entry)
         if num is not None:
             nums.add(num)
-    open_dir = issues_dir / "open"
-    if open_dir.is_dir():
-        for entry in open_dir.iterdir():
-            num = _parse_number(entry)
-            if num is not None:
-                nums.add(num)
     sorted_nums = sorted(nums, reverse=True)
     return sorted_nums[:5]
 
@@ -1832,12 +1767,54 @@ def build_parser() -> argparse.ArgumentParser:
     return parser
 
 
+def _check_legacy_formats(issues_dir: Path) -> None:
+    """Emit a warning if legacy issue directory formats are detected.
+
+    Checks for:
+    1. .issues/open/ or .issues/closed/ subdirectories
+    2. Directories matching legacy slug format {N}-{slug} (regex: ^\\d+-.+)
+
+    Fires at most once per session via .issues/.legacy-warned sentinel.
+    """
+    sentinel = issues_dir / ".legacy-warned"
+    if sentinel.exists():
+        return
+
+    legacy_found = False
+
+    # Check for open/ or closed/ subdirectories
+    for legacy_sub in ("open", "closed"):
+        if (issues_dir / legacy_sub).is_dir():
+            legacy_found = True
+            break
+
+    # Check for legacy slug-format directories (^\d+-.+)
+    if not legacy_found and issues_dir.is_dir():
+        for entry in issues_dir.iterdir():
+            if not entry.is_dir():
+                continue
+            if re.match(r"^\d+-.+", entry.name):  # noqa: SIM114
+                legacy_found = True
+                break
+
+    if legacy_found:
+        print(
+            "Warning: Legacy issue directory format detected in .issues/. "
+            "AI agent must inspect and remediate manually.",
+            file=sys.stderr,
+        )
+        sentinel.parent.mkdir(parents=True, exist_ok=True)
+        sentinel.touch()
+
+
 def main() -> None:
     if len(sys.argv) == 2 and sys.argv[1] == "--description":
         print("Local issue tracking CLI tool for .issues/ directory.")
         return
     parser = build_parser()
     args = parser.parse_args()
+
+    _check_legacy_formats(Path(ISSUES_DIR))
 
     command_map = {
         "create": cmd_create,


### PR DESCRIPTION
## Summary

Implements spec #1309: local-issues legacy slug detection with AI agent remediation warning, strict `{N}` flat path lookup, and Phase 2 skill task file remediation.

## Outcome

**Phase 1 — Tool Detection + Strict Lookup (SC-1 through SC-7):**
- Added `_check_legacy_formats()`: detects `.issues/open/`, `.issues/closed/`, and `{N}-{slug}` legacy dirs → generic stderr warning
- Warning is non-prescriptive: "AI agent must inspect and remediate manually"
- Sentinel file (`.legacy-warned`) prevents re-fire per session
- Non-legacy dirs (`research-cards/`, `templates/`) silently ignored
- No warning on `--description` command
- Stripped all slug + padded prefix matching from `_find_issue_dir()` and `_find_issue_dir_in_repo()` — strict `{N}` only
- Stripped `open/` subdirectory traversal from `_count_issues()` and `_recent_issue_numbers()`
- Fixed `_repo_has_issue()` to accept directory existence as sufficient (SC-15)

**Phase 2 — Skill Task File Remediation (SC-8 through SC-14):**
- `platforms/local/SKILL.md` architecture diagram: `001-slug/` → `{N}/`
- `platforms/local/tasks/close.md`: removed `open/`→`closed/` move pattern, flat directory close
- `platforms/local/tasks/delete.md`: replaced `open/`/`closed/` refs with `{N}`
- `tasks/import-remote.md`: removed slug algorithm, all paths → `{N}`
- `tasks/creation.md`: all `NNN-slug`, `open/` refs → `{N}`
- `tasks/body-edit.md`: `open/`/`closed/` → `{N}`
- `tasks/sync-pull-to-local.md`: slug/`open/`/`closed/` → `{N}`

## Fixes

- Closes https://github.com/michael-conrad/.opencode/issues/1309

🤖 Co-authored with AI: OpenCode (deepseek-v4-flash)

---

**Branch:** `feature/1309-legacy-slug-detection` → `dev`