### PR TITLE
feat(#1346): multi-file plan format with master ToC, sub-plans, dispatch contracts, and checkpoint tag creation

### DIFF
--- a/skills/implementation-pipeline/SKILL.md
+++ b/skills/implementation-pipeline/SKILL.md
@@ -32,6 +32,7 @@ The orchestrator is a pure router — never reads task file content, never perfo
 | "post-red-enforcement" / "RED gate" | `post-red-enforcement` | `sub-task` | {issue_number} |
 | "green-phase" / "implement" | `green-phase` | `sub-task` | {issue_number} |
 | "post-green-enforcement" / "GREEN gate" | `post-green-enforcement` | `sub-task` | {issue_number} |
+| "checkpoint-tag-create" / "create checkpoint tag" | `checkpoint-tag-create` | `sub-task` | {issue_number} |
 | "checkpoint-commit" / "save checkpoint" | `checkpoint-commit` | `sub-task` | {issue_number} |
 | "structural-checks" / "lint/typecheck" | `structural-checks` | `sub-task` | {issue_number} |
 | "green-doublecheck" / "verify GREEN" | `green-doublecheck` | `sub-task` | {issue_number} |
@@ -53,6 +54,7 @@ The orchestrator is a pure router — never reads task file content, never perfo
 | `post-red-enforcement` | `implementation-pipeline --task post-red-enforcement` (git diff --name-only -- src/ \| wc -l) | git diff structural gate result |
 | `green-phase` | `test-driven-development --task green` | implementation code + test pass |
 | `post-green-enforcement` | `implementation-pipeline --task post-green-enforcement` (git diff --name-only -- test/ \| wc -l) | git diff structural gate result |
+| `checkpoint-tag-create` | `git-workflow --task commit-prep` (git tag `<parent>/checkpoint/<issue>/phase-<N>-<submodule>`) | checkpoint tag created |
 | `checkpoint-commit` | `git-workflow --task commit-prep` | commit status |
 | `structural-checks` | `finishing-a-development-branch --task checklist` | lint/typecheck/format results |
 | `green-doublecheck` | `verification-before-completion --task verify` (semantic-intent verification) | GREEN-side SC evidence + intent verdict |
@@ -75,7 +77,7 @@ Before the pipeline dispatches to `sc-coherence-gate`, the orchestrator MUST run
 
 ## Step Labels (for #932 naming convention)
 
-`sc-coherence-gate`, `pre-red-baseline`, `red-phase`, `red-doublecheck`, `post-red-enforcement`, `green-phase`, `post-green-enforcement`, `checkpoint-commit`, `structural-checks`, `green-doublecheck`, `green-vbc`, `adversarial-audit`, `cross-validate`, `regression-check`, `review-prep`, `exec-summary`
+`sc-coherence-gate`, `pre-red-baseline`, `red-phase`, `red-doublecheck`, `post-red-enforcement`, `green-phase`, `post-green-enforcement`, `checkpoint-tag-create`, `checkpoint-commit`, `structural-checks`, `green-doublecheck`, `green-vbc`, `adversarial-audit`, `cross-validate`, `regression-check`, `review-prep`, `exec-summary`
 
 ## Invocation
 
@@ -208,6 +210,7 @@ At the start of each pipeline step, clean previous-run artifacts for that step t
 | `red-phase` | `rm -f ./tmp/{issue-N}/artifacts/pipeline-red-phase-*` |
 | `green-phase` | `rm -f ./tmp/{issue-N}/artifacts/pipeline-green-phase-*` |
 | `post-green-enforcement` | `rm -f ./tmp/{issue-N}/artifacts/pipeline-post-green-enforcement-*` |
+| `checkpoint-tag-create` | `rm -f ./tmp/{issue-N}/artifacts/pipeline-checkpoint-tag-create-*` |
 | `checkpoint-commit` | `rm -f ./tmp/{issue-N}/artifacts/pipeline-checkpoint-commit-*` |
 | `structural-checks` | `rm -f ./tmp/{issue-N}/artifacts/pipeline-structural-checks-*` |
 | `green-doublecheck` | `rm -f ./tmp/{issue-N}/artifacts/pipeline-green-doublecheck-*` |

--- a/skills/implementation-pipeline/pipeline-state-machine.yaml
+++ b/skills/implementation-pipeline/pipeline-state-machine.yaml
@@ -15,6 +15,7 @@ variables:
       - red-phase
       - red-doublecheck
       - green-phase
+      - checkpoint-tag-create
       - checkpoint-commit
       - structural-checks
       - green-doublecheck
@@ -33,6 +34,7 @@ variables:
       - red-phase
       - red-doublecheck
       - green-phase
+      - checkpoint-tag-create
       - checkpoint-commit
       - structural-checks
       - green-doublecheck
@@ -51,7 +53,8 @@ preconditions:
   - "z3.Implies(previous_step == z3.StringVal('sc-coherence-gate'), z3.Or(current_step == z3.StringVal('red-phase'), current_step == z3.StringVal('pre-red-baseline')))"
   - "z3.Implies(previous_step == z3.StringVal('red-phase'), current_step == z3.StringVal('red-doublecheck'))"
   - "z3.Implies(previous_step == z3.StringVal('red-doublecheck'), z3.Or(current_step == z3.StringVal('green-phase'), current_step == z3.StringVal('red-phase')))"
-  - "z3.Implies(previous_step == z3.StringVal('green-phase'), current_step == z3.StringVal('checkpoint-commit'))"
+  - "z3.Implies(previous_step == z3.StringVal('green-phase'), current_step == z3.StringVal('checkpoint-tag-create'))"
+  - "z3.Implies(previous_step == z3.StringVal('checkpoint-tag-create'), current_step == z3.StringVal('checkpoint-commit'))"
   - "z3.Implies(previous_step == z3.StringVal('checkpoint-commit'), z3.Or(current_step == z3.StringVal('structural-checks'), current_step == z3.StringVal('green-phase')))"
   - "z3.Implies(previous_step == z3.StringVal('structural-checks'), z3.Or(current_step == z3.StringVal('green-doublecheck'), current_step == z3.StringVal('green-phase')))"
   - "z3.Implies(previous_step == z3.StringVal('green-doublecheck'), z3.Or(current_step == z3.StringVal('green-vbc'), current_step == z3.StringVal('green-phase')))"

--- a/skills/writing-plans/SKILL.md
+++ b/skills/writing-plans/SKILL.md
@@ -33,10 +33,10 @@ Plan Author. Focus: transform spec into phased plan with file structure, TDD ste
 
 ## Plan Model
 
-**All plans are local artifacts.** Plans are stored at `.issues/{N}/plan.md`. Phases are sections in the local plan file.
+**All plans are local artifacts.** Plans use the multi-file format: master ToC + per-phase sub-plans.
 
-- **Separate (multi-task):** `.issues/{N}/plan.md` with stand-alone phase sections, each with concern boundary annotations
-- **Combined (single-task):** `.issues/{N}/plan.md` referencing spec content inline
+- **Separate (multi-task):** Multi-file format — master ToC at `.issues/{N}/plan.md` (≤50 lines, phase list table with Depends On and Exit Criteria columns) + per-phase sub-plans at `.issues/{N}/plan-phase-{N}.md` (one per phase, each with YAML header, three-section structure, dispatch contracts, commits:true, and explicit checkpoint tag creation step)
+- **Combined (single-task):** Single-file format — `.issues/{N}/plan.md` referencing spec content inline
 
 ## Invocation
 

--- a/skills/writing-plans/tasks/create/create-and-validate.md
+++ b/skills/writing-plans/tasks/create/create-and-validate.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-Write plan document to `.issues/{N}/plan.md`, validate structure, and handle approval cascade with scope-aware auto-approval.
+Write plan document(s) to `.issues/{N}/` (master ToC `plan.md` + per-phase sub-plans `plan-phase-N.md`), validate structure, and handle approval cascade with scope-aware auto-approval. Produces the new multi-file format with dispatch contracts, commit boundaries, and explicit checkpoint tag creation steps.
 
 ## Entry Criteria
 

--- a/skills/writing-plans/tasks/create/plan-structure.md
+++ b/skills/writing-plans/tasks/create/plan-structure.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-Structure the implementation plan from approved spec: verification gate, combined/separate decision, file structure mapping, and TDD task definition with RED verification checkpoints.
+Structure the implementation plan from approved spec: verification gate, combined/separate decision, file structure mapping, and TDD task definition with RED verification checkpoints. Produces the new multi-file format: master ToC (`plan.md`) + per-phase sub-plans (`plan-phase-N.md`) with dispatch contracts, commit boundaries, and explicit checkpoint tag creation steps.
 
 ## Entry Criteria
 
@@ -81,26 +81,29 @@ This is a hard gate — the plan-writer MUST NOT proceed without a PASS from the
 
 | Condition | Outcome |
 | -- | -- |
-| Multi-task spec (mixed concerns or independence) | **Always separate** — separate phase sections in `.issues/{N}/plan.md` |
+| Multi-task spec (mixed concerns or independence) | **Always separate** — multi-file format: master ToC (`plan.md`) + per-phase sub-plans (`plan-phase-N.md`) |
 | Single-task spec AND spec body can absorb plan content | **Candidate for combined** — agent evaluates readability |
-| Single-task AND combining makes document hard to read | **Separate** — stand-alone sections in `.issues/{N}/plan.md` |
+| Single-task AND combining makes document hard to read | **Separate** — multi-file format |
 
 **Decision output (MANDATORY):**
 
 ```
 Plan structure decision: combined/separate
+Format: multi-file (master ToC + sub-plans) / single-file
 Reason: <justification referencing evaluation criteria>
 ```
 
-**If COMBINED:**
+**If COMBINED (single-file):**
 
 - Write to `.issues/{N}/plan.md`, reference spec content inline
 - Retain `[SPEC]` title prefix
 - Proceed to Step 2
 
-**If SEPARATE:**
+**If SEPARATE (multi-file):**
 
-- Write to `.issues/{N}/plan.md` with separate phase sections
+- Write master ToC to `.issues/{N}/plan.md` (≤50 lines, phase list table with Depends On and Exit Criteria columns)
+- Write per-phase sub-plans to `.issues/{N}/plan-phase-{N}.md` (one per phase)
+- Each sub-plan includes: YAML header (phase, concern, depends_on, scs, checkpoint_tag), three-section structure (Pre-RED Common, Per-Item RED/GREEN Chains, Post-RED/green), dispatch contract fields (must_receive/must_not_receive), commits:true declarations, and explicit checkpoint tag creation step
 - Proceed to Step 2
 
 ### Step 1.6: Duplicate Plan Check


### PR DESCRIPTION
## Summary

Replaces the monolithic single-file plan format with a multi-file format: master ToC + per-phase sub-plans with dispatch contracts, commit boundaries, and explicit checkpoint tag creation steps.

## Changes

### Phase 1-3: Plan format definition (local `.issues/1346/` artifacts)
- Master ToC (`plan.md`) — routing index, ≤50 lines, phase list table with Depends On and Exit Criteria columns
- Per-phase sub-plans (`plan-phase-N.md`) — YAML headers, three-section structure, dispatch contracts, `commits:true`, `checkpoint_tag`
- Work state file format (`.tmp/work-state-NNN.yaml`) — Z3-verifiable contracts, session-resilient disk persistence

### Phase 4: implementation-pipeline skill update
- Added `checkpoint-tag-create` as explicit step in dispatch routing table (between `post-green-enforcement` and `checkpoint-commit`)
- Updated Z3 state machine (`pipeline-state-machine.yaml`) with new step and valid transitions
- Added pre-cleanup entry for checkpoint-tag-create artifacts

### Phase 5: writing-plans skill changes
- Updated SKILL.md Plan Model to describe multi-file format
- Updated `plan-structure.md` with multi-file output procedure (master ToC + sub-plans)
- Updated `create-and-validate.md` to reference multi-file format

## Files Modified
- `.opencode/skills/implementation-pipeline/SKILL.md`
- `.opencode/skills/implementation-pipeline/pipeline-state-machine.yaml`
- `.opencode/skills/writing-plans/SKILL.md`
- `.opencode/skills/writing-plans/tasks/create/plan-structure.md`
- `.opencode/skills/writing-plans/tasks/create/create-and-validate.md`

Fixes #1346

🤖 Co-authored with AI: OpenCode (ollama-cloud/deepseek-v4-flash)