### PR TITLE
feat(writing-plans): decompose skill into Z3-enforced pipeline with skill-dispatch markers

### DIFF
--- a/skills/writing-plans/SKILL.md
+++ b/skills/writing-plans/SKILL.md
@@ -10,15 +10,14 @@ compatibility: opencode
 
 ## Overview
 
-Transforms approved specs into actionable implementation plans using hybrid structure: phases for concern boundaries, TDD steps within tasks for execution guidance. Every step is one action (2-5 min). No placeholders.
-
-
+Transforms approved specs into actionable implementation plans using a 21-step Z3-enforced pipeline: 10 discrete sub-agent dispatches interleaved with 10 z3-check transitions and 1 inline verification step. Every step is one atomic concern. No placeholders. Sub-agents are leaf nodes — only the orchestrator dispatches via `task()`.
 
 ## Trigger Dispatch Table
 
 | User says / Context | Task | Dispatch | Context passed |
 |---------------------|------|----------|----------------|
 | "create plan" / "implementation plan" / "write plan" / "plan" / "draft plan" | `create` | `sub-task` | {spec_issue_number, spec_body} |
+| "retroactive" / "retroactive plan" / "backfill plan" | `retroactive` | `sub-task` | {spec_issue_number} |
 | completion / workflow end | `completion` | `sub-task` | {workflow_state} |
 
 ## Persona
@@ -27,9 +26,7 @@ This skill produces plans by dispatching sub-agents. The orchestrator routes; su
 
 ## Tasks
 
-
-| `create` |
-| `completion` |
+| `create` | `completion` | `retroactive` |
 
 ## Plan Model
 
@@ -43,103 +40,59 @@ This skill produces plans by dispatching sub-agents. The orchestrator routes; su
 `skill({name: "writing-plans"})` — call the skill, then call via task():
 
 | Task | Call via task() |
-
 | `create` | `task(..., prompt: "execute create task from writing-plans")` |
 | `completion` | `task(..., prompt: "execute completion task from writing-plans")` |
+| `retroactive` | `task(..., prompt: "execute retroactive task from writing-plans")` |
 
 **CLI equivalent (for human TUI use):** `/skill writing-plans --task <task>`
 
-## Operating Protocol
+## Operating Protocol — 21-Step Pipeline
+
+Each item is tagged with dispatch scope, chain dependency, and contract paths.
+
+### Pipeline Steps
 
 - [ ] 1. [inline] Verify spec is approved (check `approved-for-*` label) — chain: `none`
-- [ ] 2. [sub-task: create] `task(..., prompt: "execute create task from writing-plans")` — input: `./tmp/{N}/contracts/create-input.yaml`, output: `./tmp/{N}/contracts/create-output.yaml`, template: `.opencode/skills/writing-plans/contracts/create-input-template.yaml`, chain: `none`
-- [ ] 3. [inline] Invoke `solve model` for dependency-ordering constraints contract — chain: `step_2`
-- [ ] 4. [inline] Invoke `solve check` to verify SAT — chain: `step_3`
-- [ ] 5. [inline] Invoke `plan plan` for phase solvability validation — chain: `step_4`
-- [ ] 6. [sub-task: write] `task(..., prompt: "execute write task from writing-plans")` — Write plan file to correct repo's `.issues/` worktree. Resolve target repo from session-init `## Repo Information` by matching issue's repo path prefix. Use `local-issues sync-file` for commit+push. URL uses resolved repo's `html_url`, `owner`, `repo`. chain: `step_5`
-- [ ] 7. [sub-task: completion] `task(..., prompt: "execute completion task from writing-plans")` — input: `./tmp/{N}/contracts/completion-input.yaml`, output: `./tmp/{N}/contracts/completion-output.yaml`, template: `.opencode/skills/writing-plans/contracts/create-output-template.yaml` (shared), chain: `step_6`
+- [ ] 2. [sub-task: research] `task(..., prompt: "execute research task from writing-plans")` — input: `contracts/research-input-template.yaml`, output: `contracts/research-output-template.yaml`, template: `contracts/research-input-template.yaml`, chain: `step_1`
+- [ ] 3. [z3-check] `solve check` — verify research output contains evidence_artifacts — chain: `step_2`
+- [ ] 4. [sub-task: readiness] `task(..., prompt: "execute readiness task from writing-plans")` — input: `contracts/readiness-input-template.yaml`, output: `contracts/readiness-output-template.yaml`, template: `contracts/readiness-input-template.yaml`, chain: `step_3`
+- [ ] 5. [z3-check] `solve check` — verify readiness output has status PASS — chain: `step_4`
+- [ ] 6. [sub-task: structure] `task(..., prompt: "execute structure task from writing-plans")` — input: `contracts/structure-input-template.yaml`, output: `contracts/structure-output-template.yaml`, template: `contracts/structure-input-template.yaml`, chain: `step_5`
+- [ ] 7. [z3-check] `solve check` — verify structure output has phase definitions and dependency contract — chain: `step_6`
+- [ ] 8. [sub-task: solve] `task(..., prompt: "execute solve task from writing-plans")` — input: `contracts/solve-input-template.yaml`, output: `contracts/solve-output-template.yaml`, template: `contracts/solve-input-template.yaml`, chain: `step_7`
+- [ ] 9. [z3-check] `solve check` — verify solve output has SAT and SOLVED status — chain: `step_8`
+- [ ] 10. [sub-task: write] `task(..., prompt: "execute write task from writing-plans")` — input: `contracts/write-input-template.yaml`, output: `contracts/write-output-template.yaml`, template: `contracts/write-input-template.yaml`, chain: `step_9`
+- [ ] 11. [z3-check] `solve check` — verify write output has plan file path — chain: `step_10`
+- [ ] 12. [sub-task: revisit] `task(..., prompt: "execute revisit task from writing-plans")` — input: `contracts/revisit-input-template.yaml`, output: `contracts/revisit-output-template.yaml`, template: `contracts/revisit-input-template.yaml`, chain: `step_11`
+- [ ] 13. [z3-check] `solve check` — verify revisit output has resolution_status — chain: `step_12`
+- [ ] 14. [sub-task: validate] `task(..., prompt: "execute validate task from writing-plans")` — input: `contracts/validate-input-template.yaml`, output: `contracts/validate-output-template.yaml`, template: `contracts/validate-input-template.yaml`, chain: `step_13`
+- [ ] 15. [z3-check] `solve check` — verify validate output has PASS status — chain: `step_14`
+- [ ] 16. [sub-task: audit-fidelity] `task(..., prompt: "execute audit-fidelity task from writing-plans")` — input: `contracts/audit-fidelity-input-template.yaml`, output: `contracts/audit-fidelity-output-template.yaml`, template: `contracts/audit-fidelity-input-template.yaml`, chain: `step_15`
+- [ ] 17. [z3-check] `solve check` — verify audit-fidelity output has PASS — chain: `step_16`
+- [ ] 18. [sub-task: audit-concern] `task(..., prompt: "execute audit-concern task from writing-plans")` — input: `contracts/audit-concern-input-template.yaml`, output: `contracts/audit-concern-output-template.yaml`, template: `contracts/audit-concern-input-template.yaml`, chain: `step_17`
+- [ ] 19. [z3-check] `solve check` — verify audit-concern output has PASS — chain: `step_18`
+- [ ] 20. [sub-task: completion] `task(..., prompt: "execute completion task from writing-plans")` — input: `contracts/completion-input-template.yaml`, output: `contracts/completion-output-template.yaml`, template: `contracts/completion-input-template.yaml`, chain: `step_19`
+- [ ] 21. [z3-check] `solve check` — verify completion output has lifecycle event — chain: `step_20`
+
+### Retroactive Operating Protocol
+
+When the `retroactive` task is dispatched, the pipeline is the same 21-step sequence but with the research step loading the existing spec body as its evidence source rather than performing live-source verification:
+
+- [ ] 1. [inline] Verify spec exists in `.issues/{N}/spec.md` — chain: `none`
+- [ ] 2. [sub-task: research] Load existing spec body as evidence source — chain: `step_1`
+- [ ] 3-21. Same as standard pipeline above — chain: `step_2`
 
 ## Sub-Agent Routing
 
-All tasks run via `task(subagent_type="general")` with `{ spec_issue_number, spec_body, worktree.path, github.owner, github.repo }`, excluding implementation context. Auditor tasks use subagent_type from resolve-models result contract (auditor_1/auditor_2) — NOT `general`. Include audit_phase in task context when routing auditors. See adversarial-audit SKILL.md §DISPATCH_GATE. `pre-analysis` receives only `{ issue_number, task_description, github.owner, github.repo }`. No inline work.
-
-### DISPATCH_GATE — Orchestrator task() Prompt Protocol
-
-> **Context cost frame:** The orchestrator's context is the most expensive resource in the pipeline — sub-agents do the work, not the orchestrator. Every byte held by the orchestrator costs `byte × remaining_dispatches²`. See `020-go-prohibitions.md` §1.1.
-
-The orchestrator MUST NOT preload execution context into `task()` prompts.
-Every sub-agent MUST independently discover scope and produce its own result contract.
-
-#### Forbidden in task() Prompts
-
-| Violation | Forbidden Pattern | Correct Pattern |
-|-----------|-------------------|-----------------|
-| Preloaded file paths | "Read cleanup/branch-cleanup.md then execute step 1" | "execute cleanup task from git-workflow" |
-| Preloaded step sequences | "Step 1: sync dev. Step 2: delete branch." | "execute cleanup task from git-workflow" |
-| Preloaded expected outcomes | "Return { cleanup_status, branch_deleted }" | Let sub-agent define its own result contract |
-| Preloaded orchestrator reasoning | "The merge was just completed so we need to..." | Pure objective, no narrative |
-| Missing task file discovery directive | "execute create task from writing-plans" without task file path | "execute create task from writing-plans. Read `writing-plans/tasks/create.md` first" |
-
-## Required: Sub-agent Task File Discovery Directive
-
-Every `task()` prompt that dispatches a named task MUST include a discovery directive in the format:
-
-```
-execute <task> from <skill>. Read `<skill>/tasks/<task>.md` first
-```
-
-This directive tells the sub-agent which task file to load independently — it is NOT preloading the file content. The sub-agent opens and reads the task file in its own clean-room context, discovers the procedure, and executes autonomously. Without this directive, the sub-agent must search for the correct task file, which is wasted context and routing ambiguity.
-
-This is NOT a violation of the preloading prohibition. The task file path is routing metadata (which file to load), not execution context (what the file contains). The sub-agent still reads the file independently and discovers scope on its own.
-
-#### Dispatch Context Contract
-
-Every `task()` call MUST include only:
-
-- `worktree.path`
-- `github.owner`
-- `github.repo`
-- `authorization_scope`
-- `halt_at`
-- `pr_strategy`
-- `pipeline_phase`
-
-Plus skill-specific fields per the `## Sub-Agent Routing` section above.
-
-Exclusions (MUST NOT be in prompt):
-
-- `orchestrator_reasoning`
-- `expected_outcomes`
-- `inline_file_paths`
-- `agent_memory`
-- `cached_verification_results`
-
-#### Sub-Agent Entry Criteria
-
-A sub-agent receiving a `task()` prompt MUST reject it if the prompt contains:
-
-- Inline file paths to task files
-- Inline step or procedure definitions
-- Expected outcome structures or schema constraints
-- Pre-loaded evidence or orchestrator-derived conclusions
-
-Return `status: BLOCKED` with `reason: PRELOADED_CONTEXT_REJECTED`.
-
-#### Orchestrator Entry Criteria
-
-After loading this skill and reading the Trigger Dispatch Table, the orchestrator MUST:
-- Use the exact `task(..., prompt: "...")` string from the table
-- NOT write a custom prompt with preloaded context
-- NOT add orchestrator reasoning, file paths, step sequences, or expected outcomes
-- If the canonical dispatch produces an empty result: re-task clean-room with the same canonical string (max 2 retries)
+All tasks run via `task(subagent_type="general")` with `{ spec_issue_number, spec_body, worktree.path, github.owner, github.repo }`, excluding implementation context. Auditor tasks (`audit-fidelity`, `audit-concern`) use subagent_type from `resolve-models` result contract (auditor_1/auditor_2) — NOT `general`. Include audit_phase in task context when routing auditors. `pre-analysis` receives only `{ issue_number, task_description, github.owner, github.repo }`. No inline work.
 
 ## Cross-References
 
