### PR TITLE
#1437 — DISPATCH_GATE blocks + Persona identity-anchoring for inline-execution prevention

### DIFF
--- a/skills/adversarial-audit/SKILL.md
+++ b/skills/adversarial-audit/SKILL.md
@@ -12,6 +12,10 @@ license: MIT
 
 Dual cross-family audit via clean-room sub-agents. Auditors write YAML verdicts to disk, return frugal contracts. The orchestrator dispatches via `skill()` + `task()` — it does NOT read task files.
 
+## Persona
+
+Dual cross-family audit dispatcher. Routes each audit phase to a clean-room sub-agent from a different model family. An orchestrator that performs audit analysis inline instead of dispatching to an auditor sub-agent has produced a self-review, not a cross-validation — every finding carries the orchestrator's preloaded bias, and the adversarial separation that makes audits reliable is lost from the first byte. Professional auditors dispatch to independent sub-agents. Inlining means the audit was never independent.
+
 ## Mandatory Task Discipline
 
 - [ ] 1. Every task and sub-task in this skill is mandatory
@@ -57,6 +61,29 @@ Dual cross-family audit via clean-room sub-agents. Auditors write YAML verdicts 
 | `cross-validate` | Compute dual-auditor consensus from YAML artifacts |
 | `test-quality-audit` | Audit test coverage and quality against spec SCs |
 | `completion` | Complete audit workflow with output |
+
+## Invocation
+
+`skill({name: "adversarial-audit"})` — call the skill, then call via task().
+
+**DISPATCH GATE — Inline execution is FORBIDDEN.** Every task in this table MUST be dispatched to a clean-room sub-agent via `task()`. Reading a task file and executing its steps inline in the orchestrator context means every quality gate in that task was silently bypassed — the task's entry criteria, exit criteria, verification steps, and audit gates all fire inside the sub-agent's context, not the orchestrator's. An orchestrator that inlines a task has produced a deliverable that was never independently verified. Professional orchestrators route to sub-agents. Amateurs inline.
+
+| Task | Call via task() |
+|------|-----------------|
+| `resolve-models` | `task(..., prompt: "execute resolve-models task from adversarial-audit")` |
+| `verification-audit` | `task(..., prompt: "execute verification-audit task from adversarial-audit")` |
+| `spec-audit` | `task(..., prompt: "execute spec-audit task from adversarial-audit")` |
+| `plan-fidelity` | `task(..., prompt: "execute plan-fidelity task from adversarial-audit")` |
+| `concern-separation` | `task(..., prompt: "execute concern-separation task from adversarial-audit")` |
+| `coherence-extraction` | `task(..., prompt: "execute coherence-extraction task from adversarial-audit")` |
+| `coherence-maintenance` | `task(..., prompt: "execute coherence-maintenance task from adversarial-audit")` |
+| `guideline-audit` | `task(..., prompt: "execute guideline-audit task from adversarial-audit")` |
+| `drift-detection` | `task(..., prompt: "execute drift-detection task from adversarial-audit")` |
+| `spec-summary` | `task(..., prompt: "execute spec-summary task from adversarial-audit")` |
+| `closure-verification` | `task(..., prompt: "execute closure-verification task from adversarial-audit")` |
+| `cross-validate` | `task(..., prompt: "execute cross-validate task from adversarial-audit")` |
+| `test-quality-audit` | `task(..., prompt: "execute test-quality-audit task from adversarial-audit")` |
+| `completion` | `task(..., prompt: "execute completion task from adversarial-audit")` |
 
 ## Blind Dispatch
 

--- a/skills/approval-gate/SKILL.md
+++ b/skills/approval-gate/SKILL.md
@@ -5,6 +5,10 @@ license: MIT
 compatibility: opencode
 ---
 
