### PR TITLE
fix(#1376): implementation-pipeline SKILL.md orchestrator entry point, assemble-work task, pipeline-executor fix

### DIFF
--- a/skills/implementation-pipeline/SKILL.md
+++ b/skills/implementation-pipeline/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: implementation-pipeline
-description: "Use when orchestrating multi-item implementation through a serial 14-step pipeline with per-step dispatch routing, Z3-verified step transitions, and YAML contract artifact tracking. Professional engineers route each step through clean-room sub-agents."
+description: "Use when executing an approved plan through the implementation pipeline. MUST dispatch here after plan approval, before any file modification. Professional engineers route each step through clean-room sub-agents."
 type: discipline-enforcing
 license: MIT
 compatibility: opencode
@@ -15,9 +15,9 @@ compatibility: opencode
 
 ## Overview
 
-Pure orchestrator routing table with 17 serial dispatch steps. The orchestrator holds only routing metadata — each step dispatches to an existing skill's task file via `task()`. Step transitions are validated by Z3 via `solve check` against `pipeline-state-machine.yaml`. YAML contract artifacts at `./tmp/{issue-N}/artifacts/pipeline-{step_label}-{STATUS}-{timestamp}.yaml`.
+Orchestrator-facing dispatch router for the implementation pipeline. The orchestrator holds only routing metadata — each step dispatches to an existing skill's task file via `task()`. The orchestrator is a pure router — never reads task file content, never performs inline analysis. Sub-agents do the work.
 
-The orchestrator is a pure router — never reads task file content, never performs inline analysis. Sub-agents do the work.
+**MUST dispatch here after plan approval, before any file modification.** This is the mandatory entry point for all implementation work.
 
 ## Mandatory Task Discipline
 
@@ -31,6 +31,7 @@ The orchestrator is a pure router — never reads task file content, never perfo
 
 | User says / Context | Task | Dispatch | Context passed |
 |---------------------|------|----------|----------------|
+| "execute plan" / "implement spec" / "run pipeline" / "assemble work" | `assemble-work` | `orchestrator` | {issue_number, plan_path, authorization_scope, halt_at, pr_strategy} |
 | "sc-coherence-gate" / "coherence gate" | `sc-coherence-gate` | `sub-task` | {issue_number} |
 | "pre-red-baseline" / "baseline check" | `pre-red-baseline` | `sub-task` | {issue_number} |
 | "red-phase" / "write failing test" | `red-phase` | `sub-task` | {issue_number} |
@@ -96,10 +97,17 @@ Before the pipeline dispatches to `sc-coherence-gate`, the orchestrator MUST run
 `skill({name: "implementation-pipeline"})` — call the skill, then dispatch each step via task():
 
 | Step | Call via task() |
-
+|------|----------------|
+| `assemble-work` (orchestrator entry) | `task(..., prompt: "execute assemble-work from implementation-pipeline")` |
 | Any dispatch step | `task(..., prompt: "execute <step_label> from implementation-pipeline")` |
 
-**Exception:** The `adversarial-audit` step uses orchestrator multi-dispatch (resolve-models → auditor_1 → remediate → auditor_2 → cross-validate), not `sub-task` dispatch. The orchestrator manages the full multi-dispatch sequence inline — see Dispatch Routing Table for the complete sequence.
+**Exception — adversarial-audit sequence:** The adversarial audit is a multi-step sequence, not a single dispatch. Each step is a separate numbered item:
+1. `resolve-models` (inline) — run `.opencode/tools/resolve-models`
+2. `auditor-1 dispatch` (sub-agent) — dispatch audit task with auditor_1
+3. `auditor-1 remediate` (inline) — if non-clean-pass, remediate and restart
+4. `auditor-2 dispatch` (sub-agent) — dispatch audit task with auditor_2
+5. `auditor-2 remediate` (inline) — if non-clean-pass, remediate and restart
+6. `cross-validate` (clean-room) — produce cross-validate findings
 
 Every task context MUST include the authorization context block:
 
@@ -113,9 +121,11 @@ authorization_source: "User approved #N on YYYY-MM-DD"
 
 ## Sub-Agent Routing
 
+**Orchestrator entry point:** `assemble-work` is the mandatory entry point. The orchestrator dispatches here after plan approval via `task(..., prompt: "execute assemble-work from implementation-pipeline")`. `assemble-work` reads the plan, creates branches, dispatches sub-agents, and routes to `pipeline-executor` for the internal step dispatch sequence.
+
 All substantive work runs via `task(subagent_type="general")`. The orchestrator is a pure router — no creative work, no file edits, no inline analysis. Auditor tasks use subagent_type from resolve-models result contract (auditor_1/auditor_2) — NOT `general`. Include `audit_phase` in task context when routing auditors. See adversarial-audit SKILL.md §DISPATCH_GATE. `pre-analysis` receives only `{ issue_number, task_description, github.owner, github.repo }`.
 
-**Exception — adversarial-audit:** The `adversarial-audit` step bypasses the `task()` protocol because it requires orchestrator-managed multi-dispatch (resolve-models → auditor_1 → remediate → auditor_2 → cross-validate). The orchestrator runs the full sequence inline, dispatching each auditor via `task()` with `subagent_type` from resolve-models, remediating between auditors, and collecting artifact paths for cross-validate.
+**Exception — adversarial-audit sequence:** The adversarial audit is a multi-step sequence, not a single dispatch. Each step is a separate numbered item (resolve-models inline, auditor-1 sub-agent, auditor-1 remediate inline, auditor-2 sub-agent, auditor-2 remediate inline, cross-validate clean-room). See Invocation section for the complete sequence.
 
 Exclusions: implementation context, agent memory, cached verification results.
 

--- a/skills/implementation-pipeline/tasks/assemble-work.md
+++ b/skills/implementation-pipeline/tasks/assemble-work.md
@@ -1,0 +1,149 @@
+# Task: assemble-work
+
+<!-- SPDX-FileCopyrightText: 2026 Michael Conrad -->
+<!-- SPDX-License-Identifier: MIT -->
+<!-- Provenance: AI-generated -->
+
+Co-authored with AI: OpenCode (ollama-cloud/deepseek-v4-flash)
+
+## Purpose
+
+Orchestrator entry point for the implementation pipeline. Called after plan approval, before any file modification. Reads the approved plan, creates feature branches and worktrees, dispatches sub-agents for each implementation item, runs verification gates, and routes to `pipeline-executor` for the internal step dispatch sequence.
+
+This is the **mandatory entry point** — the orchestrator MUST dispatch here after plan approval. Skipping this task means skipping pre-flight verification, branch creation, sub-agent dispatch, and verification gates.
+
+## Entry Criteria
+
+- [ ] 1. Approved plan exists at `.issues/{N}/plan.md` or `*/.issues/{N}/plan.md`
+- [ ] 2. Authorization scope covers `for_implementation` or higher (or `for_pr`/`for_pr_only`)
+- [ ] 3. Authorization context available (`authorization_scope`, `halt_at`, `pr_strategy`)
+- [ ] 4. Feature branch does not yet exist for this issue (or exists from pre-work)
+
+## Exit Criteria
+
+- [ ] 1. Feature branches and worktrees created for each implementation item
+- [ ] 2. Sub-agents dispatched for each item and results collected
+- [ ] 3. Post-sub-agent completion checkpoint verified (hash mismatch detection)
+- [ ] 4. Work state claims verified against live state
+- [ ] 5. Feature branches squash-merged into work branch
+- [ ] 6. Verification gates passed (verification-before-completion, finishing-a-development-branch)
+- [ ] 7. Result contract returned with status and artifact path
+
+## Procedure
+
+### Step 1: Read Plan and Work State
+
+- [ ] 1. Read plan from `.issues/{N}/plan.md` or `*/.issues/{N}/plan.md` — extract phases, items, SCs, dependencies. **→ SC-5**
+- [ ] 2. Read work state file from `./tmp/{N}/work.md` — extract current progress, completed items, blocked items.
+- [ ] 3. Verify pre-flight conditions:
+   - Feature branch exists (or create via `git-workflow --task pre-work`)
+   - Working tree is clean (`git status --porcelain` returns empty)
+   - Authorization scope covers the current pipeline phase
+- [ ] 4. Create Step 1.5 entry proof marker — write `./tmp/{N}/artifacts/entry-proof-{timestamp}.yaml` with:
+   ```yaml
+   step: 1.5
+   timestamp: "<ISO8601>"
+   issuer: "<AgentName> (<ModelId>)"
+   plan_path: ".issues/{N}/plan.md"
+   authorization_scope: "<scope>"
+   halt_at: "<halt_at>"
+   pr_strategy: "<strategy>"
+   ```
+   **→ SC-11**
+
+### Step 2: Create Feature Branches and Worktrees
+
+- [ ] 1. For each implementation item in the plan, create a feature branch:
+   - Single-item plan: use the existing feature branch
+   - Multi-item plan: create sub-branches per item
+- [ ] 2. If `WORKTREE_REQUIRED` is set, create worktrees via `using-git-worktrees` skill
+- [ ] 3. Record branch/worktree state in work state file
+
+### Step 3: Dispatch Sub-Agents
+
+- [ ] 1. For each implementation item, dispatch a clean-room sub-agent via `task()`:
+   - Context: `{issue_number, item_description, plan_path, authorization_scope, halt_at, pr_strategy, worktree.path, github.owner, github.repo}`
+   - Prompt: `"execute <item> from implementation-pipeline. Read the plan at <plan_path> first"`
+- [ ] 2. Collect result contracts from each sub-agent:
+   - `status`: DONE | BLOCKED | OVERFLOW
+   - `artifact_path`: path to full evidence on disk
+   - `finding_summary`: 1-3 sentence summary
+   - `blocker_reason`: if BLOCKED
+
+### Step 4: Handle OVERFLOW Results
+
+- [ ] 1. If a sub-agent returns `status: OVERFLOW`:
+   - Record completed items in work state file
+   - Apply split strategy from overflow-signal.md:
+     - Per-item: one sub-agent per remaining item
+     - Per-phase: split at phase boundaries
+     - Chunked: 2-3 equal chunks
+     - Fallback: HALT and report context overflow
+   - Re-dispatch new sub-agent(s) with reduced scope
+   - Continue orchestration with accumulated results
+   **→ SC-12**
+
+### Step 5: Post-Sub-Agent Completion Checkpoint
+
+- [ ] 1. After all sub-agents return, run completion checkpoint:
+   - Verify all result contracts have `status: DONE`
+   - Run hash mismatch detection: compare expected file hashes against actual
+   - If hash mismatch detected: flag for re-dispatch of affected items
+   **→ SC-14**
+
+### Step 6: Work State Verification
+
+- [ ] 1. Verify every claim in work state file against live state:
+   - Sub-agent completed → result contract exists with status DONE
+   - Issue created → issue exists on GitHub with correct title/labels
+   - Sub-issues linked → `github_issue_read(method=get_sub_issues)` returns expected
+   - Branch created → `git rev-parse --verify <branch>` succeeds
+   - Worktree path set → worktree directory is git repository
+   - All phases complete → every phase in work state has status DONE
+   **→ SC-13**
+- [ ] 2. If any claim fails verification: flag as VERIFICATION-GAP, remediate before proceeding
+
+### Step 7: Squash-Merge and Verification Gates
+
+- [ ] 1. Squash-merge feature branches into work branch
+- [ ] 2. Run `verification-before-completion --task verify` — verify all SCs
+- [ ] 3. Run `finishing-a-development-branch --task checklist` — structural checks
+
+### Step 8: Route to pipeline-executor
+
+- [ ] 1. Route to `pipeline-executor` for the internal step dispatch sequence:
+   - Call `skill({name: "implementation-pipeline"})`
+   - Dispatch `pipeline-executor` with accumulated context
+   **→ SC-6**
+
+### Step 9: Return Result Contract
+
+- [ ] 1. Return frugal result contract:
+   ```yaml
+   status: DONE | BLOCKED | OVERFLOW
+   artifact_path: "./tmp/{N}/artifacts/assemble-work-{STATUS}-{timestamp}.yaml"
+   finding_summary: "<1-3 sentence summary>"
+   blocker_reason: "<if BLOCKED>"
+   ```
+
+## Context Required
+
+- `issue_number`
+- `plan_path` — path to `.issues/{N}/plan.md` or `*/.issues/{N}/plan.md`
+- `authorization_scope`
+- `halt_at`
+- `pr_strategy`
+- `worktree.path`
+- `github.owner`
+- `github.repo`
+
+## Related Files
+
+- `implementation-pipeline/tasks/pipeline-executor.md` — internal step dispatch table
+- `implementation-pipeline/enforcement/overflow-signal.md` — OVERFLOW contract and re-routing
+- `implementation-pipeline/enforcement/work-state-verification.md` — verification table and work state format
+- `implementation-pipeline/SKILL.md` — dispatch routing table
+- `git-workflow/tasks/pre-work.md` — feature branch creation
+- `verification-before-completion/tasks/verify.md` — SC verification
+- `finishing-a-development-branch/tasks/checklist.md` — structural checks
+- `completion-core/tasks/completion.md` — exec-summary

--- a/skills/implementation-pipeline/tasks/pipeline-executor.md
+++ b/skills/implementation-pipeline/tasks/pipeline-executor.md
@@ -4,7 +4,9 @@ Co-authored with AI: OpenCode (ollama-cloud/deepseek-v4-flash)
 
 ## Purpose
 
-This is the core dispatch routing table for the 14-step serial implementation pipeline. Each step dispatches to an existing skill's task file via `task()` using clean-room sub-agents. Step transitions are validated by Z3 via `solve check` against `pipeline-state-machine.yaml`.
+Internal step dispatch table for a single implementation item within the pipeline. Each step dispatches to an existing skill's task file via `task()` using clean-room sub-agents. Step transitions are validated by Z3 via `solve check` against `pipeline-state-machine.yaml`.
+
+This is NOT the orchestrator entry point. The orchestrator entry point is `assemble-work` — this task runs after `assemble-work` routes to it for the internal step dispatch sequence.
 
 ## Entry Criteria
 
@@ -34,7 +36,7 @@ A status of `DONE_WITH_CONCERNS` is coerced to FAIL — caveats are defects, not
 - `github.repo`
 - `issue_number`
 
-## 17-Step Dispatch Table
+## Dispatch Table
 
 | Step # | Step Label | Dispatches To | Artifact Produced | YAML Contract Schema |
 |--------|------------|---------------|-------------------|---------------------|

--- a/skills/writing-plans/tasks/create.md
+++ b/skills/writing-plans/tasks/create.md
@@ -102,6 +102,8 @@ Every step MUST use one of three dispatch indicators:
 - **No shared cross-references** — each phase is self-contained. Do not reference steps from other phases.
 - **No zero-indexed numbering** — phases start at 1, steps start at 1.
 - **No line number references** — use stable anchors (function names, section headers).
+- **No multi-dispatch steps** — every step dispatches exactly one sub-agent or executes inline. A step MUST NOT bundle multiple dispatches (e.g., "resolve-models → dispatch auditor_1 → remediate → dispatch auditor_2"). Each dispatch is a separate numbered step with its own dispatch indicator.
+- **No non-standard dispatch indicators** — only `(**sub-agent**)`, `(**clean-room**)`, and `(**inline**)` are valid. `(**orchestrator**)`, `(**orchestrator**)`, or any other indicator is prohibited.
 
 ### Validation Rules
 


### PR DESCRIPTION
## Summary

Fixes implementation-pipeline SKILL.md to provide an orchestrator-facing entry point, creates the missing `assemble-work.md` task file, and fixes `pipeline-executor.md` purpose statement.

## Outcome

- **SKILL.md**: Description and Overview rewritten to be orchestrator-facing (no internal pipeline details). Trigger Dispatch Table now has orchestrator entry point for "execute plan" / "implement spec". Invocation and Sub-Agent Routing sections reference `assemble-work` as the mandatory entry point.
- **`tasks/assemble-work.md`** (new): Orchestrator entry point task that reads the plan, creates branches, dispatches sub-agents, handles OVERFLOW, verifies work state, runs completion checkpoints, and routes to pipeline-executor.
- **`tasks/pipeline-executor.md`**: Purpose section fixed — removed stale "14-step" count, now describes itself as internal step dispatch table (not orchestrator entry point).
- **`writing-plans/tasks/create.md`**: Added prohibited patterns for multi-dispatch steps and non-standard dispatch indicators.

## Fixes

https://github.com/michael-conrad/.opencode/issues/1376

🤖 Co-authored with AI: OpenCode (ollama-cloud/deepseek-v4-flash)