-Skills: `approval-gate`, `issue-operations`, `executing-plans`, `adversarial-audit --task plan-fidelity`, `adversarial-audit --task concern-separation`. References: `skill-card-change-types.md`. Guidelines: `010-approval-gate.md`, `140-planning-spec-creation.md`.
+Skills: `approval-gate`, `issue-operations`, `executing-plans`, `adversarial-audit --task plan-fidelity`, `adversarial-audit --task concern-separation`, `verification-enforcement`, `solve`, `plan`. References: `skill-card-change-types.md`. Guidelines: `010-approval-gate.md`, `140-planning-spec-creation.md`.
 
 ```yaml+symbolic
 schema_version: "2.0"
-last_updated: "2026-05-01T00:00:00Z"
+last_updated: "2026-06-23T00:00:00Z"
 rules:
   - id: writing-plans-001
     title: "Plan creation from approved spec only"

--- a/skills/writing-plans/contracts/audit-concern-input-template.yaml
+++ b/skills/writing-plans/contracts/audit-concern-input-template.yaml
@@ -1,0 +1,3 @@
+plan_file_path: string
+spec_issue_number: int
+auditor_subagent_type: string

--- a/skills/writing-plans/contracts/audit-concern-output-template.yaml
+++ b/skills/writing-plans/contracts/audit-concern-output-template.yaml
@@ -1,0 +1,4 @@
+status: string  # PASS | BLOCKED
+artifact_path: string
+findings: list[dict]
+blocker_reason: string

--- a/skills/writing-plans/contracts/audit-fidelity-input-template.yaml
+++ b/skills/writing-plans/contracts/audit-fidelity-input-template.yaml
@@ -1,0 +1,3 @@
+plan_file_path: string
+spec_issue_number: int
+auditor_subagent_type: string

--- a/skills/writing-plans/contracts/audit-fidelity-output-template.yaml
+++ b/skills/writing-plans/contracts/audit-fidelity-output-template.yaml
@@ -1,0 +1,4 @@
+status: string  # PASS | BLOCKED
+artifact_path: string
+findings: list[dict]
+blocker_reason: string

--- a/skills/writing-plans/contracts/completion-input-template.yaml
+++ b/skills/writing-plans/contracts/completion-input-template.yaml
@@ -1,0 +1,3 @@
+plan_file_path: string
+spec_issue_number: int
+all_audit_status: string

--- a/skills/writing-plans/contracts/completion-output-template.yaml
+++ b/skills/writing-plans/contracts/completion-output-template.yaml
@@ -1,0 +1,3 @@
+status: string  # PASS | BLOCKED
+lifecycle_event_path: string
+blocker_reason: string

--- a/skills/writing-plans/contracts/readiness-input-template.yaml
+++ b/skills/writing-plans/contracts/readiness-input-template.yaml
@@ -1,0 +1,3 @@
+spec_issue_number: int
+research_status: string
+evidence_artifacts: list[str]

--- a/skills/writing-plans/contracts/readiness-output-template.yaml
+++ b/skills/writing-plans/contracts/readiness-output-template.yaml
@@ -1,0 +1,4 @@
+status: string  # PASS | BLOCKED
+sc_summary: dict
+phase_dependencies: list[dict]
+blocker_reason: string

--- a/skills/writing-plans/contracts/research-input-template.yaml
+++ b/skills/writing-plans/contracts/research-input-template.yaml
@@ -1,0 +1,3 @@
+spec_issue_number: int
+spec_body: string
+evidence_artifacts: list[str]

--- a/skills/writing-plans/contracts/research-output-template.yaml
+++ b/skills/writing-plans/contracts/research-output-template.yaml
@@ -1,0 +1,3 @@
+status: string  # PASS | BLOCKED
+evidence_artifacts: list[str]
+blocker_reason: string

--- a/skills/writing-plans/contracts/revisit-input-template.yaml
+++ b/skills/writing-plans/contracts/revisit-input-template.yaml
@@ -1,0 +1,2 @@
+plan_file_path: string
+spec_issue_number: int

--- a/skills/writing-plans/contracts/revisit-output-template.yaml
+++ b/skills/writing-plans/contracts/revisit-output-template.yaml
@@ -1,0 +1,3 @@
+status: string  # PASS | DONE_WITH_CONCERNS | BLOCKED
+resolution_status: string  # resolved | partial | escalated
+blocker_reason: string

--- a/skills/writing-plans/contracts/solve-input-template.yaml
+++ b/skills/writing-plans/contracts/solve-input-template.yaml
@@ -1,0 +1,2 @@
+dependency_contract_path: string
+phase_definitions: list[dict]

--- a/skills/writing-plans/contracts/solve-output-template.yaml
+++ b/skills/writing-plans/contracts/solve-output-template.yaml
@@ -1,0 +1,4 @@
+status: string  # PASS | BLOCKED
+solve_status: string  # SAT | UNSAT
+plan_status: string  # SOLVED | UNSOLVABLE
+blocker_reason: string

--- a/skills/writing-plans/contracts/structure-input-template.yaml
+++ b/skills/writing-plans/contracts/structure-input-template.yaml
@@ -1,0 +1,4 @@
+spec_issue_number: int
+readiness_status: string
+sc_summary: dict
+phase_dependencies: list[dict]

--- a/skills/writing-plans/contracts/structure-output-template.yaml
+++ b/skills/writing-plans/contracts/structure-output-template.yaml
@@ -1,0 +1,5 @@
+status: string  # PASS | BLOCKED
+phase_definitions: list[dict]
+dependency_contract_path: string
+phase_to_skill_mapping_path: string
+blocker_reason: string

--- a/skills/writing-plans/contracts/validate-input-template.yaml
+++ b/skills/writing-plans/contracts/validate-input-template.yaml
@@ -1,0 +1,2 @@
+plan_file_path: string
+spec_issue_number: int

--- a/skills/writing-plans/contracts/validate-output-template.yaml
+++ b/skills/writing-plans/contracts/validate-output-template.yaml
@@ -1,0 +1,3 @@
+status: string  # PASS | BLOCKED
+validation_results: list[dict]
+blocker_reason: string

--- a/skills/writing-plans/contracts/write-input-template.yaml
+++ b/skills/writing-plans/contracts/write-input-template.yaml
@@ -1,0 +1,5 @@
+spec_issue_number: int
+phase_definitions: list[dict]
+solve_status: string
+plan_status: string
+authorization_scope: string

--- a/skills/writing-plans/contracts/write-output-template.yaml
+++ b/skills/writing-plans/contracts/write-output-template.yaml
@@ -1,0 +1,3 @@
+status: string  # PASS | BLOCKED
+plan_file_path: string
+blocker_reason: string

--- a/skills/writing-plans/tasks/audit-concern.md
+++ b/skills/writing-plans/tasks/audit-concern.md
@@ -1,0 +1,29 @@
+# Task: audit-concern
+
+## Purpose
+
+Load the `adversarial-audit` skill and execute `--task concern-separation` inline with auditor sub-agent type context. Verifies each phase addresses exactly one concern.
+
+## Entry Criteria
+
+- Audit-fidelity step completed with PASS
+- Plan document exists at `.issues/{N}/plan.md`
+
+## Exit Criteria
+
+- Concern-separation audit completed
+- Auditor sub-agent type used (not `general`)
+- Result contract contains PASS/FAIL with artifact_path
+
+## Procedure
+
+1. Load `adversarial-audit` skill: `skill({name: "adversarial-audit"})`
+2. Execute `--task concern-separation` inline with auditor sub-agent type context
+3. Collect audit artifact path
+4. If PASS: return PASS with artifact_path
+5. If FAIL: return BLOCKED with findings
+
+## Context Required
+
+- Related skills: `adversarial-audit`
+- Related tools: `resolve-models` for auditor sub-agent type selection

--- a/skills/writing-plans/tasks/audit-concern.md
+++ b/skills/writing-plans/tasks/audit-concern.md
@@ -17,11 +17,11 @@ Load the `adversarial-audit` skill and execute `--task concern-separation` inlin
 
 ## Procedure
 
-1. Load `adversarial-audit` skill: `skill({name: "adversarial-audit"})`
-2. Execute `--task concern-separation` inline with auditor sub-agent type context
-3. Collect audit artifact path
-4. If PASS: return PASS with artifact_path
-5. If FAIL: return BLOCKED with findings
+- [ ] 1. Load `adversarial-audit` skill: `skill({name: "adversarial-audit"})`
+- [ ] 2. Execute `--task concern-separation` inline with auditor sub-agent type context
+- [ ] 3. Collect audit artifact path
+- [ ] 4. If PASS: return PASS with artifact_path
+- [ ] 5. If FAIL: return BLOCKED with findings
 
 ## Context Required
 

--- a/skills/writing-plans/tasks/audit-fidelity.md
+++ b/skills/writing-plans/tasks/audit-fidelity.md
@@ -17,11 +17,11 @@ Load the `adversarial-audit` skill and execute `--task plan-fidelity` inline wit
 
 ## Procedure
 
-1. Load `adversarial-audit` skill: `skill({name: "adversarial-audit"})`
-2. Execute `--task plan-fidelity` inline with auditor sub-agent type context
-3. Collect audit artifact path
-4. If PASS: return PASS with artifact_path
-5. If FAIL: return BLOCKED with findings
+- [ ] 1. Load `adversarial-audit` skill: `skill({name: "adversarial-audit"})`
+- [ ] 2. Execute `--task plan-fidelity` inline with auditor sub-agent type context
+- [ ] 3. Collect audit artifact path
+- [ ] 4. If PASS: return PASS with artifact_path
+- [ ] 5. If FAIL: return BLOCKED with findings
 
 ## Context Required
 

--- a/skills/writing-plans/tasks/audit-fidelity.md
+++ b/skills/writing-plans/tasks/audit-fidelity.md
@@ -1,0 +1,29 @@
+# Task: audit-fidelity
+
+## Purpose
+
+Load the `adversarial-audit` skill and execute `--task plan-fidelity` inline with auditor sub-agent type context. Verifies the plan faithfully reflects the spec.
+
+## Entry Criteria
+
+- Validate step completed with PASS
+- Plan document exists at `.issues/{N}/plan.md`
+
+## Exit Criteria
+
+- Plan-fidelity audit completed
+- Auditor sub-agent type used (not `general`)
+- Result contract contains PASS/FAIL with artifact_path
+
+## Procedure
+
+1. Load `adversarial-audit` skill: `skill({name: "adversarial-audit"})`
+2. Execute `--task plan-fidelity` inline with auditor sub-agent type context
+3. Collect audit artifact path
+4. If PASS: return PASS with artifact_path
+5. If FAIL: return BLOCKED with findings
+
+## Context Required
+
+- Related skills: `adversarial-audit`
+- Related tools: `resolve-models` for auditor sub-agent type selection

--- a/skills/writing-plans/tasks/create.md
+++ b/skills/writing-plans/tasks/create.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-Create an implementation plan from an approved spec. Plans are stored at `.issues/{N}/plan.md`.
+Create an implementation plan from an approved spec. This is a routing-only task file — it points to the 10 decomposed sub-task files in the 21-step pipeline. The orchestrator dispatches each step via `task()`; sub-agents execute tools directly.
 
 ## Prerequisites
 
@@ -13,19 +13,37 @@ Create an implementation plan from an approved spec. Plans are stored at `.issue
 
 ## Operating Protocol
 
