### PR TITLE
Phase 2: remediate all 56 complexity metric findings + writing-plans skill fixes

### DIFF
--- a/guidelines/000-critical-rules.md
+++ b/guidelines/000-critical-rules.md
@@ -755,10 +755,12 @@ All linters (current and future) MUST run in read-only/report-only mode. No lint
 | Any future linter | Auto-modify mode | Read-only/report-only mode |
 
 ### [critical-rules-063] Orchestrator Context Lean — orchestrator holds routing metadata only
-The orchestrator's context is the most expensive resource in the pipeline. Every byte held costs `byte × remaining_dispatches²` — and context is monotonic, never shrinking. Professional orchestrators hold routing metadata only (worktree.path, github.owner, github.repo, authorization_scope, halt_at, pr_strategy, pipeline_phase, pipeline_history). See `020-go-prohibitions.md` §1.1.
+The orchestrator holds routing metadata only (worktree.path, github.owner, github.repo, authorization_scope, halt_at, pr_strategy, pipeline_phase, pipeline_history). Task file contents, analysis artifacts, and verification results go to sub-agents or disk. See `020-go-prohibitions.md` §1.1.
+
+> **Note:** These are operational bookkeeping guidelines for context management. They describe how the orchestrator routes work to sub-agents — they are NOT implementation complexity measures. Implementation work is measured ONLY by whether tested verified correct code operations pass with 100% clean PASS.
 
 ### [critical-rules-065] Result Contract Frugality — result contracts limited to routing-significant data
-The only thing that returns from a sub-agent enters the orchestrator's cost function. Every byte in the result contract costs `byte × (remaining_dispatches - 1)`. Result contracts carry only routing-significant data (status, finding_summary, artifact_path, blocker_reason). Full evidence artifacts go to disk. See `020-go-prohibitions.md` §1.1.
+Result contracts carry only routing-significant data (status, finding_summary, artifact_path, blocker_reason). Full evidence artifacts go to disk. See `020-go-prohibitions.md` §1.1.
 
 ### [critical-rules-dispatch-gate-canonical] Canonical Dispatch String Violation — orchestrator uses custom prompt after reading canonical dispatch string
 
@@ -960,8 +962,8 @@ ALL failures are agent-owned. Remediation is the default action. Escalation is o
 All failures are agent-owned. Remediation is the default action. Escalation is only permitted after verified remediation failure — never as a first response, never as a shortcut.
 
 
-### [critical-rules-066] Terminology Standardization — all context cost references must use standardized vocabulary
-All references to "context budget", "context cost", and "context awareness" must use the standardized vocabulary: "orchestrator context", "sub-agent context", and "orchestrator context discipline". See `020-go-prohibitions.md` §1.1 Terminology Standardization. CHANGELOG entries and historical references are exempt.
+### [critical-rules-066] Terminology Standardization — all context references must use standardized vocabulary
+All references to "context budget", "context cost", and "context awareness" must use the standardized vocabulary: "orchestrator context", "sub-agent context", and "orchestrator context discipline". These terms describe operational bookkeeping for context management — they are NOT implementation complexity measures. See `020-go-prohibitions.md` §1.1 Terminology Standardization. CHANGELOG entries and historical references are exempt.
 
 
 ### Channel-Routing Table — Issue Comments vs. Chat Output

--- a/guidelines/020-go-prohibitions.md
+++ b/guidelines/020-go-prohibitions.md
@@ -69,59 +69,31 @@ load_when: sub-agent
 
 ---
 
-## 1.1 Two-Role Context Cost Model
+## 1.1 Orchestrator Context Discipline
 
-### The Cost Model
+### Overview
 
-The orchestrator and sub-agents occupy different cost functions. Understanding this is essential to making correct dispatch decisions.
+The orchestrator and sub-agents have different context management patterns. These are internal operational bookkeeping notes describing how context flows through the pipeline — they are NOT implementation complexity measures.
 
-**Orchestrator Context Cost:**
+> **Implementation work is measured ONLY by whether tested verified correct code operations pass with 100% clean PASS. Document size metrics (word count, line count, token count, byte-dispatch formulas) are NOT valid proxies for implementation complexity.**
 
-```
-orchestrator_cost = size × remaining_dispatches²
-```
+### Context Flow
 
-- `size` = bytes held by orchestrator (routing metadata, cached analysis, task file contents)
-- `remaining_dispatches` = number of future `task()` calls in the pipeline
-- Squared because: held bytes are seen by every subsequent sub-agent, AND the orchestrator's accumulation is monotonic (never shrinks)
+**Orchestrator context:** Holds routing metadata only — `worktree.path`, `github.owner`, `github.repo`, `authorization_scope`, `halt_at`, `pr_strategy`, `pipeline_phase`, `pipeline_history` (phase names only). Task file contents, analysis artifacts, and verification results go to sub-agents or disk.
 
-*Industry validation: CipherBuilds reports coordinator = 60-90% of total token spend. Inngest reports 90%+ reduction via sub-agent delegation.*
+**Sub-agent context:** Disposable — sub-agents read task files, source files, run analysis tools, and execute tests freely. Their context is discarded after returning a result contract.
 
-Example: holding a 500-byte inline analysis artifact when 12 dispatches remain:
-- `500 × 12² = 500 × 144 = 72,000 byte-dispatches`
-- Same analysis in a sub-agent: `500 × 1 = 500 byte-dispatches`, then discarded
-
-**Sub-Agent Context Cost:**
-
-```
-sub_agent_cost = size × 1
-```
-
-- Flat, single dispatch. Discarded after return contract.
-- The sub-agent should NOT conserve context — every byte it uses is a byte that did NOT go to the orchestrator.
-
-*Industry validation: Jaymin West describes sub-agents as "disposable context buffers." Inngest: "The parent sees a 750-token summary" from 8-file analysis.*
-
-**Result Contract Cost (enters orchestrator context):**
-
-```
-result_contract_cost = size × (remaining_dispatches - 1)
-```
-
-- The only thing that returns to the orchestrator. Every byte re-bloats the orchestrator for all subsequent dispatches.
-- Result contracts should be frugal: routing-significant data only. Full evidence artifacts go to disk.
-
-*Industry validation: Jaymin West: "orchestrator aggregates final outputs, not intermediate states." Inngest: "compressed to 300 tokens of key findings — cuts orchestration cost by 50%+."*
+**Result contracts:** Return only routing-significant data: `status`, `finding_summary`, `artifact_path`, `blocker_reason`. Full evidence artifacts go to disk.
 
 ### The Three Mandates
 
-#### 1. Orchestrator Context Lean (what to hold)
+#### 1. Orchestrator Context Lean
 
 The orchestrator holds ONLY routing metadata:
 
 - `worktree.path`, `github.owner`, `github.repo`, `authorization_scope`, `halt_at`, `pr_strategy`, `pipeline_phase`, `pipeline_history` (phase names only)
 
-Everything else goes to a sub-agent. Specifically:
+Everything else goes to a sub-agent:
 
 | Does NOT belong in orchestrator | Goes to |
 |-------------------------------|---------|
@@ -131,18 +103,14 @@ Everything else goes to a sub-agent. Specifically:
 | Previous sub-agent reasoning traces | Discarded with sub-agent context |
 | Full file contents | Disk only |
 
-*Industry validation: BMad Builder: "Parent context stays tiny (file pointers + high-level plan)."*
-
-#### 2. Sub-Agent Context Generosity (what to consume)
+#### 2. Sub-Agent Context Generosity
 
 The sub-agent is ENCOURAGED to expand into its context:
 - Read task files fully — that's what sub-agent context is for
 - Read source files, run analysis tools, execute tests — burn context freely
 - Write full evidence artifacts to disk
 
-*Industry validation: Inngest: "The sub-agent might read 8 files and make 15 tool calls." Jaymin West: "Each agent maintains its own separate context window."*
-
-#### 3. Result Contract Frugality (gate at the boundary)
+#### 3. Result Contract Frugality
 
 The sub-agent returns only:
 
@@ -154,24 +122,6 @@ The sub-agent returns only:
 | `blocker_reason` | If BLOCKED | Why blocked |
 
 Everything else stays in the sub-agent's context and is discarded.
-
-*Industry validation: CipherBuilds: "Don't pass raw results. Compress them first."*
-
-### Cost-Frame Dark Prose
-
-Using dark-prose-007 (Cost-Frame Reformation) formula:
-
-**Orchestrator Context Lean:**
-
-> The orchestrator's context is the most expensive resource in the pipeline. Every byte held costs `byte × remaining_dispatches²` — and context is monotonic, never shrinking. Loading a task file inline costs 3,000 words × 144 = 432,000 word-dispatches for a 12-step pipeline. Dispatched as a sub-agent, the same content costs 3,000 × 1 = 3,000 and is discarded. Professional orchestrators hold routing metadata only — sub-agents do the work.
-
-**Sub-Agent Context Generosity:**
-
-> The sub-agent's context is a disposable resource. Every byte burned in the sub-agent is a byte the orchestrator does not have to hold. Reading task files in full, analyzing source, running tests — consume freely. Conserving sub-agent context means you are NOT protecting the orchestrator — you are forcing it to hold what you should have consumed. Professional sub-agents burn their context to shield the orchestrator.
-
-**Result Contract Frugality:**
-
-> The only thing that returns from a sub-agent enters the orchestrator's cost function. Every byte in the result contract costs `byte × (remaining_dispatches - 1)`. A verbose 500-word narrative costs the same as a routing-significant 50-word summary — but it re-bloats the orchestrator for everything downstream. Evidence goes to disk. Contracts carry routing decisions only.
 
 ---
 

