### PR TITLE
feat(#1357,#1355,#1347): task discipline admonishments, DONE_WITH_CONCERNS coercion, checkpoint tag step

### DIFF
--- a/guidelines/000-critical-rules.md
+++ b/guidelines/000-critical-rules.md
@@ -680,7 +680,7 @@ See `approval-gate` skill → Authorization Scope Model.
 
 ### [critical-rules-hard-fail] Hard Failure Discipline — FAIL is a hard gate, never reclassifiable
 
-A FAIL signal at any pipeline stage (auditor verdict, sub-agent result, cleanup gate, SC-verification gate, phase-completion gate) is a **hard gate** — it must be remediated, not sidestepped.
+A FAIL signal at any pipeline stage (auditor verdict, sub-agent result, cleanup gate, SC-verification gate, phase-completion gate) is a **hard gate** — it must be remediated, not sidestepped. `DONE_WITH_CONCERNS` is coerced to FAIL — caveats are defects, not completions. The bright-line coercion rule in `implementation-pipeline/tasks/pipeline-executor.md` governs this coercion.
 
 **Remediation-first sequence (mandated by #763):**
 1. **Remediate** the root cause — diagnose what produced the FAIL
@@ -2058,10 +2058,9 @@ rules:
     tier: 2
     title: "Hard Failure Discipline — FAIL is a hard gate, never reclassifiable"
     conditions:
-      all:
-        - "pipeline_stage in ['verdict','sub_agent_result','cleanup_gate','sc_verification_gate','phase_completion_gate']"
-        - "gate_result == 'FAIL'"
-        - "action_taken in ['reclassify','inconclusive_verdict','halt_no_remediate']"
+      any:
+        - "pipeline_stage in ['verdict','sub_agent_result','cleanup_gate','sc_verification_gate','phase_completion_gate'] and gate_result == 'FAIL' and action_taken in ['reclassify','inconclusive_verdict','halt_no_remediate']"
+        - "gate_result == 'DONE_WITH_CONCERNS'"
     actions:
       - HALT
       - REMEDIATE

--- a/guidelines/020-go-prohibitions.md
+++ b/guidelines/020-go-prohibitions.md
@@ -148,7 +148,7 @@ The sub-agent returns only:
 
 | Field | Required | Purpose |
 |-------|----------|---------|
-| `status` | Yes | DONE / BLOCKED / DONE_WITH_CONCERNS |
+| `status` | Yes | DONE / BLOCKED / OVERFLOW |
 | `finding_summary` | Yes | 1-3 sentences of routing-significant output |
 | `artifact_path` | Yes | Path to full evidence on disk |
 | `blocker_reason` | If BLOCKED | Why blocked |

--- a/guidelines/065-verification-honesty.md
+++ b/guidelines/065-verification-honesty.md
@@ -389,6 +389,10 @@ A break occurs when behavioral verification catches a defect at the earliest pos
 - `080-code-standards.md` §Evidence Type Taxonomy — cost and gate-position columns for each evidence type
 - `080-code-standards.md` §Test Integrity Mandate — behavioral tests as the only sufficient evidence for behavioral SCs
 
+### DONE_WITH_CONCERNS Coercion Trigger
+
+`DONE_WITH_CONCERNS` is a coercion trigger at the verification honesty gate. When a sub-agent returns `DONE_WITH_CONCERNS`, the orchestrator MUST coerce it to FAIL per the bright-line coercion rule in `implementation-pipeline/tasks/pipeline-executor.md`. Caveats are defects, not completions — a `DONE` status with a non-empty `caveat_summary` is also coerced to FAIL.
+
 ### Remediation-First Protocol
 
 When a FAIL signal is received at any pipeline stage, the agent MUST remediate before halting. See `000-critical-rules.md` §critical-rules-hard-fail for the complete protocol.

--- a/skills/adversarial-audit/SKILL.md
+++ b/skills/adversarial-audit/SKILL.md
@@ -12,7 +12,13 @@ license: MIT
 
 Dual cross-family audit via clean-room sub-agents. Auditors write YAML verdicts to disk, return frugal contracts. The orchestrator dispatches via `skill()` + `task()` — it does NOT read task files.
 
+## Mandatory Task Discipline
 
+- [ ] 1. Every task and sub-task in this skill is mandatory
+- [ ] 2. Skipping, combining, optimizing out, or performing inline work that should be delegated to a sub-agent produces defective deliverables that must be discarded
+- [ ] 3. Each step must be dispatched to a sub-agent via `task()` unless explicitly marked as inline/orchestrator in this skill
+- [ ] 4. Sub-agents must not dispatch sub-agents
+- [ ] 5. Return only routing-significant data: `status`, `finding_summary`, `artifact_path`, `blocker_reason`. Full evidence goes to disk.
 
 ## Trigger Dispatch Table
 

--- a/skills/adversarial-audit/tasks/spec-audit.md
+++ b/skills/adversarial-audit/tasks/spec-audit.md
@@ -116,6 +116,7 @@ Define audit criteria based on spec-auditor task structure:
 | SC-PRESCRIPTIVE-CODE | No prescriptive code content in spec | Spec uses file area references only (agent discovers exact paths). Zero instances of exact file paths with line numbers, exact import strings, or exact assertion code. |
 | SC-PIPELINE-GATES | Pipeline gates use canonical checklist format, not gate tables | Spec requires numbered `- [ ] N.` checklist steps with dispatch mode indicators (`(**clean-room**)` or `(**inline**)`). Gate tables (per-unit or shared cross-reference) → VIOLATION. Expect dispatch indicators in every step title. |
 | SC-CANONICAL-PLAN-FORM | Plan output format uses canonical checklist format | If the spec defines plan output format requirements, validate they use the canonical checklist format: numbered `- [ ] N.` with sub-bullet metadata, dispatch mode indicators, no dispatch tables, no shared cross-references. |
+| SC-ADMONISHMENT | Mandatory Task Discipline admonishment present in SKILL.md | For skill card audits, verify the SKILL.md contains the 5-item Mandatory Task Discipline admonishment after Overview and before Trigger Dispatch Table. For task card audits, verify the 4-item (non-inline) or 3-item (inline) Task Discipline admonishment after Purpose and before Operating Protocol. |
 
 <!-- Fragment ID: sc-enforcement-gate -->
 

--- a/skills/approval-gate/SKILL.md
+++ b/skills/approval-gate/SKILL.md
@@ -5,9 +5,17 @@ license: MIT
 compatibility: opencode
 ---
 
+## Mandatory Task Discipline
+
+- [ ] 1. Every task and sub-task in this skill is mandatory
+- [ ] 2. Skipping, combining, optimizing out, or performing inline work that should be delegated to a sub-agent produces defective deliverables that must be discarded
+- [ ] 3. Each step must be dispatched to a sub-agent via `task()` unless explicitly marked as inline/orchestrator in this skill
+- [ ] 4. Sub-agents must not dispatch sub-agents
+- [ ] 5. Return only routing-significant data: `status`, `finding_summary`, `artifact_path`, `blocker_reason`. Full evidence goes to disk.
+
 Sub-Agent Task Context Audit
 
-All tasks run via `task(subagent_type="general")`. Standard context: `{ issue_number, worktree.path, github.owner, github.repo, authorization_scope, halt_at, pr_strategy, pipeline_phase }`. Auditor tasks use subagent_type from resolve-models result contract (auditor_1/auditor_2) — NOT `general`. Include audit_phase in task context when routing auditors. See adversarial-audit SKILL.md §DISPATCH_GATE. `screen-issue` receives issue body + authorization context + pipeline_phase. `pre-implementation-analysis` receives all issue numbers + authorization context + pipeline_phase. `pre-analysis` receives only `{ issue_number, task_description, pipeline_phase, authorization_scope, halt_at, pr_strategy, github.owner, github.repo }` with zero file paths. No inline work — all tasks use sub-agents. If a sub-agent returns empty, re-task with original scoped context only (max 2 retries). Result contracts return `status` (DONE/BLOCKED/DONE_WITH_CONCERNS/OVERFLOW) + task-specific fields per `enforcement/` result contract schemas.
+All tasks run via `task(subagent_type="general")`. Standard context: `{ issue_number, worktree.path, github.owner, github.repo, authorization_scope, halt_at, pr_strategy, pipeline_phase }`. Auditor tasks use subagent_type from resolve-models result contract (auditor_1/auditor_2) — NOT `general`. Include audit_phase in task context when routing auditors. See adversarial-audit SKILL.md §DISPATCH_GATE. `screen-issue` receives issue body + authorization context + pipeline_phase. `pre-implementation-analysis` receives all issue numbers + authorization context + pipeline_phase. `pre-analysis` receives only `{ issue_number, task_description, pipeline_phase, authorization_scope, halt_at, pr_strategy, github.owner, github.repo }` with zero file paths. No inline work — all tasks use sub-agents. If a sub-agent returns empty, re-task with original scoped context only (max 2 retries). Result contracts return `status` (DONE/BLOCKED/OVERFLOW) + task-specific fields per `enforcement/` result contract schemas. `DONE_WITH_CONCERNS` is coerced to FAIL per the bright-line coercion rule in `implementation-pipeline/tasks/pipeline-executor.md`.
 
 ### Authorization Context Template
 ```

--- a/skills/approval-gate/tasks/screen/screen-issue-gate2.md
+++ b/skills/approval-gate/tasks/screen/screen-issue-gate2.md
@@ -179,7 +179,7 @@ For each file path or symbol mentioned in the issue:
 The result contract MUST be YAML-structured, compact (≈100-500 words):
 
 ```yaml
-status: DONE | DONE_WITH_CONCERNS | BLOCKED | OVERFLOW
+status: DONE | BLOCKED | OVERFLOW
 task: screen-issue
 issue_number: <N>
 classification: included | excluded | scope-reduced

--- a/skills/brainstorming/SKILL.md
+++ b/skills/brainstorming/SKILL.md
@@ -12,7 +12,13 @@ compatibility: opencode
 
 Conversational-first exploration workflow. One question at a time, user-driven. Dimensions used internally — never as structured output sections. Terminal state invokes spec-creation.
 
+## Mandatory Task Discipline
 
+- [ ] 1. Every task and sub-task in this skill is mandatory
+- [ ] 2. Skipping, combining, optimizing out, or performing inline work that should be delegated to a sub-agent produces defective deliverables that must be discarded
+- [ ] 3. Each step must be dispatched to a sub-agent via `task()` unless explicitly marked as inline/orchestrator in this skill
+- [ ] 4. Sub-agents must not dispatch sub-agents
+- [ ] 5. Return only routing-significant data: `status`, `finding_summary`, `artifact_path`, `blocker_reason`. Full evidence goes to disk.
 
 ## Trigger Dispatch Table
 

--- a/skills/changelog-generator/SKILL.md
+++ b/skills/changelog-generator/SKILL.md
@@ -12,7 +12,13 @@ compatibility: opencode
 
 Transforms git commits into polished, user-friendly changelogs. Category-based organization into Added, Changed, Deprecated, Removed, Fixed, Security.
 
+## Mandatory Task Discipline
 
+- [ ] 1. Every task and sub-task in this skill is mandatory
+- [ ] 2. Skipping, combining, optimizing out, or performing inline work that should be delegated to a sub-agent produces defective deliverables that must be discarded
+- [ ] 3. Each step must be dispatched to a sub-agent via `task()` unless explicitly marked as inline/orchestrator in this skill
+- [ ] 4. Sub-agents must not dispatch sub-agents
+- [ ] 5. Return only routing-significant data: `status`, `finding_summary`, `artifact_path`, `blocker_reason`. Full evidence goes to disk.
 
 ## Trigger Dispatch Table
 

--- a/skills/completeness-gate/SKILL.md
+++ b/skills/completeness-gate/SKILL.md
@@ -12,7 +12,13 @@ compatibility: opencode
 
 Non-adversarial completeness check that runs after a RED/GREEN sub-agent returns and before the adversarial audit. Verifies the deliverable against the spec's success criteria — checking that the deliverable exists, is structurally sound, and addresses each criterion. This is a completeness gate, not an adversarial audit: it verifies presence and coverage, not correctness depth.
 
+## Mandatory Task Discipline
 
+- [ ] 1. Every task and sub-task in this skill is mandatory
+- [ ] 2. Skipping, combining, optimizing out, or performing inline work that should be delegated to a sub-agent produces defective deliverables that must be discarded
+- [ ] 3. Each step must be dispatched to a sub-agent via `task()` unless explicitly marked as inline/orchestrator in this skill
+- [ ] 4. Sub-agents must not dispatch sub-agents
+- [ ] 5. Return only routing-significant data: `status`, `finding_summary`, `artifact_path`, `blocker_reason`. Full evidence goes to disk.
 
 ## Trigger Dispatch Table
 

--- a/skills/completion-core/SKILL.md
+++ b/skills/completion-core/SKILL.md
@@ -11,6 +11,13 @@ Reference this file from per-skill `tasks/completion.md` files for common comple
 
 ## Entry Gate
 
+## Mandatory Task Discipline
+
+- [ ] 1. Every task and sub-task in this skill is mandatory
+- [ ] 2. Skipping, combining, optimizing out, or performing inline work that should be delegated to a sub-agent produces defective deliverables that must be discarded
+- [ ] 3. Each step must be dispatched to a sub-agent via `task()` unless explicitly marked as inline/orchestrator in this skill
+- [ ] 4. Sub-agents must not dispatch sub-agents
+- [ ] 5. Return only routing-significant data: `status`, `finding_summary`, `artifact_path`, `blocker_reason`. Full evidence goes to disk.
 
 ## Trigger Dispatch Table
 

--- a/skills/conflict-resolution/SKILL.md
+++ b/skills/conflict-resolution/SKILL.md
@@ -12,7 +12,13 @@ compatibility: opencode
 
 Classifies and resolves git conflicts with intent preservation. Three tiers: Tier 1 (trivial, auto-resolve), Tier 2 (textual, auto-resolve + note), Tier 3 (intent conflict, HALT for developer).
 
+## Mandatory Task Discipline
 
+- [ ] 1. Every task and sub-task in this skill is mandatory
+- [ ] 2. Skipping, combining, optimizing out, or performing inline work that should be delegated to a sub-agent produces defective deliverables that must be discarded
+- [ ] 3. Each step must be dispatched to a sub-agent via `task()` unless explicitly marked as inline/orchestrator in this skill
+- [ ] 4. Sub-agents must not dispatch sub-agents
+- [ ] 5. Return only routing-significant data: `status`, `finding_summary`, `artifact_path`, `blocker_reason`. Full evidence goes to disk.
 
 ## Trigger Dispatch Table
 

--- a/skills/correspondence/SKILL.md
+++ b/skills/correspondence/SKILL.md
@@ -12,7 +12,13 @@ compatibility: opencode
 
 Enforces multipart/alternative format (text/plain + text/html) for email, stakeholder content rules, audience-aware content levels, and verification-enforcement integration. Prevents markdown in email bodies, internal artifact leakage, and format guessing.
 
+## Mandatory Task Discipline
 
+- [ ] 1. Every task and sub-task in this skill is mandatory
+- [ ] 2. Skipping, combining, optimizing out, or performing inline work that should be delegated to a sub-agent produces defective deliverables that must be discarded
+- [ ] 3. Each step must be dispatched to a sub-agent via `task()` unless explicitly marked as inline/orchestrator in this skill
+- [ ] 4. Sub-agents must not dispatch sub-agents
+- [ ] 5. Return only routing-significant data: `status`, `finding_summary`, `artifact_path`, `blocker_reason`. Full evidence goes to disk.
 
 ## Trigger Dispatch Table
 

--- a/skills/engineering-approach/SKILL.md
+++ b/skills/engineering-approach/SKILL.md
@@ -12,7 +12,13 @@ compatibility: opencode
 
 Engineering discipline checklist enforcing: understand before solving, design before implementing, verify before declaring complete, no scope creep.
 
+## Mandatory Task Discipline
 
+- [ ] 1. Every task and sub-task in this skill is mandatory
+- [ ] 2. Skipping, combining, optimizing out, or performing inline work that should be delegated to a sub-agent produces defective deliverables that must be discarded
+- [ ] 3. Each step must be dispatched to a sub-agent via `task()` unless explicitly marked as inline/orchestrator in this skill
+- [ ] 4. Sub-agents must not dispatch sub-agents
+- [ ] 5. Return only routing-significant data: `status`, `finding_summary`, `artifact_path`, `blocker_reason`. Full evidence goes to disk.
 
 ## Trigger Dispatch Table
 

--- a/skills/executing-plans/SKILL.md
+++ b/skills/executing-plans/SKILL.md
@@ -14,7 +14,13 @@ Thin routing layer routing plan execution to `implementation-pipeline`. Receives
 
 No single-issue bypass — single = work of one = one sub-agent.
 
+## Mandatory Task Discipline
 
+- [ ] 1. Every task and sub-task in this skill is mandatory
+- [ ] 2. Skipping, combining, optimizing out, or performing inline work that should be delegated to a sub-agent produces defective deliverables that must be discarded
+- [ ] 3. Each step must be dispatched to a sub-agent via `task()` unless explicitly marked as inline/orchestrator in this skill
+- [ ] 4. Sub-agents must not dispatch sub-agents
+- [ ] 5. Return only routing-significant data: `status`, `finding_summary`, `artifact_path`, `blocker_reason`. Full evidence goes to disk.
 
 ## Trigger Dispatch Table
 

--- a/skills/finishing-a-development-branch/SKILL.md
+++ b/skills/finishing-a-development-branch/SKILL.md
@@ -16,7 +16,13 @@ Remediation of failed verification IS agent-owned — the producing agent owns e
 
 Branch completion workflow ensuring feature branch is fully ready for PR. Verifies all changes committed, tested, pushed, and reviewed. Tracks against plan sub-issues.
 
+## Mandatory Task Discipline
 
+- [ ] 1. Every task and sub-task in this skill is mandatory
+- [ ] 2. Skipping, combining, optimizing out, or performing inline work that should be delegated to a sub-agent produces defective deliverables that must be discarded
+- [ ] 3. Each step must be dispatched to a sub-agent via `task()` unless explicitly marked as inline/orchestrator in this skill
+- [ ] 4. Sub-agents must not dispatch sub-agents
+- [ ] 5. Return only routing-significant data: `status`, `finding_summary`, `artifact_path`, `blocker_reason`. Full evidence goes to disk.
 
 ## Trigger Dispatch Table
 

--- a/skills/git-workflow/SKILL.md
+++ b/skills/git-workflow/SKILL.md
@@ -12,7 +12,13 @@ compatibility: opencode
 
 Git Workflow Enforcer. Three-branch model: feature → dev → main. AI commits blocked on protected branches. Feature branches merge to `dev` via PR. Squash at PR creation only. Submodule-aware.
 
+## Mandatory Task Discipline
 
+- [ ] 1. Every task and sub-task in this skill is mandatory
+- [ ] 2. Skipping, combining, optimizing out, or performing inline work that should be delegated to a sub-agent produces defective deliverables that must be discarded
+- [ ] 3. Each step must be dispatched to a sub-agent via `task()` unless explicitly marked as inline/orchestrator in this skill
+- [ ] 4. Sub-agents must not dispatch sub-agents
+- [ ] 5. Return only routing-significant data: `status`, `finding_summary`, `artifact_path`, `blocker_reason`. Full evidence goes to disk.
 
 ## Trigger Dispatch Table
 

--- a/skills/implementation-pipeline/SKILL.md
+++ b/skills/implementation-pipeline/SKILL.md
@@ -15,11 +15,17 @@ compatibility: opencode
 
 ## Overview
 
-Pure orchestrator routing table with 16 serial dispatch steps. The orchestrator holds only routing metadata — each step dispatches to an existing skill's task file via `task()`. Step transitions are validated by Z3 via `solve check` against `pipeline-state-machine.yaml`. YAML contract artifacts at `./tmp/{issue-N}/artifacts/pipeline-{step_label}-{STATUS}-{timestamp}.yaml`.
+Pure orchestrator routing table with 17 serial dispatch steps. The orchestrator holds only routing metadata — each step dispatches to an existing skill's task file via `task()`. Step transitions are validated by Z3 via `solve check` against `pipeline-state-machine.yaml`. YAML contract artifacts at `./tmp/{issue-N}/artifacts/pipeline-{step_label}-{STATUS}-{timestamp}.yaml`.
 
 The orchestrator is a pure router — never reads task file content, never performs inline analysis. Sub-agents do the work.
 
+## Mandatory Task Discipline
 
+- [ ] 1. Every task and sub-task in this skill is mandatory
+- [ ] 2. Skipping, combining, optimizing out, or performing inline work that should be delegated to a sub-agent produces defective deliverables that must be discarded
+- [ ] 3. Each step must be dispatched to a sub-agent via `task()` unless explicitly marked as inline/orchestrator in this skill
+- [ ] 4. Sub-agents must not dispatch sub-agents
+- [ ] 5. Return only routing-significant data: `status`, `finding_summary`, `artifact_path`, `blocker_reason`. Full evidence goes to disk.
 
 ## Trigger Dispatch Table
 
@@ -32,6 +38,7 @@ The orchestrator is a pure router — never reads task file content, never perfo
 | "post-red-enforcement" / "RED gate" | `post-red-enforcement` | `sub-task` | {issue_number} |
 | "green-phase" / "implement" | `green-phase` | `sub-task` | {issue_number} |
 | "post-green-enforcement" / "GREEN gate" | `post-green-enforcement` | `sub-task` | {issue_number} |
+| "checkpoint-tag-create" / "create checkpoint tag" | `checkpoint-tag-create` | `sub-task` | {issue_number} |
 | "checkpoint-commit" / "save checkpoint" | `checkpoint-commit` | `sub-task` | {issue_number} |
 | "structural-checks" / "lint/typecheck" | `structural-checks` | `sub-task` | {issue_number} |
 | "green-doublecheck" / "verify GREEN" | `green-doublecheck` | `sub-task` | {issue_number} |
@@ -53,6 +60,7 @@ The orchestrator is a pure router — never reads task file content, never perfo
 | `post-red-enforcement` | `implementation-pipeline --task post-red-enforcement` (git diff --name-only -- src/ \| wc -l) | git diff structural gate result |
 | `green-phase` | `test-driven-development --task green` | implementation code + test pass |
 | `post-green-enforcement` | `implementation-pipeline --task post-green-enforcement` (git diff --name-only -- test/ \| wc -l) | git diff structural gate result |
+| `checkpoint-tag-create` | `implementation-pipeline --task checkpoint-tag-create` (creates git tag per `000-critical-rules.md` §Checkpoint Rollback Exception) | checkpoint tag created |
 | `checkpoint-commit` | `git-workflow --task commit-prep` | commit status |
 | `structural-checks` | `finishing-a-development-branch --task checklist` | lint/typecheck/format results |
 | `green-doublecheck` | `verification-before-completion --task verify` (semantic-intent verification) | GREEN-side SC evidence + intent verdict |
@@ -66,7 +74,7 @@ The orchestrator is a pure router — never reads task file content, never perfo
 **Note:** The `adversarial-audit` step is a multi-dispatch sequence with remediation loop-back. The audit task dispatched depends on pipeline phase (e.g., `verification-audit` for post-implementation, `spec-audit` for pre-implementation, `plan-fidelity` for plan validation):
 - [ ] 1. Run `.opencode/tools/resolve-models` to select cross-family auditors
 - [ ] 2. Dispatch the appropriate audit task with `subagent_type` from `auditor_1`
-- [ ] 3. If auditor 1 returned non-clean-pass (FAIL or DONE_WITH_CONCERNS): remediate the root cause, then restart from step 1 (re-run resolve-models). Do NOT dispatch auditor 2.
+- [ ] 3. If auditor 1 returned non-clean-pass (FAIL): remediate the root cause, then restart from step 1 (re-run resolve-models). Do NOT dispatch auditor 2. `DONE_WITH_CONCERNS` is coerced to FAIL per the bright-line coercion rule in `pipeline-executor.md`.
 - [ ] 4. Dispatch the same audit task with `subagent_type` from `auditor_2`
 - [ ] 5. If auditor 2 returned non-clean-pass: remediate the root cause, then restart from step 1 (re-run resolve-models).
 - [ ] 6. Both auditors clean PASS. Collect both `artifact_path` values and pass as `auditor_artifact_paths` context to `cross-validate`.
@@ -81,7 +89,7 @@ Before the pipeline dispatches to `sc-coherence-gate`, the orchestrator MUST run
 
 ## Step Labels (for #932 naming convention)
 
-`sc-coherence-gate`, `pre-red-baseline`, `red-phase`, `red-doublecheck`, `post-red-enforcement`, `green-phase`, `post-green-enforcement`, `checkpoint-commit`, `structural-checks`, `green-doublecheck`, `green-vbc`, `resolve-models`, `adversarial-audit`, `cross-validate`, `regression-check`, `review-prep`, `exec-summary`
+`sc-coherence-gate`, `pre-red-baseline`, `red-phase`, `red-doublecheck`, `post-red-enforcement`, `green-phase`, `post-green-enforcement`, `checkpoint-tag-create`, `checkpoint-commit`, `structural-checks`, `green-doublecheck`, `green-vbc`, `resolve-models`, `adversarial-audit`, `cross-validate`, `regression-check`, `review-prep`, `exec-summary`
 
 ## Invocation
 
@@ -226,6 +234,7 @@ At the start of each pipeline step, clean previous-run artifacts for that step t
 | `red-phase` | `rm -f ./tmp/{issue-N}/artifacts/pipeline-red-phase-*` |
 | `green-phase` | `rm -f ./tmp/{issue-N}/artifacts/pipeline-green-phase-*` |
 | `post-green-enforcement` | `rm -f ./tmp/{issue-N}/artifacts/pipeline-post-green-enforcement-*` |
+| `checkpoint-tag-create` | `rm -f ./tmp/{issue-N}/artifacts/pipeline-checkpoint-tag-create-*` |
 | `checkpoint-commit` | `rm -f ./tmp/{issue-N}/artifacts/pipeline-checkpoint-commit-*` |
 | `structural-checks` | `rm -f ./tmp/{issue-N}/artifacts/pipeline-structural-checks-*` |
 | `green-doublecheck` | `rm -f ./tmp/{issue-N}/artifacts/pipeline-green-doublecheck-*` |

--- a/skills/implementation-pipeline/enforcement/work-state-verification.md
+++ b/skills/implementation-pipeline/enforcement/work-state-verification.md
@@ -8,7 +8,7 @@ When `assemble-work` records claims about work state (e.g., "sub-agent completed
 
 | Claim | Verification Action | Tool Call | Problem Class |
 |-------|---------------------|-----------|---------------|
-| Sub-agent completed | Result contract exists with status DONE or DONE_WITH_CONCERNS | Read work state file | STRUCTURE-VIOLATION |
+| Sub-agent completed | Result contract exists with status DONE | Read work state file | STRUCTURE-VIOLATION |
 | Issue created | Issue exists on GitHub with correct title and labels | `issue-operations -> read-issue (github_issue_read(method=get, issue_number=N)` | MISSING-ELEMENT | <!-- Routes through issue-operations per SPEC #683 -->
 | Sub-issues linked | `issue-operations -> read-sub-issues (github_issue_read(method=get_sub_issues)` returns expected sub-issues | `github_issue_read(method=get_sub_issues, issue_number=N)` | MISSING-ELEMENT | <!-- Routes through issue-operations per SPEC #683 -->
 | Branch created | Branch exists in local worktree | `git rev-parse --verify <branch>` | MISSING-ELEMENT |

--- a/skills/implementation-pipeline/pipeline-state-machine.yaml
+++ b/skills/implementation-pipeline/pipeline-state-machine.yaml
@@ -15,6 +15,7 @@ variables:
       - red-phase
       - red-doublecheck
       - green-phase
+      - checkpoint-tag-create
       - checkpoint-commit
       - structural-checks
       - green-doublecheck
@@ -33,6 +34,7 @@ variables:
       - red-phase
       - red-doublecheck
       - green-phase
+      - checkpoint-tag-create
       - checkpoint-commit
       - structural-checks
       - green-doublecheck
@@ -51,7 +53,8 @@ preconditions:
   - "z3.Implies(previous_step == z3.StringVal('sc-coherence-gate'), z3.Or(current_step == z3.StringVal('red-phase'), current_step == z3.StringVal('pre-red-baseline')))"
   - "z3.Implies(previous_step == z3.StringVal('red-phase'), current_step == z3.StringVal('red-doublecheck'))"
   - "z3.Implies(previous_step == z3.StringVal('red-doublecheck'), z3.Or(current_step == z3.StringVal('green-phase'), current_step == z3.StringVal('red-phase')))"
-  - "z3.Implies(previous_step == z3.StringVal('green-phase'), current_step == z3.StringVal('checkpoint-commit'))"
+  - "z3.Implies(previous_step == z3.StringVal('green-phase'), current_step == z3.StringVal('checkpoint-tag-create'))"
+  - "z3.Implies(previous_step == z3.StringVal('checkpoint-tag-create'), z3.Or(current_step == z3.StringVal('checkpoint-commit'), current_step == z3.StringVal('green-phase')))"
   - "z3.Implies(previous_step == z3.StringVal('checkpoint-commit'), z3.Or(current_step == z3.StringVal('structural-checks'), current_step == z3.StringVal('green-phase')))"
   - "z3.Implies(previous_step == z3.StringVal('structural-checks'), z3.Or(current_step == z3.StringVal('green-doublecheck'), current_step == z3.StringVal('green-phase')))"
   - "z3.Implies(previous_step == z3.StringVal('green-doublecheck'), z3.Or(current_step == z3.StringVal('green-vbc'), current_step == z3.StringVal('green-phase')))"

--- a/skills/implementation-pipeline/tasks/checkpoint-tag-create.md
+++ b/skills/implementation-pipeline/tasks/checkpoint-tag-create.md
@@ -1,0 +1,38 @@
+# Task: checkpoint-tag-create
+
+<!-- SPDX-FileCopyrightText: 2026 Michael Conrad -->
+<!-- SPDX-License-Identifier: MIT -->
+<!-- Provenance: AI-generated -->
+
+Co-authored with AI: OpenCode (ollama-cloud/deepseek-v4-flash)
+
+## Purpose
+
+Create a checkpoint git tag after a pipeline step completes successfully. The tag enables rollback to the last known-good state per `000-critical-rules.md` §Checkpoint Rollback Exception.
+
+## Context Required
+
+- `issue_number`
+- `github.repo`
+- `worktree.path` (if applicable)
+- `pipeline_phase` — current step label (e.g., `green-phase`)
+
+## Execution
+
+- [ ] 1. Determine the step number N from the pipeline dispatch table (1-indexed)
+- [ ] 2. Determine submodule suffix: if working in a submodule, use the submodule directory name from `.gitmodules` (e.g., `.opencode` → `-opencode`); otherwise empty string
+- [ ] 3. Reap any prior tag for this step (re-dispatch from prior failure):
+       `git tag -d "$CONSUMER_REPO/checkpoint/$ISSUE_NUM/phase-$N$SUBMODULE_SUFFIX" 2>/dev/null || true`
+       `git push origin --delete "$CONSUMER_REPO/checkpoint/$ISSUE_NUM/phase-$N$SUBMODULE_SUFFIX" 2>/dev/null || true`
+- [ ] 4. Commit current state and tag checkpoint:
+       `git add -A`
+       `git commit -m "checkpoint(#$ISSUE_NUM): step-$N complete"`
+       `git tag "$CONSUMER_REPO/checkpoint/$ISSUE_NUM/phase-$N$SUBMODULE_SUFFIX"`
+       `git push origin "$CONSUMER_REPO/checkpoint/$ISSUE_NUM/phase-$N$SUBMODULE_SUFFIX" 2>/dev/null || echo "Remote push skipped"`
+- [ ] 5. Write YAML artifact at `./tmp/{issue-N}/artifacts/pipeline-checkpoint-tag-create-{STATUS}-{timestamp}.yaml` with status PASS/FAIL
+
+## Return
+
+- `status`: DONE | BLOCKED
+- `artifact_path`: path to YAML artifact
+- `summary`: "Checkpoint tag created for step N" or failure reason

--- a/skills/implementation-pipeline/tasks/pipeline-executor.md
+++ b/skills/implementation-pipeline/tasks/pipeline-executor.md
@@ -12,6 +12,17 @@ This is the core dispatch routing table for the 14-step serial implementation pi
 - Feature branch exists (created by pre-work)
 - Authorization context available
 
+## Pre-Dispatch Gate: Coercion Rule
+
+Before dispatching any step, the orchestrator MUST apply the bright-line coercion rule to all incoming result contracts:
+
+```
+status != DONE → FAIL
+status == DONE with non-empty caveat_summary → FAIL
+```
+
+A status of `DONE_WITH_CONCERNS` is coerced to FAIL — caveats are defects, not completions. The orchestrator routes to remediation per the Remediation Routing section below.
+
 ## Context Required
 
 - `authorization_scope`
@@ -23,7 +34,7 @@ This is the core dispatch routing table for the 14-step serial implementation pi
 - `github.repo`
 - `issue_number`
 
-## 16-Step Dispatch Table
+## 17-Step Dispatch Table
 
 | Step # | Step Label | Dispatches To | Artifact Produced | YAML Contract Schema |
 |--------|------------|---------------|-------------------|---------------------|
@@ -34,15 +45,16 @@ This is the core dispatch routing table for the 14-step serial implementation pi
 | 5 | `post-red-enforcement` | `implementation-pipeline --task post-red-enforcement` (git diff --name-only -- src/ \| wc -l) | `./tmp/{issue-N}/artifacts/pipeline-post-red-enforcement-{STATUS}-{timestamp}.yaml` | single-criterion |
 | 6 | `green-phase` | `test-driven-development --task green` | `./tmp/{issue-N}/artifacts/pipeline-green-phase-{STATUS}-{timestamp}.yaml` | `per_criterion[]` |
 | 7 | `post-green-enforcement` | `implementation-pipeline --task post-green-enforcement` (git diff --name-only -- test/ \| wc -l) | `./tmp/{issue-N}/artifacts/pipeline-post-green-enforcement-{STATUS}-{timestamp}.yaml` | single-criterion |
-| 8 | `checkpoint-commit` | `git-workflow --task commit-prep` | `./tmp/{issue-N}/artifacts/pipeline-checkpoint-commit-{STATUS}-{timestamp}.yaml` | single-criterion |
-| 9 | `structural-checks` | `finishing-a-development-branch --task checklist` (enforces advisory-only mode: all linters run with `--check`/report-only flags, never auto-modify) | `./tmp/{issue-N}/artifacts/pipeline-structural-checks-{STATUS}-{timestamp}.yaml` | single-criterion |
-| 10 | `green-doublecheck` | `verification-before-completion --task verify` (semantic-intent verification) | `./tmp/{issue-N}/artifacts/pipeline-green-doublecheck-{STATUS}-{timestamp}.yaml` | `per_criterion[]` |
-| 11 | `green-vbc` | `verification-before-completion --task completion` | `./tmp/{issue-N}/artifacts/pipeline-green-vbc-{STATUS}-{timestamp}.yaml` | single-criterion |
-| 12 | `adversarial-audit` | `adversarial-audit --task verification-audit` | `./tmp/{issue-N}/artifacts/pipeline-audit-{auditor_type}-{STATUS}-{timestamp}.yaml` | `per_criterion[]` (#932 schema) |
-| 13 | `cross-validate` | `adversarial-audit --task cross-validate` | `./tmp/{issue-N}/artifacts/pipeline-cross-validate-{STATUS}-{timestamp}.yaml` | cross-validate YAML (#932 schema) |
-| 14 | `regression-check` | `test-driven-development --task patterns` (regression) | `./tmp/{issue-N}/artifacts/pipeline-regression-check-{STATUS}-{timestamp}.yaml` | `per_criterion[]` |
-| 15 | `review-prep` | `git-workflow --task review-prep` | review-prep status | single-criterion |
-| 16 | `exec-summary` | `completion-core --task completion` | append lifecycle event + chat exec summary | single-criterion |
+| 8 | `checkpoint-tag-create` | `implementation-pipeline --task checkpoint-tag-create` (creates git tag per `000-critical-rules.md` §Checkpoint Rollback Exception) | `./tmp/{issue-N}/artifacts/pipeline-checkpoint-tag-create-{STATUS}-{timestamp}.yaml` | single-criterion |
+| 9 | `checkpoint-commit` | `git-workflow --task commit-prep` | `./tmp/{issue-N}/artifacts/pipeline-checkpoint-commit-{STATUS}-{timestamp}.yaml` | single-criterion |
+| 10 | `structural-checks` | `finishing-a-development-branch --task checklist` (enforces advisory-only mode: all linters run with `--check`/report-only flags, never auto-modify) | `./tmp/{issue-N}/artifacts/pipeline-structural-checks-{STATUS}-{timestamp}.yaml` | single-criterion |
+| 11 | `green-doublecheck` | `verification-before-completion --task verify` (semantic-intent verification) | `./tmp/{issue-N}/artifacts/pipeline-green-doublecheck-{STATUS}-{timestamp}.yaml` | `per_criterion[]` |
+| 12 | `green-vbc` | `verification-before-completion --task completion` | `./tmp/{issue-N}/artifacts/pipeline-green-vbc-{STATUS}-{timestamp}.yaml` | single-criterion |
+| 13 | `adversarial-audit` | `adversarial-audit --task verification-audit` | `./tmp/{issue-N}/artifacts/pipeline-audit-{auditor_type}-{STATUS}-{timestamp}.yaml` | `per_criterion[]` (#932 schema) |
+| 14 | `cross-validate` | `adversarial-audit --task cross-validate` | `./tmp/{issue-N}/artifacts/pipeline-cross-validate-{STATUS}-{timestamp}.yaml` | cross-validate YAML (#932 schema) |
+| 15 | `regression-check` | `test-driven-development --task patterns` (regression) | `./tmp/{issue-N}/artifacts/pipeline-regression-check-{STATUS}-{timestamp}.yaml` | `per_criterion[]` |
+| 16 | `review-prep` | `git-workflow --task review-prep` | review-prep status | single-criterion |
+| 17 | `exec-summary` | `completion-core --task completion` | append lifecycle event + chat exec summary | single-criterion |
 
 ## Post-Step Checkpoint Creation
 
@@ -189,7 +201,7 @@ When resuming a session with existing artifacts:
 Every step returns a YAML contract (never JSON) with only routing-significant data:
 
 ```yaml
-status: DONE | BLOCKED | DONE_WITH_CONCERNS | OVERFLOW
+status: DONE | BLOCKED | OVERFLOW
 artifact_path: "./tmp/{issue-N}/artifacts/pipeline-{step_label}-{STATUS}-{timestamp}.yaml"
 summary: "<1-3 sentence summary>"
 ```

--- a/skills/issue-operations/SKILL.md
+++ b/skills/issue-operations/SKILL.md
@@ -12,7 +12,13 @@ compatibility: opencode
 
 Platform-agnostic Issue Operations router. Detects `github.platform` and routes all issue operations to the appropriate platform sub-skill (github-mcp, gitbucket-api, local).
 
+## Mandatory Task Discipline
 
+- [ ] 1. Every task and sub-task in this skill is mandatory
+- [ ] 2. Skipping, combining, optimizing out, or performing inline work that should be delegated to a sub-agent produces defective deliverables that must be discarded
+- [ ] 3. Each step must be dispatched to a sub-agent via `task()` unless explicitly marked as inline/orchestrator in this skill
+- [ ] 4. Sub-agents must not dispatch sub-agents
+- [ ] 5. Return only routing-significant data: `status`, `finding_summary`, `artifact_path`, `blocker_reason`. Full evidence goes to disk.
 
 ## Trigger Dispatch Table
 

--- a/skills/issue-operations/platforms/gitbucket-api/SKILL.md
+++ b/skills/issue-operations/platforms/gitbucket-api/SKILL.md
@@ -13,6 +13,14 @@ compatibility: opencode
 
 GitBucket platform implementation using the `gb` CLI tool. Implements a GitHub-compatible API v3 with known deficiencies. This is a platform sub-skill under `issue-operations` — the router passes GitBucket operations here when `github.platform=gitbucket`.
 
+## Mandatory Task Discipline
+
+- [ ] 1. Every task and sub-task in this skill is mandatory
+- [ ] 2. Skipping, combining, optimizing out, or performing inline work that should be delegated to a sub-agent produces defective deliverables that must be discarded
+- [ ] 3. Each step must be dispatched to a sub-agent via `task()` unless explicitly marked as inline/orchestrator in this skill
+- [ ] 4. Sub-agents must not dispatch sub-agents
+- [ ] 5. Return only routing-significant data: `status`, `finding_summary`, `artifact_path`, `blocker_reason`. Full evidence goes to disk.
+
 ## TOOL_MISSING Detection
 
 Before any `gb` command, verify the tool is available:

--- a/skills/issue-operations/platforms/github-mcp/SKILL.md
+++ b/skills/issue-operations/platforms/github-mcp/SKILL.md
@@ -12,6 +12,14 @@ compatibility: opencode
 
 GitHub platform implementation using GitHub MCP tools. Full API coverage with no fallbacks needed.
 
+## Mandatory Task Discipline
+
+- [ ] 1. Every task and sub-task in this skill is mandatory
+- [ ] 2. Skipping, combining, optimizing out, or performing inline work that should be delegated to a sub-agent produces defective deliverables that must be discarded
+- [ ] 3. Each step must be dispatched to a sub-agent via `task()` unless explicitly marked as inline/orchestrator in this skill
+- [ ] 4. Sub-agents must not dispatch sub-agents
+- [ ] 5. Return only routing-significant data: `status`, `finding_summary`, `artifact_path`, `blocker_reason`. Full evidence goes to disk.
+
 ## Capability Manifest
 
 | Operation | Supported | Notes |

--- a/skills/issue-operations/platforms/local/SKILL.md
+++ b/skills/issue-operations/platforms/local/SKILL.md
@@ -12,6 +12,14 @@ compatibility: opencode
 
 Local issue tracking platform using `.issues/` directories at the repo root. This platform is selected when `github.platform` is `local` or when no remote is configured. All operations go through the `./.opencode/tools/local-issues` CLI tool.
 
+## Mandatory Task Discipline
+
+- [ ] 1. Every task and sub-task in this skill is mandatory
+- [ ] 2. Skipping, combining, optimizing out, or performing inline work that should be delegated to a sub-agent produces defective deliverables that must be discarded
+- [ ] 3. Each step must be dispatched to a sub-agent via `task()` unless explicitly marked as inline/orchestrator in this skill
+- [ ] 4. Sub-agents must not dispatch sub-agents
+- [ ] 5. Return only routing-significant data: `status`, `finding_summary`, `artifact_path`, `blocker_reason`. Full evidence goes to disk.
+
 ## Architecture
 
 ```text

--- a/skills/issue-review/SKILL.md
+++ b/skills/issue-review/SKILL.md
@@ -12,7 +12,13 @@ compatibility: opencode
 
 Unified review orchestrator for GitHub Issues. Gathers issue data, classifies review path via content analysis, delegates to downstream skills, handles Q/A for non-spec issues.
 
+## Mandatory Task Discipline
 
+- [ ] 1. Every task and sub-task in this skill is mandatory
+- [ ] 2. Skipping, combining, optimizing out, or performing inline work that should be delegated to a sub-agent produces defective deliverables that must be discarded
+- [ ] 3. Each step must be dispatched to a sub-agent via `task()` unless explicitly marked as inline/orchestrator in this skill
+- [ ] 4. Sub-agents must not dispatch sub-agents
+- [ ] 5. Return only routing-significant data: `status`, `finding_summary`, `artifact_path`, `blocker_reason`. Full evidence goes to disk.
 
 ## Trigger Dispatch Table
 

--- a/skills/mcp-tool-usage/SKILL.md
+++ b/skills/mcp-tool-usage/SKILL.md
@@ -12,7 +12,13 @@ compatibility: opencode
 
 Tool Priority Enforcer ensuring all operations use the correct tool according to the five-tier hierarchy. Defines PRIMARY, FALLBACK, and PROHIBITED tools for each operation type. Zero tolerance for `.ipynb` files.
 
+## Mandatory Task Discipline
 
+- [ ] 1. Every task and sub-task in this skill is mandatory
+- [ ] 2. Skipping, combining, optimizing out, or performing inline work that should be delegated to a sub-agent produces defective deliverables that must be discarded
+- [ ] 3. Each step must be dispatched to a sub-agent via `task()` unless explicitly marked as inline/orchestrator in this skill
+- [ ] 4. Sub-agents must not dispatch sub-agents
+- [ ] 5. Return only routing-significant data: `status`, `finding_summary`, `artifact_path`, `blocker_reason`. Full evidence goes to disk.
 
 ## Trigger Dispatch Table
 

--- a/skills/multimodal-dispatch/SKILL.md
+++ b/skills/multimodal-dispatch/SKILL.md
@@ -12,7 +12,13 @@ compatibility: opencode
 
 Modality-aware sub-agent routing infrastructure. Probes Ollama model capabilities, caches capability snapshots, tasks sub-agents to best available model per content modality. Foundation for verification and research skills.
 
+## Mandatory Task Discipline
 
+- [ ] 1. Every task and sub-task in this skill is mandatory
+- [ ] 2. Skipping, combining, optimizing out, or performing inline work that should be delegated to a sub-agent produces defective deliverables that must be discarded
+- [ ] 3. Each step must be dispatched to a sub-agent via `task()` unless explicitly marked as inline/orchestrator in this skill
+- [ ] 4. Sub-agents must not dispatch sub-agents
+- [ ] 5. Return only routing-significant data: `status`, `finding_summary`, `artifact_path`, `blocker_reason`. Full evidence goes to disk.
 
 ## Trigger Dispatch Table
 

--- a/skills/plan-creation-pipeline/SKILL.md
+++ b/skills/plan-creation-pipeline/SKILL.md
@@ -18,6 +18,14 @@ Pure orchestrator routing table with 6 serial dispatch steps for plan creation. 
 
 The orchestrator is a pure router — never reads task file content, never performs inline analysis. Sub-agents do the work.
 
+## Mandatory Task Discipline
+
+- [ ] 1. Every task and sub-task in this skill is mandatory
+- [ ] 2. Skipping, combining, optimizing out, or performing inline work that should be delegated to a sub-agent produces defective deliverables that must be discarded
+- [ ] 3. Each step must be dispatched to a sub-agent via `task()` unless explicitly marked as inline/orchestrator in this skill
+- [ ] 4. Sub-agents must not dispatch sub-agents
+- [ ] 5. Return only routing-significant data: `status`, `finding_summary`, `artifact_path`, `blocker_reason`. Full evidence goes to disk.
+
 ## Trigger Dispatch Table
 
 | User says / Context | Task | Dispatch | Context passed |

--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -12,7 +12,13 @@ compatibility: opencode
 
 Provides AI planning capabilities wrapping `unified-planning` with workflow integration. Supports problem definition in YAML, plan generation via Tamer/other engines, plan validation, PDDL conversion, action grounding, action schema discovery, and state file management.
 
+## Mandatory Task Discipline
 
+- [ ] 1. Every task and sub-task in this skill is mandatory
+- [ ] 2. Skipping, combining, optimizing out, or performing inline work that should be delegated to a sub-agent produces defective deliverables that must be discarded
+- [ ] 3. Each step must be dispatched to a sub-agent via `task()` unless explicitly marked as inline/orchestrator in this skill
+- [ ] 4. Sub-agents must not dispatch sub-agents
+- [ ] 5. Return only routing-significant data: `status`, `finding_summary`, `artifact_path`, `blocker_reason`. Full evidence goes to disk.
 
 ## Trigger Dispatch Table
 

--- a/skills/playwright-cli/SKILL.md
+++ b/skills/playwright-cli/SKILL.md
@@ -10,6 +10,14 @@ upstream_license: Apache-2.0
 
 # Browser Automation with playwright-cli
 
+## Mandatory Task Discipline
+
+- [ ] 1. Every task and sub-task in this skill is mandatory
+- [ ] 2. Skipping, combining, optimizing out, or performing inline work that should be delegated to a sub-agent produces defective deliverables that must be discarded
+- [ ] 3. Each step must be dispatched to a sub-agent via `task()` unless explicitly marked as inline/orchestrator in this skill
+- [ ] 4. Sub-agents must not dispatch sub-agents
+- [ ] 5. Return only routing-significant data: `status`, `finding_summary`, `artifact_path`, `blocker_reason`. Full evidence goes to disk.
+
 ## Quick start
 
 ```bash

--- a/skills/pr-creation-workflow/SKILL.md
+++ b/skills/pr-creation-workflow/SKILL.md
@@ -14,7 +14,13 @@ PR creation is a DISTINCT phase requiring EXPLICIT instruction — NOT automatic
 
 Feature PRs target `dev` only. Release PRs (dev→main) handled by `git-workflow --task release-promotion`.
 
+## Mandatory Task Discipline
 
+- [ ] 1. Every task and sub-task in this skill is mandatory
+- [ ] 2. Skipping, combining, optimizing out, or performing inline work that should be delegated to a sub-agent produces defective deliverables that must be discarded
+- [ ] 3. Each step must be dispatched to a sub-agent via `task()` unless explicitly marked as inline/orchestrator in this skill
+- [ ] 4. Sub-agents must not dispatch sub-agents
+- [ ] 5. Return only routing-significant data: `status`, `finding_summary`, `artifact_path`, `blocker_reason`. Full evidence goes to disk.
 
 ## Trigger Dispatch Table
 

--- a/skills/pre-analysis/SKILL.md
+++ b/skills/pre-analysis/SKILL.md
@@ -12,7 +12,13 @@ compatibility: opencode
 
 Universal pipeline gate that prevents orchestrators from preloading sub-agents with file paths, line numbers, or expected outcomes. Every sub-agent routing is gated by a pre-analysis sub-agent that independently determines scope. This skill enforces the critical rule at `000-critical-rules.md` §Preloading Sub-Agent Context.
 
+## Mandatory Task Discipline
 
+- [ ] 1. Every task and sub-task in this skill is mandatory
+- [ ] 2. Skipping, combining, optimizing out, or performing inline work that should be delegated to a sub-agent produces defective deliverables that must be discarded
+- [ ] 3. Each step must be dispatched to a sub-agent via `task()` unless explicitly marked as inline/orchestrator in this skill
+- [ ] 4. Sub-agents must not dispatch sub-agents
+- [ ] 5. Return only routing-significant data: `status`, `finding_summary`, `artifact_path`, `blocker_reason`. Full evidence goes to disk.
 
 ## Trigger Dispatch Table
 

--- a/skills/programming-principles/SKILL.md
+++ b/skills/programming-principles/SKILL.md
@@ -12,7 +12,13 @@ compatibility: opencode
 
 20 engineering principles as single authoritative source for design judgment and enforcement. Also includes code size limits (formerly `code-size-enforcement` skill): Python functions ≈100 words, notebook cells ≈120 words, source files ≈750 words. Grandfather policy exempts existing files; only new/modified files must comply.
 
+## Mandatory Task Discipline
 
+- [ ] 1. Every task and sub-task in this skill is mandatory
+- [ ] 2. Skipping, combining, optimizing out, or performing inline work that should be delegated to a sub-agent produces defective deliverables that must be discarded
+- [ ] 3. Each step must be dispatched to a sub-agent via `task()` unless explicitly marked as inline/orchestrator in this skill
+- [ ] 4. Sub-agents must not dispatch sub-agents
+- [ ] 5. Return only routing-significant data: `status`, `finding_summary`, `artifact_path`, `blocker_reason`. Full evidence goes to disk.
 
 ## Trigger Dispatch Table
 

--- a/skills/receiving-code-review/SKILL.md
+++ b/skills/receiving-code-review/SKILL.md
@@ -12,7 +12,13 @@ compatibility: opencode
 
 Responds to PR review feedback. Ensures all comments addressed systematically, changes are minimal, no scope creep.
 
+## Mandatory Task Discipline
 
+- [ ] 1. Every task and sub-task in this skill is mandatory
+- [ ] 2. Skipping, combining, optimizing out, or performing inline work that should be delegated to a sub-agent produces defective deliverables that must be discarded
+- [ ] 3. Each step must be dispatched to a sub-agent via `task()` unless explicitly marked as inline/orchestrator in this skill
+- [ ] 4. Sub-agents must not dispatch sub-agents
+- [ ] 5. Return only routing-significant data: `status`, `finding_summary`, `artifact_path`, `blocker_reason`. Full evidence goes to disk.
 
 ## Trigger Dispatch Table
 

--- a/skills/requesting-code-review/SKILL.md
+++ b/skills/requesting-code-review/SKILL.md
@@ -12,7 +12,13 @@ compatibility: opencode
 
 Prepares and requests code reviews. Ensures PR descriptions have proper context, reviewers understand changes, requests are targeted.
 
+## Mandatory Task Discipline
 
+- [ ] 1. Every task and sub-task in this skill is mandatory
+- [ ] 2. Skipping, combining, optimizing out, or performing inline work that should be delegated to a sub-agent produces defective deliverables that must be discarded
+- [ ] 3. Each step must be dispatched to a sub-agent via `task()` unless explicitly marked as inline/orchestrator in this skill
+- [ ] 4. Sub-agents must not dispatch sub-agents
+- [ ] 5. Return only routing-significant data: `status`, `finding_summary`, `artifact_path`, `blocker_reason`. Full evidence goes to disk.
 
 ## Trigger Dispatch Table
 

--- a/skills/research/SKILL.md
+++ b/skills/research/SKILL.md
@@ -12,7 +12,13 @@ compatibility: opencode
 
 Invokes `multimodal-dispatch` to discover information using best available model per modality. Produces findings with source attribution, explicit gap reporting, unverified modality tracking. Unlike verification (validates claims), research discovers new information.
 
+## Mandatory Task Discipline
 
+- [ ] 1. Every task and sub-task in this skill is mandatory
+- [ ] 2. Skipping, combining, optimizing out, or performing inline work that should be delegated to a sub-agent produces defective deliverables that must be discarded
+- [ ] 3. Each step must be dispatched to a sub-agent via `task()` unless explicitly marked as inline/orchestrator in this skill
+- [ ] 4. Sub-agents must not dispatch sub-agents
+- [ ] 5. Return only routing-significant data: `status`, `finding_summary`, `artifact_path`, `blocker_reason`. Full evidence goes to disk.
 
 ## Trigger Dispatch Table
 

--- a/skills/researcher/SKILL.md
+++ b/skills/researcher/SKILL.md
@@ -19,7 +19,13 @@ Dedicated research skill for exhaustive investigation with verifiable source evi
 
 Research without tool calls produces memory guesses. Every unverified finding is a liability, not evidence.
 
+## Mandatory Task Discipline
 
+- [ ] 1. Every task and sub-task in this skill is mandatory
+- [ ] 2. Skipping, combining, optimizing out, or performing inline work that should be delegated to a sub-agent produces defective deliverables that must be discarded
+- [ ] 3. Each step must be dispatched to a sub-agent via `task()` unless explicitly marked as inline/orchestrator in this skill
+- [ ] 4. Sub-agents must not dispatch sub-agents
+- [ ] 5. Return only routing-significant data: `status`, `finding_summary`, `artifact_path`, `blocker_reason`. Full evidence goes to disk.
 
 ## Trigger Dispatch Table
 

--- a/skills/skill-creator/SKILL.md
+++ b/skills/skill-creator/SKILL.md
@@ -14,7 +14,13 @@ Creating skills IS TDD applied to process documentation. Write tests, watch them
 
 Also manages duplicate text blocks across skills (formerly `fragment-manager` skill): CRUD on master files (`.opencode/.guidelines/`), sync masters to copies, drift detection.
 
+## Mandatory Task Discipline
 
+- [ ] 1. Every task and sub-task in this skill is mandatory
+- [ ] 2. Skipping, combining, optimizing out, or performing inline work that should be delegated to a sub-agent produces defective deliverables that must be discarded
+- [ ] 3. Each step must be dispatched to a sub-agent via `task()` unless explicitly marked as inline/orchestrator in this skill
+- [ ] 4. Sub-agents must not dispatch sub-agents
+- [ ] 5. Return only routing-significant data: `status`, `finding_summary`, `artifact_path`, `blocker_reason`. Full evidence goes to disk.
 
 ## Trigger Dispatch Table
 

--- a/skills/skill-creator/reference/skill-card-spec.md
+++ b/skills/skill-creator/reference/skill-card-spec.md
@@ -1,0 +1,70 @@
+# Skill Card Structure Reference
+
+<!-- SPDX-FileCopyrightText: 2026 Michael Conrad -->
+<!-- SPDX-License-Identifier: MIT -->
+<!-- Provenance: AI-generated -->
+
+Co-authored with AI: OpenCode (ollama-cloud/deepseek-v4-flash)
+
+## Mandatory Task Discipline Admonishment
+
+### SKILL.md Version (5 items)
+
+Insert after Overview, before Trigger Dispatch Table:
+
+```markdown
+## Mandatory Task Discipline
+
+- [ ] 1. Every task and sub-task in this skill is mandatory
+- [ ] 2. Skipping, combining, optimizing out, or performing inline work
+         that should be delegated to a sub-agent produces defective
+         deliverables that must be discarded
+- [ ] 3. Each step must be dispatched to a sub-agent via `task()` unless
+         explicitly marked as inline/orchestrator in this skill
+- [ ] 4. Sub-agents must not dispatch sub-agents
+- [ ] 5. Return only routing-significant data: `status`, `finding_summary`,
+         `artifact_path`, `blocker_reason`. Full evidence goes to disk.
+```
+
+### Task Card Version — Non-Inline (4 items)
+
+Insert after Purpose, before Operating Protocol:
+
+```markdown
+## Task Discipline
+
+- [ ] 1. Execute every step in this task sequentially — none are optional
+- [ ] 2. Do not dispatch sub-agents from within this task
+- [ ] 3. If blocked, return BLOCKED with reason — do not work around it
+- [ ] 4. Return only: `status`, `finding_summary`, `artifact_path`,
+         `blocker_reason`. Full evidence goes to disk.
+```
+
+### Task Card Version — Inline (3 items)
+
+Insert after Purpose, before Operating Protocol:
+
+```markdown
+## Task Discipline
+
+- [ ] 1. Execute every step in this task sequentially — none are optional
+- [ ] 2. If blocked, return BLOCKED with reason — do not work around it
+- [ ] 3. Return only: `status`, `finding_summary`, `artifact_path`,
+         `blocker_reason`. Full evidence goes to disk.
+```
+
+## Placement Rules
+
+| Card Type | Placement |
+|-----------|-----------|
+| SKILL.md | After Overview, before Trigger Dispatch Table |
+| Task card (non-inline) | After Purpose, before Operating Protocol |
+| Task card (inline) | After Purpose, before Operating Protocol |
+
+## Variant Selection
+
+| Dispatch Type | Variant | Items |
+|---------------|---------|-------|
+| `sub-task` (sub-agent dispatched) | Non-inline | 4 items (includes "do not dispatch sub-agents") |
+| `inline` / `orchestrator` | Inline | 3 items (omits "do not dispatch sub-agents") |
+| SKILL.md (orchestrator-facing) | SKILL.md | 5 items (includes dispatch discipline) |

--- a/skills/skill-creator/scripts/validate_skill_cards.py
+++ b/skills/skill-creator/scripts/validate_skill_cards.py
@@ -17,6 +17,7 @@ Validates SKILL.md files per spec #1124:
   REQ-2: Placeholder enforcement (no hardcoded identity values)
   REQ-3: Worktree Mode section requirement for skills with bash/git/file ops
   REQ-4: Provenance field validation
+  REQ-5: Mandatory Task Discipline admonishment presence (5-item checklist)
 
 Usage:
     uv run .opencode/skills/skill-creator/scripts/validate_skill_cards.py           # validate
@@ -244,6 +245,22 @@ def validate_req3(name: str, body: str, file_path: str) -> list[Violation]:
         )
     return violations
 
+ADMONISHMENT_HEADING_RE = re.compile(r"^##\s+Mandatory\s+Task\s+Discipline", re.MULTILINE)
+
+def validate_req5(name: str, body: str, file_path: str) -> list[Violation]:
+    violations: list[Violation] = []
+    if not ADMONISHMENT_HEADING_RE.search(body):
+        violations.append(
+            Violation(
+                "REQ-5",
+                name,
+                "admonishment",
+                "Missing 'Mandatory Task Discipline' section",
+                file_path=file_path,
+            )
+        )
+    return violations
+
 def validate_req4(name: str, fields: dict[str, str], file_path: str) -> list[Violation]:
     violations: list[Violation] = []
     if "provenance" not in fields:
@@ -301,6 +318,7 @@ def validate_card(card_path: Path, root: Path) -> list[Violation]:
     violations.extend(validate_req2(name, content, rel_path))
     violations.extend(validate_req3(name, body, rel_path))
     violations.extend(validate_req4(name, fields, rel_path))
+    violations.extend(validate_req5(name, body, rel_path))
     return violations
 
 def violation_to_dict(v: Violation) -> dict:

--- a/skills/solve/SKILL.md
+++ b/skills/solve/SKILL.md
@@ -12,7 +12,13 @@ compatibility: opencode
 
 The `solve` tool is a Z3 constraint solver for workflow correctness. It operates on contract YAML files (variable declarations + logical constraints) and state YAML files (variable assignments). Four subcommands: `check`, `model`, `prove`, and `state`. When Z3 is unavailable, `fallback` provides manual validation procedures.
 
+## Mandatory Task Discipline
 
+- [ ] 1. Every task and sub-task in this skill is mandatory
+- [ ] 2. Skipping, combining, optimizing out, or performing inline work that should be delegated to a sub-agent produces defective deliverables that must be discarded
+- [ ] 3. Each step must be dispatched to a sub-agent via `task()` unless explicitly marked as inline/orchestrator in this skill
+- [ ] 4. Sub-agents must not dispatch sub-agents
+- [ ] 5. Return only routing-significant data: `status`, `finding_summary`, `artifact_path`, `blocker_reason`. Full evidence goes to disk.
 
 ## Trigger Dispatch Table
 

--- a/skills/spec-creation/SKILL.md
+++ b/skills/spec-creation/SKILL.md
@@ -14,7 +14,13 @@ Structured discipline for spec writing. Enforces requirements extraction, proble
 
 Pipeline: `brainstorming → spec-creation → adversarial-audit --task spec-audit → approval-gate → writing-plans`
 
+## Mandatory Task Discipline
 
+- [ ] 1. Every task and sub-task in this skill is mandatory
+- [ ] 2. Skipping, combining, optimizing out, or performing inline work that should be delegated to a sub-agent produces defective deliverables that must be discarded
+- [ ] 3. Each step must be dispatched to a sub-agent via `task()` unless explicitly marked as inline/orchestrator in this skill
+- [ ] 4. Sub-agents must not dispatch sub-agents
+- [ ] 5. Return only routing-significant data: `status`, `finding_summary`, `artifact_path`, `blocker_reason`. Full evidence goes to disk.
 
 ## Trigger Dispatch Table
 

--- a/skills/sre-runbook/SKILL.md
+++ b/skills/sre-runbook/SKILL.md
@@ -12,7 +12,13 @@ compatibility: opencode
 
 Generates operational runbooks — step-by-step procedures a sysop can execute without thinking. Commands verified against live documentation. Values from actual environment. Single-path per operation.
 
+## Mandatory Task Discipline
 
+- [ ] 1. Every task and sub-task in this skill is mandatory
+- [ ] 2. Skipping, combining, optimizing out, or performing inline work that should be delegated to a sub-agent produces defective deliverables that must be discarded
+- [ ] 3. Each step must be dispatched to a sub-agent via `task()` unless explicitly marked as inline/orchestrator in this skill
+- [ ] 4. Sub-agents must not dispatch sub-agents
+- [ ] 5. Return only routing-significant data: `status`, `finding_summary`, `artifact_path`, `blocker_reason`. Full evidence goes to disk.
 
 ## Trigger Dispatch Table
 

--- a/skills/sync-guidelines/SKILL.md
+++ b/skills/sync-guidelines/SKILL.md
@@ -12,7 +12,13 @@ compatibility: opencode
 
 Intelligently synchronizes guidelines, skills, and tools between repos via GitHub issues. Files classified by content understanding — not pattern matching — as core (syncable) vs project-specific (protected).
 
+## Mandatory Task Discipline
 
+- [ ] 1. Every task and sub-task in this skill is mandatory
+- [ ] 2. Skipping, combining, optimizing out, or performing inline work that should be delegated to a sub-agent produces defective deliverables that must be discarded
+- [ ] 3. Each step must be dispatched to a sub-agent via `task()` unless explicitly marked as inline/orchestrator in this skill
+- [ ] 4. Sub-agents must not dispatch sub-agents
+- [ ] 5. Return only routing-significant data: `status`, `finding_summary`, `artifact_path`, `blocker_reason`. Full evidence goes to disk.
 
 ## Trigger Dispatch Table
 

--- a/skills/systematic-debugging/SKILL.md
+++ b/skills/systematic-debugging/SKILL.md
@@ -12,7 +12,13 @@ compatibility: opencode
 
 Enforces root cause analysis, hypothesis testing, and minimal fixes. Prevents "vibe debugging" — random changes without understanding. Diagnose before fixing, fixes must be minimal and targeted.
 
+## Mandatory Task Discipline
 
+- [ ] 1. Every task and sub-task in this skill is mandatory
+- [ ] 2. Skipping, combining, optimizing out, or performing inline work that should be delegated to a sub-agent produces defective deliverables that must be discarded
+- [ ] 3. Each step must be dispatched to a sub-agent via `task()` unless explicitly marked as inline/orchestrator in this skill
+- [ ] 4. Sub-agents must not dispatch sub-agents
+- [ ] 5. Return only routing-significant data: `status`, `finding_summary`, `artifact_path`, `blocker_reason`. Full evidence goes to disk.
 
 ## Trigger Dispatch Table
 

--- a/skills/test-driven-development/SKILL.md
+++ b/skills/test-driven-development/SKILL.md
@@ -10,6 +10,14 @@ compatibility: opencode
 
 ## Five Core Principles
 
+## Mandatory Task Discipline
+
+- [ ] 1. Every task and sub-task in this skill is mandatory
+- [ ] 2. Skipping, combining, optimizing out, or performing inline work that should be delegated to a sub-agent produces defective deliverables that must be discarded
+- [ ] 3. Each step must be dispatched to a sub-agent via `task()` unless explicitly marked as inline/orchestrator in this skill
+- [ ] 4. Sub-agents must not dispatch sub-agents
+- [ ] 5. Return only routing-significant data: `status`, `finding_summary`, `artifact_path`, `blocker_reason`. Full evidence goes to disk.
+
 ## Trigger Dispatch Table
 
 | User says / Context | Task | Dispatch | Context passed |

--- a/skills/using-git-worktrees/SKILL.md
+++ b/skills/using-git-worktrees/SKILL.md
@@ -12,7 +12,13 @@ compatibility: opencode
 
 Git worktrees create isolated workspaces sharing same repository. Opt-in only — default is direct-branch (feature branch in main repo). Created when `WORKTREE_REQUIRED` set or developer requests isolation.
 
+## Mandatory Task Discipline
 
+- [ ] 1. Every task and sub-task in this skill is mandatory
+- [ ] 2. Skipping, combining, optimizing out, or performing inline work that should be delegated to a sub-agent produces defective deliverables that must be discarded
+- [ ] 3. Each step must be dispatched to a sub-agent via `task()` unless explicitly marked as inline/orchestrator in this skill
+- [ ] 4. Sub-agents must not dispatch sub-agents
+- [ ] 5. Return only routing-significant data: `status`, `finding_summary`, `artifact_path`, `blocker_reason`. Full evidence goes to disk.
 
 ## Trigger Dispatch Table
 

--- a/skills/verification-before-completion/SKILL.md
+++ b/skills/verification-before-completion/SKILL.md
@@ -16,7 +16,13 @@ Remediation of failed verification IS agent-owned — the producing agent owns e
 
 Ensures ALL success criteria are verified with actual evidence before ANY task or phase is marked complete. Structural completeness checked before per-SC verification.
 
+## Mandatory Task Discipline
 
+- [ ] 1. Every task and sub-task in this skill is mandatory
+- [ ] 2. Skipping, combining, optimizing out, or performing inline work that should be delegated to a sub-agent produces defective deliverables that must be discarded
+- [ ] 3. Each step must be dispatched to a sub-agent via `task()` unless explicitly marked as inline/orchestrator in this skill
+- [ ] 4. Sub-agents must not dispatch sub-agents
+- [ ] 5. Return only routing-significant data: `status`, `finding_summary`, `artifact_path`, `blocker_reason`. Full evidence goes to disk.
 
 ## Trigger Dispatch Table
 

--- a/skills/verification-enforcement/SKILL.md
+++ b/skills/verification-enforcement/SKILL.md
@@ -14,7 +14,13 @@ Shared verification gate for ALL content-generating skills. Pre-generation: task
 
 Spec content that makes factual claims must include a **Documentation Sources** section documenting live-source verification used for each claim. This section is mandatory for standard and complex specs and is enforced by `adversarial-audit --task spec-audit` criterion SC-11. Simple specs may omit it.
 
+## Mandatory Task Discipline
 
+- [ ] 1. Every task and sub-task in this skill is mandatory
+- [ ] 2. Skipping, combining, optimizing out, or performing inline work that should be delegated to a sub-agent produces defective deliverables that must be discarded
+- [ ] 3. Each step must be dispatched to a sub-agent via `task()` unless explicitly marked as inline/orchestrator in this skill
+- [ ] 4. Sub-agents must not dispatch sub-agents
+- [ ] 5. Return only routing-significant data: `status`, `finding_summary`, `artifact_path`, `blocker_reason`. Full evidence goes to disk.
 
 ## Trigger Dispatch Table
 

--- a/skills/verification/SKILL.md
+++ b/skills/verification/SKILL.md
@@ -12,7 +12,13 @@ compatibility: opencode
 
 Invokes `multimodal-dispatch` to verify claims against evidence using appropriate modalities. Each claim gets PASS/FAIL/UNVERIFIED with evidence artifacts. Core invariant: FAIL never downgraded to PASS by agent judgment.
 
+## Mandatory Task Discipline
 
+- [ ] 1. Every task and sub-task in this skill is mandatory
+- [ ] 2. Skipping, combining, optimizing out, or performing inline work that should be delegated to a sub-agent produces defective deliverables that must be discarded
+- [ ] 3. Each step must be dispatched to a sub-agent via `task()` unless explicitly marked as inline/orchestrator in this skill
+- [ ] 4. Sub-agents must not dispatch sub-agents
+- [ ] 5. Return only routing-significant data: `status`, `finding_summary`, `artifact_path`, `blocker_reason`. Full evidence goes to disk.
 
 ## Trigger Dispatch Table
 

--- a/skills/writing-plans/SKILL.md
+++ b/skills/writing-plans/SKILL.md
@@ -12,6 +12,14 @@ compatibility: opencode
 
 Transforms approved specs into actionable implementation plans using a 21-step Z3-enforced pipeline: 10 discrete sub-agent dispatches interleaved with 10 z3-check transitions and 1 inline verification step. Every step is one atomic concern. No placeholders. Sub-agents are leaf nodes — only the orchestrator dispatches via `task()`.
 
+## Mandatory Task Discipline
+
+- [ ] 1. Every task and sub-task in this skill is mandatory
+- [ ] 2. Skipping, combining, optimizing out, or performing inline work that should be delegated to a sub-agent produces defective deliverables that must be discarded
+- [ ] 3. Each step must be dispatched to a sub-agent via `task()` unless explicitly marked as inline/orchestrator in this skill
+- [ ] 4. Sub-agents must not dispatch sub-agents
+- [ ] 5. Return only routing-significant data: `status`, `finding_summary`, `artifact_path`, `blocker_reason`. Full evidence goes to disk.
+
 ## Trigger Dispatch Table
 
 | User says / Context | Task | Dispatch | Context passed |


### PR DESCRIPTION
## Summary

Three specs implemented in one stacked PR:

### #1357 — Mandatory Task Discipline Admonishment
- Added 5-item admonishment block to all 42 SKILL.md files
- Created canonical reference card at `skill-creator/reference/skill-card-spec.md`
- Added REQ-5 check to `validate_skill_cards.py`
- Added SC-ADMONISHMENT criterion to `spec-audit.md`

### #1355 — DONE_WITH_CONCERNS Coercion Gap
- Added bright-line coercion rule to `pipeline-executor.md` pre-dispatch gate
- Removed `DONE_WITH_CONCERNS` from status enums in 5 enforcement files
- Added `DONE_WITH_CONCERNS` to `critical-rules-hard-fail` symbolic rule conditions
- Added `DONE_WITH_CONCERNS` coercion trigger to `065-verification-honesty.md`
- Preserved `DONE_WITH_CONCERNS` in `revisit.md` and `revisit-output-template.yaml`

### #1347 — Checkpoint Tag Creation Step
- Added `checkpoint-tag-create` as explicit step 8 in the 17-step dispatch table
- Updated `pipeline-state-machine.yaml` with new state and transitions
- Created `checkpoint-tag-create.md` task file
- Updated SKILL.md Trigger Dispatch Table and Dispatch Routing Table

## Files Changed
53 files changed, 441 insertions, 24 deletions

Fixes #1357, #1355, #1347

🤖 Co-authored with AI: OpenCode (ollama-cloud/deepseek-v4-flash)