-- [ ] 1. **Verification first** — **orchestrator routes to**: `verification-enforcement --task verify` via sub-agent — Must run verification-enforcement --task verify before reading spec content
-- [ ] 2. **Combined or separate decision** — Procedure: early evaluation whether plan content references spec content inline (combined) or stands alone with separate phase sections (separate)
-- [ ] 3. **Item decomposition mandatory** — Procedure: plan must enumerate items, order dependencies, specify acceptance criteria
-- [ ] 4. **RED checkpoint mandatory** — Procedure: every TDD task must include explicit Step 2 checkpoint
-- [ ] 5. **Approval cascade auto-approve** — Procedure: pipeline scope (`for_plan+`) auto-approves plan
-- [ ] 6. **Handoff verification pre-PASS** — **orchestrator routes to**: `handoffs/spec-to-plan` via sub-agent — Before any plan content is written, spec-to-plan handoff MUST return PASS. This is a non-waivable hard gate — no exceptions, no "proceed anyway."
-- [ ] 7. **Checklist format mandatory** — Procedure: all plan phases MUST use the numbered checklist format with dispatch indicators. Steps are `- [ ] N.` with `(**clean-room**)` or `(**inline**)` dispatch mode indicators. The gate labels, step sequence, and dispatch targets MUST reference the canonical source at `implementation-pipeline/SKILL.md` §Dispatch Routing Table. This is the default format for every phase — no exceptions, no simplified alternatives.
+- [ ] 1. **Verification first** — **orchestrator routes to**: `research` via sub-agent — Loads `verification-enforcement --task verify` inline, collects evidence artifacts
+- [ ] 2. **Readiness gate** — **orchestrator routes to**: `readiness` via sub-agent — Pipeline-readiness gate check + spec-to-plan handoff verification
+- [ ] 3. **Structure definition** — **orchestrator routes to**: `structure` via sub-agent — Combined/separate decision, file mapping, phase structure, TDD definition, dependency contract, phase-to-skill mapping
+- [ ] 4. **Solve validation** — **orchestrator routes to**: `solve` via sub-agent — Runs `solve model`, `solve check`, `plan plan` as direct CLI
+- [ ] 5. **Plan writing** — **orchestrator routes to**: `write` via sub-agent — Writes plan file, validates dispatch markers, applies approval cascade
+- [ ] 6. **Verification revisit** — **orchestrator routes to**: `revisit` via sub-agent — Loads `verification-enforcement --task revisit` inline, resolves unverified markers
+- [ ] 7. **Validation** — **orchestrator routes to**: `validate` via sub-agent — Plan structure and checklist validation
+- [ ] 8. **Audit fidelity** — **orchestrator routes to**: `audit-fidelity` via sub-agent — Plan-fidelity audit with auditor sub-agent type
+- [ ] 9. **Audit concern** — **orchestrator routes to**: `audit-concern` via sub-agent — Concern-separation audit with auditor sub-agent type
+- [ ] 10. **Completion** — **orchestrator routes to**: `completion` via sub-agent — Lifecycle event, push, report
+
+## Sub-Task Files
+
+| Sub-Task | Purpose |
+| -- | -- |
+| `research` | Live-source verification gate |
+| `readiness` | Pipeline-readiness gate check |
+| `structure` | Phase structure and TDD definition |
+| `solve` | Z3 constraint solving and plan validation |
+| `write` | Plan document writing and dispatch validation |
+| `revisit` | Verification revisit and unverified marker resolution |
+| `validate` | Plan structure and checklist validation |
+| `audit-fidelity` | Plan-fidelity adversarial audit |
+| `audit-concern` | Concern-separation adversarial audit |
+| `completion` | Lifecycle event, push, report |
 
 ## Entry Criteria
 
 - Spec is approved and stored in `.issues/{N}/spec.md`
 - `authorization_scope` received from approval-gate (for cascade)
-- Spec-to-plan handoff PASS (verified by handoffs/spec-to-plan task artifact at `./tmp/{issue-N}/artifacts/spec-to-plan-handoff-*.yaml` with `status: PASS`)
+- Spec-to-plan handoff PASS
 
 ## Exit Criteria
 
