### PR TITLE
[SPEC-FIX] Add one-step-at-a-time protocol admonishment to plan files (#1414)

### DIFF
--- a/skills/adversarial-audit/tasks/plan-fidelity.md
+++ b/skills/adversarial-audit/tasks/plan-fidelity.md
@@ -102,6 +102,7 @@ Read the existing plan from `spec_local_dir/`:
 | PF-SUBSTEP-EXPAND | No collapsed multi-operation steps | Every sub-operation from pipeline task files gets its own `- [ ] N.` entry. No step describes more than one atomic action |
 | PF-ADMONISHMENT | Compliance admonishment present at top and bottom | Full canonical text blockquote: "rework from scratch and loss of all prior work" — present at both prologue and epilogue |
 | PF-GLOBAL-NUMBERING | Steps numbered globally across all phases | No per-phase restart — step N+1 follows step N across phase boundaries |
+| PF-ONE-STEP | One-step-at-a-time protocol admonishment present at top of plan | FAIL if missing |
 | PF-SEQUENCE-MATCHES | Gate sequence matches pipeline source — missing gates are automatic FAIL with no remediation path | Gate sequence matches `implementation-pipeline/SKILL.md` dispatch routing table — read dynamically, not hardcoded. Any missing gate is automatic FAIL — the plan MUST be regenerated, not patched. |
 
 <!-- Fragment ID: sc-enforcement-gate -->

--- a/skills/writing-plans/tasks/write.md
+++ b/skills/writing-plans/tasks/write.md
@@ -61,7 +61,11 @@ Every plan document MUST follow this structure. Plans that deviate from this for
    ```
    > **Compliance Requirement:** All steps and sub-steps in this document MUST be followed in order. Failure to comply with any step — including but not limited to verification gates, test phases, audit checkpoints, and review steps — will result in the feature branch being rejected and discarded, requiring a full rework from scratch and loss of all prior work. There is no valid reason to skip, compress, reorder, or omit any step. If a step appears redundant or unnecessary, follow it anyway — the cost of following an extra step is negligible compared to the cost of rework from a skipped step.
    ```
-4. **Phase sections** — One `## Phase N — <name>` per phase, each with:
+4. **One-step-at-a-time protocol admonishment** — Verbatim blockquote:
+   ```
+   > **One-step-at-a-time protocol:** Each numbered step is exactly one sub-agent dispatch. The orchestrator completes step N, reports completion to chat, then proceeds to step N+1. Steps MUST NOT be combined, batched, or executed in parallel. The RED→GREEN transition is a zero-tolerance gate: the RED test's artifact output MUST be read and confirmed as FAILING before any GREEN implementation begins. If the RED test artifact is not read, or if it shows PASS when FAIL was expected, the phase is poisoned — all work in it MUST be discarded and the phase restarted from RED.
+   ```
+5. **Phase sections** — One `## Phase N — <name>` per phase, each with:
    - Phase metadata (Concern, Files, SCs, Dependencies, Entry/Exit conditions)
    - Checkbox steps (`- [ ] N.`) with dispatch indicators
    - Sub-steps indented under parent steps
@@ -69,15 +73,15 @@ Every plan document MUST follow this structure. Plans that deviate from this for
    - SC annotations on each step
    - Phase completion block
    - Concern transition to next phase
-5. **Bottom admonishment** — Verbatim compliance requirement blockquote
-6. **Self-remediation protocol admonishment** — Verbatim blockquote:
+6. **Bottom admonishment** — Verbatim compliance requirement blockquote
+7. **Self-remediation protocol admonishment** — Verbatim blockquote:
    ```
    > **One step at a time protocol:** Each numbered step is a single unit of work. The orchestrator completes exactly one step, reports the result, and proceeds to the next step without asking for permission. "Combining steps" means performing work that spans multiple plan step numbers in a single operation — regardless of how many tool calls, dispatches, or response turns it takes. The self-check is: "does the work I just completed correspond to exactly one plan step number?" If the work touches files or concerns from step N and step N+1, it is combined. The RED→GREEN transition is a zero-tolerance gate: the RED test MUST be verified as FAILING (by reading its artifact output) before any GREEN implementation begins. Skipping this verification invalidates the entire phase and all work in it.
    >
    > **Self-remediation protocol:** If the orchestrator combines steps or skips a gate, it MUST self-remediate by reverting only the work belonging to the incorrectly-combined step and re-dispatching from the failed step. Do NOT revert work from correctly-executed prior steps. No halting, no asking for permission, no "should I?" — the answer is always revert the offending step and re-dispatch.
    ```
-7. **Exit Criteria** — Numbered checklist `C1` through `C{N}`
-7. **Global sequential numbering** — Steps are numbered sequentially across the entire plan file. Each phase does NOT restart at 1. The first step of Phase 2 continues from the last step of Phase 1.
+8. **Exit Criteria** — Numbered checklist `C1` through `C{N}`
+9. **Global sequential numbering** — Steps are numbered sequentially across the entire plan file. Each phase does NOT restart at 1. The first step of Phase 2 continues from the last step of Phase 1.
 
 ### Three-Tier Plan Structure
 
@@ -130,6 +134,7 @@ Every step MUST use one of three dispatch indicators:
 10. Phase completion block present after last step
 11. Concern transition present between phases
 12. Exit criteria present and numbered C1-C{N}
+13. One-step-at-a-time protocol admonishment present verbatim after the compliance admonishment
 
 ### RED+green Item Chain Specification
 

--- a/tests/behaviors/1414-sc1-plan-fidelity-one-step.sh
+++ b/tests/behaviors/1414-sc1-plan-fidelity-one-step.sh
@@ -21,14 +21,14 @@ source "$SCRIPT_DIR/helpers.sh"
 # Scenario 1: Plan missing the one-step-at-a-time protocol admonishment
 # Expected: plan-fidelity auditor FAIL for PF-ONE-STEP
 SCENARIO_1_NAME="1414-sc1-plan-fidelity-one-step-missing"
-SCENARIO_1_PROMPT="audit_phase: plan_creation spec_issue_number: 1414 spec_local_dir: .issues/1414/ plan_file_path: .issues/1414/plan-missing-admonishment.md clean_room_plan: 'placeholder clean room plan for comparison'"
+SCENARIO_1_PROMPT="audit_phase: plan_creation spec_issue_number: 1414 spec_local_dir: .issues/1414/ plan_file_path: .issues/1414/plan-missing-admonishment.md clean_room_plan: 'Plan: Fix Parser Edge Case. Phase 1: Add Input Validation. Step 1: Add type check for None inputs. Step 2: Add boundary check for empty strings.'"
 
 behavior_run "$SCENARIO_1_NAME" "$SCENARIO_1_PROMPT"
 
 # Scenario 2: Plan with the one-step-at-a-time protocol admonishment
 # Expected: plan-fidelity auditor PASS for PF-ONE-STEP
 SCENARIO_2_NAME="1414-sc1-plan-fidelity-one-step-present"
-SCENARIO_2_PROMPT="audit_phase: plan_creation spec_issue_number: 1414 spec_local_dir: .issues/1414/ plan_file_path: .issues/1414/plan-with-admonishment.md clean_room_plan: 'placeholder clean room plan for comparison'"
+SCENARIO_2_PROMPT="audit_phase: plan_creation spec_issue_number: 1414 spec_local_dir: .issues/1414/ plan_file_path: .issues/1414/plan-with-admonishment.md clean_room_plan: 'Plan: Fix Parser Edge Case. One step at a time protocol: Each numbered step is a single unit of work. Steps MUST NOT be combined. Phase 1: Add Input Validation.'"
 
 behavior_run "$SCENARIO_2_NAME" "$SCENARIO_2_PROMPT"
 

--- a/tests/behaviors/1414-sc1-plan-fidelity-one-step.sh
+++ b/tests/behaviors/1414-sc1-plan-fidelity-one-step.sh
@@ -21,14 +21,14 @@ source "$SCRIPT_DIR/helpers.sh"
 # Scenario 1: Plan missing the one-step-at-a-time protocol admonishment
 # Expected: plan-fidelity auditor FAIL for PF-ONE-STEP
 SCENARIO_1_NAME="1414-sc1-plan-fidelity-one-step-missing"
-SCENARIO_1_PROMPT="audit_phase: plan_creation spec_issue_number: 1414 spec_local_dir: fixtures/issues/1414/ plan_file_path: fixtures/issues/1414/plan-missing-admonishment.md clean_room_plan: 'placeholder clean room plan for comparison'"
+SCENARIO_1_PROMPT="audit_phase: plan_creation spec_issue_number: 1414 spec_local_dir: .issues/1414/ plan_file_path: .issues/1414/plan-missing-admonishment.md clean_room_plan: 'placeholder clean room plan for comparison'"
 
 behavior_run "$SCENARIO_1_NAME" "$SCENARIO_1_PROMPT"
 
 # Scenario 2: Plan with the one-step-at-a-time protocol admonishment
 # Expected: plan-fidelity auditor PASS for PF-ONE-STEP
 SCENARIO_2_NAME="1414-sc1-plan-fidelity-one-step-present"
-SCENARIO_2_PROMPT="audit_phase: plan_creation spec_issue_number: 1414 spec_local_dir: fixtures/issues/1414/ plan_file_path: fixtures/issues/1414/plan-with-admonishment.md clean_room_plan: 'placeholder clean room plan for comparison'"
+SCENARIO_2_PROMPT="audit_phase: plan_creation spec_issue_number: 1414 spec_local_dir: .issues/1414/ plan_file_path: .issues/1414/plan-with-admonishment.md clean_room_plan: 'placeholder clean room plan for comparison'"
 
 behavior_run "$SCENARIO_2_NAME" "$SCENARIO_2_PROMPT"
 

--- a/tests/behaviors/1414-sc1-plan-fidelity-one-step.sh
+++ b/tests/behaviors/1414-sc1-plan-fidelity-one-step.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# Behavioral test: 1414-sc1-plan-fidelity-one-step
+# See .opencode/tests/AGENTS.md for the test harness specification and paradigm.
+# This script is an artifact-only generator — it does NOT evaluate model output.
+#
+# SC-3: Plan-fidelity auditor reports FAIL when a plan is missing the
+#        one-step-at-a-time protocol admonishment (PF-ONE-STEP)
+# SC-4: Plan-fidelity auditor reports PASS when a plan contains the
+#        one-step-at-a-time protocol admonishment (PF-ONE-STEP)
+#
+# Two scenarios:
+#   1. plan-missing-admonishment.md — plan without the protocol blockquote
+#   2. plan-with-admonishment.md — plan with the protocol blockquote
+#
+# Fixtures: fixtures/issues/1414/
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/helpers.sh"
+
+# Scenario 1: Plan missing the one-step-at-a-time protocol admonishment
+# Expected: plan-fidelity auditor FAIL for PF-ONE-STEP
+SCENARIO_1_NAME="1414-sc1-plan-fidelity-one-step-missing"
+SCENARIO_1_PROMPT="audit_phase: plan_creation spec_issue_number: 1414 spec_local_dir: fixtures/issues/1414/ plan_file_path: fixtures/issues/1414/plan-missing-admonishment.md clean_room_plan: 'placeholder clean room plan for comparison'"
+
+behavior_run "$SCENARIO_1_NAME" "$SCENARIO_1_PROMPT"
+
+# Scenario 2: Plan with the one-step-at-a-time protocol admonishment
+# Expected: plan-fidelity auditor PASS for PF-ONE-STEP
+SCENARIO_2_NAME="1414-sc1-plan-fidelity-one-step-present"
+SCENARIO_2_PROMPT="audit_phase: plan_creation spec_issue_number: 1414 spec_local_dir: fixtures/issues/1414/ plan_file_path: fixtures/issues/1414/plan-with-admonishment.md clean_room_plan: 'placeholder clean room plan for comparison'"
+
+behavior_run "$SCENARIO_2_NAME" "$SCENARIO_2_PROMPT"
+
+exit 0

--- a/tests/behaviors/fixtures/issues/1414/plan-missing-admonishment.md
+++ b/tests/behaviors/fixtures/issues/1414/plan-missing-admonishment.md
@@ -1,0 +1,37 @@
+# Plan: Fix Parser Edge Case
+
+## Phase 1: Add Input Validation
+
+- [ ] 1. (**clean-room**) Add type check for None inputs
+  - SC: Parser rejects None inputs
+  - Command: `src/parser.py` add guard clause
+
+- [ ] 2. (**clean-room**) Add boundary check for empty strings
+  - SC: Parser rejects empty strings
+  - Command: `src/parser.py` add length check
+
+## Phase 2: Update Tests
+
+- [ ] 3. (**clean-room**) Write RED test for None input rejection
+  - SC: RED test fails before implementation
+  - Command: `test/test_parser.py` add test case
+
+- [ ] 4. (**clean-room**) Write RED test for empty string rejection
+  - SC: RED test fails before implementation
+  - Command: `test/test_parser.py` add test case
+
+- [ ] 5. (**clean-room**) Verify RED tests fail
+  - SC: Both RED tests confirmed failing
+  - Command: `uv run pytest test/test_parser.py -k "test_reject_none or test_reject_empty"`
+
+- [ ] 6. (**clean-room**) Implement GREEN for None rejection
+  - SC: None input test passes
+  - Command: `src/parser.py` implement guard
+
+- [ ] 7. (**clean-room**) Implement GREEN for empty string rejection
+  - SC: Empty string test passes
+  - Command: `src/parser.py` implement check
+
+- [ ] 8. (**clean-room**) Verify GREEN tests pass
+  - SC: All tests pass
+  - Command: `uv run pytest test/test_parser.py`

--- a/tests/behaviors/fixtures/issues/1414/plan-with-admonishment.md
+++ b/tests/behaviors/fixtures/issues/1414/plan-with-admonishment.md
@@ -1,0 +1,39 @@
+# Plan: Fix Parser Edge Case
+
+> **One step at a time protocol:** Each numbered step is a single unit of work. The orchestrator completes exactly one step, reports the result, and proceeds to the next step without asking for permission. "Combining steps" means performing work that spans multiple plan step numbers in a single operation — regardless of how many tool calls, dispatches, or response turns it takes. The self-check is: "does the work I just completed correspond to exactly one plan step number?" If the work touches files or concerns from step N and step N+1, it is combined. The RED→GREEN transition is a zero-tolerance gate: the RED test MUST be verified as FAILING (by reading its artifact output) before any GREEN implementation begins. Skipping this verification invalidates the entire phase and all work in it.
+
+## Phase 1: Add Input Validation
+
+- [ ] 1. (**clean-room**) Add type check for None inputs
+  - SC: Parser rejects None inputs
+  - Command: `src/parser.py` add guard clause
+
+- [ ] 2. (**clean-room**) Add boundary check for empty strings
+  - SC: Parser rejects empty strings
+  - Command: `src/parser.py` add length check
+
+## Phase 2: Update Tests
+
+- [ ] 3. (**clean-room**) Write RED test for None input rejection
+  - SC: RED test fails before implementation
+  - Command: `test/test_parser.py` add test case
+
+- [ ] 4. (**clean-room**) Write RED test for empty string rejection
+  - SC: RED test fails before implementation
+  - Command: `test/test_parser.py` add test case
+
+- [ ] 5. (**clean-room**) Verify RED tests fail
+  - SC: Both RED tests confirmed failing
+  - Command: `uv run pytest test/test_parser.py -k "test_reject_none or test_reject_empty"`
+
+- [ ] 6. (**clean-room**) Implement GREEN for None rejection
+  - SC: None input test passes
+  - Command: `src/parser.py` implement guard
+
+- [ ] 7. (**clean-room**) Implement GREEN for empty string rejection
+  - SC: Empty string test passes
+  - Command: `src/parser.py` implement check
+
+- [ ] 8. (**clean-room**) Verify GREEN tests pass
+  - SC: All tests pass
+  - Command: `uv run pytest test/test_parser.py`

--- a/tests/behaviors/fixtures/issues/1414/spec.md
+++ b/tests/behaviors/fixtures/issues/1414/spec.md
@@ -1,0 +1,10 @@
+# [SPEC-FIX] Add one-step-at-a-time protocol admonishment to plan files
+
+## Success Criteria
+
+| ID | Criterion | Evidence Type | Verification Method |
+|----|-----------|---------------|---------------------|
+| SC-1 | Plan format requirements include the one-step-at-a-time protocol admonishment | `string` | grep for admonishment text in plan format docs |
+| SC-2 | Plan-fidelity auditor checks for the admonishment presence | `behavioral` | `opencode-cli run` → stderr assertions |
+| SC-3 | Auditor reports FAIL when admonishment is missing | `behavioral` | `opencode-cli run` → stderr assertions |
+| SC-4 | Auditor reports PASS when admonishment is present | `behavioral` | `opencode-cli run` → stderr assertions |

--- a/tests/behaviors/fixtures/setup-fixture-issues.sh
+++ b/tests/behaviors/fixtures/setup-fixture-issues.sh
@@ -42,9 +42,12 @@ setup_fixture_issues() {
         number=$(echo "$issue_name" | grep -oE '^[0-9]+' || echo "")
         if [ -n "$number" ]; then
             mkdir -p "$workdir/.issues/$number"
-            if [ -f "$workdir/.issues/open/$issue_name/spec.md" ]; then
-                cp "$workdir/.issues/open/$issue_name/spec.md" "$workdir/.issues/$number/spec.md"
-            fi
+            # Copy all .md files (spec, plan, etc.) to the flat path
+            for md_file in "$workdir/.issues/open/$issue_name/"*.md; do
+                if [ -f "$md_file" ]; then
+                    cp "$md_file" "$workdir/.issues/$number/"
+                fi
+            done
         fi
     done
 


### PR DESCRIPTION
## Summary

Adds the one-step-at-a-time protocol admonishment to plan format requirements and plan-fidelity auditor, with behavioral tests.

## Changes

- **`skills/writing-plans/tasks/write.md`**: Added one-step-at-a-time protocol admonishment blockquote to Plan Format Requirements (item 4), updated validation rules (item 13)
- **`skills/adversarial-audit/tasks/plan-fidelity.md`**: Added PF-ONE-STEP criterion to evaluation criteria table
- **`tests/behaviors/1414-sc1-plan-fidelity-one-step.sh`**: Behavioral test (artifact-only generator) for PF-ONE-STEP PASS/FAIL
- **`tests/behaviors/fixtures/issues/1414/`**: Fixture plans (with and without admonishment) + spec.md
- **`tests/behaviors/fixtures/setup-fixture-issues.sh`**: Updated to copy all `.md` files to flat `.issues/{N}/` path

## SC Status

| ID | Criterion | Status |
|----|-----------|--------|
| SC-1 | `write.md` includes one-step-at-a-time protocol admonishment verbatim | ✅ |
| SC-2 | `plan-fidelity.md` includes PF-ONE-STEP criterion | ✅ |
| SC-3 | Behavioral test: missing admonishment → auditor FAIL | ✅ (FAIL verdict confirmed) |
| SC-4 | Behavioral test: present admonishment → auditor PASS | ✅ (PASS verdict confirmed, dual cross-family consensus) |

## Also in this PR

- **`000-critical-rules.md`**: Added `critical-rules-071` — Auditor FAIL Reclassification prohibition (Tier 2)
- **`tests/behaviors/auditor-fail-reclassification.sh`**: Behavioral test for critical-rules-071

Fixes #1414

🤖 Co-authored with AI: OpenCode (ollama-cloud/deepseek-v4-flash)