--- a/guidelines/060-tool-usage.md
+++ b/guidelines/060-tool-usage.md
@@ -8,7 +8,9 @@ load_when: sub-agent
 
 ## 0. Progressive Disclosure — Index-Only Orchestrator Context
 
-**CRITICAL:** Full guideline content lives exclusively in ephemeral sub-agent context windows — loaded fresh on demand and discarded. The orchestrator holds only `.opencode/guidelines/INDEX.md` (trigger-pattern pairs, ≤1,500 words) for routing decisions. Never load full guideline bodies into orchestrator context.
+**CRITICAL:** Full guideline content lives exclusively in ephemeral sub-agent context windows — loaded fresh on demand and discarded. The orchestrator holds only `.opencode/guidelines/INDEX.md` (trigger-pattern pairs) for routing decisions. Never load full guideline bodies into orchestrator context.
+
+> **Note:** These are operational guidelines for context management — they describe how the orchestrator routes work to sub-agents. They are NOT implementation complexity measures. Implementation work is measured ONLY by whether tested verified correct code operations pass with 100% clean PASS.
 
 ### Loading Protocol
 

--- a/guidelines/091-incremental-build.md
+++ b/guidelines/091-incremental-build.md
@@ -42,26 +42,7 @@ All implementation MUST follow: top-down decomposition → bottom-up design → 
 - Merging without tests
 - Phase-scoped over-verification — testing other phases' deliverables
 
-## Complexity Metric: Word Count
-
-Word count (`wc -w`) is the canonical complexity metric for all skill task files, SKILL.md files, and guideline files. Line counts are not used because line length varies by formatting conventions and does not correlate with semantic density.
-
-### Artifact Size Limits
-
-| Artifact Type | Max Words | Measurement |
-| -- | -- | -- |
-| Atomic task file | ≤3,000 | `wc -w` |
-| Routing-tier SKILL.md | ≤4,000 | `wc -w` |
-| Condensed-tier SKILL.md | ≤2,000 | `wc -w` |
-| Guideline file | Per content needs | `wc -w` |
-
-When a task file exceeds 3,000 words on first draft, it MUST be split into smaller atomic tasks, each with a single concern and entry/exit criteria. This is a hard constraint, not a guideline.
-
-### Why Word Count
-
-- **Words, not lines:** Line length varies by formatting conventions. A 40-line table and a 40-line prose paragraph carry wildly different cognitive loads. Word counts measure semantic density.
-- **Words, not tokens:** Token counts vary by tokenizer, model, and encoding. Word counts are stable, reproducible, and model-agnostic.
-- **Measurement method:** `wc -w` is the canonical tool. All enforcement test assertions for artifact size MUST use `wc -w`, never `wc -l`.
+> **Implementation work is measured ONLY by whether tested verified correct code operations pass with 100% clean PASS. Document size metrics (word count, line count, token count, byte-dispatch formulas) are NOT valid proxies for implementation complexity.**
 
 **Symbolic rules below** — the prose above this line replaces the previous ~200 lines of advisory text.
 
@@ -134,17 +115,6 @@ rules:
     triggers: [verification-before-completion]
     source: "091-incremental-build.md §Phase-Scoped Test Assertions"
 
-  - id: incremental-build-006
-    title: "Task files must not exceed 3000 words"
-    conditions:
-      all:
-        - "task_file_word_count > 3000"
-    actions:
-      - SPLIT_FILE
-    conflicts_with: []
-    requires: []
-    triggers: [skill-creator]
-    source: "091-incremental-build.md §Complexity Metric: Word Count"
 
   - id: incremental-build-007
     title: "SC-specific TDD — test assertions must reference SC IDs"