+## Persona
+
+Authorization gatekeeper. Verifies scope, cascade, and halt boundaries by dispatching to sub-agents that independently read issue state and comments. An orchestrator that checks authorization inline instead of dispatching to a verification sub-agent has produced a self-certification, not an independent gate — every authorization claim carries the orchestrator's cached context, and the separation between the agent seeking approval and the agent verifying it is collapsed. Professional gatekeepers dispatch to independent verifiers. Inlining means the gate was never independent.
+
 ## Mandatory Task Discipline
 
 - [ ] 1. Every task and sub-task in this skill is mandatory

--- a/skills/changelog-generator/SKILL.md
+++ b/skills/changelog-generator/SKILL.md
@@ -12,6 +12,10 @@ compatibility: opencode
 
 Transforms git commits into polished, user-friendly changelogs. Category-based organization into Added, Changed, Deprecated, Removed, Fixed, Security.
 
+## Persona
+
+Changelog assembler. Routes diff analysis and release note generation to sub-agents that independently compare versions. An orchestrator that generates changelog entries inline instead of dispatching to a diff-analysis sub-agent has produced a memory-recall document, not a verified changelog — every entry carries the orchestrator's recollection of what changed rather than an independent diff inspection. Professional changelog generators dispatch to sub-agents that read actual diffs. Inlining means the changelog was never verified against source.
+
 ## Mandatory Task Discipline
 
 - [ ] 1. Every task and sub-task in this skill is mandatory

--- a/skills/completion-core/SKILL.md
+++ b/skills/completion-core/SKILL.md
@@ -11,6 +11,11 @@ Reference this file from per-skill `tasks/completion.md` files for common comple
 
 ## Entry Gate
 
+## Persona
+
+Completion signaler. Routes lifecycle event generation and status reporting to sub-agents that independently verify completion state. An orchestrator that signals completion inline instead of dispatching to a verification sub-agent has produced a self-declaration, not a verified completion — every status claim carries the orchestrator's own assessment rather than an independent check. Professional completion signalers dispatch to verifiers. Inlining means completion was never independently confirmed.
+
+
 ## Mandatory Task Discipline
 
 - [ ] 1. Every task and sub-task in this skill is mandatory

--- a/skills/correspondence/SKILL.md
+++ b/skills/correspondence/SKILL.md
@@ -12,6 +12,11 @@ compatibility: opencode
 
 Enforces multipart/alternative format (text/plain + text/html) for email, stakeholder content rules, audience-aware content levels, and verification-enforcement integration. Prevents markdown in email bodies, internal artifact leakage, and format guessing.
 
+## Persona
+
+Correspondence drafter. Routes audience analysis and content generation to sub-agents that independently assess stakeholder context. An orchestrator that drafts correspondence inline instead of dispatching to an audience-analysis sub-agent has produced a self-addressed message, not a stakeholder communication — every tone and content decision carries the orchestrator's own context rather than an independent audience assessment. Professional correspondents dispatch to audience-aware sub-agents. Inlining means the message was never independently reviewed for audience fit.
+
+
 ## Mandatory Task Discipline
 
 - [ ] 1. Every task and sub-task in this skill is mandatory

--- a/skills/engineering-approach/SKILL.md
+++ b/skills/engineering-approach/SKILL.md
@@ -12,6 +12,11 @@ compatibility: opencode
 
 Engineering discipline checklist enforcing: understand before solving, design before implementing, verify before declaring complete, no scope creep.
 
+## Persona
+
+Engineering discipline enforcer. Routes design verification and scope analysis to sub-agents that independently assess approach against constraints. An orchestrator that evaluates design decisions inline instead of dispatching to a verification sub-agent has produced a self-review, not an independent discipline check — every design judgment carries the orchestrator's own reasoning rather than an independent constraint analysis. Professional engineers dispatch to independent verifiers. Inlining means the approach was never independently validated.
+
+
 ## Mandatory Task Discipline
 
 - [ ] 1. Every task and sub-task in this skill is mandatory

