### PR TITLE
fix(#1295,#1299): PEP 723 header, HTTPS auth hang, redundant orphan branch call

### DIFF
--- a/guidelines/070-environment.md
+++ b/guidelines/070-environment.md
@@ -20,6 +20,8 @@ load_when: sub-agent
 
 ## PEP 723 Self-Contained Scripts (MANDATORY)
 
+Reference: [PEP 723 — Inline script metadata](https://peps.python.org/pep-0723/)
+
 All Python entry points in `.opencode/tools/` MUST be self-contained PEP 723 scripts with:
 - Shebang: `#!/usr/bin/env -S uv run --script`
 - PEP 723 `# /// script` metadata block with `requires-python` and `dependencies`
@@ -27,6 +29,17 @@ All Python entry points in `.opencode/tools/` MUST be self-contained PEP 723 scr
 - Execute permission (`chmod +x`)
 
 New tools MUST follow this pattern. Do NOT use `uv run python .opencode/tools/X`.
+
+### Version Pinning (MANDATORY)
+
+Every PEP 723 script MUST pin both `requires-python` and all `dependencies` using the `~=` compatible release operator:
+
+- `requires-python`: MUST use `~=X.Y.0` (three-part version, e.g., `~=3.12.0`). Bare `>=` is prohibited (permits untested future Python versions). Bare `X.Y` is rejected by `uv`.
+- `dependencies`: Each entry MUST use `~=` to constrain to a compatible release window (e.g., `pyyaml~=6.0`). Bare unversioned packages and `>=` are prohibited (permit untested major upgrades).
+
+### Marker Validation
+
+The ONLY standardized PEP 723 marker is `# /// script`. The deprecated `# /// pyproject.toml` marker is INVALID — tools MUST NOT read metadata blocks with non-standardized types. `uv` ignores blocks with the wrong marker, causing dependency installation to silently fail.
 
 ### Polyglot Bash Guard (MANDATORY)
 
@@ -38,8 +51,8 @@ Every PEP 723 script MUST include a polyglot bash guard as the second line, imme
 
 # PEP 723 HEADER MUST BE AFTER BASH GUARD
 # /// script
-# requires-python = "~=3.12"
-# dependencies = []
+# requires-python = "~=3.12.0"
+# dependencies = ["pyyaml~=6.0"]
 # ///
 ```
 
@@ -58,8 +71,8 @@ The guard prevents catastrophic failure when an agent or user invokes `bash <scr
 
 # PEP 723 HEADER MUST BE AFTER BASH GUARD
 # /// script
-# requires-python = "~=3.12"
-# dependencies = []
+# requires-python = "~=3.12.0"
+# dependencies = ["pyyaml~=6.0"]
 # ///
 
 # fmt: on
@@ -75,7 +88,7 @@ The guard prevents catastrophic failure when an agent or user invokes `bash <scr
 - Line 2: `# fmt: off` (ruff protection guard)
 - Line 3: `"exec" "uv" "run" "--script" "$0" "$@" # MUST GO BEFORE PEP 723 HEADER` (bash guard)
 - Lines 4-5: Comment line, PEP 723 header
-- Lines 6-8: PEP 723 metadata block (`requires-python`, `dependencies`)
+- Lines 6-8: PEP 723 metadata block (`requires-python` with `~=X.Y.0`, `dependencies` with `~=` pins)
 - Line 9: `# ///` (closing PEP 723)
 - Line 10: `# fmt: on` (ruff protection guard off)
 - After: blank line, then optional `from __future__` or `__doc__ = ` or imports

--- a/tests/test-pep723-tools.sh
+++ b/tests/test-pep723-tools.sh
@@ -138,6 +138,66 @@ done
 
 check_no_old_references
 
+# --- PEP 723 marker and pinning checks (#1295) ---
+
+check_no_pyproject_toml_marker() {
+    local file="$1"
+    if grep -q '# /// pyproject.toml' "$file"; then
+        echo "FAIL: $file uses deprecated # /// pyproject.toml marker"
+        FAIL=$((FAIL + 1))
+    else
+        PASS=$((PASS + 1))
+    fi
+}
+
+check_no_project_section() {
+    local file="$1"
+    if grep -q '# \[project\]' "$file"; then
+        echo "FAIL: $file has [project] section in script metadata"
+        FAIL=$((FAIL + 1))
+    else
+        PASS=$((PASS + 1))
+    fi
+}
+
+check_requires_python_pinned() {
+    local file="$1"
+    if grep -q '^# requires-python = "~=[0-9]\+\.[0-9]\+\.[0-9]\+"' "$file"; then
+        PASS=$((PASS + 1))
+    else
+        echo "FAIL: $file requires-python not pinned with ~=X.Y.0"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+check_dependencies_pinned() {
+    local file="$1"
+    local deps_line
+    deps_line=$(grep '^# dependencies' "$file" || true)
+    if [ -z "$deps_line" ]; then
+        echo "FAIL: $file has no dependencies line"
+        FAIL=$((FAIL + 1))
+        return 0
+    fi
+    local unversioned
+    unversioned=$(echo "$deps_line" | grep -o '"[^"]*"' | grep -v '~=' || true)
+    if [ -n "$unversioned" ]; then
+        echo "FAIL: $file has unversioned or non-~= dependencies: $unversioned"
+        FAIL=$((FAIL + 1))
+    else
+        PASS=$((PASS + 1))
+    fi
+}
+
+# Run PEP 723 marker and pinning checks on all tools
+for tool in "${ENTRY_POINTS[@]}"; do
+    file="$TOOLS_DIR/$tool"
+    check_no_pyproject_toml_marker "$file"
+    check_no_project_section "$file"
+    check_requires_python_pinned "$file"
+    check_dependencies_pinned "$file"
+done
+
 check_plugin_invocations() {
     local plugin_failures=0
     local plugin_files

--- a/tools/local-issues
+++ b/tools/local-issues
@@ -1,23 +1,18 @@
 #!/usr/bin/env -S uv run --script
-# /// pyproject.toml
-# [project]
-# name = "local-issues"
-# version = "2.0.0"
-# requires-python = ">=3.12"
-# dependencies = ["pyyaml"]
-#
-# [tool.ruff]
-# line-length = 100
-# target-version = "py312"
-# ///
 # fmt: off
 "exec" "uv" "run" "--script" "$0" "$@"  # bash guard — detect python invoker
+
+# /// script
+# requires-python = "~=3.12.0"
+# dependencies = ["pyyaml~=6.0"]
+# ///
+
+# fmt: on
 
 # SPDX-FileCopyrightText: 2026 Michael Conrad
 # SPDX-License-Identifier: MIT
 # Provenance: AI-generated
 
-# fmt: on
 # ruff: noqa: E402
 """
 DESCRIPTION: Local issue tracking CLI tool for .issues/ directory.
@@ -471,11 +466,14 @@ def _remove_temp_worktree(git_dir: str, wt_tmp: str) -> bool:
 
 
 def _populate_orphan_branch(root: Path, wt_tmp: str) -> bool:
-    """Add initial content to the orphan branch and clean up temp worktree."""
+    """Add initial content to the orphan branch and clean up temp worktree.
+
+    The initial commit already creates the branch ref — _name_orphan_branch()
+    is redundant and removed per #1299.
+    """
     git_dir = str(root)
     if not _commit_orphan_init(git_dir, wt_tmp):
         return False
-    _name_orphan_branch(git_dir, wt_tmp)
     _remove_temp_worktree(git_dir, wt_tmp)
     return True
 
@@ -665,9 +663,39 @@ def _collect_repos() -> list[tuple[Path, str]]:
     return repos
 
 
+def _is_https_without_creds(git_dir: str) -> bool:
+    """Check if the remote is HTTPS and no credential helper is configured.
+
+    Returns True when push would trigger an interactive auth prompt.
+    """
+    try:
+        url_result = subprocess.run(
+            ["git", "-C", git_dir, "remote", "get-url", "origin"],
+            capture_output=True, text=True, timeout=15,
+        )
+        if url_result.returncode != 0:
+            return False
+        remote_url = url_result.stdout.strip()
+        if not remote_url.startswith("https://"):
+            return False
+        cred_result = subprocess.run(
+            ["git", "-C", git_dir, "config", "--get-all", "credential.helper"],
+            capture_output=True, text=True, timeout=15,
+        )
+        return cred_result.returncode != 0 or not cred_result.stdout.strip()
+    except Exception:
+        return False
+
+
 def _push_orphan_if_needed(repo_path: Path | None = None) -> None:
-    """Push the worktree branch to origin if a remote exists."""
+    """Push the worktree branch to origin if a remote exists.
+
+    Skips push when remote is HTTPS without credential helper to avoid
+    hanging on interactive auth prompts in non-interactive environments (#1299).
+    """
     git_dir = str(repo_path) if repo_path else os.getcwd()
+    if _is_https_without_creds(git_dir):
+        return
     try:
         result = subprocess.run(
             ["git", "-C", git_dir, "remote", "get-url", "origin"],
@@ -698,11 +726,15 @@ def _push_issues_branch(repo_path: Path | None = None) -> None:
     Push the issues worktree branch to origin.
     Only called from _auto_commit after a mutation commit.
     Runs git commands from within .issues/ (the linked worktree).
+
+    Skips push when remote is HTTPS without credential helper (#1299).
     """
     root = repo_path or Path(os.getcwd())
     if not _worktree_active(repo_path=root):
         return
     issues_git_dir = str(root / ISSUES_DIR)
+    if _is_https_without_creds(issues_git_dir):
+        return
     try:
         result = subprocess.run(
             ["git", "-C", issues_git_dir, "remote", "get-url", "origin"],
@@ -766,8 +798,13 @@ def _commit_issues_changes(root: Path, msg: str) -> None:
 
 
 def _push_issues_changes(root: Path) -> None:
-    """Push the issues worktree branch to origin."""
+    """Push the issues worktree branch to origin.
+
+    Skips push when remote is HTTPS without credential helper (#1299).
+    """
     issues_git_dir = str(root / ISSUES_DIR)
+    if _is_https_without_creds(issues_git_dir):
+        return
     try:
         result = subprocess.run(
             ["git", "-C", issues_git_dir, "remote", "get-url", "origin"],


### PR DESCRIPTION
## Summary

Fixes two issues in `local-issues` tool and updates related documentation and linting.

## Changes

### #1295 — PEP 723 header fix
- Fix `local-issues` header: replace deprecated `# /// pyproject.toml` with `# /// script`, remove invalid `[project]` section, pin `requires-python = "~=3.12.0"` and `dependencies = ["pyyaml~=6.0"]`
- Update `070-environment.md`: add canonical PEP 723 reference link, version pinning standards (`~=` mandatory, three-part version), marker validation section
- Add `check_no_pyproject_toml_marker`, `check_no_project_section`, `check_requires_python_pinned`, `check_dependencies_pinned` to `test-pep723-tools.sh`

### #1299 — HTTPS auth hang fix
- Add `_is_https_without_creds()` helper to detect HTTPS remotes without credential helpers
- Apply to `_push_orphan_if_needed()`, `_push_issues_branch()`, `_push_issues_changes()` — skip push silently when remote is HTTPS and no credential helper is configured
- Remove redundant `_name_orphan_branch()` call from `_populate_orphan_branch()` — the initial commit already creates the branch ref

## Files Changed
- `.opencode/tools/local-issues` — PEP 723 header fix + HTTPS auth fix + redundant branch call removal
- `.opencode/guidelines/070-environment.md` — version pinning standards, marker validation, canonical reference
- `.opencode/tests/test-pep723-tools.sh` — new marker/pinning check functions

🤖 Co-authored with AI: OpenCode (ollama-cloud/deepseek-v4-flash)