### PR TITLE
[SPEC-FIX] Update verification-before-completion SKILL.md description for D1 compliance (#1455)

### DIFF
--- a/skills/verification-before-completion/SKILL.md
+++ b/skills/verification-before-completion/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: verification-before-completion
-description: "Verification is REQUIRED and not optional. MUST use when claiming a task is complete, marking a step done, or closing an issue. A completion claim without verification is not a completion — it is a placeholder for undiscovered defects."
+description: "Use when claiming a task is complete, marking a step done, or closing an issue. Verification is REQUIRED and not optional — MUST use before any completion claim."
 type: discipline-enforcing
 license: MIT
 compatibility: opencode

--- a/tests/content-verification/d1-description-format.sh
+++ b/tests/content-verification/d1-description-format.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Content-verification test: D1 description format for verification-before-completion
+#
+# Asserts the description starts with "Use when" — RED phase expects FAIL.
+set -euo pipefail
+
+SKILL_FILE=".opencode/skills/verification-before-completion/SKILL.md"
+
+# SC-1: Description starts with "Use when"
+if grep -q '^description: "Use when' "$SKILL_FILE"; then
+  echo "PASS: SC-1 — description starts with 'Use when'"
+else
+  echo "FAIL: SC-1 — description does NOT start with 'Use when'"
+  exit 1
+fi
+
+echo "All D1 checks PASS"


### PR DESCRIPTION
**Summary:**

Fixes the `verification-before-completion` SKILL.md description format to start with "Use when" per D1 compliance requirement, making the skill visible to CSO trigger discovery.

**Outcome:** The skill card passes D1 format validation and is discoverable by the CSO trigger matching system.

**Verification Attestation:** All success criteria verified PASS — exact-match against live file content. String evidence confirms the description matches the proposed text exactly.

**Detail: Per-SC Evidence**

| SC ID | Success Criterion | Evidence Type | Command | Result |
|-------|-------------------|---------------|---------|--------|
| SC-1 | Description starts with "Use when" | `string` | `head -8 SKILL.md` | PASS |
| SC-2 | Retains all dispatch conditions (complete, step done, close issue) | `string` | `head -8 SKILL.md` | PASS |
| SC-3 | Retains mandatory language (REQUIRED, MUST) | `string` | `head -8 SKILL.md` | PASS |
| SC-4 | Narrative-only sentence removed | `string` | `head -8 SKILL.md` | PASS |
| SC-5 | Description matches proposed text exactly | `string` | `head -8 SKILL.md` | PASS |

Implements #1455

🤖 Co-authored with AI: OpenCode (opencode/deepseek-v4-flash-free)