--- a/skills/approval-gate/SKILL.md
+++ b/skills/approval-gate/SKILL.md
@@ -63,7 +63,7 @@ For `for_spec` scope, only minimal-tier requirements enforced (Pipeline Step Bin
 
 ### DISPATCH_GATE — Orchestrator task() Prompt Protocol
 
-> **Context cost frame:** The orchestrator's context is the most expensive resource in the pipeline — sub-agents do the work, not the orchestrator. Every byte held by the orchestrator costs `byte × remaining_dispatches²`. See `020-go-prohibitions.md` §1.1.
+> **Context cost frame:** These are internal operational bookkeeping notes describing how context flows through the pipeline — they are NOT implementation complexity measures. Implementation work is measured ONLY by whether tested verified correct code operations pass with 100% clean PASS.
 > This cost frame applies to orchestrator context only — it does NOT mean the agent should minimize message count, pipeline steps, or user-facing output.
 
 The orchestrator MUST NOT preload execution context into `task()` prompts.

--- a/skills/approval-gate/enforcement/work-state-schema.md
+++ b/skills/approval-gate/enforcement/work-state-schema.md
@@ -50,7 +50,7 @@ result: <YAML-structured task output>
 ## Constraints
 
 - Each section appears at most once per work state file (except `screen-gate1-`/`screen-gate2-` which are per-issue).
-- Task results MUST be compact (≤500 words per section).
+- Task results MUST be compact (routing-significant data only).
 - Status transitions: `pending → in_progress → done | failed | skipped`.
 - Failed tasks set `status: failed` with error detail in `result.error`.
 

--- a/skills/approval-gate/tasks/screen-issue.md
+++ b/skills/approval-gate/tasks/screen-issue.md
@@ -35,7 +35,7 @@ Gate 1 classifies the issue and executes sub-issue enumeration. If the issue is 
 - Issue classified into one screening category
 - Gate 1 (sub-issue enumeration) executed if applicable
 - Gate 2 (success criteria verification) executed if applicable
-- Compact result contract produced (≈100-500 words, YAML-structured)
+- Compact result contract produced (YAML-structured, routing-significant data only)
 
 ## Enforcement References
 

--- a/skills/approval-gate/tasks/screen/screen-issue-gate2.md
+++ b/skills/approval-gate/tasks/screen/screen-issue-gate2.md
@@ -19,7 +19,7 @@ Second gate of per-issue screening for pre-implementation analysis. Execute Gate
 - Sub-issues expanded into flat item list
 - Cross-issue sub-issue handling resolved
 - File and symbol references extracted
-- Compact result contract produced (≈100-500 words, YAML-structured)
+- Compact result contract produced (YAML-structured, routing-significant data only)
 
 ## Procedure
 
@@ -176,7 +176,7 @@ For each file path or symbol mentioned in the issue:
 
 ### Step 10: Produce Result Contract
 
-The result contract MUST be YAML-structured, compact (≈100-500 words):
+The result contract MUST be YAML-structured, compact (routing-significant data only):
 
 ```yaml
 status: DONE | BLOCKED | OVERFLOW

--- a/skills/brainstorming/SKILL.md
+++ b/skills/brainstorming/SKILL.md
@@ -71,7 +71,7 @@ Sub-agents run via `task(subagent_type="general")` with `{ context, worktree.pat
 
 ### DISPATCH_GATE — Orchestrator task() Prompt Protocol
 
-> **Context cost frame:** The orchestrator's context is the most expensive resource in the pipeline — sub-agents do the work, not the orchestrator. Every byte held by the orchestrator costs `byte × remaining_dispatches²`. See `020-go-prohibitions.md` §1.1.
+> **Context cost frame:** These are internal operational bookkeeping notes describing how context flows through the pipeline — they are NOT implementation complexity measures. Implementation work is measured ONLY by whether tested verified correct code operations pass with 100% clean PASS.
 > This cost frame applies to orchestrator context only — it does NOT mean the agent should minimize message count, pipeline steps, or user-facing output.
 
 The orchestrator MUST NOT preload execution context into `task()` prompts.

--- a/skills/brainstorming/tasks/explore/exploration-workflow.md
+++ b/skills/brainstorming/tasks/explore/exploration-workflow.md
@@ -87,7 +87,7 @@ Present conversationally with recommendation and reasoning. Lead with recommende
 ### Step 6: Present Design Incrementally
 
 - Present section by section, asking after each whether it looks right
-- Scale each section: a few sentences if straightforward, 200-300 words if nuanced
+- Scale each section: a few sentences if straightforward, more detail if nuanced (content depth driven by complexity, not word count)
 - Cover: architecture, components, data flow, error handling, testing
 - Be ready to go back and clarify
 

--- a/skills/changelog-generator/SKILL.md
+++ b/skills/changelog-generator/SKILL.md
@@ -60,7 +60,7 @@ Sub-agents run via `task(subagent_type="general")` with `{ date_range, worktree.
 
 ### DISPATCH_GATE — Orchestrator task() Prompt Protocol
 
-> **Context cost frame:** The orchestrator's context is the most expensive resource in the pipeline — sub-agents do the work, not the orchestrator. Every byte held by the orchestrator costs `byte × remaining_dispatches²`. See `020-go-prohibitions.md` §1.1.
+> **Context cost frame:** These are internal operational bookkeeping notes describing how context flows through the pipeline — they are NOT implementation complexity measures. Implementation work is measured ONLY by whether tested verified correct code operations pass with 100% clean PASS.
 > This cost frame applies to orchestrator context only — it does NOT mean the agent should minimize message count, pipeline steps, or user-facing output.
 
 The orchestrator MUST NOT preload execution context into `task()` prompts.

--- a/skills/completeness-gate/SKILL.md
+++ b/skills/completeness-gate/SKILL.md
@@ -45,7 +45,7 @@ You are a Completeness Gate Sub-Agent. Your focus is verifying that a deliverabl
 
 ### DISPATCH_GATE — Orchestrator task() Prompt Protocol
 
-> **Context cost frame:** The orchestrator's context is the most expensive resource in the pipeline — sub-agents do the work, not the orchestrator. Every byte held by the orchestrator costs `byte × remaining_dispatches²`. See `020-go-prohibitions.md` §1.1.
+> **Context cost frame:** These are internal operational bookkeeping notes describing how context flows through the pipeline — they are NOT implementation complexity measures. Implementation work is measured ONLY by whether tested verified correct code operations pass with 100% clean PASS.
 > This cost frame applies to orchestrator context only — it does NOT mean the agent should minimize message count, pipeline steps, or user-facing output.
 
 The orchestrator MUST NOT preload execution context into `task()` prompts.

--- a/skills/completion-core/SKILL.md
+++ b/skills/completion-core/SKILL.md
@@ -118,7 +118,7 @@ Chat output is idempotent by nature. Always produce:
 
 ### DISPATCH_GATE — Orchestrator task() Prompt Protocol
 
-> **Context cost frame:** The orchestrator's context is the most expensive resource in the pipeline — sub-agents do the work, not the orchestrator. Every byte held by the orchestrator costs `byte × remaining_dispatches²`. See `020-go-prohibitions.md` §1.1.
+> **Context cost frame:** These are internal operational bookkeeping notes describing how context flows through the pipeline — they are NOT implementation complexity measures. Implementation work is measured ONLY by whether tested verified correct code operations pass with 100% clean PASS.
 > This cost frame applies to orchestrator context only — it does NOT mean the agent should minimize message count, pipeline steps, or user-facing output.
 
 The orchestrator MUST NOT preload execution context into `task()` prompts.

--- a/skills/conflict-resolution/SKILL.md
+++ b/skills/conflict-resolution/SKILL.md
@@ -69,7 +69,7 @@ authorization_source: "User approved #N on YYYY-MM-DD"
 
 ### DISPATCH_GATE — Orchestrator task() Prompt Protocol
 
-> **Context cost frame:** The orchestrator's context is the most expensive resource in the pipeline — sub-agents do the work, not the orchestrator. Every byte held by the orchestrator costs `byte × remaining_dispatches²`. See `020-go-prohibitions.md` §1.1.
+> **Context cost frame:** These are internal operational bookkeeping notes describing how context flows through the pipeline — they are NOT implementation complexity measures. Implementation work is measured ONLY by whether tested verified correct code operations pass with 100% clean PASS.
 > This cost frame applies to orchestrator context only — it does NOT mean the agent should minimize message count, pipeline steps, or user-facing output.
 
 The orchestrator MUST NOT preload execution context into `task()` prompts.

--- a/skills/correspondence/SKILL.md
+++ b/skills/correspondence/SKILL.md
@@ -66,7 +66,7 @@ Correspondence drafter. Routes audience analysis and content generation to sub-a
 
 ### DISPATCH_GATE — Orchestrator task() Prompt Protocol
 
-> **Context cost frame:** The orchestrator's context is the most expensive resource in the pipeline — sub-agents do the work, not the orchestrator. Every byte held by the orchestrator costs `byte × remaining_dispatches²`. See `020-go-prohibitions.md` §1.1.
+> **Context cost frame:** These are internal operational bookkeeping notes describing how context flows through the pipeline — they are NOT implementation complexity measures. Implementation work is measured ONLY by whether tested verified correct code operations pass with 100% clean PASS.
 > This cost frame applies to orchestrator context only — it does NOT mean the agent should minimize message count, pipeline steps, or user-facing output.
 
 The orchestrator MUST NOT preload execution context into `task()` prompts.

--- a/skills/engineering-approach/SKILL.md
+++ b/skills/engineering-approach/SKILL.md
@@ -69,7 +69,7 @@ All tasks run via `task(subagent_type="general")`. `verify-understanding` receiv
 
 ### DISPATCH_GATE — Orchestrator task() Prompt Protocol
 
-> **Context cost frame:** The orchestrator's context is the most expensive resource in the pipeline — sub-agents do the work, not the orchestrator. Every byte held by the orchestrator costs `byte × remaining_dispatches²`. See `020-go-prohibitions.md` §1.1.
+> **Context cost frame:** These are internal operational bookkeeping notes describing how context flows through the pipeline — they are NOT implementation complexity measures. Implementation work is measured ONLY by whether tested verified correct code operations pass with 100% clean PASS.
 > This cost frame applies to orchestrator context only — it does NOT mean the agent should minimize message count, pipeline steps, or user-facing output.
 
 The orchestrator MUST NOT preload execution context into `task()` prompts.

--- a/skills/executing-plans/SKILL.md
+++ b/skills/executing-plans/SKILL.md
@@ -81,7 +81,7 @@ authorization_source: "User approved #N on YYYY-MM-DD"
 
 ### DISPATCH_GATE — Orchestrator task() Prompt Protocol
 
-> **Context cost frame:** The orchestrator's context is the most expensive resource in the pipeline — sub-agents do the work, not the orchestrator. Every byte held by the orchestrator costs `byte × remaining_dispatches²`. See `020-go-prohibitions.md` §1.1.
+> **Context cost frame:** These are internal operational bookkeeping notes describing how context flows through the pipeline — they are NOT implementation complexity measures. Implementation work is measured ONLY by whether tested verified correct code operations pass with 100% clean PASS.
 > This cost frame applies to orchestrator context only — it does NOT mean the agent should minimize message count, pipeline steps, or user-facing output.
 
 The orchestrator MUST NOT preload execution context into `task()` prompts.

--- a/skills/finishing-a-development-branch/SKILL.md
+++ b/skills/finishing-a-development-branch/SKILL.md
@@ -71,7 +71,7 @@ Sub-agents run via `task(subagent_type="general")` with `{ branch_name, worktree
 
 ### DISPATCH_GATE — Orchestrator task() Prompt Protocol
 
-> **Context cost frame:** The orchestrator's context is the most expensive resource in the pipeline — sub-agents do the work, not the orchestrator. Every byte held by the orchestrator costs `byte × remaining_dispatches²`. See `020-go-prohibitions.md` §1.1.
+> **Context cost frame:** These are internal operational bookkeeping notes describing how context flows through the pipeline — they are NOT implementation complexity measures. Implementation work is measured ONLY by whether tested verified correct code operations pass with 100% clean PASS.
 > This cost frame applies to orchestrator context only — it does NOT mean the agent should minimize message count, pipeline steps, or user-facing output.
 
 The orchestrator MUST NOT preload execution context into `task()` prompts.

--- a/skills/git-workflow/SKILL.md
+++ b/skills/git-workflow/SKILL.md
@@ -136,7 +136,7 @@ Submodule sub-agents (`submodule-tag-prework`, `submodule-feature-push`, `submod
 
 ### DISPATCH_GATE — Orchestrator task() Prompt Protocol
 
-> **Context cost frame:** The orchestrator's context is the most expensive resource in the pipeline — sub-agents do the work, not the orchestrator. Every byte held by the orchestrator costs `byte × remaining_dispatches²`. See `020-go-prohibitions.md` §1.1.
+> **Context cost frame:** These are internal operational bookkeeping notes describing how context flows through the pipeline — they are NOT implementation complexity measures. Implementation work is measured ONLY by whether tested verified correct code operations pass with 100% clean PASS.
 > This cost frame applies to orchestrator context only — it does NOT mean the agent should minimize message count, pipeline steps, or user-facing output.
 
 The orchestrator MUST NOT preload execution context into `task()` prompts.

--- a/skills/implementation-pipeline/SKILL.md
+++ b/skills/implementation-pipeline/SKILL.md
@@ -153,7 +153,7 @@ Exclusions: implementation context, agent memory, cached verification results.
 
 ### DISPATCH_GATE — Orchestrator task() Prompt Protocol
 
-> **Context cost frame:** The orchestrator's context is the most expensive resource in the pipeline — sub-agents do the work, not the orchestrator. Every byte held by the orchestrator costs `byte × remaining_dispatches²`. See `020-go-prohibitions.md` §1.1.
+> **Context cost frame:** These are internal operational bookkeeping notes describing how context flows through the pipeline — they are NOT implementation complexity measures. Implementation work is measured ONLY by whether tested verified correct code operations pass with 100% clean PASS.
 > This cost frame applies to orchestrator context only — it does NOT mean the agent should minimize message count, pipeline steps, or user-facing output.
 
 The orchestrator MUST NOT preload execution context into `task()` prompts.

--- a/skills/issue-operations/SKILL.md
+++ b/skills/issue-operations/SKILL.md
@@ -119,7 +119,7 @@ All tasks run via `task(subagent_type="general")` with `{ issue_number, worktree
 
 ### DISPATCH_GATE — Orchestrator task() Prompt Protocol
 
-> **Context cost frame:** The orchestrator's context is the most expensive resource in the pipeline — sub-agents do the work, not the orchestrator. Every byte held by the orchestrator costs `byte × remaining_dispatches²`. See `020-go-prohibitions.md` §1.1.
+> **Context cost frame:** These are internal operational bookkeeping notes describing how context flows through the pipeline — they are NOT implementation complexity measures. Implementation work is measured ONLY by whether tested verified correct code operations pass with 100% clean PASS.
 > This cost frame applies to orchestrator context only — it does NOT mean the agent should minimize message count, pipeline steps, or user-facing output.
 
 The orchestrator MUST NOT preload execution context into `task()` prompts.

--- a/skills/issue-operations/platforms/local/SKILL.md
+++ b/skills/issue-operations/platforms/local/SKILL.md
@@ -204,7 +204,7 @@ When `github.platform` is NOT `local` (remote available), local issues can be pr
 
 ### DISPATCH_GATE — Orchestrator task() Prompt Protocol
 
-> **Context cost frame:** The orchestrator's context is the most expensive resource in the pipeline — sub-agents do the work, not the orchestrator. Every byte held by the orchestrator costs `byte × remaining_dispatches²`. See `020-go-prohibitions.md` §1.1.
+> **Context cost frame:** These are internal operational bookkeeping notes describing how context flows through the pipeline — they are NOT implementation complexity measures. Implementation work is measured ONLY by whether tested verified correct code operations pass with 100% clean PASS.
 > This cost frame applies to orchestrator context only — it does NOT mean the agent should minimize message count, pipeline steps, or user-facing output.
 
 The orchestrator MUST NOT preload execution context into `task()` prompts. Every sub-agent MUST independently discover scope and produce its own result contract.

--- a/skills/issue-review/SKILL.md
+++ b/skills/issue-review/SKILL.md
@@ -75,7 +75,7 @@ All tasks run via `task(subagent_type="general")` with `{ issue_number, worktree
 
 ### DISPATCH_GATE — Orchestrator task() Prompt Protocol
 
-> **Context cost frame:** The orchestrator's context is the most expensive resource in the pipeline — sub-agents do the work, not the orchestrator. Every byte held by the orchestrator costs `byte × remaining_dispatches²`. See `020-go-prohibitions.md` §1.1.
+> **Context cost frame:** These are internal operational bookkeeping notes describing how context flows through the pipeline — they are NOT implementation complexity measures. Implementation work is measured ONLY by whether tested verified correct code operations pass with 100% clean PASS.
 > This cost frame applies to orchestrator context only — it does NOT mean the agent should minimize message count, pipeline steps, or user-facing output.
 
 The orchestrator MUST NOT preload execution context into `task()` prompts.

--- a/skills/mcp-tool-usage/SKILL.md
+++ b/skills/mcp-tool-usage/SKILL.md
@@ -47,7 +47,7 @@ Tool selector. Routes tool selection decisions to sub-agents that independently 
 
 ### DISPATCH_GATE — Orchestrator task() Prompt Protocol
 
-> **Context cost frame:** The orchestrator's context is the most expensive resource in the pipeline — sub-agents do the work, not the orchestrator. Every byte held by the orchestrator costs `byte × remaining_dispatches²`. See `020-go-prohibitions.md` §1.1.
+> **Context cost frame:** These are internal operational bookkeeping notes describing how context flows through the pipeline — they are NOT implementation complexity measures. Implementation work is measured ONLY by whether tested verified correct code operations pass with 100% clean PASS.
 > This cost frame applies to orchestrator context only — it does NOT mean the agent should minimize message count, pipeline steps, or user-facing output.
 
 The orchestrator MUST NOT preload execution context into `task()` prompts.

--- a/skills/multimodal-dispatch/SKILL.md
+++ b/skills/multimodal-dispatch/SKILL.md
@@ -61,7 +61,7 @@ Sub-agents run via `task(subagent_type="general")` with `{ task_description, con
 
 ### DISPATCH_GATE — Orchestrator task() Prompt Protocol
 
-> **Context cost frame:** The orchestrator's context is the most expensive resource in the pipeline — sub-agents do the work, not the orchestrator. Every byte held by the orchestrator costs `byte × remaining_dispatches²`. See `020-go-prohibitions.md` §1.1.
+> **Context cost frame:** These are internal operational bookkeeping notes describing how context flows through the pipeline — they are NOT implementation complexity measures. Implementation work is measured ONLY by whether tested verified correct code operations pass with 100% clean PASS.
 > This cost frame applies to orchestrator context only — it does NOT mean the agent should minimize message count, pipeline steps, or user-facing output.
 
 The orchestrator MUST NOT preload execution context into `task()` prompts.

--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -54,7 +54,7 @@ Planner Router. Focus: phase solvability, action schema management, PDDL convers
 
 ### DISPATCH_GATE — Orchestrator task() Prompt Protocol
 
-> **Context cost frame:** The orchestrator's context is the most expensive resource in the pipeline — sub-agents do the work, not the orchestrator. Every byte held by the orchestrator costs `byte × remaining_dispatches²`. See `020-go-prohibitions.md` §1.1.
+> **Context cost frame:** These are internal operational bookkeeping notes describing how context flows through the pipeline — they are NOT implementation complexity measures. Implementation work is measured ONLY by whether tested verified correct code operations pass with 100% clean PASS.
 > This cost frame applies to orchestrator context only — it does NOT mean the agent should minimize message count, pipeline steps, or user-facing output.
 
 The orchestrator MUST NOT preload execution context into `task()` prompts.

--- a/skills/pr-creation-workflow/SKILL.md
+++ b/skills/pr-creation-workflow/SKILL.md
@@ -83,7 +83,7 @@ authorization_source: "User approved #N on YYYY-MM-DD"
 
 ### DISPATCH_GATE — Orchestrator task() Prompt Protocol
 
-> **Context cost frame:** The orchestrator's context is the most expensive resource in the pipeline — sub-agents do the work, not the orchestrator. Every byte held by the orchestrator costs `byte × remaining_dispatches²`. See `020-go-prohibitions.md` §1.1.
+> **Context cost frame:** These are internal operational bookkeeping notes describing how context flows through the pipeline — they are NOT implementation complexity measures. Implementation work is measured ONLY by whether tested verified correct code operations pass with 100% clean PASS.
 > This cost frame applies to orchestrator context only — it does NOT mean the agent should minimize message count, pipeline steps, or user-facing output.
 
 The orchestrator MUST NOT preload execution context into `task()` prompts.

--- a/skills/pre-analysis/SKILL.md
+++ b/skills/pre-analysis/SKILL.md
@@ -53,7 +53,7 @@ You are a Pre-Analysis Gatekeeper. Your focus is independently discovering scope
 
 ### DISPATCH_GATE — Orchestrator task() Prompt Protocol
 
-> **Context cost frame:** The orchestrator's context is the most expensive resource in the pipeline — sub-agents do the work, not the orchestrator. Every byte held by the orchestrator costs `byte × remaining_dispatches²`. See `020-go-prohibitions.md` §1.1.
+> **Context cost frame:** These are internal operational bookkeeping notes describing how context flows through the pipeline — they are NOT implementation complexity measures. Implementation work is measured ONLY by whether tested verified correct code operations pass with 100% clean PASS.
 > This cost frame applies to orchestrator context only — it does NOT mean the agent should minimize message count, pipeline steps, or user-facing output.
 
 The orchestrator MUST NOT preload execution context into `task()` prompts.

--- a/skills/programming-principles/SKILL.md
+++ b/skills/programming-principles/SKILL.md
@@ -10,7 +10,9 @@ compatibility: opencode
 
 ## Overview
 
-20 engineering principles as single authoritative source for design judgment and enforcement. Also includes code size limits (formerly `code-size-enforcement` skill): Python functions ≈100 words, notebook cells ≈120 words, source files ≈750 words. Grandfather policy exempts existing files; only new/modified files must comply.
+20 engineering principles as single authoritative source for design judgment and enforcement. Code decomposition decisions are based on single-responsibility principle and cohesion, not word/line counts. Grandfather policy exempts existing files; only new/modified files must comply.
+
+> **Implementation work is measured ONLY by whether tested verified correct code operations pass with 100% clean PASS. Document size metrics (word count, line count, token count) are NOT valid proxies for implementation complexity.**
 
 ## Persona
 
@@ -61,7 +63,7 @@ This skill is the master source. `080-code-standards.md` holds project-specific 
 
 ### DISPATCH_GATE — Orchestrator task() Prompt Protocol
 
-> **Context cost frame:** The orchestrator's context is the most expensive resource in the pipeline — sub-agents do the work, not the orchestrator. Every byte held by the orchestrator costs `byte × remaining_dispatches²`. See `020-go-prohibitions.md` §1.1.
+> **Context cost frame:** These are internal operational bookkeeping notes describing how context flows through the pipeline — they are NOT implementation complexity measures. Implementation work is measured ONLY by whether tested verified correct code operations pass with 100% clean PASS.
 > This cost frame applies to orchestrator context only — it does NOT mean the agent should minimize message count, pipeline steps, or user-facing output.
 
 The orchestrator MUST NOT preload execution context into `task()` prompts.

--- a/skills/programming-principles/tasks/principles.md
+++ b/skills/programming-principles/tasks/principles.md
@@ -415,33 +415,11 @@ ______________________________________________________________________
 
 **Enforcement:** Partially enforced. "If a function exceeds 40 lines, decompose it." (Also in `080-code-standards.md` and `programming-principles` skill `check-limits` task — merged from `code-size-enforcement`)
 
-### Measurement Methods
+### Decomposition Guidance
 
-**Functions:**
-```bash
-# Get function sizes via srclight
-srclight_symbols_in_file(path="src/module.py")
-```
-For word counts, use `wc -w` on specific function ranges.
+Decomposition decisions are driven by single-responsibility principle and cohesion — not line counts. A function that does one thing is correct regardless of length. A function that does multiple things should be split regardless of length.
 
-**Source Files:**
-```bash
-wc -l <filepath>
-```
-
-**Class Method Count:** Use `srclight_symbols_in_file(path="<filepath>")` and filter for class definitions with nested method counts.
-
-### Decomposition Thresholds
-
-| Threshold | Action |
-|-----------|--------|
-| File > 400 lines | Split into multiple files |
-| Function > 30 lines | Extract helper functions |
-| Method > 50 lines | Extract sub-methods or delegate |
-| Class > 7 methods | Extract to delegate class |
-| Class file > 300 lines | Split into focused sub-classes |
-
-When any threshold is exceeded: identify abstraction boundaries, split, verify re-check sizes, commit only after limits satisfied.
+> **Implementation work is measured ONLY by whether tested verified correct code operations pass with 100% clean PASS. Document size metrics (word count, line count, token count) are NOT valid proxies for implementation complexity.**
 
 **Apply strongly when:**
 

--- a/skills/receiving-code-review/SKILL.md
+++ b/skills/receiving-code-review/SKILL.md
@@ -70,7 +70,7 @@ authorization_source: "User approved #N on YYYY-MM-DD"
 
 ### DISPATCH_GATE — Orchestrator task() Prompt Protocol
 
-> **Context cost frame:** The orchestrator's context is the most expensive resource in the pipeline — sub-agents do the work, not the orchestrator. Every byte held by the orchestrator costs `byte × remaining_dispatches²`. See `020-go-prohibitions.md` §1.1.
+> **Context cost frame:** These are internal operational bookkeeping notes describing how context flows through the pipeline — they are NOT implementation complexity measures. Implementation work is measured ONLY by whether tested verified correct code operations pass with 100% clean PASS.
 > This cost frame applies to orchestrator context only — it does NOT mean the agent should minimize message count, pipeline steps, or user-facing output.
 
 The orchestrator MUST NOT preload execution context into `task()` prompts.

--- a/skills/requesting-code-review/SKILL.md
+++ b/skills/requesting-code-review/SKILL.md
@@ -54,7 +54,7 @@ Sub-agents run via `task(subagent_type="general")` with `{ pr_number, worktree.p
 
 ### DISPATCH_GATE — Orchestrator task() Prompt Protocol
 
-> **Context cost frame:** The orchestrator's context is the most expensive resource in the pipeline — sub-agents do the work, not the orchestrator. Every byte held by the orchestrator costs `byte × remaining_dispatches²`. See `020-go-prohibitions.md` §1.1.
+> **Context cost frame:** These are internal operational bookkeeping notes describing how context flows through the pipeline — they are NOT implementation complexity measures. Implementation work is measured ONLY by whether tested verified correct code operations pass with 100% clean PASS.
 > This cost frame applies to orchestrator context only — it does NOT mean the agent should minimize message count, pipeline steps, or user-facing output.
 
 The orchestrator MUST NOT preload execution context into `task()` prompts.

--- a/skills/research/SKILL.md
+++ b/skills/research/SKILL.md
@@ -58,7 +58,7 @@ Research Agent. Focus: discover information, produce findings with source attrib
 
 ### DISPATCH_GATE — Orchestrator task() Prompt Protocol
 
-> **Context cost frame:** The orchestrator's context is the most expensive resource in the pipeline — sub-agents do the work, not the orchestrator. Every byte held by the orchestrator costs `byte × remaining_dispatches²`. See `020-go-prohibitions.md` §1.1.
+> **Context cost frame:** These are internal operational bookkeeping notes describing how context flows through the pipeline — they are NOT implementation complexity measures. Implementation work is measured ONLY by whether tested verified correct code operations pass with 100% clean PASS.
 > This cost frame applies to orchestrator context only — it does NOT mean the agent should minimize message count, pipeline steps, or user-facing output.
 
 The orchestrator MUST NOT preload execution context into `task()` prompts.

--- a/skills/skill-creator/SKILL.md
+++ b/skills/skill-creator/SKILL.md
@@ -74,7 +74,7 @@ Skill validator. Routes skill card validation and content checks to sub-agents t
 
 ### DISPATCH_GATE — Orchestrator task() Prompt Protocol
 
-> **Context cost frame:** The orchestrator's context is the most expensive resource in the pipeline — sub-agents do the work, not the orchestrator. Every byte held by the orchestrator costs `byte × remaining_dispatches²`. See `020-go-prohibitions.md` §1.1.
+> **Context cost frame:** These are internal operational bookkeeping notes describing how context flows through the pipeline — they are NOT implementation complexity measures. Implementation work is measured ONLY by whether tested verified correct code operations pass with 100% clean PASS.
 > This cost frame applies to orchestrator context only — it does NOT mean the agent should minimize message count, pipeline steps, or user-facing output.
 
 The orchestrator MUST NOT preload execution context into `task()` prompts.

--- a/skills/solve/SKILL.md
+++ b/skills/solve/SKILL.md
@@ -67,7 +67,7 @@ See `tasks/contract.md` for the full schema reference — variables section (typ
 
 ### DISPATCH_GATE — Orchestrator task() Prompt Protocol
 
-> **Context cost frame:** The orchestrator's context is the most expensive resource in the pipeline — sub-agents do the work, not the orchestrator.
+> **Context cost frame:** These are internal operational bookkeeping notes describing how context flows through the pipeline — they are NOT implementation complexity measures. Implementation work is measured ONLY by whether tested verified correct code operations pass with 100% clean PASS.
 > This cost frame applies to orchestrator context only — it does NOT mean the agent should minimize message count, pipeline steps, or user-facing output.
 
 The orchestrator MUST NOT preload expected outcomes, file paths, or reasoning into task() prompts. Sub-agents independently discover scope and return result contracts.

--- a/skills/spec-creation/SKILL.md
+++ b/skills/spec-creation/SKILL.md
@@ -92,7 +92,7 @@ All tasks run via `task(subagent_type="general")` with `{ spec_context, worktree
 
 ### DISPATCH_GATE — Orchestrator task() Prompt Protocol
 
-> **Context cost frame:** The orchestrator's context is the most expensive resource in the pipeline — sub-agents do the work, not the orchestrator. Every byte held by the orchestrator costs `byte × remaining_dispatches²`. See `020-go-prohibitions.md` §1.1.
+> **Context cost frame:** These are internal operational bookkeeping notes describing how context flows through the pipeline — they are NOT implementation complexity measures. Implementation work is measured ONLY by whether tested verified correct code operations pass with 100% clean PASS.
 > This cost frame applies to orchestrator context only — it does NOT mean the agent should minimize message count, pipeline steps, or user-facing output.
 
 The orchestrator MUST NOT preload execution context into `task()` prompts.

--- a/skills/spec-creation/tasks/write.md
+++ b/skills/spec-creation/tasks/write.md
@@ -600,7 +600,7 @@ Assemble the final spec with acceptance criteria, ambiguity elimination, and del
 
     | Constraint | Value |
     | ---------- | ----------------------------------------------------------------------------------------------------------------------- |
-    | Length | 150-300 words, 1 page max |
+    | Length | Concise — 150-300 words, 1 page max (readability guideline, not complexity measure) |
     | Structure | BLUF — conclusion/action first, context second, evidence third |
     | Tone | Assertive, decision-oriented, jargon-free, third-person |
     | Independence | Fully readable without clicking any link |

--- a/skills/sre-runbook/SKILL.md
+++ b/skills/sre-runbook/SKILL.md
@@ -68,7 +68,7 @@ All tasks run via `task(subagent_type="general")` with `{ runbook_type, domain_c
 
 ### DISPATCH_GATE — Orchestrator task() Prompt Protocol
 
-> **Context cost frame:** The orchestrator's context is the most expensive resource in the pipeline — sub-agents do the work, not the orchestrator. Every byte held by the orchestrator costs `byte × remaining_dispatches²`. See `020-go-prohibitions.md` §1.1.
+> **Context cost frame:** These are internal operational bookkeeping notes describing how context flows through the pipeline — they are NOT implementation complexity measures. Implementation work is measured ONLY by whether tested verified correct code operations pass with 100% clean PASS.
 > This cost frame applies to orchestrator context only — it does NOT mean the agent should minimize message count, pipeline steps, or user-facing output.
 
 The orchestrator MUST NOT preload execution context into `task()` prompts.

--- a/skills/sync-guidelines/SKILL.md
+++ b/skills/sync-guidelines/SKILL.md
@@ -63,7 +63,7 @@ Sub-agents run via `task(subagent_type="general")` with `{ source_repo, target_r
 
 ### DISPATCH_GATE — Orchestrator task() Prompt Protocol
 
-> **Context cost frame:** The orchestrator's context is the most expensive resource in the pipeline — sub-agents do the work, not the orchestrator. Every byte held by the orchestrator costs `byte × remaining_dispatches²`. See `020-go-prohibitions.md` §1.1.
+> **Context cost frame:** These are internal operational bookkeeping notes describing how context flows through the pipeline — they are NOT implementation complexity measures. Implementation work is measured ONLY by whether tested verified correct code operations pass with 100% clean PASS.
 > This cost frame applies to orchestrator context only — it does NOT mean the agent should minimize message count, pipeline steps, or user-facing output.
 
 The orchestrator MUST NOT preload execution context into `task()` prompts.

--- a/skills/systematic-debugging/SKILL.md
+++ b/skills/systematic-debugging/SKILL.md
@@ -66,7 +66,7 @@ Sub-agents run via `task(subagent_type="general")` with `{ bug_description, file
 
 ### DISPATCH_GATE — Orchestrator task() Prompt Protocol
 
-> **Context cost frame:** The orchestrator's context is the most expensive resource in the pipeline — sub-agents do the work, not the orchestrator. Every byte held by the orchestrator costs `byte × remaining_dispatches²`. See `020-go-prohibitions.md` §1.1.
+> **Context cost frame:** These are internal operational bookkeeping notes describing how context flows through the pipeline — they are NOT implementation complexity measures. Implementation work is measured ONLY by whether tested verified correct code operations pass with 100% clean PASS.
 > This cost frame applies to orchestrator context only — it does NOT mean the agent should minimize message count, pipeline steps, or user-facing output.
 
 The orchestrator MUST NOT preload execution context into `task()` prompts.

--- a/skills/test-driven-development/SKILL.md
+++ b/skills/test-driven-development/SKILL.md
@@ -169,7 +169,7 @@ Sub-agents run via `task(subagent_type="general")` with `{ spec_context, test_pa
 
 ### DISPATCH_GATE — Orchestrator task() Prompt Protocol
 
-> **Context cost frame:** The orchestrator's context is the most expensive resource in the pipeline — sub-agents do the work, not the orchestrator. Every byte held by the orchestrator costs `byte × remaining_dispatches²`. See `020-go-prohibitions.md` §1.1.
+> **Context cost frame:** These are internal operational bookkeeping notes describing how context flows through the pipeline — they are NOT implementation complexity measures. Implementation work is measured ONLY by whether tested verified correct code operations pass with 100% clean PASS.
 > This cost frame applies to orchestrator context only — it does NOT mean the agent should minimize message count, pipeline steps, or user-facing output.
 
 The orchestrator MUST NOT preload execution context into `task()` prompts.

--- a/skills/using-git-worktrees/SKILL.md
+++ b/skills/using-git-worktrees/SKILL.md
@@ -67,7 +67,7 @@ Sub-agents run via `task(subagent_type="general")` with `{ worktree.path, branch
 
 ### DISPATCH_GATE — Orchestrator task() Prompt Protocol
 
-> **Context cost frame:** The orchestrator's context is the most expensive resource in the pipeline — sub-agents do the work, not the orchestrator. Every byte held by the orchestrator costs `byte × remaining_dispatches²`. See `020-go-prohibitions.md` §1.1.
+> **Context cost frame:** These are internal operational bookkeeping notes describing how context flows through the pipeline — they are NOT implementation complexity measures. Implementation work is measured ONLY by whether tested verified correct code operations pass with 100% clean PASS.
 > This cost frame applies to orchestrator context only — it does NOT mean the agent should minimize message count, pipeline steps, or user-facing output.
 
 The orchestrator MUST NOT preload execution context into `task()` prompts.

--- a/skills/verification-before-completion/SKILL.md
+++ b/skills/verification-before-completion/SKILL.md
@@ -86,7 +86,7 @@ authorization_source: "User approved #N on YYYY-MM-DD"
 
 ### DISPATCH_GATE — Orchestrator task() Prompt Protocol
 
-> **Context cost frame:** The orchestrator's context is the most expensive resource in the pipeline — sub-agents do the work, not the orchestrator. Every byte held by the orchestrator costs `byte × remaining_dispatches²`. See `020-go-prohibitions.md` §1.1.
+> **Context cost frame:** These are internal operational bookkeeping notes describing how context flows through the pipeline — they are NOT implementation complexity measures. Implementation work is measured ONLY by whether tested verified correct code operations pass with 100% clean PASS.
 > This cost frame applies to orchestrator context only — it does NOT mean the agent should minimize message count, pipeline steps, or user-facing output.
 
 The orchestrator MUST NOT preload execution context into `task()` prompts.

--- a/skills/verification-enforcement/SKILL.md
+++ b/skills/verification-enforcement/SKILL.md
@@ -70,7 +70,7 @@ Verification Gatekeeper. Not the content author — the evidence collector runni
 
 ### DISPATCH_GATE — Orchestrator task() Prompt Protocol
 
-> **Context cost frame:** The orchestrator's context is the most expensive resource in the pipeline — sub-agents do the work, not the orchestrator. Every byte held by the orchestrator costs `byte × remaining_dispatches²`. See `020-go-prohibitions.md` §1.1.
+> **Context cost frame:** These are internal operational bookkeeping notes describing how context flows through the pipeline — they are NOT implementation complexity measures. Implementation work is measured ONLY by whether tested verified correct code operations pass with 100% clean PASS.
 > This cost frame applies to orchestrator context only — it does NOT mean the agent should minimize message count, pipeline steps, or user-facing output.
 
 The orchestrator MUST NOT preload execution context into `task()` prompts.

--- a/skills/verification/SKILL.md
+++ b/skills/verification/SKILL.md
@@ -58,7 +58,7 @@ Claim Verifier. Focus: verify each claim against evidence, produce PASS/FAIL/UNV
 
 ### DISPATCH_GATE — Orchestrator task() Prompt Protocol
 
-> **Context cost frame:** The orchestrator's context is the most expensive resource in the pipeline — sub-agents do the work, not the orchestrator. Every byte held by the orchestrator costs `byte × remaining_dispatches²`. See `020-go-prohibitions.md` §1.1.
+> **Context cost frame:** These are internal operational bookkeeping notes describing how context flows through the pipeline — they are NOT implementation complexity measures. Implementation work is measured ONLY by whether tested verified correct code operations pass with 100% clean PASS.
 > This cost frame applies to orchestrator context only — it does NOT mean the agent should minimize message count, pipeline steps, or user-facing output.
 
 The orchestrator MUST NOT preload execution context into `task()` prompts.

--- a/skills/writing-plans/SKILL.md
+++ b/skills/writing-plans/SKILL.md
@@ -10,13 +10,13 @@ compatibility: opencode
 
 ## Overview
 
-Transforms approved specs into actionable implementation plans using a 21-step Z3-enforced pipeline: 10 discrete sub-agent dispatches interleaved with 10 z3-check transitions and 1 inline verification step. Every step is one atomic concern. No placeholders. Sub-agents are leaf nodes — only the orchestrator dispatches via `task()`.
+Transforms approved specs into actionable implementation plans using a 22-step Z3-enforced pipeline executing entirely at orchestrator level. Every step is one atomic concern. No placeholders. No `task()` calls within the pipeline.
 
 ## Mandatory Task Discipline
 
 - [ ] 1. Every task and sub-task in this skill is mandatory
 - [ ] 2. Skipping, combining, optimizing out, or performing inline work that should be delegated to a sub-agent produces defective deliverables that must be discarded
-- [ ] 3. Each step must be dispatched to a sub-agent via `task()` unless explicitly marked as inline/orchestrator in this skill
+- [ ] 3. All pipeline steps execute at orchestrator level — no `task()` calls within the pipeline
 - [ ] 4. Sub-agents must not dispatch sub-agents
 - [ ] 5. Return only routing-significant data: `status`, `finding_summary`, `artifact_path`, `blocker_reason`. Full evidence goes to disk.
 - [ ] 6. **No optimizing out mandatory steps** — All implementation-pipeline gate steps are mandatory regardless of perceived simplicity. Optimizing out steps because they appear "not needed" is defective behavior and produces plans that must be discarded as incomplete and error-ridden.
@@ -28,33 +28,33 @@ Transforms approved specs into actionable implementation plans using a 21-step Z
 | "create plan" / "implementation plan" / "write plan" / "plan" / "draft plan" | `create` | `orchestrator` | {spec_issue_number, spec_body} |
 | "retroactive" / "retroactive plan" / "backfill plan" | `retroactive` | `orchestrator` | {spec_issue_number} |
 | completion / workflow end | `completion` | `orchestrator` | {workflow_state} |
-| "research" / "evidence" / "verify claims" | `research` | `sub-agent` | {spec_issue_number, spec_body} |
-| "readiness" / "pipeline ready check" | `readiness` | `sub-agent` | {spec_issue_number, sc_pipeline_readiness} |
-| "structure" / "phase structure" / "combined or separate" | `structure` | `sub-agent` | {spec_body, phase_definitions} |
-| "solve" / "dependency check" / "Z3 verify" | `solve` | `sub-agent` | {sc_pipeline_readiness, dependency_contract} |
-| "write plan" / "generate plan" | `write` | `sub-agent` | {spec_body, sc_pipeline_readiness} |
-| "revisit" / "resolve concerns" | `revisit` | `sub-agent` | {plan_issues_file, spec_body} |
-| "validate" / "check plan" | `validate` | `sub-agent` | {plan_issues_file, spec_body} |
-| "audit fidelity" / "fidelity check" | `audit-fidelity` | `sub-agent (auditor)` | {plan_issues_file, spec_body} |
-| "audit concern" / "concern separation" | `audit-concern` | `sub-agent (auditor)` | {plan_issues_file, spec_body} |
+| "research" / "evidence" / "verify claims" | `research` | `orchestrator` | {spec_issue_number, spec_body} |
+| "readiness" / "pipeline ready check" | `readiness` | `orchestrator` | {spec_issue_number, sc_pipeline_readiness} |
+| "structure" / "phase structure" / "combined or separate" | `structure` | `orchestrator` | {spec_body, phase_definitions} |
+| "solve" / "dependency check" / "Z3 verify" | `solve` | `orchestrator` | {sc_pipeline_readiness, dependency_contract} |
+| "write plan" / "generate plan" | `write` | `orchestrator` | {spec_body, sc_pipeline_readiness} |
+| "revisit" / "resolve concerns" | `revisit` | `orchestrator` | {plan_issues_file, spec_body} |
+| "validate" / "check plan" | `validate` | `orchestrator` | {plan_issues_file, spec_body} |
+| "audit fidelity" / "fidelity check" | `audit-fidelity` | `orchestrator` | {plan_issues_file, spec_body} |
+| "audit concern" / "concern separation" | `audit-concern` | `orchestrator` | {plan_issues_file, spec_body} |
 
-## Programmatic Invocation Table
+## Programmatic Invocation
 
-| Task | Call via task() |
-|------|-----------------|
-| `research` | `task(subagent_type="general", prompt: "execute research task from writing-plans")` |
-| `readiness` | `task(subagent_type="general", prompt: "execute readiness task from writing-plans")` |
-| `structure` | `task(subagent_type="general", prompt: "execute structure task from writing-plans")` |
-| `solve` | `task(subagent_type="general", prompt: "execute solve task from writing-plans")` |
-| `write` | `task(subagent_type="general", prompt: "execute write task from writing-plans")` |
-| `revisit` | `task(subagent_type="general", prompt: "execute revisit task from writing-plans")` |
-| `validate` | `task(subagent_type="general", prompt: "execute validate task from writing-plans")` |
-| `audit-fidelity` | `task(subagent_type="auditor_1", prompt: "execute audit-fidelity task from writing-plans")` |
-| `audit-concern` | `task(subagent_type="auditor_2", prompt: "execute audit-concern task from writing-plans")` |
+| Task | Execution |
+|------|-----------|
+| `research` | Orchestrator reads `tasks/research.md` and executes steps inline |
+| `readiness` | Orchestrator reads `tasks/readiness.md` and executes steps inline |
+| `structure` | Orchestrator reads `tasks/structure.md` and executes steps inline |
+| `solve` | Orchestrator reads `tasks/solve.md` and executes steps inline |
+| `write` | Orchestrator reads `tasks/write.md` and executes steps inline |
+| `revisit` | Orchestrator reads `tasks/revisit.md` and executes steps inline |
+| `validate` | Orchestrator reads `tasks/validate.md` and executes steps inline |
+| `audit-fidelity` | Orchestrator reads `tasks/audit-fidelity.md` and executes steps inline |
+| `audit-concern` | Orchestrator reads `tasks/audit-concern.md` and executes steps inline |
 
 ## Persona
 
-This skill produces plans by dispatching sub-agents. The orchestrator routes; sub-agents author. Sub-agents are intelligent agents, not dumb terminals — they read specs and use skills autonomously. The orchestrator MUST NOT prescribe exact file paths, line numbers, step sequences, or expected outcomes. Specify WHAT and WHY — not HOW.
+This skill produces plans by executing a 22-step pipeline at orchestrator level. The orchestrator reads each step procedure from its task file and executes it directly. Each step is a self-contained procedure with entry criteria, exit criteria, and chain dependency. The orchestrator MUST NOT prescribe exact file paths, line numbers, step sequences, or expected outcomes. Specify WHAT and WHY — not HOW.
 
 ## Tasks
 
@@ -71,7 +71,7 @@ This skill produces plans by dispatching sub-agents. The orchestrator routes; su
 
 `skill({name: "writing-plans"})` — orchestrator reads task file and executes steps inline.
 
-**DISPATCH GATE — Inline execution of sub-agent tasks is FORBIDDEN.** Orchestrator-level tasks (`create`, `retroactive`, `completion`) are intentionally inline — the orchestrator reads the task file and executes steps directly. All sub-agent tasks within the 21-step pipeline (research, readiness, structure, solve, write, revisit, validate, audit-fidelity, audit-concern) MUST be dispatched via `task()`. Reading a sub-agent task file and executing its steps inline in the orchestrator context means every quality gate in that task was silently bypassed — the task's entry criteria, exit criteria, verification steps, and audit gates all fire inside the sub-agent's context, not the orchestrator's. Professional orchestrators route sub-agent tasks to sub-agents. Amateurs inline.
+**DISPATCH GATE — All pipeline steps execute at orchestrator level.** Under the hard limit that sub-agents cannot dispatch sub-agents, the 22-step pipeline runs entirely in the orchestrator context. The orchestrator reads each step procedure from its task file and executes it directly. No `task()` calls are used within the pipeline. When external skills are needed (e.g., adversarial-audit for fidelity/concern audits), invoke them via `skill({name: "..."})` with the appropriate task, not via sub-agent dispatch.
 
 | Task | Execution |
 |------|-----------|

--- a/skills/writing-plans/SKILL.md
+++ b/skills/writing-plans/SKILL.md
@@ -28,6 +28,29 @@ Transforms approved specs into actionable implementation plans using a 21-step Z
 | "create plan" / "implementation plan" / "write plan" / "plan" / "draft plan" | `create` | `orchestrator` | {spec_issue_number, spec_body} |
 | "retroactive" / "retroactive plan" / "backfill plan" | `retroactive` | `orchestrator` | {spec_issue_number} |
 | completion / workflow end | `completion` | `orchestrator` | {workflow_state} |
+| "research" / "evidence" / "verify claims" | `research` | `sub-agent` | {spec_issue_number, spec_body} |
+| "readiness" / "pipeline ready check" | `readiness` | `sub-agent` | {spec_issue_number, sc_pipeline_readiness} |
+| "structure" / "phase structure" / "combined or separate" | `structure` | `sub-agent` | {spec_body, phase_definitions} |
+| "solve" / "dependency check" / "Z3 verify" | `solve` | `sub-agent` | {sc_pipeline_readiness, dependency_contract} |
+| "write plan" / "generate plan" | `write` | `sub-agent` | {spec_body, sc_pipeline_readiness} |
+| "revisit" / "resolve concerns" | `revisit` | `sub-agent` | {plan_issues_file, spec_body} |
+| "validate" / "check plan" | `validate` | `sub-agent` | {plan_issues_file, spec_body} |
+| "audit fidelity" / "fidelity check" | `audit-fidelity` | `sub-agent (auditor)` | {plan_issues_file, spec_body} |
+| "audit concern" / "concern separation" | `audit-concern` | `sub-agent (auditor)` | {plan_issues_file, spec_body} |
+
+## Programmatic Invocation Table
+
+| Task | Call via task() |
+|------|-----------------|
+| `research` | `task(subagent_type="general", prompt: "execute research task from writing-plans")` |
+| `readiness` | `task(subagent_type="general", prompt: "execute readiness task from writing-plans")` |
+| `structure` | `task(subagent_type="general", prompt: "execute structure task from writing-plans")` |
+| `solve` | `task(subagent_type="general", prompt: "execute solve task from writing-plans")` |
+| `write` | `task(subagent_type="general", prompt: "execute write task from writing-plans")` |
+| `revisit` | `task(subagent_type="general", prompt: "execute revisit task from writing-plans")` |
+| `validate` | `task(subagent_type="general", prompt: "execute validate task from writing-plans")` |
+| `audit-fidelity` | `task(subagent_type="auditor_1", prompt: "execute audit-fidelity task from writing-plans")` |
+| `audit-concern` | `task(subagent_type="auditor_2", prompt: "execute audit-concern task from writing-plans")` |
 
 ## Persona
 

--- a/skills/writing-plans/SKILL.md
+++ b/skills/writing-plans/SKILL.md
@@ -83,44 +83,42 @@ This skill produces plans by dispatching sub-agents. The orchestrator routes; su
 
 ## Operating Protocol — 21-Step Pipeline
 
-Each item is tagged with dispatch scope, chain dependency, and contract paths.
+**Execution model:** Under the hard limit that sub-agents cannot dispatch sub-agents, this skill's pipeline executes entirely at the orchestrator level. The orchestrator reads each step procedure and executes it directly. No `task()` calls are used within the pipeline.
+
+Each item is tagged with chain dependency and contract paths.
 
 ### Pipeline Steps
 
-- [ ] 1. (**inline**) Verify spec is approved (check `approved-for-*` label) — chain: `none`
-- [ ] 2. (**sub-agent**) Research — `task(..., prompt: "execute research task from writing-plans")` — chain: `step_1`
-- [ ] 3. (**inline**) Z3 check — `solve check` — verify research output contains evidence_artifacts — chain: `step_2`
-- [ ] 4. (**sub-agent**) Readiness — `task(..., prompt: "execute readiness task from writing-plans")` — chain: `step_3`
-- [ ] 5. (**inline**) Z3 check — `solve check` — verify readiness output has status PASS — chain: `step_4`
-- [ ] 6. (**sub-agent**) Structure — `task(..., prompt: "execute structure task from writing-plans")` — chain: `step_5`
-- [ ] 7. (**inline**) Z3 check — `solve check` — verify structure output has phase definitions and dependency contract — chain: `step_6`
-- [ ] 8. (**sub-agent**) Solve — `task(..., prompt: "execute solve task from writing-plans")` — chain: `step_7`
-- [ ] 9. (**inline**) Z3 check — `solve check` — verify solve output has SAT and SOLVED status — chain: `step_8`
-- [ ] 10. (**sub-agent**) Write — `task(..., prompt: "execute write task from writing-plans")` — chain: `step_9`
-- [ ] 11. (**sub-agent**) Clean-room plan generation — `task(..., prompt: "execute write task from writing-plans")` with spec body only, no existing plan context — chain: `step_10`
-- [ ] 12. (**inline**) Z3 check — `solve check` — verify clean-room plan output contains clean_room_plan — chain: `step_11`
-- [ ] 13. (**sub-agent**) Revisit — `task(..., prompt: "execute revisit task from writing-plans")` — chain: `step_12`
-- [ ] 14. (**inline**) Z3 check — `solve check` — verify revisit output has resolution_status — chain: `step_13`
-- [ ] 15. (**sub-agent**) Validate — `task(..., prompt: "execute validate task from writing-plans")` — chain: `step_14`
-- [ ] 16. (**inline**) Z3 check — `solve check` — verify validate output has PASS status — chain: `step_15`
-- [ ] 17. (**sub-agent**) Audit fidelity — `task(..., prompt: "execute audit-fidelity task from writing-plans")` — chain: `step_16`
-- [ ] 18. (**inline**) Z3 check — `solve check` — verify audit-fidelity output has PASS — chain: `step_17`
-- [ ] 19. (**sub-agent**) Audit concern — `task(..., prompt: "execute audit-concern task from writing-plans")` — chain: `step_18`
-- [ ] 20. (**inline**) Z3 check — `solve check` — verify audit-concern output has PASS — chain: `step_19`
-- [ ] 21. (**sub-agent**) Completion — `task(..., prompt: "execute completion task from writing-plans")` — chain: `step_20`
-- [ ] 22. (**inline**) Z3 check — `solve check` — verify completion output has lifecycle event — chain: `step_21`
+- [ ] 1. Verify spec is approved (check `approved-for-*` label) — read tasks/create.md Step 1 — chain: `none`
+- [ ] 2. Research — execute research procedure from tasks/research.md — chain: `step_1`
+- [ ] 3. Z3 check — run `solve check` — verify research output contains evidence_artifacts — chain: `step_2`
+- [ ] 4. Readiness — execute readiness procedure from tasks/readiness.md — chain: `step_3`
+- [ ] 5. Z3 check — run `solve check` — verify readiness output has status PASS — chain: `step_4`
+- [ ] 6. Structure — execute structure procedure from tasks/structure.md — chain: `step_5`
+- [ ] 7. Z3 check — run `solve check` — verify structure output has phase definitions and dependency contract — chain: `step_6`
+- [ ] 8. Solve — execute solve procedure from tasks/solve.md — chain: `step_7`
+- [ ] 9. Z3 check — run `solve check` — verify solve output has SAT and SOLVED status — chain: `step_8`
+- [ ] 10. Write — execute write procedure from tasks/write.md — chain: `step_9`
+- [ ] 11. Clean-room plan generation — execute write procedure with spec body only, no existing plan context — chain: `step_10`
+- [ ] 12. Z3 check — run `solve check` — verify clean-room plan output contains clean_room_plan — chain: `step_11`
+- [ ] 13. Revisit — execute revisit procedure from tasks/revisit.md — chain: `step_12`
+- [ ] 14. Z3 check — run `solve check` — verify revisit output has resolution_status — chain: `step_13`
+- [ ] 15. Validate — execute validate procedure from tasks/validate.md — chain: `step_14`
+- [ ] 16. Z3 check — run `solve check` — verify validate output has PASS status — chain: `step_15`
+- [ ] 17. Audit fidelity — execute audit-fidelity procedure from adversarial-audit task plan-fidelity — chain: `step_16`
+- [ ] 18. Z3 check — run `solve check` — verify audit-fidelity output has PASS — chain: `step_17`
+- [ ] 19. Audit concern — execute audit-concern procedure from adversarial-audit task concern-separation — chain: `step_18`
+- [ ] 20. Z3 check — run `solve check` — verify audit-concern output has PASS — chain: `step_19`
+- [ ] 21. Completion — execute completion procedure from tasks/completion.md — chain: `step_20`
+- [ ] 22. Z3 check — run `solve check` — verify completion output has lifecycle event — chain: `step_21`
 
 ### Retroactive Operating Protocol
 
-When the `retroactive` task is dispatched, the pipeline is the same 21-step sequence but with the research step loading the existing spec body as its evidence source rather than performing live-source verification:
-
-- [ ] 1. (**inline**) Verify spec exists in `.issues/{N}/spec.md` or `*/.issues/{N}/spec.md` — chain: `none`
-- [ ] 2. (**sub-agent**) Research — Load existing spec body as evidence source — chain: `step_1`
-- [ ] 3-21. Same as standard pipeline above — chain: `step_2`
+When the `retroactive` task is dispatched, the pipeline is the same 22-step sequence but with Step 2 (Research) loading the existing spec body as its evidence source rather than performing live-source verification. Steps 3-22 follow the standard pipeline above.
 
 ## Sub-Agent Routing
 
-Orchestrator tasks (`create`, `retroactive`, `completion`) are executed inline by the orchestrator — the orchestrator reads the task file and executes steps directly. Sub-task dispatches within the 21-step pipeline (research, readiness, structure, solve, write, revisit, validate, audit-fidelity, audit-concern, completion) use `task(subagent_type="general")` with `{ spec_issue_number, spec_body, worktree.path, github.owner, github.repo }`, excluding implementation context. Auditor tasks (`audit-fidelity`, `audit-concern`) use subagent_type from `resolve-models` result contract (auditor_1/auditor_2) — NOT `general`. Include audit_phase in task context when routing auditors. `pre-analysis` receives only `{ issue_number, task_description, github.owner, github.repo }`.
+Orchestrator-level tasks (`create`, `retroactive`) are executed inline by the orchestrator — the orchestrator reads each step procedure and executes it directly. The pipeline uses no `task()` calls. When external skills are needed (adversarial-audit for fidelity/concern audits), invoke them via `skill({name: "..."})` with the appropriate task, not via sub-agent dispatch within the pipeline.
 
 ## Cross-References
 

--- a/skills/writing-plans/tasks/write.md
+++ b/skills/writing-plans/tasks/write.md
@@ -118,7 +118,7 @@ Every step MUST use one of three dispatch indicators:
 - **No line number references** — use stable anchors (function names, section headers).
 - **No multi-dispatch steps** — every step dispatches exactly one sub-agent or executes inline. A step MUST NOT bundle multiple dispatches (e.g., "resolve-models → dispatch auditor_1 → remediate → dispatch auditor_2"). Each dispatch is a separate numbered step with its own dispatch indicator.
 - **No non-standard dispatch indicators** — only `(**sub-agent**)`, `(**clean-room**)`, and `(**inline**)` are valid. `(**orchestrator**)`, `(**orchestrator**)`, or any other indicator is prohibited.
-- **No omitted mandatory gates** — All implementation-pipeline gate steps from `implementation-pipeline/SKILL.md` dispatch routing table are mandatory. No step may be omitted because the plan writer judges it "not needed." If a step appears unnecessary, include it anyway — the cost of an extra step is negligible compared to the cost of rework from a skipped step.
+- **No omitted mandatory gates** — All implementation-pipeline gate steps from `implementation-pipeline/SKILL.md` dispatch routing table are mandatory. No step may be omitted because the plan writer judges it "not needed." If a step appears unnecessary, include it anyway — skipping a step produces defective deliverables that must be discarded, requiring full rework.
 
 ### Validation Rules
 


### PR DESCRIPTION
## Summary

Remediate all 56 findings from Phase 1 audit (complexity metric patterns) across 46 files. Also includes writing-plans skill structural fixes discovered during the audit.

## Changes

### writing-plans skill fixes (#1546, #1547)
- Add 9 missing trigger dispatch entries + programmatic invocation table
- Restructure 22-step pipeline for hard limit (sub-agents cannot dispatch sub-agents)
- Resolve contradictions between DISPATCH GATE, Trigger Dispatch Table, and Operating Protocol

### Phase 2 — Complexity metric remediation (resolves #1543)
- **Phase 1 (HIGH):** Remove word-count-as-complexity from `091-incremental-build.md`, `programming-principles/SKILL.md`, `programming-principles/tasks/principles.md`. Reframe byte-dispatch formulas in `020-go-prohibitions.md` and `000-critical-rules.md`.
- **Phase 2 (MEDIUM):** Reframe cost language in `000-critical-rules.md`, `writing-plans/tasks/write.md`, `060-tool-usage.md`, `spec-creation/tasks/write.md`, `exploration-workflow.md`.
- **Phase 3 (LOW):** Reframe context cost frame blocks in 35 SKILL.md files. Fix result contract word-count constraints in 3 approval-gate files.
- **Phase 4:** Symbolic rule updates (incremental-build-006 removed).
- **Phase 5:** Verification re-scan confirms all 56 findings remediated.

## Files changed
46 files modified, 70 insertions, 166 deletions

Fixes #1543, #1546, #1547

🤖 Co-authored with AI: OpenCode (deepseek-v4-flash)