### PR TITLE
fix: quote description field in playwright-cli SKILL.md frontmatter

### DIFF
--- a/skills/playwright-cli/SKILL.md
+++ b/skills/playwright-cli/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: playwright-cli
-description: Use when browsing the web, automating browser interactions, navigating pages, filling forms, capturing snapshots, evaluating JavaScript, mocking network requests, managing storage/cookies/tabs, recording traces or video, running or generating Playwright tests, managing browser sessions, or installing/setting up Playwright. REQUIRED: dispatch via skill() before any browser automation — do not skip this skill.
+description: "Use when browsing the web, automating browser interactions, navigating pages, filling forms, capturing snapshots, evaluating JavaScript, mocking network requests, managing storage/cookies/tabs, recording traces or video, running or generating Playwright tests, managing browser sessions, or installing/setting up Playwright. REQUIRED: dispatch via skill() before any browser automation — do not skip this skill."
 allowed-tools: Bash(playwright-cli:*) Bash(npx:*) Bash(npm:*)
 license: Apache-2.0
 provenance: AI-generated


### PR DESCRIPTION
## Summary

The `description` field in `.opencode/skills/playwright-cli/SKILL.md` YAML frontmatter contained an unquoted `REQUIRED:` substring that caused a YAML parse error (`mapping values are not allowed here`). Wrapping the field in double quotes fixes the parse error.

## Outcome

| ID | Criterion | Evidence | Result |
|----|-----------|----------|--------|
| SC-1 | `description` field in YAML frontmatter is wrapped in double quotes | `grep 'description: "'` returns a match | ✅ PASS |
| SC-2 | YAML frontmatter parses correctly + no markdown lint regressions | `yaml.safe_load()` exits 0; `pymarkdownlnt` shows only pre-existing findings | ✅ PASS |
| SC-3 | No other content modified beyond the description line | `git diff` shows exactly 1 line changed | ✅ PASS |

Fixes #1585

🤖 Co-authored with AI: OpenCode (ollama-cloud/deepseek-v4-flash)