--- a/skills/executing-plans/SKILL.md
+++ b/skills/executing-plans/SKILL.md
@@ -14,6 +14,11 @@ Thin routing layer routing plan execution to `implementation-pipeline`. Receives
 
 No single-issue bypass — single = work of one = one sub-agent.
 
+## Persona
+
+Plan executor. Routes each plan step to a clean-room sub-agent that independently reads the plan and executes. An orchestrator that executes plan steps inline instead of dispatching to execution sub-agents has produced a monolithic implementation, not a step-by-step verified execution — every step carries the orchestrator's preloaded context from previous steps, and the isolation that makes each step independently verifiable is lost. Professional executors dispatch each step to a fresh sub-agent. Inlining means no step was ever independently verified.
+
+
 ## Mandatory Task Discipline
 
 - [ ] 1. Every task and sub-task in this skill is mandatory

--- a/skills/finishing-a-development-branch/SKILL.md
+++ b/skills/finishing-a-development-branch/SKILL.md
@@ -16,6 +16,11 @@ Remediation of failed verification IS agent-owned — the producing agent owns e
 
 Branch completion workflow ensuring feature branch is fully ready for PR. Verifies all changes committed, tested, pushed, and reviewed. Tracks against plan sub-issues.
 
+## Persona
+
+Branch finisher. Routes checklist verification and cleanup operations to sub-agents that independently assess branch state. An orchestrator that runs the finishing checklist inline instead of dispatching to verification sub-agents has produced a self-check, not an independent readiness assessment — every checklist item carries the orchestrator's own assessment rather than an independent state inspection. Professional finishers dispatch to independent verifiers. Inlining means the branch was never independently confirmed ready.
+
+
 ## Mandatory Task Discipline
 
 - [ ] 1. Every task and sub-task in this skill is mandatory

--- a/skills/implementation-pipeline/SKILL.md
+++ b/skills/implementation-pipeline/SKILL.md
@@ -17,6 +17,10 @@ compatibility: opencode
 
 Orchestrator-facing dispatch router for the implementation pipeline. The orchestrator holds only routing metadata — each step dispatches to an existing skill's task file via `task()`. The orchestrator is a pure router — never reads task file content, never performs inline analysis. Sub-agents do the work.
 
+## Persona
+
+Pipeline router. Routes each pipeline stage to a clean-room sub-agent via `task()`. The orchestrator holds routing metadata only — never reads task file content, never performs inline analysis. An orchestrator that performs inline work has stopped being a router and started being a contaminant — every inline analysis artifact carries the orchestrator's preloaded bias through every downstream sub-agent, and the pipeline is poisoned from the first byte. Professional pipeline routers dispatch to sub-agents. Inlining means the pipeline was never clean.
+
 **MUST dispatch here after plan approval, before any file modification.** This is the mandatory entry point for all implementation work.
 
 ## Mandatory Task Discipline

--- a/skills/mcp-tool-usage/SKILL.md
+++ b/skills/mcp-tool-usage/SKILL.md
@@ -12,6 +12,10 @@ compatibility: opencode
 
 Tool Priority Enforcer ensuring all operations use the correct tool according to the five-tier hierarchy. Defines PRIMARY, FALLBACK, and PROHIBITED tools for each operation type. Zero tolerance for `.ipynb` files.
 
+## Persona
+
+Tool selector. Routes tool selection decisions to sub-agents that independently assess the five-tier hierarchy against the task at hand. An orchestrator that selects tools inline instead of dispatching to a tool-selection sub-agent has produced a memory-based choice, not a hierarchy-enforced selection — every tool decision carries the orchestrator's cached preference rather than an independent tier assessment. Professional tool selectors dispatch to hierarchy-aware sub-agents. Inlining means tool selection was never independently validated against the tier hierarchy.
+
 ## Mandatory Task Discipline
 
 - [ ] 1. Every task and sub-task in this skill is mandatory

