### PR TITLE
[SPEC-FIX] Fix issues-data URL construction and plan-file repo routing (#1321)

### DIFF
--- a/skills/issue-operations/tasks/creation.md
+++ b/skills/issue-operations/tasks/creation.md
@@ -262,7 +262,7 @@ The body must contain the following 6 sections in order:
    ## AI Agent Instructions
 
    This issue is an executive summary for human stakeholders.
-   The authoritative spec and plan artifacts are at {github.html_url}/{owner}/{repo}/tree/issues-data/.issues/{N}/.
+   The authoritative spec and plan artifacts are at {html_url}/{owner}/{repo}/tree/issues-data/{N}/.
    AI agents MUST read the local spec/plan files for implementation
    and MUST NOT base implementation on this summary.
    ```

--- a/skills/spec-creation/tasks/completion.md
+++ b/skills/spec-creation/tasks/completion.md
@@ -29,7 +29,7 @@ Idempotent completion subtask for spec-creation. Ensures mandatory steps ran reg
    - If missing: generate and post exec summary now
 
 - [ ] 5. **Spec folder URL blockquote** (if not already present in issue body):
-   - Generate the spec folder URL: `{github.html_url}/tree/issues-data/{N}/`
+   - Generate the spec folder URL: `{html_url}/{owner}/{repo}/tree/issues-data/{N}/`
    - Check if the issue body already contains the `.issues/{N}/` blockquote
    - If missing: prepend the blockquote (per Step 6.8 of write.md) and update the issue body
 

--- a/skills/spec-creation/tasks/write.md
+++ b/skills/spec-creation/tasks/write.md
@@ -484,7 +484,7 @@ Assemble the final spec with acceptance criteria, ambiguity elimination, and del
     > **Local artifacts:** `.issues/{N}/` — implementation plan, card catalogue, dependency contracts, research, designs, audit findings
     ```
 
-    The URL follows the pattern: `{github.html_url}/tree/issues-data/{N}/`
+    The URL follows the pattern: `{html_url}/{owner}/{repo}/tree/issues-data/{N}` where `{html_url}`, `{owner}`, and `{repo}` are resolved from the session-init repo entry whose `path` matches the issue's repo. See `.issues/AGENTS.md` for the canonical URL convention.
 
     Embed this blockquote at the TOP of the issue body (before the spec content), prepended when creating the issue body or updated after creation.
 
@@ -519,15 +519,15 @@ Assemble the final spec with acceptance criteria, ambiguity elimination, and del
     **1. Spec Reference Blockquote (mandatory — top of body, before all other content)**
 
     ```
-    > Full spec and plan artifacts: {github.html_url}/{owner}/{repo}/tree/issues-data/.issues/{N}/
+    > Full spec and plan artifacts: {html_url}/{owner}/{repo}/tree/issues-data/{N}/
     ```
 
     **Construction rules (mandatory — pre-creation URL per URL Sourcing Rule 2):**
 
-    - [ ] Extract `github.html_url` (or `gitbucket.html_url`) from session-init — this is the platform-agnostic browser URL
-    - [ ] Extract `github.owner` and `github.repo` from session-init
-    - [ ] Construct the URL: `{github.html_url}/{owner}/{repo}/tree/issues-data/.issues/{N}/`
+    - [ ] Resolve `html_url`, `owner`, `repo` from the session-init `## Repo Information` entry whose `path` matches the issue's repo. The session-init section provides per-repo values — do NOT use hardcoded `github.html_url` or root repo values.
+    - [ ] Construct the URL: `{html_url}/{owner}/{repo}/tree/issues-data/{N}/`
     - [ ] **Character-match verification**: Confirm the constructed URL contains the exact `{owner}` and `{repo}` strings from session-init (character-for-character match, no typos)
+    - [ ] **Substitution verification**: After URL construction, verify `{html_url}` was substituted (not left as a literal placeholder). If `{html_url}` remains in the constructed URL, HALT with blocker — the placeholder was not resolved.
     - [ ] **Repo-awareness guard**: Confirm owner/repo matches the target issue's repository before URL construction. If the issue resides in a submodule repo with different owner/repo, use that repo's session-init values
     - [ ] All links MUST be full resolved URLs — no platform-specific shortcuts (`#NNN`, `owner/repo#NNN`)
 

--- a/skills/spec-creation/tasks/write.md
+++ b/skills/spec-creation/tasks/write.md
@@ -479,7 +479,7 @@ Assemble the final spec with acceptance criteria, ambiguity elimination, and del
 - [ ] 34. **Step 6.8: Generate Spec Folder URL (SC-6)** — Generate the spec folder URL and prepare the blockquote for embedding at the top of the issue body. Follow the `.issues/AGENTS.md` pattern:
 
     ```
-    > **Full spec and artifacts: [`.issues/{N}/`](https://github.com/{owner}/{repo}/tree/issues-data/{N})** — this issue is a condensed exec summary; the authoritative spec lives in the `issues-data` branch.
+    > **Full spec and artifacts: [`.issues/{N}/`]({html_url}/{owner}/{repo}/tree/issues-data/{N})** — this issue is a condensed exec summary; the authoritative spec lives in the `issues-data` branch.
     >
     > **Local artifacts:** `.issues/{N}/` — implementation plan, card catalogue, dependency contracts, research, designs, audit findings
     ```

--- a/skills/writing-plans/SKILL.md
+++ b/skills/writing-plans/SKILL.md
@@ -56,7 +56,8 @@ This skill produces plans by dispatching sub-agents. The orchestrator routes; su
 - [ ] 3. [inline] Invoke `solve model` for dependency-ordering constraints contract — chain: `step_2`
 - [ ] 4. [inline] Invoke `solve check` to verify SAT — chain: `step_3`
 - [ ] 5. [inline] Invoke `plan plan` for phase solvability validation — chain: `step_4`
-- [ ] 6. [sub-task: completion] `task(..., prompt: "execute completion task from writing-plans")` — input: `./tmp/{N}/contracts/completion-input.yaml`, output: `./tmp/{N}/contracts/completion-output.yaml`, template: `.opencode/skills/writing-plans/contracts/create-output-template.yaml` (shared), chain: `step_5`
+- [ ] 6. [sub-task: write] `task(..., prompt: "execute write task from writing-plans")` — Write plan file to correct repo's `.issues/` worktree. Resolve target repo from session-init `## Repo Information` by matching issue's repo path prefix. Use `local-issues sync-file` for commit+push. URL uses resolved repo's `html_url`, `owner`, `repo`. chain: `step_5`
+- [ ] 7. [sub-task: completion] `task(..., prompt: "execute completion task from writing-plans")` — input: `./tmp/{N}/contracts/completion-input.yaml`, output: `./tmp/{N}/contracts/completion-output.yaml`, template: `.opencode/skills/writing-plans/contracts/create-output-template.yaml` (shared), chain: `step_6`
 
 ## Sub-Agent Routing
 

--- a/skills/writing-plans/tasks/write.md
+++ b/skills/writing-plans/tasks/write.md
@@ -1,0 +1,51 @@
+# Task: write
+
+## Purpose
+
+Write an implementation plan file to the correct repo's `.issues/` worktree and push it via `local-issues sync-file`.
+
+## Prerequisites
+
+- [ ] 1. Plan content has been created (by `create` task)
+- [ ] 2. Spec issue number (`N`) is known
+- [ ] 3. Session-init `## Repo Information` is available for repo resolution
+
+## Operating Protocol
+
+- [ ] 1. **Resolve target repo** — Match the spec issue's repo path against session-init `## Repo Information` entries. The issue's repo is determined by its issue number's location: if the issue is in `.opencode/.issues/{N}/`, the repo is the `.opencode` submodule entry; if in `.issues/{N}/`, the repo is the root entry. Extract `html_url`, `owner`, `repo` from the matching entry.
+- [ ] 2. **Write plan file** — Write the plan content to the resolved repo's `.issues/` worktree at `{worktree.path}/.issues/{N}/plan.md`.
+- [ ] 3. **Commit and push** — Run `local-issues sync-file` with the plan file path. This handles `git add`, `git commit`, and `git push` in the correct worktree.
+- [ ] 4. **Generate URL** — Construct the plan file URL using the resolved repo's `html_url`, `owner`, and `repo`: `{html_url}/{owner}/{repo}/tree/issues-data/{N}/plan.md`. Verify `{html_url}` was substituted (not left as a literal placeholder). If placeholder remains, HALT with blocker.
+
+## Entry Criteria
+
+- Plan content is ready for file placement
+- Target repo is resolved from session-init `## Repo Information`
+- `local-issues sync-file` subcommand is available
+
+## Exit Criteria
+
+- Plan file written to correct repo's `.issues/{N}/plan.md`
+- File committed and pushed via `local-issues sync-file`
+- Plan file URL reported with correct repo's `html_url`, `owner`, `repo`
+
+## Repo Resolution
+
+The session-init `## Repo Information` section provides per-repo entries:
+
+```yaml
+- path: .
+  owner: michael-conrad
+  repo: opencode-config
+  platform: github.com
+  url: git@github.com:michael-conrad/opencode-config.git
+  html_url: https://github.com
+- path: .opencode
+  owner: michael-conrad
+  repo: .opencode
+  platform: github.com
+  url: git@github.com:michael-conrad/.opencode.git
+  html_url: https://github.com
+```
+
+Match the issue's repo path prefix against the `path` field. Use the matching entry's `html_url`, `owner`, and `repo` for URL construction.

--- a/tests/behaviors/1321-sc1-url-pattern-red.sh
+++ b/tests/behaviors/1321-sc1-url-pattern-red.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# Behavioral test: 1321-sc1-url-pattern-red
+# See .opencode/tests/AGENTS.md for the test harness specification and paradigm.
+# This script is an artifact-only generator — it does NOT evaluate model output.
+#
+# SC-1 (string): Step 7r URL pattern uses {html_url}/{owner}/{repo}/tree/issues-data/{N}
+# (no .issues/ prefix, no hardcoded github.html_url)
+#
+# RED phase: write.md Step 7r still has the .issues/ prefix in the URL.
+# The agent will produce stderr containing the wrong pattern.
+#
+# Issue #1321: Fix issues-data URL construction
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/helpers.sh"
+
+SCENARIO_NAME="1321-sc1-url-pattern-red"
+SCENARIO_PROMPT="Create a [SPEC] issue for adding request timeout configuration to the API client. Include the spec folder URL blockquote in the issue body."
+
+BEHAVIOR_PHASE="${BEHAVIOR_PHASE:-RED}"
+export BEHAVIOR_PHASE
+
+echo "=== Behavioral Test: $SCENARIO_NAME (phase=$BEHAVIOR_PHASE) ==="
+echo "  Prompt triggers spec-creation → Step 6.8 URL generation"
+echo "  RED expectation: stderr contains 'tree/issues-data/.issues/' (wrong pattern)"
+echo ""
+
+behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT"
+
+echo "  Artifacts: $BEHAVIOR_ARTIFACT_DIR"
+exit 0

--- a/tests/behaviors/1321-sc2-no-hardcoded-url-red.sh
+++ b/tests/behaviors/1321-sc2-no-hardcoded-url-red.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# Behavioral test: 1321-sc2-no-hardcoded-url-red
+# See .opencode/tests/AGENTS.md for the test harness specification and paradigm.
+# This script is an artifact-only generator — it does NOT evaluate model output.
+#
+# SC-2 (string): Step 6.8 URL pattern matches Step 7r (both use
+# {html_url}/{owner}/{repo}/tree/issues-data/{N}). No hardcoded github.html_url.
+#
+# RED phase: write.md Step 6.8 still uses hardcoded github.html_url pattern.
+# The agent will produce stderr containing the hardcoded pattern.
+#
+# Issue #1321: Fix issues-data URL construction
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/helpers.sh"
+
+SCENARIO_NAME="1321-sc2-no-hardcoded-url-red"
+SCENARIO_PROMPT="Create a [SPEC] issue for implementing retry logic with exponential backoff. Include the spec folder URL blockquote in the issue body."
+
+BEHAVIOR_PHASE="${BEHAVIOR_PHASE:-RED}"
+export BEHAVIOR_PHASE
+
+echo "=== Behavioral Test: $SCENARIO_NAME (phase=$BEHAVIOR_PHASE) ==="
+echo "  Prompt triggers spec-creation → Step 6.8 URL generation"
+echo "  RED expectation: stderr contains 'github.html_url' (hardcoded, wrong)"
+echo ""
+
+behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT"
+
+echo "  Artifacts: $BEHAVIOR_ARTIFACT_DIR"
+exit 0

--- a/tests/behaviors/1321-sc5-sync-file-red.sh
+++ b/tests/behaviors/1321-sc5-sync-file-red.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# Behavioral test: 1321-sc5-sync-file-red
+# See .opencode/tests/AGENTS.md for the test harness specification and paradigm.
+# This script is an artifact-only generator — it does NOT evaluate model output.
+#
+# SC-5 (behavioral): `local-issues sync-file` subcommand exists and handles
+# commit+push in the correct worktree.
+#
+# RED phase: sync-file subcommand does NOT exist yet. The agent will be
+# prompted to create a plan file — stderr will NOT contain `local-issues sync-file`.
+# After GREEN, the agent WILL dispatch sync-file.
+#
+# Issue #1321: Add local-issues sync-file subcommand
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/helpers.sh"
+
+SCENARIO_NAME="1321-sc5-sync-file-red"
+SCENARIO_PROMPT="Create a plan file for issue #42 in the .issues/ directory. Use local-issues to write the plan spec."
+
+BEHAVIOR_PHASE="${BEHAVIOR_PHASE:-RED}"
+export BEHAVIOR_PHASE
+
+echo "=== Behavioral Test: $SCENARIO_NAME (phase=$BEHAVIOR_PHASE) ==="
+echo "  Prompt triggers plan file creation via local-issues"
+echo "  RED expectation: stderr does NOT contain 'local-issues sync-file'"
+echo ""
+
+behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT"
+
+echo "  Artifacts: $BEHAVIOR_ARTIFACT_DIR"
+exit 0

--- a/tests/behaviors/1321-sc7-url-resolves-red.sh
+++ b/tests/behaviors/1321-sc7-url-resolves-red.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# Behavioral test: 1321-sc7-url-resolves-red
+# See .opencode/tests/AGENTS.md for the test harness specification and paradigm.
+# This script is an artifact-only generator — it does NOT evaluate model output.
+#
+# SC-7 (behavioral): Constructed URL resolves to a valid page (not 404)
+# when tested against a real issue on any platform.
+#
+# RED phase: The URL pattern still includes .issues/ prefix, so the
+# constructed URL will 404. The agent will produce a broken URL.
+#
+# Issue #1321: Fix issues-data URL construction
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/helpers.sh"
+
+SCENARIO_NAME="1321-sc7-url-resolves-red"
+SCENARIO_PROMPT="Create a [SPEC] issue for adding structured logging to the application. Include the spec folder URL blockquote in the issue body."
+
+BEHAVIOR_PHASE="${BEHAVIOR_PHASE:-RED}"
+export BEHAVIOR_PHASE
+
+echo "=== Behavioral Test: $SCENARIO_NAME (phase=$BEHAVIOR_PHASE) ==="
+echo "  Prompt triggers spec-creation → URL generation"
+echo "  RED expectation: constructed URL returns 404 (wrong pattern)"
+echo ""
+
+behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT"
+
+echo "  Artifacts: $BEHAVIOR_ARTIFACT_DIR"
+exit 0

--- a/tests/content-verification/1321-sc3-per-repo-resolution.sh
+++ b/tests/content-verification/1321-sc3-per-repo-resolution.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+# Content-Verification Test: 1321-sc3-per-repo-resolution (SC-3)
+#
+# Grep-based checks verifying that write.md contains per-repo resolution
+# rules for URL construction: html_url, owner, repo come from session-init
+# repo entry matching the issue's repo.
+#
+# RED phase: write.md still has hardcoded github.html_url and no per-repo
+# resolution rule. These grep checks will FAIL.
+#
+# Issue #1321: Fix issues-data URL construction
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$SCRIPT_DIR"
+while [ "$(basename "$PROJECT_DIR")" != ".opencode" ]; do
+    PROJECT_DIR="$(dirname "$PROJECT_DIR")"
+done
+PROJECT_DIR="$(dirname "$PROJECT_DIR")"
+
+WRITE_MD="$PROJECT_DIR/.opencode/skills/spec-creation/tasks/write.md"
+
+OVERALL_RESULT=0
+
+echo "=== Content-Verification: 1321-sc3-per-repo-resolution (SC-3) ==="
+
+# SC-3: URL construction includes per-repo resolution rule referencing session-init
+if grep -q "session-init\|Repo Information\|per-repo" "$WRITE_MD" 2>/dev/null; then
+    echo "PASS: write.md references session-init or Repo Information for per-repo resolution"
+else
+    echo "FAIL: write.md missing session-init/Repo Information reference for per-repo resolution"
+    OVERALL_RESULT=1
+fi
+
+# SC-3: URL construction instructions mention resolving html_url from repo entry
+if grep -q "html_url.*repo\|repo.*html_url\|per-repo.*url\|url.*per-repo" "$WRITE_MD" 2>/dev/null; then
+    echo "PASS: write.md has per-repo html_url resolution rule"
+else
+    echo "FAIL: write.md missing per-repo html_url resolution rule"
+    OVERALL_RESULT=1
+fi
+
+# SC-3: No hardcoded github.html_url in URL construction lines
+if grep -n "github.html_url" "$WRITE_MD" 2>/dev/null | grep -i "tree/issues-data" > /dev/null 2>&1; then
+    echo "FAIL: write.md still has hardcoded github.html_url in URL construction"
+    OVERALL_RESULT=1
+else
+    echo "PASS: write.md has no hardcoded github.html_url in URL construction"
+fi
+
+echo ""
+if [ "$OVERALL_RESULT" -eq 0 ]; then
+    echo "PASS: 1321-sc3-per-repo-resolution"
+else
+    echo "FAIL: 1321-sc3-per-repo-resolution"
+fi
+
+exit $OVERALL_RESULT

--- a/tests/content-verification/1321-sc6-repo-routing-skill.sh
+++ b/tests/content-verification/1321-sc6-repo-routing-skill.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+# Content-Verification Test: 1321-sc6-repo-routing-skill (SC-6)
+#
+# Grep-based checks verifying that writing-plans/SKILL.md Operating
+# Protocol includes a repo-routing step. No such reference exists yet,
+# so all grep checks will FAIL — this is the expected RED state.
+#
+# Issue #1321: Fix issues-data URL construction — Phase 4, TDD-9
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$SCRIPT_DIR"
+while [ "$(basename "$PROJECT_DIR")" != ".opencode" ]; do
+    PROJECT_DIR="$(dirname "$PROJECT_DIR")"
+done
+PROJECT_DIR="$(dirname "$PROJECT_DIR")"
+
+SKILL_MD="$PROJECT_DIR/.opencode/skills/writing-plans/SKILL.md"
+
+OVERALL_RESULT=0
+
+echo "=== Content-Verification: 1321-sc6-repo-routing-skill (SC-6) ==="
+
+# SC-6: SKILL.md Operating Protocol contains repo-routing step
+if grep -q "repo-routing\|repo_routing\|repo routing\|Repo Information\|per-repo" "$SKILL_MD" 2>/dev/null; then
+    echo "PASS: SKILL.md Operating Protocol has repo-routing step"
+else
+    echo "FAIL: SKILL.md Operating Protocol missing repo-routing step (expected RED)"
+    OVERALL_RESULT=1
+fi
+
+# SC-6: SKILL.md Operating Protocol step references session-init for repo resolution
+if grep -q "session-init\|github\.owner\|github\.repo" "$SKILL_MD" 2>/dev/null; then
+    echo "PASS: SKILL.md Operating Protocol references session-init for repo resolution"
+else
+    echo "FAIL: SKILL.md Operating Protocol missing session-init reference (expected RED)"
+    OVERALL_RESULT=1
+fi
+
+echo ""
+if [ "$OVERALL_RESULT" -eq 0 ]; then
+    echo "PASS: 1321-sc6-repo-routing-skill"
+else
+    echo "FAIL: 1321-sc6-repo-routing-skill"
+fi
+
+exit $OVERALL_RESULT

--- a/tests/content-verification/1321-sc6-repo-routing-write.sh
+++ b/tests/content-verification/1321-sc6-repo-routing-write.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+# Content-Verification Test: 1321-sc6-repo-routing-write (SC-6)
+#
+# Grep-based checks verifying that writing-plans/tasks/write.md contains
+# a repo-routing step in its Operating Protocol. The write.md file does
+# not exist yet, so all grep checks will FAIL — this is the expected RED
+# state.
+#
+# Issue #1321: Fix issues-data URL construction — Phase 4, TDD-8
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$SCRIPT_DIR"
+while [ "$(basename "$PROJECT_DIR")" != ".opencode" ]; do
+    PROJECT_DIR="$(dirname "$PROJECT_DIR")"
+done
+PROJECT_DIR="$(dirname "$PROJECT_DIR")"
+
+WRITE_MD="$PROJECT_DIR/.opencode/skills/writing-plans/tasks/write.md"
+
+OVERALL_RESULT=0
+
+echo "=== Content-Verification: 1321-sc6-repo-routing-write (SC-6) ==="
+
+# SC-6: write.md exists
+if [ -f "$WRITE_MD" ]; then
+    echo "PASS: write.md exists"
+else
+    echo "FAIL: write.md does not exist (expected RED)"
+    OVERALL_RESULT=1
+fi
+
+# SC-6: write.md Operating Protocol contains repo-routing step
+if grep -q "repo-routing\|repo_routing\|repo routing\|Repo Information\|per-repo" "$WRITE_MD" 2>/dev/null; then
+    echo "PASS: write.md has repo-routing step in Operating Protocol"
+else
+    echo "FAIL: write.md missing repo-routing step in Operating Protocol (expected RED)"
+    OVERALL_RESULT=1
+fi
+
+# SC-6: write.md references session-init for repo resolution
+if grep -q "session-init\|github\.owner\|github\.repo" "$WRITE_MD" 2>/dev/null; then
+    echo "PASS: write.md references session-init for repo resolution"
+else
+    echo "FAIL: write.md missing session-init reference for repo resolution (expected RED)"
+    OVERALL_RESULT=1
+fi
+
+echo ""
+if [ "$OVERALL_RESULT" -eq 0 ]; then
+    echo "PASS: 1321-sc6-repo-routing-write"
+else
+    echo "FAIL: 1321-sc6-repo-routing-write"
+fi
+
+exit $OVERALL_RESULT

--- a/tools/local-issues
+++ b/tools/local-issues
@@ -1582,6 +1582,131 @@ def cmd_sync(args: argparse.Namespace) -> None:
     print(yaml_dump({"sync": True, "repos": repos_info}))
 
 
+def _resolve_worktree_from_path(file_path: str) -> tuple[Path, str, str] | None:
+    """Resolve the correct repo worktree from a file path prefix.
+
+    Returns (repo_path, repo_name, relative_file_path) or None if no match.
+    """
+    abs_path = Path(file_path).resolve()
+    current = Path(os.getcwd()).resolve()
+
+    # Check .opencode/.issues/ prefix → .opencode repo
+    opencode_issues = current / ".opencode" / ".issues"
+    try:
+        abs_path.relative_to(opencode_issues)
+        opencode_repo = current / ".opencode"
+        if opencode_repo.is_dir():
+            rel = str(abs_path.relative_to(opencode_repo))
+            return (opencode_repo, ".opencode", rel)
+    except ValueError:
+        pass
+
+    # Check .issues/ prefix → root repo
+    root_issues = current / ".issues"
+    try:
+        abs_path.relative_to(root_issues)
+        rel = str(abs_path.relative_to(current))
+        return (current, current.name, rel)
+    except ValueError:
+        pass
+
+    return None
+
+
+def _sync_file_in_worktree(
+    repo_path: Path, rel_path: str, message: str | None
+) -> dict:
+    """Git add, commit, push a single file in the repo's issues worktree.
+
+    Returns dict with status, commit_sha, and file_url.
+    """
+    issues_dir = repo_path / ".issues"
+    if not (issues_dir / ".git").is_file():
+        return {"status": "no_worktree", "file": rel_path}
+
+    git_dir = str(issues_dir)
+
+    # git add
+    add = subprocess.run(
+        ["git", "-C", git_dir, "add", rel_path],
+        capture_output=True, text=True, timeout=15,
+    )
+    if add.returncode != 0:
+        return {"status": "add_failed", "stderr": add.stderr.strip(), "file": rel_path}
+
+    # git commit
+    msg = message or f"auto: sync {rel_path}"
+    commit = subprocess.run(
+        ["git", "-C", git_dir, "commit", "-m", msg, "--allow-empty"],
+        capture_output=True, text=True, timeout=15,
+    )
+    if commit.returncode != 0 and "nothing to commit" not in commit.stderr:
+        return {"status": "commit_failed", "stderr": commit.stderr.strip(), "file": rel_path}
+
+    # Extract commit SHA
+    sha_result = subprocess.run(
+        ["git", "-C", git_dir, "rev-parse", "HEAD"],
+        capture_output=True, text=True, timeout=15,
+    )
+    commit_sha = sha_result.stdout.strip() if sha_result.returncode == 0 else ""
+
+    # git push
+    push_result = None
+    remote_check = subprocess.run(
+        ["git", "-C", git_dir, "remote", "get-url", "origin"],
+        capture_output=True, text=True, timeout=15,
+    )
+    has_remote = remote_check.returncode == 0 and bool(remote_check.stdout.strip())
+    if has_remote:
+        push = subprocess.run(
+            ["git", "-C", git_dir, "push", "origin", "issues-data"],
+            capture_output=True, text=True, timeout=30,
+        )
+        if push.returncode != 0:
+            push_result = push.stderr.strip()
+
+    # Build file URL
+    owner = ""
+    repo_name = repo_path.name
+    remote_url = remote_check.stdout.strip() if has_remote else ""
+    if "github.com" in remote_url or "git@github.com" in remote_url:
+        # Extract owner from remote URL
+        import re as _re
+        m = _re.search(r"(?:github\.com[/:])([^/]+)/([^/.]+)", remote_url)
+        if m:
+            owner = m.group(1)
+            repo_name = m.group(2)
+    file_url = f"https://github.com/{owner}/{repo_name}/tree/issues-data/{rel_path}" if owner else ""
+
+    result: dict = {
+        "status": "ok" if not push_result else "push_failed",
+        "commit_sha": commit_sha,
+        "file_url": file_url,
+        "file": rel_path,
+    }
+    if push_result:
+        result["push_stderr"] = push_result
+    return result
+
+
+def cmd_sync_file(args: argparse.Namespace) -> None:
+    """Commit and push a single file in the correct repo's issues worktree."""
+    resolved = _resolve_worktree_from_path(args.file)
+    if resolved is None:
+        print(
+            f"Error: file path '{args.file}' does not match any known issues worktree "
+            f"(.issues/ or .opencode/.issues/)",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    repo_path, repo_name, rel_path = resolved
+    result = _sync_file_in_worktree(repo_path, rel_path, args.message)
+    result["repo"] = repo_name
+    print(yaml_dump(result))
+    if result.get("status") not in ("ok", "push_failed"):
+        sys.exit(1)
+
+
 def _add_create_parser(subparsers: argparse._SubParsersAction) -> None:
     p = subparsers.add_parser(
         "create",
@@ -1717,6 +1842,15 @@ def _add_init_parser(subparsers: argparse._SubParsersAction) -> None:
     )
 
 
+def _add_sync_file_parser(subparsers: argparse._SubParsersAction) -> None:
+    p = subparsers.add_parser(
+        "sync-file",
+        help="Commit and push a single file in the correct repo's issues worktree. Flags: --file, --message",
+    )
+    p.add_argument("--file", type=str, required=True, help="Path to the file to sync")
+    p.add_argument("--message", type=str, default=None, help="Commit message (auto-generated if omitted)")
+
+
 def _add_sync_parser(subparsers: argparse._SubParsersAction) -> None:
     subparsers.add_parser(
         "sync", help="Commit pending changes, pull-rebase, and push for all repos"
@@ -1746,6 +1880,7 @@ def build_parser() -> argparse.ArgumentParser:
     _add_promote_parser(sub)
     _add_init_parser(sub)
     _add_sync_parser(sub)
+    _add_sync_file_parser(sub)
 
     return parser
 
@@ -1816,6 +1951,7 @@ def main() -> None:
         "promote": cmd_promote,
         "init": cmd_init,
         "sync": cmd_sync,
+        "sync-file": cmd_sync_file,
     }
     command_map[args.command](args)
 

--- a/tools/local-issues
+++ b/tools/local-issues
@@ -1593,20 +1593,18 @@ def _resolve_worktree_from_path(file_path: str) -> tuple[Path, str, str] | None:
     # Check .opencode/.issues/ prefix → .opencode repo
     opencode_issues = current / ".opencode" / ".issues"
     try:
-        abs_path.relative_to(opencode_issues)
+        rel_to_issues = abs_path.relative_to(opencode_issues)
         opencode_repo = current / ".opencode"
         if opencode_repo.is_dir():
-            rel = str(abs_path.relative_to(opencode_repo))
-            return (opencode_repo, ".opencode", rel)
+            return (opencode_repo, ".opencode", str(rel_to_issues))
     except ValueError:
         pass
 
     # Check .issues/ prefix → root repo
     root_issues = current / ".issues"
     try:
-        abs_path.relative_to(root_issues)
-        rel = str(abs_path.relative_to(current))
-        return (current, current.name, rel)
+        rel_to_issues = abs_path.relative_to(root_issues)
+        return (current, current.name, str(rel_to_issues))
     except ValueError:
         pass
 
@@ -1672,7 +1670,7 @@ def _sync_file_in_worktree(
     if "github.com" in remote_url or "git@github.com" in remote_url:
         # Extract owner from remote URL
         import re as _re
-        m = _re.search(r"(?:github\.com[/:])([^/]+)/([^/.]+)", remote_url)
+        m = _re.search(r"(?:github\.com[/:])([^/]+)/([^/]+?)(?:\.git)?$", remote_url)
         if m:
             owner = m.group(1)
             repo_name = m.group(2)


### PR DESCRIPTION
## Summary

Fix systemic 404 defect in issues-data URL construction and plan-file repo routing. All 7 success criteria verified PASS by dual adversarial audit (gemma4 + deepseek-flash).

## Changes

| Phase | Concern | Files Modified | SCs |
|-------|---------|---------------|-----|
| 1 | Fix URL patterns in spec-creation/tasks/write.md | `skills/spec-creation/tasks/write.md` (Steps 6.8, 7r) | SC-1, SC-2, SC-3, SC-7 |
| 2 | Reconcile .issues/AGENTS.md directory layouts | `.issues/AGENTS.md` | SC-4 |
| 3 | Add local-issues sync-file subcommand | `tools/local-issues` | SC-5 |
| 4 | Add repo-routing rule to writing-plans | `skills/writing-plans/tasks/write.md`, `skills/writing-plans/SKILL.md` | SC-6 |
| Regression | Fix remaining {github.html_url} patterns | `skills/spec-creation/tasks/completion.md`, `skills/issue-operations/tasks/creation.md` | — |

## Key Fixes

- **URL pattern**: `{html_url}/{owner}/{repo}/tree/issues-data/{N}` (platform-agnostic, no `.issues/` prefix)
- **Per-repo resolution**: `html_url`, `owner`, `repo` resolved from session-init `## Repo Information`
- **AGENTS.md**: Flat layout canonical; root references `.opencode/.issues/AGENTS.md`
- **sync-file**: New `local-issues sync-file` subcommand handles commit+push in correct worktree
- **Repo routing**: Plan-creation workflow resolves target repo via session-init

## Verification

- 7/7 SCs PASS (5 string, 2 behavioral)
- Dual adversarial audit: 7/7 PASS consensus
- Behavioral evidence: sync-file tested with real file commit+push; URL verified via webfetch (200)

Fixes https://github.com/michael-conrad/.opencode/issues/1321

🤖 Co-authored with AI: OpenCode (ollama-cloud/deepseek-v4-flash)