### PR TITLE
Fix plan writer protocol admonishment wording and add dispatch indicator validation

### DIFF
--- a/skills/writing-plans/tasks/validate.md
+++ b/skills/writing-plans/tasks/validate.md
@@ -91,6 +91,11 @@ Check an existing plan for placeholders and completeness.
   - SC: SC-6
   - Expected: both protocol admonishments present
 
+- [ ] 18. (**inline**) Dispatch indicator validation — Verify each step's dispatch indicator matches its content. `(**inline**)` steps must not contain sub-agent dispatch language; `(**sub-agent**)` steps must dispatch a sub-agent via `task()`
+  - Command: parse plan body, extract dispatch indicators, verify semantic match against step content
+  - SC: SC-5
+  - Expected: all dispatch indicators match step content; FAIL on mismatch
+
 ## Result Contract Schema
 
 Before returning, load the output contract from `contracts/validate-output-template.yaml` and validate the result against it. The contract defines the expected output structure:

--- a/skills/writing-plans/tasks/write.md
+++ b/skills/writing-plans/tasks/write.md
@@ -63,7 +63,7 @@ Every plan document MUST follow this structure. Plans that deviate from this for
    ```
 4. **One-step-at-a-time protocol admonishment** — Verbatim blockquote:
    ```
-   > **One-step-at-a-time protocol:** Each numbered step is exactly one sub-agent dispatch. The orchestrator completes step N, reports completion to chat, then proceeds to step N+1. Steps MUST NOT be combined, batched, or executed in parallel. The RED→GREEN transition is a zero-tolerance gate: the RED test's artifact output MUST be read and confirmed as FAILING before any GREEN implementation begins. If the RED test artifact is not read, or if it shows PASS when FAIL was expected, the phase is poisoned — all work in it MUST be discarded and the phase restarted from RED.
+    > **One-step-at-a-time protocol:** Each numbered step is a single unit of work. The orchestrator completes step N, reports completion to chat, then proceeds to step N+1. Steps MUST NOT be combined, batched, or executed in parallel.
    ```
 5. **Phase sections** — One `## Phase N — <name>` per phase, each with:
    - Phase metadata (Concern, Files, SCs, Dependencies, Entry/Exit conditions)
@@ -135,6 +135,7 @@ Every step MUST use one of three dispatch indicators:
 11. Concern transition present between phases
 12. Exit criteria present and numbered C1-C{N}
 13. One-step-at-a-time protocol admonishment present verbatim after the compliance admonishment
+14. Dispatch indicators match step content — `(**inline**)` steps must not contain sub-agent dispatch language; `(**sub-agent**)` steps must dispatch a sub-agent via `task()`
 
 ### RED+green Item Chain Specification
 


### PR DESCRIPTION
## Summary

Fixes 3 defects in the plan writer protocol admonishment in `writing-plans/tasks/write.md` and `writing-plans/tasks/validate.md`:

1. **Wording fix**: Top one-step-at-a-time protocol admonishment now says "a single unit of work" instead of "exactly one sub-agent dispatch"
2. **Remove RED→GREEN redundancy**: RED→GREEN-specific poisoning language removed from top admonishment (bottom self-remediation protocol retains its condensed reference)
3. **Dispatch indicator validation**: New validation rule 14 in write.md and check 18 in validate.md verify that `(**inline**)` steps don't contain sub-agent dispatch language and `(**sub-agent**)` steps dispatch via `task()`

## Changes

| File | Change |
|------|--------|
| `writing-plans/tasks/write.md` | Fix top admonishment wording (line 66), remove RED→GREEN language, add validation rule 14 |
| `writing-plans/tasks/validate.md` | Add dispatch indicator validation check 18 |

## Verification

- SC-1: Top admonishment says "a single unit of work" ✅
- SC-2: No "RED→GREEN" in top admonishment ✅
- SC-3: Bottom admonishment unchanged from spec verbatim text ✅
- SC-4: Validation rule 14 present in write.md ✅
- SC-5: Check 18 present in validate.md ✅

Fixes https://github.com/michael-conrad/.opencode/issues/1425

🤖 Co-authored with AI: OpenCode (ollama-cloud/deepseek-v4-flash)