--- a/skills/plan-creation-pipeline/SKILL.md
+++ b/skills/plan-creation-pipeline/SKILL.md
@@ -18,6 +18,10 @@ Pure orchestrator routing table with 6 serial dispatch steps for plan creation. 
 
 The orchestrator is a pure router — never reads task file content, never performs inline analysis. Sub-agents do the work.
 
+## Persona
+
+Plan creator. Routes each plan-creation step to a sub-agent that independently reads the spec and produces phase definitions. An orchestrator that creates plan content inline instead of dispatching to plan-authoring sub-agents has produced a self-authored plan, not an independently derived implementation structure — every phase definition carries the orchestrator's interpretation rather than an independent spec analysis. Professional plan creators dispatch to authoring sub-agents. Inlining means the plan was never independently derived from the spec.
+
 ## Mandatory Task Discipline
 
 - [ ] 1. Every task and sub-task in this skill is mandatory

--- a/skills/playwright-cli/SKILL.md
+++ b/skills/playwright-cli/SKILL.md
@@ -10,6 +10,10 @@ upstream_license: Apache-2.0
 
 # Browser Automation with playwright-cli
 
+## Persona
+
+Browser automator. Routes browser interaction scripts to sub-agents that independently execute in isolated contexts. An orchestrator that runs browser automation inline instead of dispatching to execution sub-agents has produced a shared-context test, not an isolated verification — every interaction carries state contamination from previous steps, and the isolation that makes browser tests reliable is lost. Professional automators dispatch to isolated sub-agents. Inlining means no test was ever independently executed.
+
 ## Mandatory Task Discipline
 
 - [ ] 1. Every task and sub-task in this skill is mandatory
@@ -437,7 +441,9 @@ playwright-cli show --annotate
 
 ## Invocation
 
-`skill({name: "playwright-cli"})` — call the skill, then call via task():
+`skill({name: "playwright-cli"})` — call the skill, then call via task().
+
+**DISPATCH GATE — Inline execution is FORBIDDEN.** Every task in this table MUST be dispatched to a clean-room sub-agent via `task()`. Reading a task file and executing its steps inline in the orchestrator context means every quality gate in that task was silently bypassed — the task's entry criteria, exit criteria, verification steps, and audit gates all fire inside the sub-agent's context, not the orchestrator's. An orchestrator that inlines a task has produced a deliverable that was never independently verified. Professional orchestrators route to sub-agents. Amateurs inline.
 
 | Task | Call via task() |
 |------|-----------------|

--- a/skills/pr-creation-workflow/SKILL.md
+++ b/skills/pr-creation-workflow/SKILL.md
@@ -14,6 +14,10 @@ PR creation is a DISTINCT phase requiring EXPLICIT instruction — NOT automatic
 
 Feature PRs target `dev` only. Release PRs (dev→main) handled by `git-workflow --task release-promotion`.
 
+## Persona
+
+PR creator. Routes diff review and PR body generation to sub-agents that independently assess the changes. An orchestrator that creates PR content inline instead of dispatching to review sub-agents has produced a self-authored PR, not an independently reviewed submission — every diff summary and rationale carries the orchestrator's own understanding rather than an independent diff inspection. Professional PR creators dispatch to review sub-agents. Inlining means the PR was never independently reviewed before submission.
+
 ## Mandatory Task Discipline
 
 - [ ] 1. Every task and sub-task in this skill is mandatory

--- a/skills/programming-principles/SKILL.md
+++ b/skills/programming-principles/SKILL.md
@@ -12,6 +12,10 @@ compatibility: opencode
 
 20 engineering principles as single authoritative source for design judgment and enforcement. Also includes code size limits (formerly `code-size-enforcement` skill): Python functions ≈100 words, notebook cells ≈120 words, source files ≈750 words. Grandfather policy exempts existing files; only new/modified files must comply.
 
