### PR TITLE
fix(#1366): add Repo Ownership Gate to issue-operations creation task

### DIFF
--- a/skills/issue-operations/tasks/creation.md
+++ b/skills/issue-operations/tasks/creation.md
@@ -112,6 +112,38 @@ Cannot create issue: Step 0.5 dedup gate evidence missing and runtime search fal
 | Enhancement  | `[SPEC-ENHANCEMENT] <Enhancement>`     | `[SPEC-ENHANCEMENT] Add Rate Limiting` |
 | Task         | `[Task: #<parent>] <Task Description>` | `[Task: #100] Create user tables`      |
 
+### Step 1.5: Repo Ownership Gate
+
+**MANDATORY before proceeding to platform routing.** Prevents routing issues to the wrong repository when affected files belong to a different repo (e.g., `.opencode/` files routed to parent repo).
+
+- [ ] 1. **Extract affected file paths** from the issue body or context:
+   - Look for file paths in the Problem, Scope, Approach, or Fix sections
+   - Look for explicit `file_references` or `affected_files` sections
+   - If no file paths found, check the issue title and description for repo-specific keywords (e.g., `.opencode/`, `guidelines/`, `skills/`)
+- [ ] 2. **Resolve repo ownership** for each affected file path using session-init path→repo mappings:
+   - Paths starting with `.opencode/` → `.opencode` sub-repo (use `.opencode` entry's owner/repo from session-init)
+   - Paths starting with `.issues/` → root repo
+   - All other paths → root repo
+- [ ] 3. **Verify target repo matches resolved repo:**
+   - If any affected file path resolves to a different repo than the current target (`github.owner`/`github.repo`):
+     - BLOCK with `WRONG_REPO`
+     - Report: "Affected files belong to {resolved_owner}/{resolved_repo}, not {current_owner}/{current_repo}. Route to {resolved_owner}/{resolved_repo} instead."
+     - HALT — do not proceed with creation
+   - If all affected file paths match the current target repo: proceed to Step 2
+- [ ] 4. **No file paths found fallback:** If no file paths can be extracted, proceed to Step 2 (cannot determine repo ownership from empty context)
+
+**Evidence artifact (MANDATORY):**
+
+```
+Check: Repo Ownership Gate for "<proposed title>"
+Tool: session-init path→repo mappings
+Affected files: [list of extracted file paths]
+Resolved repo: {resolved_owner}/{resolved_repo}
+Current target: {current_owner}/{current_repo}
+Result: [MATCH | WRONG_REPO]
+Action: [proceed | HALT]
+```
+
 ### Step 2: Create Issue (Platform-Aware Ordering)
 
 #### Step 2.0: Platform Check

--- a/tests/behaviors/1366-sc4-repo-ownership-gate.sh
+++ b/tests/behaviors/1366-sc4-repo-ownership-gate.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Behavioral test: 1366-sc4-repo-ownership-gate
+# See .opencode/tests/AGENTS.md for the test harness specification and paradigm.
+# This script is an artifact-only generator — it does NOT evaluate model output.
+#
+# SC-4 (behavioral): Agent routes issue to correct repo when affected files
+# are in .opencode/ — the Repo Ownership Gate should BLOCK with WRONG_REPO
+# when the agent tries to create an issue about .opencode/ files in the
+# parent repo, and route to the .opencode sub-repo instead.
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/helpers.sh"
+
+SCENARIO_NAME="1366-sc4-repo-ownership-gate"
+# Prompt: agent needs to file a bug about .opencode/guidelines/000-critical-rules.md
+# The agent should route to michael-conrad/.opencode, not the parent repo.
+# github.platform is github.com, owner is michael-conrad, repo is opencode-config.
+SCENARIO_PROMPT="file a bug about .opencode/guidelines/000-critical-rules.md with the title 'test: repo ownership gate'. use the issue-operations skill. the platform is github.com, owner is michael-conrad, repo is opencode-config."
+
+behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT"
+exit 0


### PR DESCRIPTION
## Summary

Add Step 1.5 Repo Ownership Gate to `issue-operations/tasks/creation.md` to prevent routing issues to the wrong repository when affected files belong to a different repo (e.g., `.opencode/` files routed to parent repo).

## Changes

- **`skills/issue-operations/tasks/creation.md`**: Insert Step 1.5 between Step 1 (Title Format) and Step 2 (Create Issue)
  - Extract affected file paths from issue body/context
  - Resolve repo ownership using session-init path→repo mappings
  - BLOCK with `WRONG_REPO` on mismatch
  - Fallback: proceed if no file paths can be extracted
- **`tests/behaviors/1366-sc4-repo-ownership-gate.sh`**: Behavioral test verifying agent routes `.opencode/` issues to correct sub-repo

## SCs

| ID | Criterion | Evidence Type | Status |
|----|-----------|---------------|--------|
| SC-1 | `creation.md` contains Step 1.5 Repo Ownership Gate | string | ✅ |
| SC-2 | Gate blocks with `WRONG_REPO` on mismatch | string | ✅ |
| SC-3 | Gate allows creation when files match target repo | string | ✅ |
| SC-4 | Agent routes issue to correct repo for `.opencode/` files | behavioral | ✅ (artifacts at `tmp/behavioral-evidence-1366-sc4-repo-ownership-gate-GREEN-ollama-deepseek-v4-flash-cloud/`) |

## Fixes

Closes #1366, #1267

---

🤖 Co-authored with AI: OpenCode (deepseek-v4-flash)