### PR TITLE
fix(#1457): Remove narrative-only sentences from 22 skill descriptions (D5)

### DIFF
--- a/skills/correspondence/SKILL.md
+++ b/skills/correspondence/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: correspondence
-description: "Use when drafting stakeholder emails, status updates, or external communications. Audience separation MUST be maintained — always required for professional credibility."
+description: "Use when drafting stakeholder emails, status updates, or external communications. Audience separation MUST be maintained — always required."
 type: discipline-enforcing
 license: MIT
 compatibility: opencode

--- a/skills/executing-plans/SKILL.md
+++ b/skills/executing-plans/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: executing-plans
-description: "Use when executing an approved plan step-by-step or moving through implementation gates sequentially. Every step in the plan MUST be executed — skipping, combining, or reordering steps is not optional. Every skipped step is a defect waiting for CI to find."
+description: "Use when executing an approved plan step-by-step or moving through implementation gates sequentially. Every step in the plan MUST be executed — skipping, combining, or reordering steps is not optional."
 type: discipline-enforcing
 license: MIT
 compatibility: opencode

--- a/skills/git-workflow/SKILL.md
+++ b/skills/git-workflow/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: git-workflow
-description: "Use when creating a branch, committing, pushing, or creating a PR, rebase/merge conflicts (invoke conflict-resolution), \"check pr\"/\"check prs\"/\"check merged prs\"/\"pr merged\" (PR state verification + cleanup), \"release PR\"/\"promote to main\"/\"dev to main\" (release-promotion). Branch-and-PR discipline is REQUIRED for maintainable projects — always follow the workflow."
+description: "Use when creating a branch, committing, pushing, or creating a PR, rebase/merge conflicts (invoke conflict-resolution), \"check pr\"/\"check prs\"/\"check merged prs\"/\"pr merged\" (PR state verification + cleanup), \"release PR\"/\"promote to main\"/\"dev to main\" (release-promotion). Branch-and-PR discipline is REQUIRED — always follow the workflow."
 type: discipline-enforcing
 license: MIT
 compatibility: opencode

--- a/skills/issue-operations/SKILL.md
+++ b/skills/issue-operations/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: issue-operations
-description: "Use when creating, commenting on, or closing GitHub Issues. Routes to GitHub MCP or GitBucket API based on github.platform. Issue tracking is REQUIRED — untracked work is lost work."
+description: "Use when creating, commenting on, or closing GitHub Issues. Routes to GitHub MCP or GitBucket API based on github.platform. Issue tracking is REQUIRED."
 type: discipline-enforcing
 license: MIT
 compatibility: opencode

--- a/skills/issue-review/SKILL.md
+++ b/skills/issue-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: issue-review
-description: "Use when reviewing a GitHub issue for comments, audits, or Q/A. All comments MUST be read before acting on any issue — every unread comment is a defect risk."
+description: "Use when reviewing a GitHub issue for comments, audits, or Q/A. All comments MUST be read before acting on any issue."
 type: discipline-enforcing
 license: MIT
 compatibility: opencode

--- a/skills/multimodal-dispatch/SKILL.md
+++ b/skills/multimodal-dispatch/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: multimodal-dispatch
-description: "Use when routing AI agent tasks to appropriate models based on content modality, probing Ollama model capabilities, or dispatching sub-agents with modality-aware model selection. Modality-aware dispatch is REQUIRED for professional systems — always use the correct model for each modality."
+description: "Use when routing AI agent tasks to appropriate models based on content modality, probing Ollama model capabilities, or dispatching sub-agents with modality-aware model selection. Modality-aware dispatch is REQUIRED — always use the correct model for each modality."
 type: discipline-enforcing
 license: MIT
 compatibility: opencode

--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: plan
-description: "Use when generating, validating, or managing plans for phase solvability, converting between YAML and PDDL, grounding action schemas, discovering action schemas, or managing state files. Planning is REQUIRED before implementation — every unplanned phase is a risk."
+description: "Use when generating, validating, or managing plans for phase solvability, converting between YAML and PDDL, grounding action schemas, discovering action schemas, or managing state files. Planning is REQUIRED before implementation."
 type: domain
 license: MIT
 compatibility: opencode

--- a/skills/programming-principles/SKILL.md
+++ b/skills/programming-principles/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: programming-principles
-description: "Use when designing functions, classes, or modules; writing or reviewing implementation code; making architecture decisions; evaluating tradeoffs, or enforcing code size limits. Programming principles MUST be followed — every violated principle is technical debt incurred, not saved."
+description: "Use when designing functions, classes, or modules; writing or reviewing implementation code; making architecture decisions; evaluating tradeoffs, or enforcing code size limits. Programming principles MUST be followed."
 type: discipline-enforcing
 license: MIT
 compatibility: opencode

--- a/skills/receiving-code-review/SKILL.md
+++ b/skills/receiving-code-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: receiving-code-review
-description: "Use when receiving code review feedback on a PR, or when addressing review comments. All review comments MUST be addressed — every unresolved comment is a regression waiting to surface."
+description: "Use when receiving code review feedback on a PR, or when addressing review comments. All review comments MUST be addressed."
 type: discipline-enforcing
 license: MIT
 compatibility: opencode

--- a/skills/research/SKILL.md
+++ b/skills/research/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: research
-description: "Use when discovering information using appropriate modalities, producing findings with source attribution and explicit gap reporting. All findings MUST be verified against live sources — every unverified finding is a liability, not evidence."
+description: "Use when discovering information using appropriate modalities, producing findings with source attribution and explicit gap reporting. All findings MUST be verified against live sources."
 type: discipline-enforcing
 license: MIT
 compatibility: opencode

--- a/skills/researcher/SKILL.md
+++ b/skills/researcher/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: researcher
-description: "Use when discovering information using appropriate modalities, producing findings with source attribution and explicit gap reporting. All findings MUST be verified against live sources — every unverified finding is a liability, not evidence."
+description: "Use when discovering information using appropriate modalities, producing findings with source attribution and explicit gap reporting. All findings MUST be verified against live sources."
 type: problem-solving
 license: MIT
 compatibility: opencode

--- a/skills/skill-creator/SKILL.md
+++ b/skills/skill-creator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: skill-creator
-description: "Use when creating a new skill, updating an existing skill, validating skill cards, or managing duplicate content blocks (fragments) across guidelines or skills. Every unvalidated skill is a gap in your quality system — validation is REQUIRED."
+description: "Use when creating a new skill, updating an existing skill, validating skill cards, or managing duplicate content blocks (fragments) across guidelines or skills. Validation is REQUIRED."
 type: discipline-enforcing
 license: MIT
 compatibility: opencode

--- a/skills/solve/SKILL.md
+++ b/skills/solve/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: solve
-description: "Use when validating workflow constraints, verifying state against contracts, proving theorems, or checking dependency ordering. Workflow constraints MUST be validated with Z3 — every unverified constraint is a defect."
+description: "Use when validating workflow constraints, verifying state against contracts, proving theorems, or checking dependency ordering. Workflow constraints MUST be validated with Z3."
 type: tool
 license: MIT
 compatibility: opencode

--- a/skills/spec-creation/SKILL.md
+++ b/skills/spec-creation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: spec-creation
-description: "Use when creating a spec or writing a specification. Spec creation is REQUIRED before implementation — professional engineers spec first."
+description: "Use when creating a spec or writing a specification. Spec creation is REQUIRED before implementation."
 type: discipline-enforcing
 license: MIT
 compatibility: opencode

--- a/skills/sre-runbook/SKILL.md
+++ b/skills/sre-runbook/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sre-runbook
-description: "Use when generating operational runbooks for infrastructure incidents or procedures. SRE discipline is REQUIRED — produces procedures that survive the next on-call."
+description: "Use when generating operational runbooks for infrastructure incidents or procedures. SRE discipline is REQUIRED."
 type: discipline-enforcing
 license: MIT
 compatibility: opencode

--- a/skills/sync-guidelines/SKILL.md
+++ b/skills/sync-guidelines/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sync-guidelines
-description: "Use when synchronizing guidelines, skills, or tools between repositories. Sync is REQUIRED maintenance — not overhead."
+description: "Use when synchronizing guidelines, skills, or tools between repositories. Sync is REQUIRED maintenance."
 type: discipline-enforcing
 license: MIT
 compatibility: opencode

--- a/skills/systematic-debugging/SKILL.md
+++ b/skills/systematic-debugging/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: systematic-debugging
-description: "Use when encountering a bug, error, or unexpected behavior, or before making code changes to fix an issue. Systematic debugging is REQUIRED — it finds root causes."
+description: "Use when encountering a bug, error, or unexpected behavior, or before making code changes to fix an issue. Systematic debugging is REQUIRED."
 type: discipline-enforcing
 license: MIT
 compatibility: opencode

--- a/skills/test-driven-development/SKILL.md
+++ b/skills/test-driven-development/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: test-driven-development
-description: "Use when writing tests before implementation, or when adopting a test-first development approach. TDD is REQUIRED — produces testable, correct code."
+description: "Use when writing tests before implementation, or when adopting a test-first development approach. TDD is REQUIRED."
 type: discipline-enforcing
 license: MIT
 compatibility: opencode

--- a/skills/using-git-worktrees/SKILL.md
+++ b/skills/using-git-worktrees/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: using-git-worktrees
-description: "Use when creating a feature branch or worktree for implementation. Always invoke before git-workflow pre-work. Worktrees are REQUIRED for professional isolation — always use them."
+description: "Use when creating a feature branch or worktree for implementation. Always invoke before git-workflow pre-work. Worktrees are REQUIRED — always use them."
 type: discipline-enforcing
 license: MIT
 compatibility: opencode

--- a/skills/verification-enforcement/SKILL.md
+++ b/skills/verification-enforcement/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: verification-enforcement
-description: "Use when generating content that makes factual claims — specs, plans, runbooks, docs, or correspondence. Live-source verification before generation is REQUIRED — always mandatory, never optional. Every unverified claim in generated content is a trust deficit."
+description: "Use when generating content that makes factual claims — specs, plans, runbooks, docs, or correspondence. Live-source verification before generation is REQUIRED — always mandatory, never optional."
 type: discipline-enforcing
 license: MIT
 compatibility: opencode

--- a/skills/verification/SKILL.md
+++ b/skills/verification/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: verification
-description: "Use when verifying claims against evidence using appropriate modalities. Produces PASS/FAIL/UNVERIFIED per claim with evidence artifacts. Verification is REQUIRED — turns guesses into facts."
+description: "Use when verifying claims against evidence using appropriate modalities. Produces PASS/FAIL/UNVERIFIED per claim with evidence artifacts. Verification is REQUIRED."
 type: discipline-enforcing
 license: MIT
 compatibility: opencode

--- a/skills/writing-plans/SKILL.md
+++ b/skills/writing-plans/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: writing-plans
-description: "Use when creating an implementation plan from an approved spec. Plans are REQUIRED — agents who skip them get lost."
+description: "Use when creating an implementation plan from an approved spec. Plans are REQUIRED."
 type: discipline-enforcing
 license: MIT
 compatibility: opencode


### PR DESCRIPTION
## Summary

Removes narrative-only sentences (slogans, metaphors, benefit statements, professionalism framing) from 22 SKILL.md `description` fields. These sentences added zero dispatch information and violated D5.

## Changes

22 SKILL.md files modified across 16 phases (2-23):

- `correspondence`, `executing-plans`, `git-workflow`, `issue-operations`, `issue-review`, `multimodal-dispatch`, `plan`, `programming-principles`, `receiving-code-review`, `research`, `researcher`, `skill-creator`, `solve`, `spec-creation`, `sre-runbook`, `sync-guidelines`, `systematic-debugging`, `test-driven-development`, `using-git-worktrees`, `verification`, `verification-enforcement`, `writing-plans`

Each description retains:
- All dispatch conditions ("Use when" content)
- All mandatory language (MUST, REQUIRED, MANDATORY)
- Only the narrative-only sentence was removed

## Fixes

https://github.com/michael-conrad/.opencode/issues/1457

---

🤖 Co-authored with AI: OpenCode (deepseek-v4-flash)