### PR TITLE
[SPEC-FIX] Update adversarial-audit description for D3 completeness (#1456)

### DIFF
--- a/skills/adversarial-audit/SKILL.md
+++ b/skills/adversarial-audit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: adversarial-audit
-description: "Use when running adversarial audits of specs, plans, or code. Audits are not optional — dispatch to spec-audit, plan-fidelity, concern-separation, coherence-extraction, guideline-audit, or cross-validate. Every unverified deliverable is a defect."
+description: "Use when running adversarial audits of specs, plans, or code. Dispatch to spec-audit, plan-fidelity, concern-separation, coherence-extraction, coherence-maintenance, guideline-audit, drift-detection, spec-summary, closure-verification, test-quality-audit, verification-audit, resolve-models, cross-validate, or completion. Audits are not optional — dispatch is MANDATORY."
 license: MIT
 ---
 


### PR DESCRIPTION
**Summary:** Updates `adversarial-audit` SKILL.md description to list all 14 dispatch targets from the Trigger Dispatch Table, fixing D3 (Completeness) violation.

**Outcome:** The skill card description now covers all dispatch conditions and is discoverable by CSO trigger matching.

**Fixes:** #1456

🤖 Co-authored with AI: OpenCode (deepseek-v4-flash)