### PR TITLE
[#1442] Auditor gate bypass fix — conditional next_step on FAIL + all_criteria_pass enforcement

### DIFF
--- a/skills/adversarial-audit/tasks/closure-verification.md
+++ b/skills/adversarial-audit/tasks/closure-verification.md
@@ -4,6 +4,8 @@
 
 > **⚠️ ROLE ANCHOR: You are the DISPATCHED AUDITOR SUB-AGENT.** Your role is to evaluate criteria and produce findings. You do NOT dispatch sub-agents, call `skill()`, or orchestrate pipeline routing. The orchestrator handles all dispatch. Read this file for evaluation criteria and procedure only — ignore any text describing orchestration responsibilities.
 
+> **Default assumption: FAIL.** The default verdict for every criterion is FAIL unless the evidence 100% supports a clean PASS with no caveats, concerns, or notes. Any hedging, partial evidence, or uncertainty results in FAIL. A clean PASS requires: (1) evidence artifacts from the implementation run are present and complete, (2) no hedging language in the explanation, (3) no caveats or concerns noted, (4) both auditors independently agree.
+
 # Task: closure-verification
 
 ## Purpose
@@ -220,8 +222,9 @@ per_criterion:
     evidence: "<tool-call reference>"
     explanation: "<reasoning>"
     remediation: ""
-    next_step: "proceed"
+    next_step: "proceed"  # Conditional: "remediate" when result is "FAIL", "proceed" when result is "PASS"
 exec_summary: "Closure verification: X/Y criteria. Consensus: PASS|FAIL."
+all_criteria_pass: false
 ```
 
 ### Step 13: Return Frugal Result Contract
@@ -230,6 +233,8 @@ exec_summary: "Closure verification: X/Y criteria. Consensus: PASS|FAIL."
 status: DONE
 artifact_path: "./tmp/{issue-N}/artifacts/pipeline-audit-closure-verification-PASS-{timestamp}.yaml"
 summary: "N criteria evaluated. X PASS, Y FAIL."
+all_criteria_pass: false
+mandatory_remediation: "Remit for mandatory remediation. Non-clean PASS requires full remediation before re-audit. Default assumption is FAIL unless 100% clean PASS with no caveats, concerns, or notes."
 ```
 
 ## Error Handling
@@ -296,4 +301,22 @@ rules:
       all: ["blocking_comments_count > 0"]
     actions: [REPORT_BLOCKERS]
     source: "closure-verification.md §Step 9"
+
+  - id: closure-verification-004
+    title: "next_step MUST be 'remediate' when result is 'FAIL', 'proceed' when result is 'PASS'"
+    conditions:
+      any:
+        - "per_criterion[].result == 'FAIL' AND per_criterion[].next_step != 'remediate'"
+        - "per_criterion[].result == 'PASS' AND per_criterion[].next_step != 'proceed'"
+    actions: [HALT, REQUIRE_CORRECT_NEXT_STEP]
+    source: "closure-verification.md §Step 12 — conditional next_step enforcement"
+
+  - id: closure-verification-005
+    title: "all_criteria_pass MUST be true when every criterion result is 'PASS', false otherwise"
+    conditions:
+      any:
+        - "all(criterion.result == 'PASS' for criterion in per_criterion) AND all_criteria_pass != true"
+        - "any(criterion.result == 'FAIL' for criterion in per_criterion) AND all_criteria_pass != false"
+    actions: [HALT, REQUIRE_CORRECT_ALL_CRITERIA_PASS]
+    source: "closure-verification.md §Step 12 — all_criteria_pass enforcement"
 ```

--- a/skills/adversarial-audit/tasks/concern-separation.md
+++ b/skills/adversarial-audit/tasks/concern-separation.md
@@ -147,13 +147,14 @@ per_criterion:
     evidence: "<tool-call reference>"
     explanation: "<reasoning>"
     remediation: ""
-    next_step: "proceed"
+    next_step: "proceed"  # Conditional: "remediate" when result is "FAIL", "proceed" when result is "PASS"
 findings:
   - type: "BOILERPLATE_TITLE"
     phase: "<phase>"
     classification: "flag-for-review"
     recommendation: "<recommendation>"
 exec_summary: "Concern separation: X/Y criteria. N phases need review."
+all_criteria_pass: false
 mandatory_remediation: "Remit for mandatory remediation. Non-clean PASS requires full remediation before re-audit. Default assumption is FAIL unless 100% clean PASS with no caveats, concerns, or notes."
 ```
 
@@ -163,6 +164,7 @@ mandatory_remediation: "Remit for mandatory remediation. Non-clean PASS requires
 status: DONE
 artifact_path: "./tmp/{issue-N}/artifacts/pipeline-audit-concern-separation-PASS-{timestamp}.yaml"
 summary: "N criteria evaluated. X PASS, Y FAIL."
+all_criteria_pass: false
 mandatory_remediation: "Remit for mandatory remediation. Non-clean PASS requires full remediation before re-audit. Default assumption is FAIL unless 100% clean PASS with no caveats, concerns, or notes."
 ```
 
@@ -225,4 +227,22 @@ rules:
       all: ["dependency_found == true", "dependency_documented == false"]
     actions: [REPORT_MISSING_DEPENDENCY]
     source: "concern-separation.md §Step 3"
+
+  - id: concern-separation-004
+    title: "next_step MUST be 'remediate' when result is 'FAIL', 'proceed' when result is 'PASS'"
+    conditions:
+      any:
+        - "per_criterion[].result == 'FAIL' AND per_criterion[].next_step != 'remediate'"
+        - "per_criterion[].result == 'PASS' AND per_criterion[].next_step != 'proceed'"
+    actions: [HALT, REQUIRE_CORRECT_NEXT_STEP]
+    source: "concern-separation.md §Step 7 — conditional next_step enforcement"
+
+  - id: concern-separation-005
+    title: "all_criteria_pass MUST be true when every criterion result is 'PASS', false otherwise"
+    conditions:
+      any:
+        - "all(criterion.result == 'PASS' for criterion in per_criterion) AND all_criteria_pass != true"
+        - "any(criterion.result == 'FAIL' for criterion in per_criterion) AND all_criteria_pass != false"
+    actions: [HALT, REQUIRE_CORRECT_ALL_CRITERIA_PASS]
+    source: "concern-separation.md §Step 7 — all_criteria_pass enforcement"
 ```

--- a/skills/adversarial-audit/tasks/cross-validate.md
+++ b/skills/adversarial-audit/tasks/cross-validate.md
@@ -167,7 +167,8 @@ result: "PASS"
 evidence: "<tool-call reference>"
 explanation: "<reasoning>"
 remediation: ""
-next_step: "proceed"
+next_step: "proceed"  # Conditional: "remediate" when result is "FAIL", "proceed" when result is "PASS"
+all_criteria_pass: false
 ---
 ---
 criterion_id: "SC-2"
@@ -394,6 +395,7 @@ overall_consensus: PASS|FAIL
 next_step: "proceed|remediate then re-audit"
 artifact_path: "./tmp/{issue-N}/artifacts/pipeline-cross-validate-{STATUS}-{timestamp}.yaml"
 summary: "N SCs: X agreed, Y disagreed, Z evidence_type_mismatch"
+all_criteria_pass: false
 mandatory_remediation: "Remit for mandatory remediation. Non-clean PASS requires full remediation before re-audit. Default assumption is FAIL unless 100% clean PASS with no caveats, concerns, or notes."
 ```
 
@@ -594,4 +596,22 @@ rules:
       any: ["error == 'MISSING_INPUT'", "error == 'MISSING_EVIDENCE_DIR'", "error == 'ARTIFACT_UNREADABLE'", "error == 'INSUFFICIENT_ARTIFACTS'"]
     actions: [RETURN_BLOCKED, NO_RECOVERY]
     source: "cross-validate.md §Non-Recovery Gates"
+
+  - id: cross-validate-019
+    title: "next_step MUST be 'remediate' when result is 'FAIL', 'proceed' when result is 'PASS'"
+    conditions:
+      any:
+        - "per_criterion[].result == 'FAIL' AND per_criterion[].next_step != 'remediate'"
+        - "per_criterion[].result == 'PASS' AND per_criterion[].next_step != 'proceed'"
+    actions: [HALT, REQUIRE_CORRECT_NEXT_STEP]
+    source: "cross-validate.md §Step 4 — conditional next_step enforcement"
+
+  - id: cross-validate-020
+    title: "all_criteria_pass MUST be true when every criterion result is 'PASS', false otherwise"
+    conditions:
+      any:
+        - "all(criterion.result == 'PASS' for criterion in per_criterion) AND all_criteria_pass != true"
+        - "any(criterion.result == 'FAIL' for criterion in per_criterion) AND all_criteria_pass != false"
+    actions: [HALT, REQUIRE_CORRECT_ALL_CRITERIA_PASS]
+    source: "cross-validate.md §Step 4 — all_criteria_pass enforcement"
 ```

--- a/skills/adversarial-audit/tasks/guideline-audit.md
+++ b/skills/adversarial-audit/tasks/guideline-audit.md
@@ -215,8 +215,9 @@ per_criterion:
     evidence: "<tool-call reference>"
     explanation: "<reasoning>"
     remediation: ""
-    next_step: "proceed"
+    next_step: "proceed"  # Conditional: "remediate" when result is "FAIL", "proceed" when result is "PASS"
 report_path: "./tmp/{issue-N}/artifacts/audit-guideline.md"
+all_criteria_pass: false
 exec_summary: "Guideline audit: N files, M problems. Consensus: PASS|FAIL."
 ```
 
@@ -226,6 +227,7 @@ exec_summary: "Guideline audit: N files, M problems. Consensus: PASS|FAIL."
 status: DONE
 artifact_path: "./tmp/{issue-N}/artifacts/pipeline-audit-guideline-audit-PASS-{timestamp}.yaml"
 summary: "N files audited, M problems found. X/Y criteria PASS."
+all_criteria_pass: false
 ```
 
 ## Error Handling
@@ -287,4 +289,22 @@ rules:
       all: ["report_written == true", "timestamp_in_report == false"]
     actions: [ADD_TIMESTAMP]
     source: "guideline-audit.md §Step 6"
+
+  - id: guideline-audit-004
+    title: "next_step MUST be 'remediate' when result is 'FAIL', 'proceed' when result is 'PASS'"
+    conditions:
+      any:
+        - "per_criterion[].result == 'FAIL' AND per_criterion[].next_step != 'remediate'"
+        - "per_criterion[].result == 'PASS' AND per_criterion[].next_step != 'proceed'"
+    actions: [HALT, REQUIRE_CORRECT_NEXT_STEP]
+    source: "guideline-audit.md §Step 7 — conditional next_step enforcement"
+
+  - id: guideline-audit-005
+    title: "all_criteria_pass MUST be true when every criterion result is 'PASS', false otherwise"
+    conditions:
+      any:
+        - "all(criterion.result == 'PASS' for criterion in per_criterion) AND all_criteria_pass != true"
+        - "any(criterion.result == 'FAIL' for criterion in per_criterion) AND all_criteria_pass != false"
+    actions: [HALT, REQUIRE_CORRECT_ALL_CRITERIA_PASS]
+    source: "guideline-audit.md §Step 7 — all_criteria_pass enforcement"
 ```

--- a/skills/adversarial-audit/tasks/plan-fidelity.md
+++ b/skills/adversarial-audit/tasks/plan-fidelity.md
@@ -160,7 +160,8 @@ per_criterion:
     evidence: "<tool-call reference>"
     explanation: "<reasoning>"
     remediation: ""
-    next_step: "proceed"
+    next_step: "proceed"  # Conditional: "remediate" when result is "FAIL", "proceed" when result is "PASS"
+all_criteria_pass: false
 auto_fixes_applied: []
 flagged_for_review: []
 exec_summary: "Plan fidelity: X/Y criteria. N discrepancies found."
@@ -173,6 +174,7 @@ mandatory_remediation: "Remit for mandatory remediation. Non-clean PASS requires
 status: DONE
 artifact_path: "./tmp/{issue-N}/artifacts/pipeline-audit-plan-fidelity-PASS-{timestamp}.yaml"
 summary: "N criteria evaluated. X PASS, Y FAIL. Z discrepancies found."
+all_criteria_pass: false
 mandatory_remediation: "Remit for mandatory remediation. Non-clean PASS requires full remediation before re-audit. Default assumption is FAIL unless 100% clean PASS with no caveats, concerns, or notes."
 ```
 
@@ -248,4 +250,22 @@ rules:
       all: ["clean_room_plan_source == 'orchestrator_inline'"]
     actions: [REJECT, RETURN_BLOCKED]
     source: "plan-fidelity.md §Step 1 — critical-rules-034"
+
+  - id: plan-fidelity-006
+    title: "next_step MUST be 'remediate' when result is 'FAIL', 'proceed' when result is 'PASS'"
+    conditions:
+      any:
+        - "per_criterion[].result == 'FAIL' AND per_criterion[].next_step != 'remediate'"
+        - "per_criterion[].result == 'PASS' AND per_criterion[].next_step != 'proceed'"
+    actions: [HALT, REQUIRE_CORRECT_NEXT_STEP]
+    source: "plan-fidelity.md §Step 7 — conditional next_step enforcement"
+
+  - id: plan-fidelity-007
+    title: "all_criteria_pass MUST be true when every criterion result is 'PASS', false otherwise"
+    conditions:
+      any:
+        - "all(criterion.result == 'PASS' for criterion in per_criterion) AND all_criteria_pass != true"
+        - "any(criterion.result == 'FAIL' for criterion in per_criterion) AND all_criteria_pass != false"
+    actions: [HALT, REQUIRE_CORRECT_ALL_CRITERIA_PASS]
+    source: "plan-fidelity.md §Step 7 — all_criteria_pass enforcement"
 ```

--- a/skills/adversarial-audit/tasks/spec-audit.md
+++ b/skills/adversarial-audit/tasks/spec-audit.md
@@ -277,10 +277,11 @@ per_criterion:
     evidence: "<tool-call reference>"
     explanation: "<reasoning>"
     remediation: ""
-    next_step: "proceed"
+    next_step: "proceed"  # Conditional: "remediate" when result is "FAIL", "proceed" when result is "PASS"
     tool_calls_made:
       - read
       - grep
+all_criteria_pass: false
 mandatory_remediation: "Remit for mandatory remediation. Non-clean PASS requires full remediation before re-audit. Default assumption is FAIL unless 100% clean PASS with no caveats, concerns, or notes."
 ```
 
@@ -290,6 +291,7 @@ mandatory_remediation: "Remit for mandatory remediation. Non-clean PASS requires
 status: DONE
 artifact_path: "./tmp/{issue-N}/artifacts/pipeline-audit-spec-audit-PASS-{timestamp}.yaml"
 summary: "N criteria evaluated. X PASS, Y FAIL."
+all_criteria_pass: false
 mandatory_remediation: "Remit for mandatory remediation. Non-clean PASS requires full remediation before re-audit. Default assumption is FAIL unless 100% clean PASS with no caveats, concerns, or notes."
 ```
 
@@ -364,4 +366,22 @@ rules:
       all: ["doc_sources_missing_or_empty == true"]
     actions: [FAIL_CRITERION(SC-11)]
     source: "spec-audit.md §Step 2"
+
+  - id: spec-audit-005
+    title: "next_step MUST be 'remediate' when result is 'FAIL', 'proceed' when result is 'PASS'"
+    conditions:
+      any:
+        - "per_criterion[].result == 'FAIL' AND per_criterion[].next_step != 'remediate'"
+        - "per_criterion[].result == 'PASS' AND per_criterion[].next_step != 'proceed'"
+    actions: [HALT, REQUIRE_CORRECT_NEXT_STEP]
+    source: "spec-audit.md §Step 6 — conditional next_step enforcement"
+
+  - id: spec-audit-006
+    title: "all_criteria_pass MUST be true when every criterion result is 'PASS', false otherwise"
+    conditions:
+      any:
+        - "all(criterion.result == 'PASS' for criterion in per_criterion) AND all_criteria_pass != true"
+        - "any(criterion.result == 'FAIL' for criterion in per_criterion) AND all_criteria_pass != false"
+    actions: [HALT, REQUIRE_CORRECT_ALL_CRITERIA_PASS]
+    source: "spec-audit.md §Step 6 — all_criteria_pass enforcement"
 ```

--- a/skills/adversarial-audit/tasks/verification-audit.md
+++ b/skills/adversarial-audit/tasks/verification-audit.md
@@ -176,7 +176,8 @@ per_criterion:
     evidence: "<tool-call reference>"
     explanation: "<reasoning>"
     remediation: ""
-    next_step: "proceed"
+    next_step: "proceed"  # Conditional: "remediate" when result is "FAIL", "proceed" when result is "PASS"
+all_criteria_pass: false
 mandatory_remediation: "Remit for mandatory remediation. Non-clean PASS requires full remediation before re-audit. Default assumption is FAIL unless 100% clean PASS with no caveats, concerns, or notes."
 ```
 
@@ -186,6 +187,7 @@ mandatory_remediation: "Remit for mandatory remediation. Non-clean PASS requires
 status: DONE
 artifact_path: "./tmp/{issue-N}/artifacts/pipeline-audit-verification-audit-PASS-{timestamp}.yaml"
 summary: "N criteria evaluated. X PASS, Y FAIL."
+all_criteria_pass: false
 mandatory_remediation: "Remit for mandatory remediation. Non-clean PASS requires full remediation before re-audit. Default assumption is FAIL unless 100% clean PASS with no caveats, concerns, or notes."
 ```
 
@@ -259,4 +261,22 @@ rules:
       all: ["auditor_context contains 'expected' OR 'should' OR 'correct'"]
     actions: [HALT, STRIP_BIASED_CONTEXT]
     source: "verification-audit.md §Step 4"
+
+  - id: verification-audit-005
+    title: "next_step MUST be 'remediate' when result is 'FAIL', 'proceed' when result is 'PASS'"
+    conditions:
+      any:
+        - "per_criterion[].result == 'FAIL' AND per_criterion[].next_step != 'remediate'"
+        - "per_criterion[].result == 'PASS' AND per_criterion[].next_step != 'proceed'"
+    actions: [HALT, REQUIRE_CORRECT_NEXT_STEP]
+    source: "verification-audit.md §Step 8 — conditional next_step enforcement"
+
+  - id: verification-audit-006
+    title: "all_criteria_pass MUST be true when every criterion result is 'PASS', false otherwise"
+    conditions:
+      any:
+        - "all(criterion.result == 'PASS' for criterion in per_criterion) AND all_criteria_pass != true"
+        - "any(criterion.result == 'FAIL' for criterion in per_criterion) AND all_criteria_pass != false"
+    actions: [HALT, REQUIRE_CORRECT_ALL_CRITERIA_PASS]
+    source: "verification-audit.md §Step 8 — all_criteria_pass enforcement"
 ```

--- a/skills/writing-plans/contracts/audit-concern-output-template.yaml
+++ b/skills/writing-plans/contracts/audit-concern-output-template.yaml
@@ -2,3 +2,4 @@ status: string  # PASS | BLOCKED
 artifact_path: string
 findings: list[dict]
 blocker_reason: string
+all_criteria_pass: bool  # true when ALL criteria PASS, false if any FAIL

--- a/skills/writing-plans/contracts/audit-fidelity-output-template.yaml
+++ b/skills/writing-plans/contracts/audit-fidelity-output-template.yaml
@@ -2,3 +2,4 @@ status: string  # PASS | BLOCKED
 artifact_path: string
 findings: list[dict]
 blocker_reason: string
+all_criteria_pass: bool  # true when ALL criteria PASS, false if any FAIL

--- a/skills/writing-plans/tasks/create.md
+++ b/skills/writing-plans/tasks/create.md
@@ -92,14 +92,14 @@ Each item is tagged with dispatch scope and chain dependency.
   - Chain: `step_16`
   - Expected: PASS in audit-fidelity output
 
-- [ ] 18. (**inline**) Z3 check — `solve check` verify audit-fidelity output has PASS per `contracts/create-output-template.yaml:audit-fidelity`
+- [ ] 18. (**inline**) Z3 check — `solve check` verify audit-fidelity output has PASS AND `all_criteria_pass == true` per `contracts/create-output-template.yaml:audit-fidelity`. If `all_criteria_pass` is `false` or missing, treat as FAIL — orchestrator MUST halt and require remediation before proceeding.
   - Chain: `step_17`
 
 - [ ] 19. (**sub-agent**) Audit concern — `task(..., prompt: "execute audit-concern task from writing-plans")`
   - Chain: `step_18`
   - Expected: PASS in audit-concern output
 
-- [ ] 20. (**inline**) Z3 check — `solve check` verify audit-concern output has PASS per `contracts/create-output-template.yaml:audit-concern`
+- [ ] 20. (**inline**) Z3 check — `solve check` verify audit-concern output has PASS AND `all_criteria_pass == true` per `contracts/create-output-template.yaml:audit-concern`. If `all_criteria_pass` is `false` or missing, treat as FAIL — orchestrator MUST halt and require remediation before proceeding.
   - Chain: `step_19`
 
 - [ ] 21. (**sub-agent**) Completion — `task(..., prompt: "execute completion task from writing-plans")`


### PR DESCRIPTION
## Summary

Fix the auditor gate bypass vulnerability where plan auditors could return FAIL findings with `next_step: proceed`, allowing the orchestrator to skip mandatory remediation.

## Changes

**Phase 1 — 7 auditor task file template fixes:**
- `plan-fidelity.md`, `concern-separation.md`, `spec-audit.md`, `guideline-audit.md`, `verification-audit.md`, `closure-verification.md`, `cross-validate.md`
- Each file: conditional `next_step` (remediate on FAIL, proceed on PASS), `all_criteria_pass: bool` field, yaml+symbolic validation rules

**Phase 2 — create.md Z3 enforcement:**
- `create.md` steps 18 and 20 now enforce `all_criteria_pass == true` (not just output field existence)
- `audit-fidelity-output-template.yaml` and `audit-concern-output-template.yaml` include `all_criteria_pass: bool`

## SC Verification

| SC | Status | Description |
|----|--------|-------------|
| SC-1 | ✅ | 7 auditor files reject `next_step: proceed` for FAIL criteria |
| SC-2 | ✅ | `all_criteria_pass: bool` in all 7 auditor files |
| SC-3 | ✅ | `create.md` step 18 enforces `all_criteria_pass == true` |
| SC-4 | ✅ | `create.md` step 20 enforces `all_criteria_pass == true` |
| SC-5 | ✅ | `cross-validate.md` has `all_criteria_pass` + conditional `next_step` |
| SC-6 | ✅ | Contract templates include `all_criteria_pass: bool` for orchestrator gate check |

Fixes #1442

🤖 Co-authored with AI: OpenCode (deepseek-v4-flash)