### PR TITLE
fix(#1389): update playwright-cli description to 'Use when' format with mandatory language

### DIFF
--- a/skills/playwright-cli/SKILL.md
+++ b/skills/playwright-cli/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: playwright-cli
-description: Automate browser interactions, test web pages and work with Playwright tests using @playwright/cli from microsoft/playwright-cli.
+description: Use when automating browser interactions, navigating pages, filling forms, capturing snapshots, evaluating JavaScript, mocking network requests, managing storage/cookies/tabs, recording traces or video, running or generating Playwright tests, managing browser sessions, or installing/setting up Playwright. REQUIRED: dispatch via skill() before any browser automation — do not skip this skill.
 allowed-tools: Bash(playwright-cli:*) Bash(npx:*) Bash(npm:*)
 license: Apache-2.0
 provenance: AI-generated

--- a/skills/playwright-cli/SKILL.md
+++ b/skills/playwright-cli/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: playwright-cli
-description: Use when automating browser interactions, navigating pages, filling forms, capturing snapshots, evaluating JavaScript, mocking network requests, managing storage/cookies/tabs, recording traces or video, running or generating Playwright tests, managing browser sessions, or installing/setting up Playwright. REQUIRED: dispatch via skill() before any browser automation — do not skip this skill.
+description: Use when browsing the web, automating browser interactions, navigating pages, filling forms, capturing snapshots, evaluating JavaScript, mocking network requests, managing storage/cookies/tabs, recording traces or video, running or generating Playwright tests, managing browser sessions, or installing/setting up Playwright. REQUIRED: dispatch via skill() before any browser automation — do not skip this skill.
 allowed-tools: Bash(playwright-cli:*) Bash(npx:*) Bash(npm:*)
 license: Apache-2.0
 provenance: AI-generated


### PR DESCRIPTION
## Summary

Fix A from audit #1384: `playwright-cli` was the only skill whose description did not start with "Use when". This PR rewrites the description to comply with D1 (format), D3 (completeness), D4 (mandatory language), and D5 (no narrative-only content).

## Outcome

- Description now starts with "Use when" and explicitly includes "browsing the web" as a use case
- Covers all 14 trigger conditions from the dispatch table
- Includes REQUIRED mandatory language signaling dispatch is not optional
- No narrative-only sentences
- Non-description frontmatter fields (license, provenance, upstream, upstream_license) preserved unchanged

## Fixes

https://github.com/michael-conrad/.opencode/issues/1389

---

🤖 Co-authored with AI: OpenCode (deepseek-v4-flash)