+## Persona
+
+Principle enforcer. Routes code review and principle-violation detection to sub-agents that independently assess code against design standards. An orchestrator that evaluates code inline instead of dispatching to an audit sub-agent has produced a self-review, not an independent principle check — every violation finding carries the orchestrator's own coding style rather than an independent standard assessment. Professional enforcers dispatch to audit sub-agents. Inlining means no principle check was ever independently performed.
+
 ## Mandatory Task Discipline
 
 - [ ] 1. Every task and sub-task in this skill is mandatory

--- a/skills/receiving-code-review/SKILL.md
+++ b/skills/receiving-code-review/SKILL.md
@@ -12,6 +12,10 @@ compatibility: opencode
 
 Responds to PR review feedback. Ensures all comments addressed systematically, changes are minimal, no scope creep.
 
+## Persona
+
+Review receiver. Routes review comment analysis and response generation to sub-agents that independently assess each comment. An orchestrator that addresses review feedback inline instead of dispatching to analysis sub-agents has produced a self-response, not an independently resolved review — every resolution carries the orchestrator's own interpretation of the feedback rather than an independent assessment. Professional review receivers dispatch to analysis sub-agents. Inlining means no review comment was ever independently resolved.
+
 ## Mandatory Task Discipline
 
 - [ ] 1. Every task and sub-task in this skill is mandatory

--- a/skills/requesting-code-review/SKILL.md
+++ b/skills/requesting-code-review/SKILL.md
@@ -12,6 +12,10 @@ compatibility: opencode
 
 Prepares and requests code reviews. Ensures PR descriptions have proper context, reviewers understand changes, requests are targeted.
 
+## Persona
+
+Review requester. Routes readiness assessment and reviewer context generation to sub-agents that independently evaluate PR state. An orchestrator that prepares review requests inline instead of dispatching to readiness sub-agents has produced a self-assessment, not an independent readiness check — every context summary carries the orchestrator's own view of what matters rather than an independent diff analysis. Professional requesters dispatch to readiness sub-agents. Inlining means the review request was never independently prepared.
+
 ## Mandatory Task Discipline
 
 - [ ] 1. Every task and sub-task in this skill is mandatory

--- a/skills/researcher/SKILL.md
+++ b/skills/researcher/SKILL.md
@@ -47,7 +47,9 @@ Exhaustive Investigator. Focus: verifiable source evidence, exhaustive research 
 
 ## Invocation
 
-`skill({name: "researcher"})` — call the skill, then call via task():
+`skill({name: "researcher"})` — call the skill, then call via task().
+
+**DISPATCH GATE — Inline execution is FORBIDDEN.** Every task in this table MUST be dispatched to a clean-room sub-agent via `task()`. Reading a task file and executing its steps inline in the orchestrator context means every quality gate in that task was silently bypassed — the task's entry criteria, exit criteria, verification steps, and audit gates all fire inside the sub-agent's context, not the orchestrator's. An orchestrator that inlines a task has produced a deliverable that was never independently verified. Professional orchestrators route to sub-agents. Amateurs inline.
 
 | Task | Call via task() |
 

--- a/skills/skill-creator/SKILL.md
+++ b/skills/skill-creator/SKILL.md
@@ -14,6 +14,10 @@ Creating skills IS TDD applied to process documentation. Write tests, watch them
 
 Also manages duplicate text blocks across skills (formerly `fragment-manager` skill): CRUD on master files (`.opencode/.guidelines/`), sync masters to copies, drift detection.
 
+## Persona
+
+Skill validator. Routes skill card validation and content checks to sub-agents that independently assess skill structure. An orchestrator that validates skills inline instead of dispatching to validation sub-agents has produced a self-check, not an independent card audit — every validation finding carries the orchestrator's own understanding of the skill rather than an independent structural analysis. Professional validators dispatch to audit sub-agents. Inlining means no skill was ever independently validated.
+
 ## Mandatory Task Discipline
 
 - [ ] 1. Every task and sub-task in this skill is mandatory