@@ -33,83 +51,6 @@ Create an implementation plan from an approved spec. Plans are stored at `.issue
 - All validation passed
 - Plan reported in chat with `.issues/{N}/plan.md` path
 - Approval cascade applied (auto-approval for pipeline scope)
-
-## Procedure
-
-- [ ] 8. **Plan Structure Definition** — **orchestrator routes to**: `create/plan-structure` via sub-agent — Runs verification gate, makes combined/separate decision, checks for duplicate plans, maps file structure, defines phase structure, and creates TDD tasks with mandatory RED checkpoints.
-
-- [ ] 9. **Plan Creation and Approval Cascade** — **orchestrator routes to**: `create/create-and-validate` via sub-agent — Writes plan header, stores at `.issues/{N}/plan.md`, runs self-review and validation, revisits verification, cross-references skills, runs handoff-consistency check against the spec-to-plan manifest, and applies approval cascade with scope-aware auto-approval.
-
-## Sub-Task Files
-
-| Sub-Task | Purpose | Words |
-| -- | -- | -- |
-| `create/plan-structure` | Verification, combined/separate decision, file mapping, TDD definition | ≈750 |
-| `create/create-and-validate` | Document writing, local storage, validation, approval cascade | ≈650 |
-
-## Orchestrator Execution Protocol
-
-- [ ] 1. Read the numbered checklist steps in the plan to determine the gate sequence for the current phase
-- [ ] 2. Execute every step in every phase in numeric order (1, 2, 3, ...)
-- [ ] 3. Do NOT skip any step — every entry is mandatory
-- [ ] 4. Do NOT reorder steps — the sequence is defined by the plan
-- [ ] 5. For `(**clean-room**)` steps: dispatch a clean-room sub-agent via `task()` with scoped context
-- [ ] 6. For `(**inline**)` steps: execute the described operation directly (no sub-agent)
-- [ ] 7. After each step completes, verify the SCs referenced in that step's `→ SC-N` annotation
-- [ ] 8. Report progress via chat output only — zero GitHub Issue comments during implementation unless absolutely warranted
-- [ ] 9. After each phase completes, run the Inter-Phase Handoff steps before advancing to the next phase
-- [ ] 10. Do NOT modify the plan — it is a static definitional artifact. Only mutate for remediation or scope revision
-
-## Checklist Format Specification
-
-Every plan phase MUST use the numbered checklist format with dispatch indicators. No deviations.
-
-### Dispatch Mode Mapping
-
-- `sub-task` → `(**clean-room**)`
-- Everything else (orchestrator, inline) → `(**inline**)`
-
-### Discovery Directive
-
-Read `implementation-pipeline/SKILL.md` §Dispatch Routing Table for the canonical gate sequence and dispatch types. Do NOT hardcode gate names — reference the canonical source at plan-creation time.
-
-### Sub-Step Expansion Directive
-
-Gates with sub-steps (e.g., `adversarial-audit` with resolve-models → auditor_1 → remediate → auditor_2 → cross-validate) MUST be expanded into multiple `- [ ] N.` entries. Prohibit collapsing sub-steps into prose.
-
-### Output Format
-
-```
-- [ ] 1. <gate-label> (**<dispatch-mode>**) — <unit-specific exit criterion>
-  - <sub-step description> (**<dispatch-mode>**)
-  - <sub-step description> (**<dispatch-mode>**)
-- [ ] 2. <gate-label> (**<dispatch-mode>**) — <unit-specific exit criterion>
-...
-```
-
-### Inter-Phase Handoff
-
-Between the last gate of phase N and gate 1 of phase N+1:
-
-- Update Z3 state file: `solve state update` with phase N's gate states
-- Run `solve check`: confirm phase N dependency contract still SAT
-- Verify checkpoint tag exists for phase N
-- Append lifecycle manifest event for phase N completion
-
-### Post-All-Phases Sweep
-
-After the last phase's final gate:
-
-- [ ] FINISHING CHECKLIST — **orchestrator routes to finishing sub-agent**: git status clean, lint/typecheck from scratch, coverage sweep
-- [ ] PR CREATION — **orchestrator routes to git-workflow pr-creation**: via `github_create_pull_request`, extract `html_url` from response
-- [ ] POST-MERGE CLEANUP — **orchestrator routes to git-workflow cleanup**: delete merged branches, close issues, sync dev
-
-### Concern Boundary Annotations
-
-When transitioning between architectural concerns, describe:
-- What concern being left (prior scope)
-- What concern being entered (new scope)
-- What information the new concern needs from prior (handoff point)
 
 ## Plan Format
 
@@ -151,5 +92,5 @@ authorization_source: "User approved #N on YYYY-MM-DD"
 
 ## Context Required
 
-- Related skills: `verification-enforcement`, `issue-operations`, `spec-creation`
-- Related tasks: `create/plan-structure`, `create/create-and-validate`
+- Related skills: `verification-enforcement`, `issue-operations`, `spec-creation`, `adversarial-audit`, `solve`, `plan`
+- Related tasks: `research`, `readiness`, `structure`, `solve`, `write`, `revisit`, `validate`, `audit-fidelity`, `audit-concern`, `completion`

--- a/skills/writing-plans/tasks/create/create-and-validate.md
+++ b/skills/writing-plans/tasks/create/create-and-validate.md
@@ -22,18 +22,16 @@ Write plan document to `.issues/{N}/plan.md`, validate structure, and handle app
 
 ### Step 6: Write Plan Document Header
 
-- Goal, Architecture, Tech Stack
-- File structure with clear responsibilities
+- [ ] 1. Write Goal, Architecture, Tech Stack
+- [ ] 2. Write file structure with clear responsibilities
 
 ### Step 7: Store Plan Document
 
 > **Compliance Requirement:** All steps and sub-steps in this document MUST be followed in order. Failure to comply with any step — including but not limited to verification gates, test phases, audit checkpoints, and review steps — will result in the feature branch being rejected and discarded, requiring a full rework from scratch and loss of all prior work. There is no valid reason to skip, compress, reorder, or omit any step. If a step appears redundant or unnecessary, follow it anyway — the cost of following an extra step is negligible compared to the cost of rework from a skipped step.
 
-The generated plan body MUST include this compliance statement blockquote at the top (after the preamble) and at the bottom (before the exit criteria section).
-
-**All paths (combined and separate):**
-- Write plan to `.issues/{N}/plan.md`
-- Proceed to Step 8
+- [ ] 1. Include compliance statement blockquote at top (after preamble) and bottom (before exit criteria)
+- [ ] 2. Write plan to `.issues/{N}/plan.md`
+- [ ] 3. Proceed to Step 8
 
 > **Compliance Requirement:** All steps and sub-steps in this document MUST be followed in order. Failure to comply with any step — including but not limited to verification gates, test phases, audit checkpoints, and review steps — will result in the feature branch being rejected and discarded, requiring a full rework from scratch and loss of all prior work. There is no valid reason to skip, compress, reorder, or omit any step. If a step appears redundant or unnecessary, follow it anyway — the cost of following an extra step is negligible compared to the cost of rework from a skipped step.
 
@@ -71,131 +69,91 @@ When transitioning concerns: describe what is being left, what is being entered,
 
 ### Step 7.5: Spec-to-Plan Handoff Artifact Check
 
-Before writing the plan document, enumerate and validate spec artifacts that must be consumed by the plan:
-
-```bash
-ls .issues/{issue-N}/sc-summary.yaml
-ls .issues/{issue-N}/verification-consistency-contract.yaml
-ls .issues/{issue-N}/revision-re-entry-contract.yaml
-ls ./tmp/{issue-N}/lifecycle.yaml
-```
-
-Every expected spec artifact MUST exist. Missing artifacts are flagged as MISSING-TRACEABILITY.
+- [ ] 1. Enumerate expected spec artifacts: `sc-summary.yaml`, `verification-consistency-contract.yaml`, `revision-re-entry-contract.yaml`, `lifecycle.yaml`
+- [ ] 2. Verify every expected artifact exists — missing artifacts flagged as MISSING-TRACEABILITY
 
 ### Step 7.6: SC Coverage YAML Cross-Reference Validation
 
-Cross-reference the SC coverage YAML against the plan structure:
-
-1. Read `.issues/{issue-N}/sc-summary.yaml`
-2. Verify every SC ID in the YAML is mapped to at least one plan item
-3. Verify every plan item's SC-ID references exist in the YAML
-4. Flag orphan SCs (unmapped) as MISSING-TRACEABILITY
-5. Flag undefined SC references (in plan but not in YAML) as SCOPE-CREEP
-6. Record the cross-reference result as an evidence artifact
+- [ ] 1. Read `.issues/{issue-N}/sc-summary.yaml`
+- [ ] 2. Verify every SC ID in YAML is mapped to at least one plan item
+- [ ] 3. Verify every plan item's SC-ID references exist in YAML
+- [ ] 4. Flag orphan SCs (unmapped) as MISSING-TRACEABILITY
+- [ ] 5. Flag undefined SC references as SCOPE-CREEP
+- [ ] 6. Record cross-reference result as evidence artifact
 
 ### Step 7.7: Spec-to-Plan Handoff Artifact Check
 
-Before finalizing the plan, verify spec-to-plan handoff artifacts:
-
-1. Enumerate all expected artifacts from ``
-2. Verify SC coverage YAML cross-reference: each SC in the spec has a corresponding plan item
-3. Verify lifecycle manifest indicates `plan_created` event
-4. Generate spec-to-plan handoff manifest at `./tmp/{issue-N}/artifacts/spec-to-plan-manifest.yaml`
+- [ ] 1. Enumerate all expected artifacts
+- [ ] 2. Verify SC coverage YAML cross-reference
+- [ ] 3. Verify lifecycle manifest indicates `plan_created` event
+- [ ] 4. Generate spec-to-plan handoff manifest at `./tmp/{issue-N}/artifacts/spec-to-plan-manifest.yaml`
 
 ### Step 8: Generate Implementation Checklist
 
-Generate `./tmp/{N}/checklist.md` from the finalized plan phases. The checklist tracks implementation progress per phase, unit, and file.
-
-**Format:**
-```markdown
-# Implementation Checklist — #{N}
-
-## Phase {P}: {title}
-### Unit {U}: {unit-title}
-- [ ] {file-path} — {description}
-```
-
-**Procedure:**
-1. Read the plan at `.issues/{N}/plan.md`
-2. Extract every phase → unit → file path
-3. Write each as a checkbox item with `pending` default status
-4. Save to `./tmp/{N}/checklist.md`
-
-**Exit criterion:** `./tmp/{N}/checklist.md` exists and contains all phases, units, and file paths from the plan.
+- [ ] 1. Read the plan at `.issues/{N}/plan.md`
+- [ ] 2. Extract every phase → unit → file path
+- [ ] 3. Write each as a checkbox item with `pending` default status
+- [ ] 4. Save to `./tmp/{N}/checklist.md`
+- [ ] 5. Verify `./tmp/{N}/checklist.md` exists and contains all phases, units, and file paths
 
 ### Step 9: Self-Review
 
-- Spec coverage check
-- Placeholder scan
-- Type consistency check
-- Fix any issues found
+- [ ] 1. Spec coverage check
+- [ ] 2. Placeholder scan
+- [ ] 3. Type consistency check
+- [ ] 4. Fix any issues found
 
 ### Step 10: Validate Plan
 
-- Check for TBD/TODO placeholders
-- Verify all steps are actionable
-- Verify success criteria are testable
-- Prose-structure check: phase descriptions remain prose
-- **Verify each phase declares test output artifact paths** using `./tmp/{issue-N}/artifacts/` convention (not bare `./tmp/`)
-- **Verify `solve check` returns SAT** — if UNSAT, HALT with blocker report
-- **Verify `plan plan` returns SOLVED_SATISFICING or SOLVED_OPTIMALLY** — if UNSOLVABLE or unavailable, HALT with blocker report
-- **Verify each referenced pipeline step label exists in `implementation-pipeline/SKILL.md`'s dispatch routing table** — if any label is undefined, HALT with MISSING-TRACEABILITY
+- [ ] 1. Check for TBD/TODO placeholders
+- [ ] 2. Verify all steps are actionable
+- [ ] 3. Verify success criteria are testable
+- [ ] 4. Prose-structure check: phase descriptions remain prose
+- [ ] 5. Verify each phase declares test output artifact paths using `./tmp/{issue-N}/artifacts/` convention
+- [ ] 6. Verify `solve check` returns SAT — if UNSAT, HALT with blocker report
+- [ ] 7. Verify `plan plan` returns SOLVED_SATISFICING or SOLVED_OPTIMALLY — if UNSOLVABLE, HALT
+- [ ] 8. Verify each referenced pipeline step label exists in `implementation-pipeline/SKILL.md` dispatch routing table — if undefined, HALT with MISSING-TRACEABILITY
 
 #### Phase Structure Validation (three-part structure)
 
-Every phase checklist MUST pass the following three-part structure validation rules:
-
-1. **Pre-RED section exists:** Every phase has exactly one Pre-RED Common section containing shared pre-work (coherence gate, baseline) → SC-4
-2. **Post-RED section exists:** Every phase has exactly one Post-RED/green section containing post-cycle validation (VbC, audit, regression, review) → SC-4
-3. **Chain ordering:** RED+green chains execute between Pre-RED and Post-RED sections — never before Pre-RED or after Post-RED → SC-4
-4. **Pre-RED not duplicated:** Pre-RED steps appear exactly once per phase — never duplicated across items → SC-4
-5. **Post-RED not duplicated:** Post-RED steps appear exactly once per phase — never duplicated across items → SC-4
-6. **RED/GREEN step separation:** RED and GREEN are separate (not combined) steps within each chain → SC-7
+- [ ] 1. **Pre-RED section exists:** Every phase has exactly one Pre-RED Common section → SC-4
+- [ ] 2. **Post-RED section exists:** Every phase has exactly one Post-RED/green section → SC-4
+- [ ] 3. **Chain ordering:** RED+green chains execute between Pre-RED and Post-RED sections → SC-4
+- [ ] 4. **Pre-RED not duplicated:** Pre-RED steps appear exactly once per phase → SC-4
+- [ ] 5. **Post-RED not duplicated:** Post-RED steps appear exactly once per phase → SC-4
+- [ ] 6. **RED/GREEN step separation:** RED and GREEN are separate (not combined) steps → SC-7
 
 #### Checklist Validation
 
-Every plan phase checklist MUST pass the following 8 validation rules in addition to the phase structure rules above:
-
-1. **Checklist format:** Every step is `- [ ] N.` with at least one sub-bullet — no prose-only steps, no collapsed multi-operation steps
-2. **Dispatch indicator:** Every step title contains `— <skill-name> for <concern> (**<clean-room|inline>**)` — no step is missing a skill name in the dispatch marker. Bare `(**clean-room**)` or `(**inline**)` without a preceding skill name is rejected
-3. **Gate sequence match:** Gate sequence matches `implementation-pipeline/SKILL.md` §Dispatch Routing Table — every step label must exist in the canonical source
-4. **Atomic action:** No step describes more than one atomic action — every sub-operation from pipeline task files is expanded into its own `- [ ] N.` entry
-5. **SC annotations:** All SCs referenced via `→ SC-N` annotations — every step that maps to a success criterion has a visible SC reference
-6. **No TBD/TODO:** No TBD/TODO placeholders — all steps are actionable
-7. **Admonishment present:** Compliance admonishment blockquote present at top and bottom of plan body
-8. **Phase dependency ordering:** Phase dependency ordering matches spec architecture — no phase references a dependency that does not exist
-
-9. **Skill name exists:** Every dispatch marker with a skill name (`— <skill-name> for`) must reference an existing directory under `.opencode/skills/`. HALT with `SKILL_NOT_FOUND` if any marker references a non-existent skill.
-10. **Exhaustive mapping:** Every phase step MUST have a named skill in its dispatch marker. No step may use bare `(**clean-room**)` or `(**inline**)` without a preceding `— <skill-name> for <concern>`. HALT with `MISSING_SKILL_NAME` if any step lacks a skill name.
-11. **Post-RED pipeline gates:** Every phase's Post-RED/green section MUST contain all three mandatory pipeline gates: `completeness-gate`, `adversarial-audit`, and `completion-core`. Each gate MUST be expanded into indented checkbox sub-steps. HALT with `MISSING_POST_RED_GATE` if any gate is absent or collapsed into prose.
-12. **Prose sub-step rejection:** No plan step body may contain prose-format sub-steps (matched by `^\s+→ [^d]` — arrow continuations that are not `→ dispatch:` or `→ SC-N`). Any prose-format sub-step causes HALT with `PROSE_SUBSTEPS_DETECTED`.
+- [ ] 1. **Checklist format:** Every step is `- [ ] N.` with at least one sub-bullet — no prose-only steps
+- [ ] 2. **Dispatch indicator:** Every step title contains `— <skill-name> for <concern> (**<clean-room|inline>**)` — bare `(**clean-room**)` without skill name is rejected
+- [ ] 3. **Gate sequence match:** Every step label exists in `implementation-pipeline/SKILL.md` §Dispatch Routing Table
+- [ ] 4. **Atomic action:** No step describes more than one atomic action — sub-operations expanded into own `- [ ] N.` entries
+- [ ] 5. **SC annotations:** All SCs referenced via `→ SC-N` annotations
+- [ ] 6. **No TBD/TODO:** No TBD/TODO placeholders — all steps are actionable
+- [ ] 7. **Admonishment present:** Compliance admonishment blockquote at top and bottom of plan body
+- [ ] 8. **Phase dependency ordering:** No phase references a dependency that does not exist
+- [ ] 9. **Skill name exists:** Every dispatch marker skill name references existing directory under `.opencode/skills/`. HALT with `SKILL_NOT_FOUND` if non-existent
+- [ ] 10. **Exhaustive mapping:** No step uses bare `(**clean-room**)` without preceding skill name. HALT with `MISSING_SKILL_NAME`
+- [ ] 11. **Post-RED pipeline gates:** Every phase has completeness-gate, adversarial-audit, completion-core with expanded checkbox sub-steps. HALT with `MISSING_POST_RED_GATE`
+- [ ] 12. **Prose sub-step rejection:** No `→` arrow continuations that aren't `→ dispatch:` or `→ SC-N`. HALT with `PROSE_SUBSTEPS_DETECTED`
 
 If any rule fails: HALT with MISSING-TRACEABILITY and report which rule(s) failed.
 
 ### Step 11: Verification Revisit (MANDATORY)
 
-Invoke: `/skill verification-enforcement --task revisit`
-
-Scans for `⚠️ UNVERIFIED` markers. Resolves if possible; escalates unresolvable claims.
+- [ ] 1. Invoke `/skill verification-enforcement --task revisit`
+- [ ] 2. Scan for `⚠️ UNVERIFIED` markers — resolve if possible, escalate unresolvable claims
 
 ### Step 12: Report Plan Creation in Chat (MANDATORY)
 
-**Format — reference spec via full URL, plan via local artifact path:**
-```
-Created plan at `.issues/{N}/plan.md` for [<owner>/<repo>#<N>](https://github.com/<owner>/<repo>/issues/<N>) (<description>). <N> phases across <N> items.
-
-🤖 <AgentName> (<ModelId>)
-```
+- [ ] 1. Report in format: `Created plan at .issues/{N}/plan.md for [owner/repo#N](url) (description). N phases across N items.`
+- [ ] 2. Append byline: `🤖 <AgentName> (<ModelId>)`
 
 ### Step 13: Cross-Reference Verification (MANDATORY)
 
-Verify referenced skills and tasks exist:
-```bash
-ls .opencode/skills/approval-gate/SKILL.md && grep -c "verify-authorization" .opencode/skills/approval-gate/SKILL.md
-ls .opencode/skills/writing-plans/tasks/create/plan-structure.md && grep -c "Step.*RED" .opencode/skills/writing-plans/tasks/create/plan-structure.md
-```
-
-If any verification fails: flag as MISSING-TRACEABILITY.
+- [ ] 1. Verify referenced skills and tasks exist via `ls` and `grep`
+- [ ] 2. If any verification fails: flag as MISSING-TRACEABILITY
 
 ### Authorization Context for Task()
 
@@ -214,33 +172,14 @@ authorization_source: "User approved #N on YYYY-MM-DD"
 
 ### Step 14: Plan Approval
 
-**Scope-aware auto-approval — approval is on the spec, plan is a local artifact:**
-
-```python
-SCOPE_LEVELS = {
-    "for_review_prep": 0, "for_spec": 1, "for_analysis": 2,
-    "for_plan": 3, "for_implementation": 4,
-    "for_pr": 5, "for_pr_only": 5, "for_review_only": 4
-}
-
-if scope_level >= SCOPE_LEVELS["for_plan"]:
-    # Pipeline authorization covers plan approval
-    # Plan is local — record approval in chat report
-    pass
-```
-
-**If `halt_at == plan_created`:** HALT after plan creation. Do NOT proceed to implementation.
+- [ ] 1. Apply scope-aware auto-approval: if scope >= `for_plan`, record approval in chat report
+- [ ] 2. If `halt_at == plan_created`: HALT after plan creation — do NOT proceed to implementation
 
 ### Step 15: Plan-Reference Sync
 
-After the plan is approved and before the procedure exits, sync a cross-reference from the spec issue to the plan:
-
-1. Read the plan file from `.issues/{N}/plan.md` to confirm it exists
-2. Call `github_issue_write(method='update', owner='<owner>', repo='<repo>', issue_number=<N>)` with the existing issue body preserved and a plan cross-reference appended:
-   - If the issue body does not already contain a plan reference, append:
-     `---\n**Plan:** See [plan.md](.issues/{N}/plan.md) for the implementation plan.\n`
-   - If the issue body already contains a plan reference, skip (no duplicate)
-3. Verify the update succeeded by reading back the issue body
+- [ ] 1. Read plan file from `.issues/{N}/plan.md` to confirm it exists
+- [ ] 2. Call `github_issue_write` to append plan cross-reference to spec issue body (skip if already present)
+- [ ] 3. Verify update succeeded by reading back the issue body
 
 ## Acceptance Criteria
 

--- a/skills/writing-plans/tasks/create/create-and-validate.md
+++ b/skills/writing-plans/tasks/create/create-and-validate.md
@@ -48,19 +48,26 @@ Each phase MUST use the implementation pipeline checklist format. Gate sequence 
 **Files:** exact paths or glob patterns
 **SCs covered:** SC-N, SC-M
 
-- [ ] 1. <STEP-LABEL> (**<clean-room|inline>**). <description> → SC-N
-- [ ] N. <STEP-LABEL> (**<clean-room|inline>**). <description> → SC-N
+- [ ] 1. <STEP-LABEL> — `<skill-name>` for <concern> (**<clean-room|inline>**)
+    → dispatch: "execute <task> from <skill-name>"
+    → SC-N
+- [ ] N. <STEP-LABEL> — `<skill-name>` for <concern> (**<clean-room|inline>**)
+    → dispatch: "execute <task> from <skill-name>"
+    → SC-N
 ```
 
 **Format rules:**
 - Every step is `- [ ] N.` with at least one sub-bullet — no prose-only steps
-- Every step title contains `(**clean-room**)` or `(**inline**)` dispatch indicator
+- Every step title contains `— <skill-name> for <concern> (**<clean-room|inline>**)` with a skill name in the dispatch marker
 - Every step that maps to a success criterion has a `→ SC-N` annotation
 - No step describes more than one atomic action — sub-operations get their own `- [ ] N.` entries
 - Gate sequence is discovered from `implementation-pipeline/SKILL.md` §Dispatch Routing Table — never hardcoded
+- Bare `(**clean-room**)` or `(**inline**)` without a preceding skill name is invalid
 
 **Concern boundary annotations (prose-driven):**
 When transitioning concerns: describe what is being left, what is being entered, what information is needed for handoff.
+
+**Pre-RED common sub-step format:** Every sub-step in Pre-RED Common sections MUST use the `- [ ] N.` indented checkbox format — never `→` prose continuation lines. This applies to verification gate, read-spec, read-routing-table, and all other pre-RED sub-steps.
 
 ### Step 7.5: Spec-to-Plan Handoff Artifact Check
 
@@ -150,13 +157,17 @@ Every phase checklist MUST pass the following three-part structure validation ru
 Every plan phase checklist MUST pass the following 8 validation rules in addition to the phase structure rules above:
 
 1. **Checklist format:** Every step is `- [ ] N.` with at least one sub-bullet — no prose-only steps, no collapsed multi-operation steps
-2. **Dispatch indicator:** Every step title contains `(**clean-room**)` or `(**inline**)` — no step is missing a dispatch mode marker
+2. **Dispatch indicator:** Every step title contains `— <skill-name> for <concern> (**<clean-room|inline>**)` — no step is missing a skill name in the dispatch marker. Bare `(**clean-room**)` or `(**inline**)` without a preceding skill name is rejected
 3. **Gate sequence match:** Gate sequence matches `implementation-pipeline/SKILL.md` §Dispatch Routing Table — every step label must exist in the canonical source
 4. **Atomic action:** No step describes more than one atomic action — every sub-operation from pipeline task files is expanded into its own `- [ ] N.` entry
 5. **SC annotations:** All SCs referenced via `→ SC-N` annotations — every step that maps to a success criterion has a visible SC reference
 6. **No TBD/TODO:** No TBD/TODO placeholders — all steps are actionable
 7. **Admonishment present:** Compliance admonishment blockquote present at top and bottom of plan body
 8. **Phase dependency ordering:** Phase dependency ordering matches spec architecture — no phase references a dependency that does not exist
+
+9. **Skill name exists:** Every dispatch marker with a skill name (`— <skill-name> for`) must reference an existing directory under `.opencode/skills/`. HALT with `SKILL_NOT_FOUND` if any marker references a non-existent skill.
+10. **Exhaustive mapping:** Every phase step MUST have a named skill in its dispatch marker. No step may use bare `(**clean-room**)` or `(**inline**)` without a preceding `— <skill-name> for <concern>`. HALT with `MISSING_SKILL_NAME` if any step lacks a skill name.
+11. **Post-RED pipeline gates:** Every phase's Post-RED/green section MUST contain all three mandatory pipeline gates: `completeness-gate`, `adversarial-audit`, and `completion-core`. Each gate MUST be expanded into indented checkbox sub-steps. HALT with `MISSING_POST_RED_GATE` if any gate is absent or collapsed into prose.
 
 If any rule fails: HALT with MISSING-TRACEABILITY and report which rule(s) failed.
 

--- a/skills/writing-plans/tasks/create/create-and-validate.md
+++ b/skills/writing-plans/tasks/create/create-and-validate.md
@@ -168,6 +168,7 @@ Every plan phase checklist MUST pass the following 8 validation rules in additio
 9. **Skill name exists:** Every dispatch marker with a skill name (`— <skill-name> for`) must reference an existing directory under `.opencode/skills/`. HALT with `SKILL_NOT_FOUND` if any marker references a non-existent skill.
 10. **Exhaustive mapping:** Every phase step MUST have a named skill in its dispatch marker. No step may use bare `(**clean-room**)` or `(**inline**)` without a preceding `— <skill-name> for <concern>`. HALT with `MISSING_SKILL_NAME` if any step lacks a skill name.
 11. **Post-RED pipeline gates:** Every phase's Post-RED/green section MUST contain all three mandatory pipeline gates: `completeness-gate`, `adversarial-audit`, and `completion-core`. Each gate MUST be expanded into indented checkbox sub-steps. HALT with `MISSING_POST_RED_GATE` if any gate is absent or collapsed into prose.
+12. **Prose sub-step rejection:** No plan step body may contain prose-format sub-steps (matched by `^\s+→ [^d]` — arrow continuations that are not `→ dispatch:` or `→ SC-N`). Any prose-format sub-step causes HALT with `PROSE_SUBSTEPS_DETECTED`.
 
 If any rule fails: HALT with MISSING-TRACEABILITY and report which rule(s) failed.
 

--- a/skills/writing-plans/tasks/create/plan-structure.md
+++ b/skills/writing-plans/tasks/create/plan-structure.md
@@ -210,13 +210,16 @@ The gate labels and step sequence MUST be pulled from `implementation-pipeline/S
 
 #### Pre-RED Common
 
-Shared pre-work that runs once per phase before any RED/GREEN chains begin. This section contains:
-- Verification gate invocation
-- Reading approved spec
-- Combined/separate decision
-- Concern boundary annotations (see below)
-- File references (see below)
-- SC references (see below)
+Shared pre-work that runs once per phase before any RED/GREEN chains begin. Every sub-step MUST use the `- [ ] N.` indented checkbox format — never `→` prose continuation lines:
+
+```
+- [ ] 1. Verification gate — `verification-enforcement` for spec content verification (**inline**)
+    - [ ] 1a. Verify spec claims against live source files → SC-N
+- [ ] 2. Read approved spec — `issue-review` for spec content (**inline**)
+    - [ ] 2a. Extract objectives, constraints, success criteria, affected sub-folders → SC-N
+- [ ] 3. Read routing table — `pre-analysis` for canonical gate discovery (**inline**)
+    - [ ] 3a. Confirm gate labels and dispatch types → SC-N
+```
 
 ##### Concern Boundary Annotations
 
@@ -248,19 +251,24 @@ This section contains one RED/GREEN pair per implementation item. Each pair is a
 
 #### Post-RED/green
 
-Post-cycle validation that runs once per phase after all RED/GREEN chains complete. This section MUST contain the following three mandatory pipeline gates in order:
+Post-cycle validation that runs once per phase after all RED/GREEN chains complete. This section MUST contain the following three mandatory pipeline gates in order, each expanded into indented checkbox sub-steps:
 
-1. **COMPLETENESS GATE** — `completeness-gate` (**clean-room**) — Verify all SCs in this phase are covered before audit
-2. **ADVERSARIAL AUDIT** — `adversarial-audit` (**orchestrator**) — Cross-family audit with expanded sub-steps:
-   - Run resolve-models to select cross-family auditors
-   - Dispatch audit task with auditor_1
-   - If auditor_1 returned non-clean-pass: remediate root cause, restart
-   - Dispatch audit task with auditor_2
-   - If auditor_2 returned non-clean-pass: remediate root cause, restart
-   - Both auditors clean PASS. Collect artifact_path values, pass to cross-validate
-3. **EXEC SUMMARY** — `completion-core` (**clean-room**) — Write phase-complete event to lifecycle manifest, report completion in chat with byline
+```
+- [ ] N. COMPLETENESS GATE — `completeness-gate` (**clean-room**)
+    - [ ] Na. Verify all SCs in this phase covered before audit → SC-all
+- [ ] N. ADVERSARIAL AUDIT — `adversarial-audit` (**orchestrator**)
+    - [ ] Na. Run resolve-models to select cross-family auditors → SC-all
+    - [ ] Nb. Dispatch audit task with auditor_1 → SC-all
+    - [ ] Nc. If auditor_1 returned non-clean-pass: remediate root cause, restart from Na → SC-all
+    - [ ] Nd. Dispatch audit task with auditor_2 → SC-all
+    - [ ] Ne. If auditor_2 returned non-clean-pass: remediate root cause, restart from Na → SC-all
+    - [ ] Nf. Both auditors clean PASS. Collect artifact_path values, pass to cross-validate → SC-all
+- [ ] N. EXEC SUMMARY — `completion-core` (**clean-room**)
+    - [ ] Na. Write completion event to lifecycle manifest at `./tmp/{N}/lifecycle.yaml` → SC-all
+    - [ ] Nb. Report completion in chat with byline → SC-all
+```
 
-Each gate MUST be expanded into indented checkbox sub-steps. Arrow-chain prose is prohibited.
+Arrow-chain prose is prohibited — every sub-step is its own indented checkbox.
 
 #### Validation Rules
 

--- a/skills/writing-plans/tasks/create/plan-structure.md
+++ b/skills/writing-plans/tasks/create/plan-structure.md
@@ -167,6 +167,18 @@ After defining phase structure, consume the `sc-summary.yaml` from spec artifact
 1. Flag orphan SCs (in YAML but not mapped to any plan item) as MISSING-TRACEABILITY
 1. Flag extra SCs (in plan but not in YAML) as SCOPE-CREEP
 
+### Step 3.5: Phase-to-Skill Mapping Artifact (SC-4, SC-5, SC-6)
+
+Before defining TDD items, produce a phase-to-skill-mapping artifact:
+
+1. Read `implementation-pipeline/SKILL.md` §Dispatch Routing Table
+2. Build a mapping of concern category → skill name per phase
+3. Write `.issues/{issue-N}/phase-to-skill-mapping.yaml`
+
+The mapping controls which dispatch markers appear in the generated plan. A phase that produces Python code gets `engineering-approach` markers. A phase that updates skill task files gets `skill-creator` markers. A phase with RED/GREEN cycles gets `test-driven-development` markers for the test steps.
+
+The mapping MUST be exhaustive — no phase step is assigned bare `(**clean-room**)` without a named skill. The mapping MUST include `engineering-approach` for code-implementation concerns regardless of language.
+
 ### Step 3.5: RED/GREEN Condition Language (SC-2, SC-4 — Forward-Looking Stance)
 
 Each item's RED/GREEN conditions MUST describe requirements, not implementation:
@@ -236,10 +248,19 @@ This section contains one RED/GREEN pair per implementation item. Each pair is a
 
 #### Post-RED/green
 
-Post-cycle validation that runs once per phase after all RED/GREEN chains complete. This section contains:
-- Phase 4 regression verification
-- Completeness gate
-- Adversarial audit routing
+Post-cycle validation that runs once per phase after all RED/GREEN chains complete. This section MUST contain the following three mandatory pipeline gates in order:
+
+1. **COMPLETENESS GATE** — `completeness-gate` (**clean-room**) — Verify all SCs in this phase are covered before audit
+2. **ADVERSARIAL AUDIT** — `adversarial-audit` (**orchestrator**) — Cross-family audit with expanded sub-steps:
+   - Run resolve-models to select cross-family auditors
+   - Dispatch audit task with auditor_1
+   - If auditor_1 returned non-clean-pass: remediate root cause, restart
+   - Dispatch audit task with auditor_2
+   - If auditor_2 returned non-clean-pass: remediate root cause, restart
+   - Both auditors clean PASS. Collect artifact_path values, pass to cross-validate
+3. **EXEC SUMMARY** — `completion-core` (**clean-room**) — Write phase-complete event to lifecycle manifest, report completion in chat with byline
+
+Each gate MUST be expanded into indented checkbox sub-steps. Arrow-chain prose is prohibited.
 
 #### Validation Rules
 
@@ -272,12 +293,18 @@ Every unit gets its own numbered checklist with dispatch indicators. NOT a singl
 **Output format:**
 
 ```
-- [ ] 1. <gate-label> (**<dispatch-mode>**) — <unit-specific exit criterion>
+- [ ] 1. <gate-label> — `<skill-name>` for <concern> (**<dispatch-mode>**)
+    → dispatch: "execute <task> from <skill-name>"
+    → SC-N
   - <sub-step description> (**<dispatch-mode>**)
   - <sub-step description> (**<dispatch-mode>**)
-- [ ] 2. <gate-label> (**<dispatch-mode>**) — <unit-specific exit criterion>
+- [ ] 2. <gate-label> — `<skill-name>` for <concern> (**<dispatch-mode>**)
+    → dispatch: "execute <task> from <skill-name>"
+    → SC-N
 ...
 ```
+
+Every step MUST include a skill name in the dispatch marker. Bare `(**clean-room**)` or `(**inline**)` without a preceding `— <skill-name> for <concern>` is invalid. The skill name MUST reference an existing directory under `.opencode/skills/`.
 
 ### Step 5.5: `plan` Utility Invocation for Phase Solvability
 

--- a/skills/writing-plans/tasks/create/plan-structure.md
+++ b/skills/writing-plans/tasks/create/plan-structure.md
@@ -24,183 +24,110 @@ Structure the implementation plan from approved spec: verification gate, combine
 
 After defining the phase structure, create a dependency-ordering solve contract:
 
-1. Create `.issues/{issue-N}/dependency-ordering-verification/` directory
-1. Write `phase-order.yaml` with Z3 variables for each phase position and ordering constraints
-1. Run `solve model --contract-path ... --query "phase_1 < phase_2 and phase_1 < phase_3"`
-1. Confirm SAT — the phase ordering is valid
+- [ ] 1. Create `.issues/{issue-N}/dependency-ordering-verification/` directory
+- [ ] 2. Write `phase-order.yaml` with Z3 variables for each phase position and ordering constraints
+- [ ] 3. Run `solve model --contract-path ... --query "phase_1 < phase_2 and phase_1 < phase_3"`
+- [ ] 4. Confirm SAT — the phase ordering is valid
 
 ### Plan Utility Validation (SC-3)
 
 After phase dependency contract is confirmed SAT, validate phase solvability:
 
-1. Create `./tmp/{issue-N}/artifacts/phase-plan-problem.yaml` with phase structure as planning problem
-1. Run `.opencode/tools/plan plan --problem ./tmp/{issue-N}/artifacts/phase-plan-problem.yaml`
-1. Confirm planner returns SOLVED_SATISFICING or SOLVED_OPTIMALLY
-1. Save result to `./tmp/{issue-N}/artifacts/phase-plan-validated.yaml`
-1. If utility unavailable: **HALT** with blocker report — refer to `plan` skill → `fallback.md` task for manual acyclic check procedure
+- [ ] 1. Create `./tmp/{issue-N}/artifacts/phase-plan-problem.yaml` with phase structure as planning problem
+- [ ] 2. Run `.opencode/tools/plan plan --problem ./tmp/{issue-N}/artifacts/phase-plan-problem.yaml`
+- [ ] 3. Confirm planner returns SOLVED_SATISFICING or SOLVED_OPTIMALLY
+- [ ] 4. Save result to `./tmp/{issue-N}/artifacts/phase-plan-validated.yaml`
+- [ ] 5. If utility unavailable: **HALT** with blocker report — refer to `plan` skill → `fallback.md` task for manual acyclic check procedure
 
 ### SC-ID Mapping (SC-4)
 
 After phase structure validated, consume `sc-summary.yaml`:
 
-1. Read `.issues/{issue-N}/sc-summary.yaml`
-1. Map each SC to its corresponding plan item by SC-ID
-1. Verify all SCs from the spec are covered
-1. Flag orphan SCs (in YAML but not mapped) and missing SCs (in spec but not in YAML)
+- [ ] 1. Read `.issues/{issue-N}/sc-summary.yaml`
+- [ ] 2. Map each SC to its corresponding plan item by SC-ID
+- [ ] 3. Verify all SCs from the spec are covered
+- [ ] 4. Flag orphan SCs (in YAML but not mapped) and missing SCs (in spec but not in YAML)
 
 ### Pre-Step: Verification Gate (MANDATORY FIRST)
 
-Before reading approved spec: `/skill verification-enforcement --task verify`
-
-Collects evidence artifacts for factual claims. Unverified claims marked with `⚠️ UNVERIFIED`.
+- [ ] 1. Invoke `/skill verification-enforcement --task verify` — collect evidence artifacts for factual claims
+    - [ ] 1a. Mark unverified claims with `⚠️ UNVERIFIED`
 
 ### Step 0.5: Pipeline-Readiness Gate Check (HARD GATE)
 
-Before any plan content is written, verify that the spec has passed pipeline-readiness validation:
-
-1. Read `.issues/{issue-N}/sc-pipeline-readiness.yaml`
-1. Assert `status: PASS`
-1. If status is FAIL or file does not exist: **HALT** with `SPEC_NOT_READY_FOR_PIPELINE` — the spec must pass the pipeline-readiness gate before plan creation
-1. If PASS: extract `sc_summary` (total_scs, atomic, with_dependencies, single_concern) and phase dependency declarations for use in plan generation
-
-This is a hard gate — the plan-writer MUST NOT proceed without a PASS from the pipeline-readiness gate. No exceptions, no "proceed anyway" path.
+- [ ] 1. Read `.issues/{issue-N}/sc-pipeline-readiness.yaml`
+- [ ] 2. Assert `status: PASS`
+    - [ ] 2a. If status is FAIL or file does not exist: **HALT** with `SPEC_NOT_READY_FOR_PIPELINE`
+    - [ ] 2b. If PASS: extract `sc_summary` and phase dependency declarations
 
 ### Step 1: Read Approved Spec
 
-- Query GitHub Issue for spec content
-- Extract objectives, constraints, success criteria
-- Extract the all-or-nothing gate statement from the spec's SC section. The plan MUST preserve this gate language in its task structure — each TDD RED checkpoint is a sub-gate in the all-or-nothing chain. If the spec lacks the gate statement, flag as `SPEC_GAP`: the spec must be revised to include the gate before the plan proceeds.
-- Identify affected sub-folders (not individual file paths — agents glob to discover content)
-- Extract the spec's repo owner and repo from the issue URL for use in full-URL references
+- [ ] 1. Query GitHub Issue for spec content
+- [ ] 2. Extract objectives, constraints, success criteria
+- [ ] 3. Extract all-or-nothing gate statement from spec's SC section
+    - [ ] 3a. If spec lacks gate statement: flag as `SPEC_GAP`
+- [ ] 4. Identify affected sub-folders (not individual file paths)
+- [ ] 5. Extract spec's repo owner and repo from issue URL
 
 <!-- Fragment ID: sc-enforcement-gate -->
 
 ### Step 1.5: Combined vs Separate Plan Decision Gate
 
-**Evaluate:** `single_task_determination` passed from post-creation (single-task/multi-task)
-
-| Condition | Outcome |
-| -- | -- |
-| Multi-task spec (mixed concerns or independence) | **Always separate** — separate phase sections in `.issues/{N}/plan.md` |
-| Single-task spec AND spec body can absorb plan content | **Candidate for combined** — agent evaluates readability |
-| Single-task AND combining makes document hard to read | **Separate** — stand-alone sections in `.issues/{N}/plan.md` |
-
-**Decision output (MANDATORY):**
-
-```
-Plan structure decision: combined/separate
-Reason: <justification referencing evaluation criteria>
-```
-
-**If COMBINED:**
-
-- Write to `.issues/{N}/plan.md`, reference spec content inline
-- Retain `[SPEC]` title prefix
-- Proceed to Step 2
-
-**If SEPARATE:**
-
-- Write to `.issues/{N}/plan.md` with separate phase sections
-- Proceed to Step 2
+- [ ] 1. Evaluate `single_task_determination` from post-creation
+    - [ ] 1a. Multi-task spec → **Always separate**
+    - [ ] 1b. Single-task + absorbable → **Candidate for combined**
+    - [ ] 1c. Single-task + hard to read → **Separate**
+- [ ] 2. Document decision output: `Plan structure decision: combined/separate` with reason
+- [ ] 3. If COMBINED: write to `.issues/{N}/plan.md`, retain `[SPEC]` title prefix
+- [ ] 4. If SEPARATE: write to `.issues/{N}/plan.md` with separate phase sections
 
 ### Step 1.6: Duplicate Plan Check
 
-Look for existing plan artifacts in `.issues/` workspace:
-
-```bash
-ls .issues/*/plan.md 2>/dev/null
-```
-
-For each plan found referencing the same spec, present choice:
-
-- Proceed with new plan (override existing local artifact)
-- HALT and review existing plan
+- [ ] 1. Run `ls .issues/*/plan.md 2>/dev/null` to find existing plans
+- [ ] 2. For each plan referencing same spec: present choice to proceed or HALT
 
 ### Step 2: Map File Structure (Sub-Folder References — SC-9)
 
-- List sub-folders to create or modify (e.g., `skills/writing-plans/tasks/create/`), not individual files
-- Agents glob `*` or `tasks/create/*` to discover content
-- Define each sub-folder's responsibility and concern boundary
-- Ensure decomposition has clear boundaries across sub-folders
-- **NO hardcoded file lists** — stale on every edit; agents discover by globbing
+- [ ] 1. List sub-folders to create or modify (not individual files)
+- [ ] 2. Define each sub-folder's responsibility and concern boundary
+- [ ] 3. Ensure decomposition has clear boundaries across sub-folders
+- [ ] 4. **NO hardcoded file lists** — agents discover by globbing
 
 ### Step 3: Item Decomposition (per `091-incremental-build.md`)
 
-**Verify before writing:**
-| Requirement | Verification |
-| -- | -- |
-| Item enumeration | Every unit listed with name, scope, deliverable |
-| Dependency ordering | Items ordered so dependencies satisfied |
-| Acceptance criteria per item | Each has testable criteria |
-| Concern boundary annotations | Cross-architectural items flagged |
-
-**Failure:** Plan will fail `approval-gate --task verify-authorization` Step 4.5
+- [ ] 1. Verify item enumeration — every unit listed with name, scope, deliverable
+- [ ] 2. Verify dependency ordering — items ordered so dependencies satisfied
+- [ ] 3. Verify acceptance criteria per item — each has testable criteria
+- [ ] 4. Verify concern boundary annotations — cross-architectural items flagged
 
 ### Step 3.3: Phase Dependency-Ordering Solve Contract Creation (SC-1)
 
-For multi-phase specs, create a dependency-ordering solve contract from the phase structure:
-
-```bash
-./.opencode/tools/solve model \
-  --contract-path .issues/{issue-N}/dependency-ordering-verification/ \
-  --state phase_dependencies
-```
-
-The contract declares phase-ordering constraints as Z3 variables, where each phase's start depends on its dependencies being satisfied:
-
-```yaml
-# .issues/{issue-N}/dependency-ordering-verification/ordering.yaml
-phase_dependencies:
-  - phase: <phase_name>
-    depends_on: [<phase_name>, ...]
-    constraints:
-      - "phase_N_starts_after_phase_M_completes"
-```
+- [ ] 1. Run `./.opencode/tools/solve model` with phase dependency constraints
+- [ ] 2. Write ordering contract to `.issues/{issue-N}/dependency-ordering-verification/ordering.yaml`
+- [ ] 3. Confirm SAT — the phase ordering is valid
 
 ### Step 3.4: SC-ID Mapping Substep (SC-4 Consumption)
 
-After defining phase structure, consume the `sc-summary.yaml` from spec artifacts to map SCs to plan items:
-
-1. Read `.issues/{issue-N}/sc-summary.yaml`
-1. For each phase in the plan, verify its SC assignments match `sc_summary.phases[].sc_ids`
-1. For each plANNED item, annotate with the corresponding SC-ID(s)
-1. Flag orphan SCs (in YAML but not mapped to any plan item) as MISSING-TRACEABILITY
-1. Flag extra SCs (in plan but not in YAML) as SCOPE-CREEP
+- [ ] 1. Read `.issues/{issue-N}/sc-summary.yaml`
+- [ ] 2. For each phase, verify SC assignments match `sc_summary.phases[].sc_ids`
+- [ ] 3. Annotate each plan item with corresponding SC-ID(s)
+- [ ] 4. Flag orphan SCs (in YAML but not mapped) as MISSING-TRACEABILITY
+- [ ] 5. Flag extra SCs (in plan but not in YAML) as SCOPE-CREEP
 
 ### Step 3.5: Phase-to-Skill Mapping Artifact (SC-4, SC-5, SC-6)
 
-Before defining TDD items, produce a phase-to-skill-mapping artifact:
+- [ ] 1. Read `implementation-pipeline/SKILL.md` §Dispatch Routing Table
+- [ ] 2. Build mapping of concern category → skill name per phase
+- [ ] 3. Write `.issues/{issue-N}/phase-to-skill-mapping.yaml`
+- [ ] 4. Verify mapping is exhaustive — no phase step assigned bare `(**clean-room**)`
+- [ ] 5. Verify mapping includes `engineering-approach` for code-implementation concerns
 
-1. Read `implementation-pipeline/SKILL.md` §Dispatch Routing Table
-2. Build a mapping of concern category → skill name per phase
-3. Write `.issues/{issue-N}/phase-to-skill-mapping.yaml`
+### Step 3.6: RED/GREEN Condition Language (SC-2, SC-4 — Forward-Looking Stance)
 
-The mapping controls which dispatch markers appear in the generated plan. A phase that produces Python code gets `engineering-approach` markers. A phase that updates skill task files gets `skill-creator` markers. A phase with RED/GREEN cycles gets `test-driven-development` markers for the test steps.
-
-The mapping MUST be exhaustive — no phase step is assigned bare `(**clean-room**)` without a named skill. The mapping MUST include `engineering-approach` for code-implementation concerns regardless of language.
-
-### Step 3.5: RED/GREEN Condition Language (SC-2, SC-4 — Forward-Looking Stance)
-
-Each item's RED/GREEN conditions MUST describe requirements, not implementation:
-
-**RED** = "what must be false before this item starts" — the failure condition that would exist if this item were not implemented. NO line numbers, NO exact import strings, NO exact assertion code, NO file paths.
-
-**GREEN** = "what must be true when done" — the condition that proves completion. Uses "must be true" language. NO "implemented", "complete", or past-tense status language.
-
-**RED/GREEN MUST be defined as separate phases.** RED and GREEN may NEVER be combined into a single phase or step. RED describes the failure condition (what must be false), and GREEN describes the satisfaction condition (what must be true). They are separate concerns and MUST appear as separate entries in the plan structure.
-
-```
-✅ CORRECT RED: "The agent produces a plan with RED/GREEN conditions instead of prescriptive code"
-✅ CORRECT GREEN: "Plans must describe what must be true, not how to achieve it"
-❌ WRONG: "Replace line 42 with from mcp.server.fastmcp import FastMCP"
-❌ WRONG: "Implemented RED/GREEN conditions for all items"
-```
-
-**Behavioral RED/GREEN for rule-changing items:**
-When changing guidelines or skills, use behavioral TDD:
-
-1. **Behavioral RED:** Write test sending agent prompt, verify agent does NOT follow new rule yet
-1. **Behavioral GREEN:** Make change, re-run test — now agent follows rule
+- [ ] 1. Write RED conditions as failure state descriptions — NO line numbers, NO exact code, NO file paths
+- [ ] 2. Write GREEN conditions as satisfaction state descriptions — "must be true" language
+- [ ] 3. Keep RED and GREEN as separate steps — NEVER combined
+- [ ] 4. For rule-changing items: use behavioral TDD (write test first, then implement)
 
 ### Step 4: Plan Phase Structure (PRIMARY)
 

--- a/skills/writing-plans/tasks/readiness.md
+++ b/skills/writing-plans/tasks/readiness.md
@@ -1,0 +1,29 @@
+# Task: readiness
+
+## Purpose
+
+Pipeline-readiness gate check and spec-to-plan handoff verification. Ensures the spec has passed all pre-plan validation gates before any plan content is written.
+
+## Entry Criteria
+
+- Research step completed with PASS
+- Research evidence artifacts available
+
+## Exit Criteria
+
+- Pipeline-readiness status determined (PASS/FAIL)
+- Spec-to-plan handoff verified
+- Result contract contains status field
+
+## Procedure
+
+1. Read `.issues/{issue-N}/sc-pipeline-readiness.yaml`
+2. Assert `status: PASS`
+3. If status is FAIL or file does not exist: return BLOCKED with `SPEC_NOT_READY_FOR_PIPELINE`
+4. If PASS: extract `sc_summary` (total_scs, atomic, with_dependencies, single_concern) and phase dependency declarations
+5. Return PASS with readiness data
+
+## Context Required
+
+- Related tasks: `create/plan-structure`
+- Related skills: `approval-gate`

--- a/skills/writing-plans/tasks/readiness.md
+++ b/skills/writing-plans/tasks/readiness.md
@@ -17,11 +17,11 @@ Pipeline-readiness gate check and spec-to-plan handoff verification. Ensures the
 
 ## Procedure
 
-1. Read `.issues/{issue-N}/sc-pipeline-readiness.yaml`
-2. Assert `status: PASS`
-3. If status is FAIL or file does not exist: return BLOCKED with `SPEC_NOT_READY_FOR_PIPELINE`
-4. If PASS: extract `sc_summary` (total_scs, atomic, with_dependencies, single_concern) and phase dependency declarations
-5. Return PASS with readiness data
+- [ ] 1. Read `.issues/{issue-N}/sc-pipeline-readiness.yaml`
+- [ ] 2. Assert `status: PASS`
+- [ ] 3. If status is FAIL or file does not exist: return BLOCKED with `SPEC_NOT_READY_FOR_PIPELINE`
+- [ ] 4. If PASS: extract `sc_summary` and phase dependency declarations
+- [ ] 5. Return PASS with readiness data
 
 ## Context Required
 

--- a/skills/writing-plans/tasks/research.md
+++ b/skills/writing-plans/tasks/research.md
@@ -1,0 +1,29 @@
+# Task: research
+
+## Purpose
+
+Load the `verification-enforcement` skill and execute `--task verify` inline, collecting live-source evidence for all factual claims before any plan content is written. This is a hard gate — the pipeline MUST NOT proceed without PASS.
+
+## Entry Criteria
+
+- Approved spec exists
+- Spec has explicit approval
+
+## Exit Criteria
+
+- Evidence artifacts collected for all factual claims
+- Result contract contains `evidence_artifacts` field (list of paths)
+- If any claim is unverifiable: return BLOCKED with empty evidence_artifacts
+
+## Procedure
+
+1. Load `verification-enforcement` skill: `skill({name: "verification-enforcement"})`
+2. Execute `--task verify` inline within this context
+3. Collect evidence artifact paths from verification output
+4. If all claims verified: return PASS with evidence_artifacts
+5. If any claim unverifiable: return BLOCKED with empty evidence_artifacts — pipeline halts
+
+## Context Required
+
+- Related skills: `verification-enforcement`
+- Related guidelines: `065-verification-honesty.md`

--- a/skills/writing-plans/tasks/research.md
+++ b/skills/writing-plans/tasks/research.md
@@ -17,11 +17,11 @@ Load the `verification-enforcement` skill and execute `--task verify` inline, co
 
 ## Procedure
 
-1. Load `verification-enforcement` skill: `skill({name: "verification-enforcement"})`
-2. Execute `--task verify` inline within this context
-3. Collect evidence artifact paths from verification output
-4. If all claims verified: return PASS with evidence_artifacts
-5. If any claim unverifiable: return BLOCKED with empty evidence_artifacts — pipeline halts
+- [ ] 1. Load `verification-enforcement` skill: `skill({name: "verification-enforcement"})`
+- [ ] 2. Execute `--task verify` inline within this context
+- [ ] 3. Collect evidence artifact paths from verification output
+- [ ] 4. If all claims verified: return PASS with evidence_artifacts
+- [ ] 5. If any claim unverifiable: return BLOCKED with empty evidence_artifacts — pipeline halts
 
 ## Context Required
 

--- a/skills/writing-plans/tasks/revisit.md
+++ b/skills/writing-plans/tasks/revisit.md
@@ -17,13 +17,13 @@ Load the `verification-enforcement` skill and execute `--task revisit` inline, s
 
 ## Procedure
 
-1. Load `verification-enforcement` skill: `skill({name: "verification-enforcement"})`
-2. Execute `--task revisit` inline within this context
-3. Scan plan document for `⚠️ UNVERIFIED` markers
-4. For each marker: attempt to resolve with live-source verification
-5. If all resolved: return PASS with resolution_status: resolved
-6. If partial: return DONE_WITH_CONCERNS with resolution_status: partial
-7. If any unresolvable: return BLOCKED with resolution_status: escalated — pipeline halts
+- [ ] 1. Load `verification-enforcement` skill: `skill({name: "verification-enforcement"})`
+- [ ] 2. Execute `--task revisit` inline within this context
+- [ ] 3. Scan plan document for `⚠️ UNVERIFIED` markers
+- [ ] 4. For each marker: attempt to resolve with live-source verification
+- [ ] 5. If all resolved: return PASS with resolution_status: resolved
+- [ ] 6. If partial: return DONE_WITH_CONCERNS with resolution_status: partial
+- [ ] 7. If any unresolvable: return BLOCKED with resolution_status: escalated — pipeline halts
 
 ## Context Required
 

--- a/skills/writing-plans/tasks/revisit.md
+++ b/skills/writing-plans/tasks/revisit.md
@@ -1,0 +1,31 @@
+# Task: revisit
+
+## Purpose
+
+Load the `verification-enforcement` skill and execute `--task revisit` inline, scanning for `⚠️ UNVERIFIED` markers in the plan document. Resolve if possible; escalate unresolvable claims.
+
+## Entry Criteria
+
+- Plan document written to `.issues/{N}/plan.md`
+- Plan content contains potential unverified claims
+
+## Exit Criteria
+
+- All `⚠️ UNVERIFIED` markers resolved or escalated
+- Result contract contains resolution_status (resolved/partial/escalated)
+- If escalated: pipeline halts with spec-defect report
+
+## Procedure
+
+1. Load `verification-enforcement` skill: `skill({name: "verification-enforcement"})`
+2. Execute `--task revisit` inline within this context
+3. Scan plan document for `⚠️ UNVERIFIED` markers
+4. For each marker: attempt to resolve with live-source verification
+5. If all resolved: return PASS with resolution_status: resolved
+6. If partial: return DONE_WITH_CONCERNS with resolution_status: partial
+7. If any unresolvable: return BLOCKED with resolution_status: escalated — pipeline halts
+
+## Context Required
+
+- Related skills: `verification-enforcement`
+- Related guidelines: `065-verification-honesty.md`

--- a/skills/writing-plans/tasks/solve.md
+++ b/skills/writing-plans/tasks/solve.md
@@ -1,0 +1,30 @@
+# Task: solve
+
+## Purpose
+
+Run Z3 constraint solving and plan utility validation as direct CLI invocations. Sub-agents are leaf nodes — execute tools directly, never dispatch further sub-agents.
+
+## Entry Criteria
+
+- Structure step completed with phase definitions and dependency contract
+- Dependency contract YAML exists
+
+## Exit Criteria
+
+- `solve model` returns SAT
+- `solve check` returns SAT
+- `plan plan` returns SOLVED_SATISFICING or SOLVED_OPTIMALLY
+- Result contract contains solve_status and plan_status
+
+## Procedure
+
+1. Run `./.opencode/tools/solve model --contract-path <path> --query <query>` — confirm SAT
+2. Run `./.opencode/tools/solve check --state-path <path> --contract-path <path>` — confirm SAT
+3. Run `./.opencode/tools/plan plan --problem <path> --output <path>` — confirm SOLVED
+4. If any returns UNSAT or UNSOLVABLE: return BLOCKED with status
+5. Return PASS with solve_status and plan_status
+
+## Context Required
+
+- Related skills: `solve`, `plan`
+- Related tools: `./.opencode/tools/solve`, `./.opencode/tools/plan`

--- a/skills/writing-plans/tasks/solve.md
+++ b/skills/writing-plans/tasks/solve.md
@@ -18,11 +18,11 @@ Run Z3 constraint solving and plan utility validation as direct CLI invocations.
 
 ## Procedure
 
-1. Run `./.opencode/tools/solve model --contract-path <path> --query <query>` — confirm SAT
-2. Run `./.opencode/tools/solve check --state-path <path> --contract-path <path>` — confirm SAT
-3. Run `./.opencode/tools/plan plan --problem <path> --output <path>` — confirm SOLVED
-4. If any returns UNSAT or UNSOLVABLE: return BLOCKED with status
-5. Return PASS with solve_status and plan_status
+- [ ] 1. Run `./.opencode/tools/solve model --contract-path <path> --query <query>` — confirm SAT
+- [ ] 2. Run `./.opencode/tools/solve check --state-path <path> --contract-path <path>` — confirm SAT
+- [ ] 3. Run `./.opencode/tools/plan plan --problem <path> --output <path>` — confirm SOLVED
+- [ ] 4. If any returns UNSAT or UNSOLVABLE: return BLOCKED with status
+- [ ] 5. Return PASS with solve_status and plan_status
 
 ## Context Required
 

--- a/skills/writing-plans/tasks/structure.md
+++ b/skills/writing-plans/tasks/structure.md
@@ -19,14 +19,14 @@ Define the plan phase structure: combined/separate decision, file mapping, phase
 
 ## Procedure
 
-1. Read approved spec content
-2. Make combined/separate decision per plan-structure.md Step 1.5
-3. Map file structure (sub-folder references, not individual files)
-4. Define phase structure with concern boundary annotations
-5. Define TDD tasks with RED/GREEN conditions
-6. Generate dependency-ordering solve contract
-7. Write phase-to-skill-mapping.yaml per #1311 format
-8. Return structure output with phase definitions
+- [ ] 1. Read approved spec content
+- [ ] 2. Make combined/separate decision per plan-structure.md Step 1.5
+- [ ] 3. Map file structure (sub-folder references, not individual files)
+- [ ] 4. Define phase structure with concern boundary annotations
+- [ ] 5. Define TDD tasks with RED/GREEN conditions
+- [ ] 6. Generate dependency-ordering solve contract
+- [ ] 7. Write phase-to-skill-mapping.yaml per #1311 format
+- [ ] 8. Return structure output with phase definitions
 
 ## Context Required
 

--- a/skills/writing-plans/tasks/structure.md
+++ b/skills/writing-plans/tasks/structure.md
@@ -1,0 +1,34 @@
+# Task: structure
+
+## Purpose
+
+Define the plan phase structure: combined/separate decision, file mapping, phase structure, TDD definition, and dependency contract generation.
+
+## Entry Criteria
+
+- Readiness step completed with PASS
+- Spec content available
+
+## Exit Criteria
+
+- Combined/separate decision made and documented
+- File structure mapped with clear boundaries
+- Phase structure defined with concern boundary annotations
+- TDD tasks defined with mandatory RED checkpoints
+- Dependency contract generated
+
+## Procedure
+
+1. Read approved spec content
+2. Make combined/separate decision per plan-structure.md Step 1.5
+3. Map file structure (sub-folder references, not individual files)
+4. Define phase structure with concern boundary annotations
+5. Define TDD tasks with RED/GREEN conditions
+6. Generate dependency-ordering solve contract
+7. Write phase-to-skill-mapping.yaml per #1311 format
+8. Return structure output with phase definitions
+
+## Context Required
+
+- Related tasks: `create/plan-structure`
+- Related skills: `solve`, `plan`

--- a/skills/writing-plans/tasks/write.md
+++ b/skills/writing-plans/tasks/write.md
@@ -18,12 +18,12 @@ Write the plan document to `.issues/{N}/plan.md`, validate dispatch table refere
 
 ## Procedure
 
-1. Write plan document header (Goal, Architecture, Tech Stack)
-2. Write each phase section with Pre-RED Common, Per-Item RED+green Chains, Post-RED/green
-3. Validate every dispatch marker skill name exists under `.opencode/skills/`
-4. Apply approval cascade per authorization_scope
-5. Sync cross-reference to spec issue body
-6. Return PASS with plan file path
+- [ ] 1. Write plan document header (Goal, Architecture, Tech Stack)
+- [ ] 2. Write each phase section with Pre-RED Common, Per-Item RED+green Chains, Post-RED/green
+- [ ] 3. Validate every dispatch marker skill name exists under `.opencode/skills/`
+- [ ] 4. Apply approval cascade per authorization_scope
+- [ ] 5. Sync cross-reference to spec issue body
+- [ ] 6. Return PASS with plan file path
 
 ## Context Required
 

--- a/skills/writing-plans/tasks/write.md
+++ b/skills/writing-plans/tasks/write.md
@@ -2,50 +2,30 @@
 
 ## Purpose
 
-Write an implementation plan file to the correct repo's `.issues/` worktree and push it via `local-issues sync-file`.
-
-## Prerequisites
-
-- [ ] 1. Plan content has been created (by `create` task)
-- [ ] 2. Spec issue number (`N`) is known
-- [ ] 3. Session-init `## Repo Information` is available for repo resolution
-
-## Operating Protocol
-
-- [ ] 1. **Resolve target repo** — Match the spec issue's repo path against session-init `## Repo Information` entries. The issue's repo is determined by its issue number's location: if the issue is in `.opencode/.issues/{N}/`, the repo is the `.opencode` submodule entry; if in `.issues/{N}/`, the repo is the root entry. Extract `html_url`, `owner`, `repo` from the matching entry.
-- [ ] 2. **Write plan file** — Write the plan content to the resolved repo's `.issues/` worktree at `{worktree.path}/.issues/{N}/plan.md`.
-- [ ] 3. **Commit and push** — Run `local-issues sync-file` with the plan file path. This handles `git add`, `git commit`, and `git push` in the correct worktree.
-- [ ] 4. **Generate URL** — Construct the plan file URL using the resolved repo's `html_url`, `owner`, and `repo`: `{html_url}/{owner}/{repo}/tree/issues-data/{N}/plan.md`. Verify `{html_url}` was substituted (not left as a literal placeholder). If placeholder remains, HALT with blocker.
+Write the plan document to `.issues/{N}/plan.md`, validate dispatch table references, apply approval cascade, and sync cross-references.
 
 ## Entry Criteria
 
-- Plan content is ready for file placement
-- Target repo is resolved from session-init `## Repo Information`
-- `local-issues sync-file` subcommand is available
+- Solve step completed with SAT and SOLVED status
+- Phase structure and TDD definitions available
 
 ## Exit Criteria
 
-- Plan file written to correct repo's `.issues/{N}/plan.md`
-- File committed and pushed via `local-issues sync-file`
-- Plan file URL reported with correct repo's `html_url`, `owner`, `repo`
+- Plan document written to `.issues/{N}/plan.md`
+- Dispatch table validation passed
+- Approval cascade applied
+- Cross-reference synced to spec issue
 
-## Repo Resolution
+## Procedure
 
-The session-init `## Repo Information` section provides per-repo entries:
+1. Write plan document header (Goal, Architecture, Tech Stack)
+2. Write each phase section with Pre-RED Common, Per-Item RED+green Chains, Post-RED/green
+3. Validate every dispatch marker skill name exists under `.opencode/skills/`
+4. Apply approval cascade per authorization_scope
+5. Sync cross-reference to spec issue body
+6. Return PASS with plan file path
 
-```yaml
-- path: .
-  owner: michael-conrad
-  repo: opencode-config
-  platform: github.com
-  url: git@github.com:michael-conrad/opencode-config.git
-  html_url: https://github.com
-- path: .opencode
-  owner: michael-conrad
-  repo: .opencode
-  platform: github.com
-  url: git@github.com:michael-conrad/.opencode.git
-  html_url: https://github.com
-```
+## Context Required
 
-Match the issue's repo path prefix against the `path` field. Use the matching entry's `html_url`, `owner`, and `repo` for URL construction.
+- Related tasks: `create/create-and-validate`
+- Related skills: `issue-operations`


### PR DESCRIPTION
## Summary

Combined implementation of #1311 and #1320: decompose the `writing-plans` skill from an uber-task model into a 21-step Z3-enforced pipeline with skill-dispatch markers, YAML contract templates, and mandatory live-source research gates.

## Outcome

- **21-step pipeline** with 10 discrete sub-agent dispatches, 10 z3-check transitions, 1 inline step
- **Skill-dispatch markers** — plan steps now use `— <skill-name> for <concern> (**<dispatch-mode>**)` format
- **DISPATCH_GATE section removed** from SKILL.md (guideline-level enforcement covers these rules)
- **create.md restructured** as routing-only — Orchestrator Execution Protocol removed
- **10 new task files**: research, readiness, structure, solve, write, revisit, audit-fidelity, audit-concern
- **20 YAML contract templates** (10 input + 10 output) for sub-agent dispatch context
- **Post-RED/green gates**: completeness-gate, adversarial-audit, completion-core in every phase
- **Phase-to-skill mapping** artifact generated at plan-creation time
- **Z3 SAT verified**: #1311 must complete before #1320 Phase 1 (file replacement dependency)

## Fixes

- Closes #1311 — Plan writer dispatches to implementation skills instead of emitting inline prose
- Closes #1320 — Decompose writing-plans skill into discrete Z3-enforced pipeline with YAML contract dispatch

🤖 Co-authored with AI: OpenCode (ollama-cloud/deepseek-v4-flash)