### PR TITLE
feat(#1407): define routing-only SKILL.md template (Phase 1)

### DIFF
--- a/skills/skill-creator/reference/routing-only-template.md
+++ b/skills/skill-creator/reference/routing-only-template.md
@@ -40,13 +40,6 @@ provenance: AI-generated
 
 ## Trigger Dispatch Table
 
-| User says / Context | Task | Dispatch | Context passed |
-|---------------------|------|----------|----------------|
-| "trigger phrase" | `task-name` | `sub-task` | {field1, field2} |
-| "another trigger" | `other-task` | `orchestrator` | {field3} |
-
-### Checkbox List Format (Alternative)
-
 - [ ] **"trigger phrase"** → `task-name` (dispatch-type)
   - Context: `{field1, field2}`
   - Task file: `skill-name/tasks/task-name.md`
@@ -62,10 +55,8 @@ provenance: AI-generated
 
 `skill({name: "skill-name"})` — call the skill, then call via task():
 
-| Task | Call via task() |
-|------|-----------------|
-| `task-name` | `task(..., prompt: "execute task-name task from skill-name")` |
-| `other-task` | `task(..., prompt: "execute other-task task from skill-name")` |
+- [ ] **`task-name`** → `task(..., prompt: "execute task-name task from skill-name")`
+- [ ] **`other-task`** → `task(..., prompt: "execute other-task task from skill-name")`
 
 **CLI equivalent (for human TUI use):** `/skill skill-name --task <task>`
 

--- a/skills/skill-creator/reference/routing-only-template.md
+++ b/skills/skill-creator/reference/routing-only-template.md
@@ -46,6 +46,8 @@ provenance: AI-generated
 - [ ] **"another trigger"** → `other-task` (dispatch-type)
   - Context: `{field3}`
   - Task file: `skill-name/tasks/other-task.md`
+  - [ ] Sub-step that must be performed (e.g., verify pre-condition)
+  - [ ] Another required sub-step (e.g., validate output)
 
 **Sub-item semantics:**
 - **Sub-bullets** (`-`): Parameter metadata — context fields, task file paths, dispatch type. Informational, not actionable.

--- a/skills/skill-creator/reference/routing-only-template.md
+++ b/skills/skill-creator/reference/routing-only-template.md
@@ -1,0 +1,131 @@
+# Routing-Only SKILL.md Template
+
+<!-- SPDX-FileCopyrightText: 2026 Michael Conrad -->
+<!-- SPDX-License-Identifier: MIT -->
+<!-- Provenance: AI-generated -->
+
+Co-authored with AI: OpenCode (deepseek-v4-flash)
+
+## Purpose
+
+This template defines the canonical structure for a routing-only SKILL.md file. A routing-only SKILL.md contains **no procedure text** — no step definitions, no entry/exit criteria, no code snippets, no "Operating Protocol" sections. The orchestrator receives only routing metadata (dispatch table, canonical strings, cross-references). Procedure content lives exclusively in `tasks/*.md` files that only sub-agents read.
+
+## Template
+
+```markdown
+---
+name: skill-name
+description: "Use when ..."
+license: MIT
+provenance: AI-generated
+---
+
+# Skill: skill-name
+
+## Overview
+
+[1-2 sentences explaining what this skill enables. No procedure text.]
+
+## Mandatory Task Discipline
+
+- [ ] 1. Every task and sub-task in this skill is mandatory
+- [ ] 2. Skipping, combining, optimizing out, or performing inline work
+     that should be delegated to a sub-agent produces defective
+     deliverables that must be discarded
+- [ ] 3. Each step must be dispatched to a sub-agent via `task()` unless
+     explicitly marked as inline/orchestrator in this skill
+- [ ] 4. Sub-agents must not dispatch sub-agents
+- [ ] 5. Return only routing-significant data: `status`, `finding_summary`,
+     `artifact_path`, `blocker_reason`. Full evidence goes to disk.
+
+## Trigger Dispatch Table
+
+| User says / Context | Task | Dispatch | Context passed |
+|---------------------|------|----------|----------------|
+| "trigger phrase" | `task-name` | `sub-task` | {field1, field2} |
+| "another trigger" | `other-task` | `orchestrator` | {field3} |
+
+### Checkbox List Format (Alternative)
+
+- [ ] **"trigger phrase"** → `task-name` (dispatch-type)
+  - Context: `{field1, field2}`
+  - Task file: `skill-name/tasks/task-name.md`
+- [ ] **"another trigger"** → `other-task` (dispatch-type)
+  - Context: `{field3}`
+  - Task file: `skill-name/tasks/other-task.md`
+
+**Sub-item semantics:**
+- **Sub-bullets** (`-`): Parameter metadata — context fields, task file paths, dispatch type. Informational, not actionable.
+- **Sub-checkboxes** (`- [ ]`): Discrete sub-steps that must be performed (as task or inline op). Actionable.
+
+## Invocation
+
+`skill({name: "skill-name"})` — call the skill, then call via task():
+
+| Task | Call via task() |
+|------|-----------------|
+| `task-name` | `task(..., prompt: "execute task-name task from skill-name")` |
+| `other-task` | `task(..., prompt: "execute other-task task from skill-name")` |
+
+**CLI equivalent (for human TUI use):** `/skill skill-name --task <task>`
+
+## Sub-Agent Routing
+
+[Routing rules: what context fields to pass, what to exclude, any special dispatch instructions.]
+
+- Standard context: `{worktree.path, github.owner, github.repo, authorization_scope, halt_at, pr_strategy, pipeline_phase}`
+- Exclusions: orchestrator reasoning, expected outcomes, inline file paths, agent memory, cached verification results
+- Auditor tasks use subagent_type from `resolve-models` result contract — NOT `general`
+- `pre-analysis` receives only `{issue_number, task_description, github.owner, github.repo}`
+
+## Cross-References
+
+Skills: [related skills]. Guidelines: [related guidelines].
+
+```yaml+symbolic
+schema_version: "2.0"
+last_updated: "YYYY-MM-DDTHH:MM:SSZ"
+rules:
+  - id: skill-name-001
+    title: "Rule title"
+    conditions:
+      all: ["condition"]
+    actions: [ACTION]
+    source: "skill-name/SKILL.md"
+```
+```
+
+## Placement Rules
+
+| Section | Placement | Required? |
+|---------|-----------|-----------|
+| YAML frontmatter | Top of file | Yes |
+| Overview | After frontmatter | Yes |
+| Mandatory Task Discipline | After Overview | Yes |
+| Trigger Dispatch Table | After Mandatory Task Discipline | Yes |
+| Invocation | After Trigger Dispatch Table | Yes |
+| Sub-Agent Routing | After Invocation | Yes |
+| Cross-References | After Sub-Agent Routing | Yes |
+| Symbolic rules (yaml+symbolic) | End of file | Optional |
+
+## Prohibited Content
+
+The following content MUST NOT appear in a routing-only SKILL.md:
+
+- Numbered step lists (`- [ ] N.` or `N. **Step**`)
+- "Entry Criteria:" / "Exit Criteria:" sections
+- "Procedure:" sections
+- "Operating Protocol:" sections
+- Code blocks with bash/python/YAML (except in the template example itself)
+- "Structuring This Skill" section
+- "Measurement Standard" section
+- "Context Window Hygiene" section
+- "Correctness-First Economics" section
+- "Resources" section with scripts/references/assets descriptions
+- Any content that tells a sub-agent HOW to do something (as opposed to WHAT task to dispatch)
+
+## See Also
+
+- `skill-card-spec.md` — Task card structure (for `tasks/*.md` files)
+- `skill-creator` skill — Validation rules for skill structure
+- `000-critical-rules.md` §critical-rules-034 (orchestrator inline work), §critical-rules-048 (pre-read + inline execution), §critical-rules-dispatch-gate-canonical (canonical dispatch string)

--- a/skills/skill-creator/reference/skill-card-spec.md
+++ b/skills/skill-creator/reference/skill-card-spec.md
@@ -68,3 +68,11 @@ Insert after Purpose, before Operating Protocol:
 | `sub-task` (sub-agent dispatched) | Non-inline | 4 items (includes "do not dispatch sub-agents") |
 | `inline` / `orchestrator` | Inline | 3 items (omits "do not dispatch sub-agents") |
 | SKILL.md (orchestrator-facing) | SKILL.md | 5 items (includes dispatch discipline) |
+
+## Routing-Only SKILL.md Template
+
+For the canonical SKILL.md structure (routing-only, no procedure text), see:
+
+- **`routing-only-template.md`** — The canonical routing-only SKILL.md template
+
+All new skills MUST use the routing-only template. The SKILL.md variant of the Mandatory Task Discipline block (5 items) is included in the template. Task cards (`tasks/*.md`) continue to use the task card variants defined above.

--- a/skills/skill-creator/scripts/init_skill.py
+++ b/skills/skill-creator/scripts/init_skill.py
@@ -51,17 +51,15 @@ provenance: AI-generated
 
 ## Trigger Dispatch Table
 
-| User says / Context | Task | Dispatch | Context passed |
-|---------------------|------|----------|----------------|
-| "[TODO: trigger phrase]" | `[TODO: task-name]` | `sub-task` | {field1, field2} |
+- [ ] **"[TODO: trigger phrase]"** → `[TODO: task-name]` (dispatch-type)
+  - Context: `{field1, field2}`
+  - Task file: `{skill_name}/tasks/[TODO: task-name].md`
 
 ## Invocation
 
 `skill({name: "{skill_name}"})` — call the skill, then call via task():
 
-| Task | Call via task() |
-|------|-----------------|
-| `[TODO: task-name]` | `task(..., prompt: "execute [TODO: task-name] task from {skill_name}")` |
+- [ ] **`[TODO: task-name]`** → `task(..., prompt: "execute [TODO: task-name] task from {skill_name}")`
 
 **CLI equivalent (for human TUI use):** `/skill {skill_name} --task <task>`
 

--- a/skills/skill-creator/scripts/init_skill.py
+++ b/skills/skill-creator/scripts/init_skill.py
@@ -26,7 +26,7 @@ from pathlib import Path
 
 SKILL_TEMPLATE = """---
 name: {skill_name}
-description: [TODO: Complete and informative explanation of what the skill does and when to use it. Include WHEN to use this skill - specific scenarios, file types, or tasks that trigger it.]
+description: "[TODO: Use when ...]"
 license: MIT
 provenance: AI-generated
 ---
@@ -35,106 +35,46 @@ provenance: AI-generated
 
 ## Overview
 
-[TODO: 1-2 sentences explaining what this skill enables]
+[TODO: 1-2 sentences explaining what this skill enables. No procedure text.]
 
-## Structuring This Skill
+## Mandatory Task Discipline
 
-[TODO: Choose the structure that best fits this skill's purpose. Common patterns:
+- [ ] 1. Every task and sub-task in this skill is mandatory
+- [ ] 2. Skipping, combining, optimizing out, or performing inline work
+     that should be delegated to a sub-agent produces defective
+     deliverables that must be discarded
+- [ ] 3. Each step must be dispatched to a sub-agent via `task()` unless
+     explicitly marked as inline/orchestrator in this skill
+- [ ] 4. Sub-agents must not dispatch sub-agents
+- [ ] 5. Return only routing-significant data: `status`, `finding_summary`,
+     `artifact_path`, `blocker_reason`. Full evidence goes to disk.
 
-**1. Workflow-Based** (best for sequential processes)
-- Works well when there are clear step-by-step procedures
-- Example: DOCX skill with "Workflow Decision Tree" → "Reading" → "Creating" → "Editing"
-- Structure: ## Overview → ## Workflow Decision Tree → ## Step 1 → ## Step 2...
+## Trigger Dispatch Table
 
-**2. Task-Based** (best for tool collections)
-- Works well when the skill offers different operations/capabilities
-- Example: PDF skill with "Quick Start" → "Merge PDFs" → "Split PDFs" → "Extract Text"
-- Structure: ## Overview → ## Quick Start → ## Task Category 1 → ## Task Category 2...
+| User says / Context | Task | Dispatch | Context passed |
+|---------------------|------|----------|----------------|
+| "[TODO: trigger phrase]" | `[TODO: task-name]` | `sub-task` | {field1, field2} |
 
-**3. Reference/Guidelines** (best for standards or specifications)
-- Works well for brand guidelines, coding standards, or requirements
-- Example: Brand styling with "Brand Guidelines" → "Colors" → "Typography" → "Features"
-- Structure: ## Overview → ## Guidelines → ## Specifications → ## Usage...
+## Invocation
 
-**4. Capabilities-Based** (best for integrated systems)
-- Works well when the skill provides multiple interrelated features
-- Example: Product Management with "Core Capabilities" → numbered capability list
-- Structure: ## Overview → ## Core Capabilities → ### 1. Feature → ### 2. Feature...
+`skill({name: "{skill_name}"})` — call the skill, then call via task():
 
-Patterns can be mixed and matched as needed. Most skills combine patterns (e.g., start with task-based, add workflow for complex operations).
+| Task | Call via task() |
+|------|-----------------|
+| `[TODO: task-name]` | `task(..., prompt: "execute [TODO: task-name] task from {skill_name}")` |
 
-Delete this entire "Structuring This Skill" section when done - it's just guidance.]
+**CLI equivalent (for human TUI use):** `/skill {skill_name} --task <task>`
 
-## [TODO: Replace with the first main section based on chosen structure]
+## Sub-Agent Routing
 
-[TODO: Add content here. See examples in existing skills:
-- Code samples for technical skills
-- Decision trees for complex workflows
-- Concrete examples with realistic user requests
-- References to scripts/templates/references as needed]
+- Standard context: `{{worktree.path, github.owner, github.repo, authorization_scope, halt_at, pr_strategy, pipeline_phase}}`
+- Exclusions: orchestrator reasoning, expected outcomes, inline file paths, agent memory, cached verification results
+- Auditor tasks use subagent_type from `resolve-models` result contract — NOT `general`
+- `pre-analysis` receives only `{{issue_number, task_description, github.owner, github.repo}}`
 
-## Measurement Standard
+## Cross-References
 
-Word count is the universal unit for skill size measurement. Use `wc -w` as the canonical measurement method.
-
-- **Why words, not tokens:** Token counts vary by tokenizer, model, and encoding. Word counts are stable, reproducible, and model-agnostic.
-- **Why words, not lines:** Line length varies by formatting conventions. Words measure semantic density.
-- **Measurement command:** `wc -w <file>`
-- **Size targets:** getting-started <150 words, frequently-loaded <200 words, other skills <500 words.
-
-## Context Window Hygiene
-
-Strongly encourage sub-agents and sub-tasks for skill operations that risk consuming significant context.
-
-- **Sub-task isolation:** Dispatch analysis, audits, or multi-step workflows to sub-tasks. Main session receives minimal result, not intermediate reasoning.
-- **When to use sub-tasks:** Any skill task producing output, any multi-file analysis, any workflow with 3+ sequential operations. Sub-agent-first dispatch is mandatory — all task dispatches go through sub-agents, no inline exceptions.
-
-## Correctness-First Economics
-
-GPU/CPU billing is flat-rate per inference, not per word. Correctness > conciseness.
-
-- **No per-token cost pressure:** Writing more words does not cost more. Writing wrong words costs human time to fix.
-- **Redundancy for enforcement:** Repetition of critical rules across sections is enforcement insurance.
-- **Anti-pattern:** Cutting a rule to "save tokens" when the rule exists because agents violated it.
-
-## Resources
-
-This skill includes example resource directories that demonstrate how to organize different types of bundled resources:
-
-### scripts/
-Executable code (Python/Bash/etc.) that can be run directly to perform specific operations.
-
-**Examples from other skills:**
-- PDF skill: `fill_fillable_fields.py`, `extract_form_field_info.py` - utilities for PDF manipulation
-- DOCX skill: `document.py`, `utilities.py` - Python modules for document processing
-
-**Appropriate for:** Python scripts, shell scripts, or any executable code that performs automation, data processing, or specific operations.
-
-**Note:** Scripts may be executed without loading into context, but can still be read by <AgentName> for patching or environment adjustments.
-
-### references/
-Documentation and reference material intended to be loaded into context to inform <AgentName>'s process and thinking.
-
-**Examples from other skills:**
-- Product management: `communication.md`, `context_building.md` - detailed workflow guides
-- BigQuery: API reference documentation and query examples
-- Finance: Schema documentation, company policies
-
-**Appropriate for:** In-depth documentation, API references, database schemas, comprehensive guides, or any detailed information that <AgentName> should reference while working.
-
-### assets/
-Files not intended to be loaded into context, but rather used within the output <AgentName> produces.
-
-**Examples from other skills:**
-- Brand styling: PowerPoint template files (.pptx), logo files
-- Frontend builder: HTML/React boilerplate project directories
-- Typography: Font files (.ttf, .woff2)
-
-**Appropriate for:** Templates, boilerplate code, document templates, images, icons, fonts, or any files meant to be copied or used in the final output.
-
----
-
-**Any unneeded directories can be deleted.** Not every skill requires all three types of resources.
+Skills: [TODO: related skills]. Guidelines: [TODO: related guidelines].
 """
 
 EXAMPLE_SCRIPT = '''#!/usr/bin/env python3


### PR DESCRIPTION
## Summary

Phase 1 of #1407: Define the canonical routing-only SKILL.md template. A routing-only SKILL.md contains no procedure text — only routing metadata (dispatch table, canonical strings, cross-references). Procedure content lives exclusively in `tasks/*.md` files.

## Outcome

- **New file**: `skills/skill-creator/reference/routing-only-template.md` — canonical routing-only SKILL.md template with frontmatter, Overview, Mandatory Task Discipline, Trigger Dispatch Table, Invocation, Sub-Agent Routing, Cross-References, and prohibited content rules
- **Updated**: `skills/skill-creator/scripts/init_skill.py` — `SKILL_TEMPLATE` replaced with routing-only structure (no "Structuring This Skill", "Measurement Standard", "Context Window Hygiene", "Correctness-First Economics", or "Resources" sections)
- **Updated**: `skills/skill-creator/reference/skill-card-spec.md` — added cross-reference to `routing-only-template.md` with guidance on when to use each

## Fixes

https://github.com/michael-conrad/.opencode/issues/1407 (Phase 1)

---

🤖 OpenCode (deepseek-v4-flash) ✅ completed