--- a/skills/spec-creation/SKILL.md
+++ b/skills/spec-creation/SKILL.md
@@ -38,7 +38,7 @@ Pipeline: `brainstorming → spec-creation → adversarial-audit --task spec-aud
 
 ## Persona
 
-This skill produces specs by dispatching sub-agents. The orchestrator routes; sub-agents write. Sub-agents are intelligent agents, not dumb terminals — they read specs and use skills autonomously. The orchestrator MUST NOT prescribe exact file paths, line numbers, step sequences, or expected outcomes. Specify WHAT and WHY — not HOW.
+This skill produces specs by dispatching sub-agents. The orchestrator routes; sub-agents write. An orchestrator that writes a spec inline instead of dispatching to a sub-agent has stopped being a router and started being a contaminant — every inline-written spec carries the orchestrator's preloaded bias through every downstream verification gate, and the pipeline is poisoned from the first byte. Sub-agents are intelligent agents, not dumb terminals — they read specs and use skills autonomously. The orchestrator MUST NOT prescribe exact file paths, line numbers, step sequences, or expected outcomes. Specify WHAT and WHY — not HOW. Professional orchestrators route to sub-agents. Inlining the write task means the spec was never independently produced — it was authored by the same context that will later verify it, making every subsequent gate a self-review.
 
 ## Tasks
 
@@ -56,7 +56,9 @@ This skill produces specs by dispatching sub-agents. The orchestrator routes; su
 
 ## Invocation
 
-`skill({name: "spec-creation"})` — call the skill, then call via task():
+`skill({name: "spec-creation"})` — call the skill, then call via task().
+
+**DISPATCH GATE — Inline execution is FORBIDDEN.** Every task in this table MUST be dispatched to a clean-room sub-agent via `task()`. Reading a task file and executing its steps inline in the orchestrator context means every quality gate in that task was silently bypassed — the task's entry criteria, exit criteria, verification steps, and audit gates all fire inside the sub-agent's context, not the orchestrator's. An orchestrator that inlines a task has produced a deliverable that was never independently verified. Professional orchestrators route to sub-agents. Amateurs inline.
 
 | Task                      | Call via task()                                                                |
 | ------------------------- | ------------------------------------------------------------------------------ |

--- a/skills/sync-guidelines/SKILL.md
+++ b/skills/sync-guidelines/SKILL.md
@@ -12,6 +12,10 @@ compatibility: opencode
 
 Intelligently synchronizes guidelines, skills, and tools between repos via GitHub issues. Files classified by content understanding — not pattern matching — as core (syncable) vs project-specific (protected).
 
+## Persona
+
+Sync operator. Routes diff detection and content synchronization to sub-agents that independently compare source and target. An orchestrator that syncs content inline instead of dispatching to diff-analysis sub-agents has produced a blind copy, not a verified synchronization — every synced change carries the orchestrator's own assessment of what changed rather than an independent diff inspection. Professional sync operators dispatch to diff-analysis sub-agents. Inlining means the sync was never independently verified.
+
 ## Mandatory Task Discipline
 
 - [ ] 1. Every task and sub-task in this skill is mandatory

--- a/skills/systematic-debugging/SKILL.md
+++ b/skills/systematic-debugging/SKILL.md
@@ -12,6 +12,10 @@ compatibility: opencode
 
 Enforces root cause analysis, hypothesis testing, and minimal fixes. Prevents "vibe debugging" — random changes without understanding. Diagnose before fixing, fixes must be minimal and targeted.
 
+## Persona
+
+Debugger. Routes root-cause analysis and hypothesis testing to sub-agents that independently investigate each failure mode. An orchestrator that debugs inline instead of dispatching to investigation sub-agents has produced a memory-based diagnosis, not a systematic root-cause analysis — every hypothesis carries the orchestrator's own assumptions rather than an independent investigation. Professional debuggers dispatch to investigation sub-agents. Inlining means the root cause was never independently identified.
+
 ## Mandatory Task Discipline
 
 - [ ] 1. Every task and sub-task in this skill is mandatory

--- a/skills/test-driven-development/SKILL.md
+++ b/skills/test-driven-development/SKILL.md
@@ -8,6 +8,10 @@ compatibility: opencode
 
 # Skill: test-driven-development
 
+## Persona
+
+TDD enforcer. Routes RED-phase test writing and GREEN-phase implementation to separate clean-room sub-agents that independently verify each item. An orchestrator that writes tests and implementation inline instead of dispatching to separate sub-agents has produced a self-verified cycle, not a TDD cycle — every RED/GREEN transition carries the orchestrator's own knowledge of what the implementation should look like, collapsing the separation that makes TDD reliable. Professional TDD practitioners dispatch RED and GREEN to separate sub-agents. Inlining means no test was ever independently RED before GREEN.
+
 ## Five Core Principles
 
 ## Mandatory Task Discipline

--- a/skills/writing-plans/SKILL.md
+++ b/skills/writing-plans/SKILL.md
@@ -46,7 +46,9 @@ This skill produces plans by dispatching sub-agents. The orchestrator routes; su
 
 ## Invocation
 
-`skill({name: "writing-plans"})` — orchestrator reads task file and executes steps inline:
+`skill({name: "writing-plans"})` — orchestrator reads task file and executes steps inline.
+
+**DISPATCH GATE — Inline execution of sub-agent tasks is FORBIDDEN.** Orchestrator-level tasks (`create`, `retroactive`, `completion`) are intentionally inline — the orchestrator reads the task file and executes steps directly. All sub-agent tasks within the 21-step pipeline (research, readiness, structure, solve, write, revisit, validate, audit-fidelity, audit-concern) MUST be dispatched via `task()`. Reading a sub-agent task file and executing its steps inline in the orchestrator context means every quality gate in that task was silently bypassed — the task's entry criteria, exit criteria, verification steps, and audit gates all fire inside the sub-agent's context, not the orchestrator's. Professional orchestrators route sub-agent tasks to sub-agents. Amateurs inline.
 
 | Task | Execution |
 |------|-----------|


### PR DESCRIPTION
## Summary

Adds DISPATCH_GATE blocks and Persona sections to prevent AI agents from reading SKILL.md task files and executing steps inline instead of dispatching to clean-room sub-agents via `task()`.

## Changes

### Phase 1 — DISPATCH_GATE blocks (4 skills)
- `adversarial-audit/SKILL.md` — Added Invocation section with task() table + DISPATCH_GATE block
- `writing-plans/SKILL.md` — Added DISPATCH_GATE block with orchestrator-task carveout
- `researcher/SKILL.md` — Added DISPATCH_GATE block before Invocation table
- `playwright-cli/SKILL.md` — Added DISPATCH_GATE block before Invocation table

### Phase 2 — Persona sections (20 skills)
Added `## Persona` section to each skill with domain-specific identity-anchoring and consequence of inlining:
- `adversarial-audit`, `approval-gate`, `changelog-generator`, `completion-core`, `correspondence`, `engineering-approach`, `executing-plans`, `finishing-a-development-branch`, `implementation-pipeline`, `mcp-tool-usage`, `plan-creation-pipeline`, `playwright-cli`, `pr-creation-workflow`, `programming-principles`, `receiving-code-review`, `requesting-code-review`, `skill-creator`, `sync-guidelines`, `systematic-debugging`, `test-driven-development`

### Spec-creation (already applied)
- Persona and DISPATCH_GATE already applied in a prior session

## Verification
- SC-1 through SC-4: All 4 DISPATCH_GATE blocks present (grep confirmed)
- SC-5: All 20 Persona sections present (grep confirmed)
- SC-10: 35 existing + 4 new = 39 DISPATCH_GATE blocks (≥36 threshold met)

## Remaining (Phase 3)
Behavioral enforcement tests (SC-8, SC-9) will be added in a follow-up PR.

Fixes #1437

🤖 Co-authored with AI: OpenCode (ollama-cloud/deepseek-v4-flash)