### PR TITLE
fix(#1353): commit 3 missing task files from PR #1174 pipeline enforcement

### DIFF
--- a/skills/implementation-pipeline/tasks/pipeline-executor.md
+++ b/skills/implementation-pipeline/tasks/pipeline-executor.md
@@ -23,24 +23,26 @@ This is the core dispatch routing table for the 14-step serial implementation pi
 - `github.repo`
 - `issue_number`
 
-## 14-Step Dispatch Table
+## 16-Step Dispatch Table
 
 | Step # | Step Label | Dispatches To | Artifact Produced | YAML Contract Schema |
 |--------|------------|---------------|-------------------|---------------------|
-| 1 | `sc-coherence-gate` | `adversarial-audit --task coherence-extraction` | `./tmp/{issue-N}/artifacts/pipeline-sc-coherence-gate-{STATUS}-{timestamp}.yaml` | `per_criterion[]` from #932 |
-| 2 | `pre-red-baseline` | `implementation-pipeline --task pre-red-baseline` (simple bash) | `./tmp/{issue-N}/state/state.yaml` + `./tmp/{issue-N}/artifacts/` YAML | pipeline state file |
+| 1 | `sc-coherence-gate` | `adversarial-audit --task coherence-extraction` (evidence-type uplift + substrate classification) | `./tmp/{issue-N}/artifacts/pipeline-sc-coherence-gate-{STATUS}-{timestamp}.yaml` | `per_criterion[]` from #932 |
+| 2 | `pre-red-baseline` | `implementation-pipeline --task pre-red-baseline` (doc-source-currency + SC-ID cross-ref traceability) | `./tmp/{issue-N}/state/state.yaml` + `./tmp/{issue-N}/artifacts/` YAML | pipeline state file |
 | 3 | `red-phase` | `test-driven-development --task red` | `./tmp/{issue-N}/artifacts/pipeline-red-phase-{STATUS}-{timestamp}.yaml` | `per_criterion[]` |
 | 4 | `red-doublecheck` | `verification-before-completion --task verify` | `./tmp/{issue-N}/artifacts/pipeline-red-doublecheck-{STATUS}-{timestamp}.yaml` | `per_criterion[]` |
-| 5 | `green-phase` | `test-driven-development --task green` | `./tmp/{issue-N}/artifacts/pipeline-green-phase-{STATUS}-{timestamp}.yaml` | `per_criterion[]` |
-| 6 | `checkpoint-commit` | `git-workflow --task commit-prep` | `./tmp/{issue-N}/artifacts/pipeline-checkpoint-commit-{STATUS}-{timestamp}.yaml` | single-criterion |
-| 7 | `structural-checks` | `finishing-a-development-branch --task checklist` (enforces advisory-only mode: all linters run with `--check`/report-only flags, never auto-modify) | `./tmp/{issue-N}/artifacts/pipeline-structural-checks-{STATUS}-{timestamp}.yaml` | single-criterion |
-| 8 | `green-doublecheck` | `verification-before-completion --task verify` | `./tmp/{issue-N}/artifacts/pipeline-green-doublecheck-{STATUS}-{timestamp}.yaml` | `per_criterion[]` |
-| 9 | `green-vbc` | `verification-before-completion --task completion` | `./tmp/{issue-N}/artifacts/pipeline-green-vbc-{STATUS}-{timestamp}.yaml` | single-criterion |
-| 10 | `adversarial-audit` | `adversarial-audit --task verification-audit` | `./tmp/{issue-N}/artifacts/pipeline-audit-{auditor_type}-{STATUS}-{timestamp}.yaml` | `per_criterion[]` (#932 schema) |
-| 11 | `cross-validate` | `adversarial-audit --task cross-validate` | `./tmp/{issue-N}/artifacts/pipeline-cross-validate-{STATUS}-{timestamp}.yaml` | cross-validate YAML (#932 schema) |
-| 12 | `regression-check` | `test-driven-development --task patterns` (regression) | `./tmp/{issue-N}/artifacts/pipeline-regression-check-{STATUS}-{timestamp}.yaml` | `per_criterion[]` |
-| 13 | `review-prep` | `git-workflow --task review-prep` | review-prep status | single-criterion |
-| 14 | `exec-summary` | `completion-core --task completion` | append lifecycle event + chat exec summary | single-criterion |
+| 5 | `post-red-enforcement` | `implementation-pipeline --task post-red-enforcement` (git diff --name-only -- src/ \| wc -l) | `./tmp/{issue-N}/artifacts/pipeline-post-red-enforcement-{STATUS}-{timestamp}.yaml` | single-criterion |
+| 6 | `green-phase` | `test-driven-development --task green` | `./tmp/{issue-N}/artifacts/pipeline-green-phase-{STATUS}-{timestamp}.yaml` | `per_criterion[]` |
+| 7 | `post-green-enforcement` | `implementation-pipeline --task post-green-enforcement` (git diff --name-only -- test/ \| wc -l) | `./tmp/{issue-N}/artifacts/pipeline-post-green-enforcement-{STATUS}-{timestamp}.yaml` | single-criterion |
+| 8 | `checkpoint-commit` | `git-workflow --task commit-prep` | `./tmp/{issue-N}/artifacts/pipeline-checkpoint-commit-{STATUS}-{timestamp}.yaml` | single-criterion |
+| 9 | `structural-checks` | `finishing-a-development-branch --task checklist` (enforces advisory-only mode: all linters run with `--check`/report-only flags, never auto-modify) | `./tmp/{issue-N}/artifacts/pipeline-structural-checks-{STATUS}-{timestamp}.yaml` | single-criterion |
+| 10 | `green-doublecheck` | `verification-before-completion --task verify` (semantic-intent verification) | `./tmp/{issue-N}/artifacts/pipeline-green-doublecheck-{STATUS}-{timestamp}.yaml` | `per_criterion[]` |
+| 11 | `green-vbc` | `verification-before-completion --task completion` | `./tmp/{issue-N}/artifacts/pipeline-green-vbc-{STATUS}-{timestamp}.yaml` | single-criterion |
+| 12 | `adversarial-audit` | `adversarial-audit --task verification-audit` | `./tmp/{issue-N}/artifacts/pipeline-audit-{auditor_type}-{STATUS}-{timestamp}.yaml` | `per_criterion[]` (#932 schema) |
+| 13 | `cross-validate` | `adversarial-audit --task cross-validate` | `./tmp/{issue-N}/artifacts/pipeline-cross-validate-{STATUS}-{timestamp}.yaml` | cross-validate YAML (#932 schema) |
+| 14 | `regression-check` | `test-driven-development --task patterns` (regression) | `./tmp/{issue-N}/artifacts/pipeline-regression-check-{STATUS}-{timestamp}.yaml` | `per_criterion[]` |
+| 15 | `review-prep` | `git-workflow --task review-prep` | review-prep status | single-criterion |
+| 16 | `exec-summary` | `completion-core --task completion` | append lifecycle event + chat exec summary | single-criterion |
 
 ## Post-Step Checkpoint Creation
 

--- a/skills/implementation-pipeline/tasks/post-green-enforcement.md
+++ b/skills/implementation-pipeline/tasks/post-green-enforcement.md
@@ -1,0 +1,56 @@
+# Task: post-green-enforcement
+
+Co-authored with AI: OpenCode (ollama-cloud/deepseek-v4-flash)
+
+## Purpose
+
+Structural gate that verifies GREEN-phase sub-agents did not modify test files. Runs after green-phase, before checkpoint-commit. Exits FAIL if any `test/` files were touched during GREEN-phase.
+
+## Entry Criteria
+
+- green-phase step completed with PASS status
+- GREEN-phase sub-agent returned DONE
+
+## Exit Criteria
+
+- Git diff structural gate result written to `./tmp/{issue-N}/artifacts/pipeline-post-green-enforcement-{STATUS}-{timestamp}.yaml`
+- Gate PASS: no `test/` files modified during GREEN-phase
+- Gate FAIL: `test/` files were modified — orchestrator re-dispatches GREEN-phase from clean-room state
+
+## Procedure
+
+- [ ] 1. Run `git diff --name-only -- test/ | wc -l` to count modified test files
+- [ ] 2. If count > 0: write FAIL artifact with list of modified files, return BLOCKED
+- [ ] 3. If count == 0: write PASS artifact, return DONE
+
+## Artifact Format
+
+```yaml
+step_label: post-green-enforcement
+issue_number: {issue-N}
+generated_at: "{timestamp}"
+status: PASS | FAIL
+summary:
+  total_criteria: 1
+  pass: <0|1>
+  fail: <0|1>
+per_criterion:
+  - criterion_id: GREEN-TEST-GATE
+    result: PASS | FAIL
+    evidence: |-
+      git diff --name-only -- test/ | wc -l
+      Modified test files: <list or "none">
+    next_step: proceed | re-evaluate
+```
+
+## Context Required
+
+- Preceded by: green-phase (implementation-pipeline step 7)
+- Feeds into: checkpoint-commit (implementation-pipeline step 9)
+- Related: `skills/test-driven-development/tasks/green.md` — GREEN persona enforcement
+
+## Related Files
+
+- `skills/implementation-pipeline/SKILL.md` — dispatch routing table
+- `skills/implementation-pipeline/tasks/pipeline-executor.md` — pipeline step definitions
+- `skills/test-driven-development/tasks/green.md` — GREEN persona enforcement block

--- a/skills/implementation-pipeline/tasks/post-red-enforcement.md
+++ b/skills/implementation-pipeline/tasks/post-red-enforcement.md
@@ -1,0 +1,56 @@
+# Task: post-red-enforcement
+
+Co-authored with AI: OpenCode (ollama-cloud/deepseek-v4-flash)
+
+## Purpose
+
+Structural gate that verifies RED-phase sub-agents did not modify implementation files. Runs after red-doublecheck, before green-phase. Exits FAIL if any `src/` files were touched during RED-phase.
+
+## Entry Criteria
+
+- red-doublecheck step completed with PASS status
+- RED-phase sub-agent returned DONE
+
+## Exit Criteria
+
+- Git diff structural gate result written to `./tmp/{issue-N}/artifacts/pipeline-post-red-enforcement-{STATUS}-{timestamp}.yaml`
+- Gate PASS: no `src/` files modified during RED-phase
+- Gate FAIL: `src/` files were modified — orchestrator re-dispatches RED-phase from clean-room state
+
+## Procedure
+
+- [ ] 1. Run `git diff --name-only -- src/ | wc -l` to count modified implementation files
+- [ ] 2. If count > 0: write FAIL artifact with list of modified files, return BLOCKED
+- [ ] 3. If count == 0: write PASS artifact, return DONE
+
+## Artifact Format
+
+```yaml
+step_label: post-red-enforcement
+issue_number: {issue-N}
+generated_at: "{timestamp}"
+status: PASS | FAIL
+summary:
+  total_criteria: 1
+  pass: <0|1>
+  fail: <0|1>
+per_criterion:
+  - criterion_id: RED-SRC-GATE
+    result: PASS | FAIL
+    evidence: |-
+      git diff --name-only -- src/ | wc -l
+      Modified src/ files: <list or "none">
+    next_step: proceed | re-evaluate
+```
+
+## Context Required
+
+- Preceded by: red-doublecheck (implementation-pipeline step 4)
+- Feeds into: green-phase (implementation-pipeline step 6)
+- Related: `skills/test-driven-development/tasks/red.md` — RED persona enforcement
+
+## Related Files
+
+- `skills/implementation-pipeline/SKILL.md` — dispatch routing table
+- `skills/implementation-pipeline/tasks/pipeline-executor.md` — pipeline step definitions
+- `skills/test-driven-development/tasks/red.md` — RED persona enforcement block

--- a/skills/implementation-pipeline/tasks/pre-red-baseline.md
+++ b/skills/implementation-pipeline/tasks/pre-red-baseline.md
@@ -1,0 +1,136 @@
+# Task: pre-red-baseline
+
+Co-authored with AI: OpenCode (ollama-cloud/deepseek-v4-flash)
+
+## Purpose
+
+Initialize pipeline state and verify document source currency before RED phase begins. Runs as step 2 of the implementation pipeline after sc-coherence-gate. Produces a machine-parseable manifest documenting document source currency and SC-ID cross-reference traceability.
+
+## Entry Criteria
+
+- sc-coherence-gate step completed with PASS status
+- Plan exists at `.issues/{issue-N}/plan.md`
+- Spec exists at `.issues/{issue-N}/spec.md`
+- Authorization context available (authorization_scope, halt_at)
+
+## Exit Criteria
+
+- Solve state initialized at `./tmp/{issue-N}/state/state.yaml`
+- Handoff manifest written at `./tmp/{issue-N}/artifacts/pipeline-pre-red-baseline-{STATUS}-{timestamp}.yaml`
+- Manifest contains `status: PASS` or `status: BLOCKED` with `blocked_reason`
+- All validation checks completed
+
+## Procedure
+
+### Step 1: Initialize Solve State
+
+- [ ] 1. Create state directory: `mkdir -p ./tmp/{issue-N}/state/`
+- [ ] 2. Initialize solve state:
+  ```bash
+  solve state init ./tmp/{issue-N}/state/
+  ```
+- [ ] 3. Verify state file created at `./tmp/{issue-N}/state/state.yaml`
+- [ ] 4. Confirm state contains `current_step: pre-red-baseline` and `pipeline_state: init`
+
+### Step 2: Document Source Currency Check
+
+- [ ] 1. Read `.issues/{issue-N}/plan.md`
+- [ ] 2. Read `.issues/{issue-N}/spec.md`
+- [ ] 3. Extract all file paths referenced in the plan (source files, test files, config files)
+- [ ] 4. For each referenced file path, verify the file exists in the codebase
+- [ ] 5. For each referenced file path, check if the file has been modified since the plan was created
+- [ ] 6. Flag missing files as `MISSING-FILE`
+- [ ] 7. Flag modified files as `SOURCE-DRIFT`
+- [ ] 8. Check the plan's creation timestamp against the spec's last revision timestamp
+- [ ] 9. Flag if spec was revised after plan creation as `SPEC-REVISED-AFTER-PLAN`
+
+### Step 3: SC-ID Cross-Reference Traceability
+
+- [ ] 1. Read `.issues/{issue-N}/sc-summary.yaml` (if exists)
+- [ ] 2. Read `.issues/{issue-N}/plan.md`
+- [ ] 3. Extract all SC-IDs referenced in the plan — collect as `sc_ids_in_plan`
+- [ ] 4. Extract all SC-IDs from `sc-summary.yaml` — collect as `sc_ids_in_summary`
+- [ ] 5. Compare `sc_ids_in_plan` against `sc_ids_in_summary`
+- [ ] 6. Flag SC-IDs in plan but not in summary as `SCOPE-CREEP`
+- [ ] 7. Flag SC-IDs in summary but not in plan as `MISSING-TRACEABILITY`
+- [ ] 8. Verify each SC-ID in the plan has a corresponding test step in the TDD structure
+- [ ] 9. Flag SC-IDs without test steps as `MISSING-TEST-STEP`
+
+### Step 4: Write Baseline Manifest
+
+Generate timestamp via `.opencode/tools/schema-version`. Store result in `$TIMESTAMP`.
+
+Write `./tmp/{issue-N}/artifacts/pipeline-pre-red-baseline-{STATUS}-$TIMESTAMP.yaml`:
+
+```yaml
+schema_version: "1.0"
+generated_at: "$TIMESTAMP"
+step_label: pre-red-baseline
+issue_number: {issue-N}
+status: PASS | BLOCKED
+blocked_reason: "<reason if BLOCKED, else null>"
+checks:
+  - check_id: SOLVE_STATE_INIT
+    result: PASS | FAIL
+    detail: "..."
+  - check_id: DOCUMENT_SOURCE_CURRENCY
+    result: PASS | FAIL
+    detail: "..."
+  - check_id: SC_ID_TRACEABILITY
+    result: PASS | FAIL
+    detail: "..."
+summary:
+  total_checks: 3
+  pass: <count>
+  fail: <count>
+  missing_files: <list>
+  source_drift: <list>
+  scope_creep: <list>
+  missing_traceability: <list>
+  missing_test_steps: <list>
+```
+
+## Context Required
+
+- Preceded by: sc-coherence-gate (implementation-pipeline step 1)
+- Feeds into: red-phase (implementation-pipeline step 3)
+- Related artifacts: `.issues/{issue-N}/plan.md`, `.issues/{issue-N}/spec.md`, `.issues/{issue-N}/sc-summary.yaml`
+
+## Z3 State Integration
+
+### State Initialization
+```bash
+solve state init ./tmp/{issue-N}/state/
+```
+
+Creates state file with:
+- `current_step: pre-red-baseline`
+- `pipeline_state: init`
+
+### State Update (after manifest write)
+```bash
+solve state update ./tmp/{issue-N}/state/ --var-name previous_step --var-value pre-red-baseline --contract-path skills/implementation-pipeline/pipeline-state-machine.yaml
+solve state update ./tmp/{issue-N}/state/ --var-name current_step --var-value red-phase --contract-path skills/implementation-pipeline/pipeline-state-machine.yaml
+solve state update ./tmp/{issue-N}/state/ --var-name pipeline_state --var-value running --contract-path skills/implementation-pipeline/pipeline-state-machine.yaml
+```
+
+### State Validation
+```bash
+solve check --state-path ./tmp/{issue-N}/state/ --contract-path skills/implementation-pipeline/pipeline-state-machine.yaml
+```
+
+## Artifact Format
+
+All artifacts follow the #932 naming convention:
+```
+./tmp/{issue-N}/artifacts/pipeline-pre-red-baseline-{STATUS}-{timestamp}.yaml
+```
+
+Where `{STATUS}` is uppercase: `PASS`, `FAIL`, `UNVERIFIED`.
+
+## Related Files
+
+- `skills/implementation-pipeline/SKILL.md` — dispatch routing table
+- `skills/implementation-pipeline/tasks/pipeline-executor.md` — pipeline step definitions
+- `skills/implementation-pipeline/pipeline-state-machine.yaml` — Z3 legal transition definitions
+- `.opencode/tools/solve` — Z3 constraint solver for state management


### PR DESCRIPTION
## Summary

PR #1174 (spec #1063) added dispatch routing entries for 3 pipeline enforcement gates but never committed the corresponding task files. This PR remediates all 3 missing SCs.

## Changes

| File | Status | SCs |
|------|--------|-----|
| `skills/implementation-pipeline/tasks/post-red-enforcement.md` | **NEW** | SC-1 |
| `skills/implementation-pipeline/tasks/post-green-enforcement.md` | **NEW** | SC-2 |
| `skills/implementation-pipeline/tasks/pre-red-baseline.md` | **NEW (was untracked)** | SC-8, SC-12 |
| `skills/implementation-pipeline/tasks/pipeline-executor.md` | **UPDATED** | 14→16 step dispatch table |

Fixes #1353

🤖 Co-authored with AI: OpenCode (ollama-cloud/deepseek-v4-flash)