### PR TITLE
feat(#1593): add approval-gate-015 pipeline-initiated non-substantive revision exception

### DIFF
--- a/guidelines/010-approval-gate.md
+++ b/guidelines/010-approval-gate.md
@@ -152,6 +152,12 @@ Authorization sets persist across scope transitions. If a developer approves `fo
 
 **Spec revision revokes all linked plan approvals.** If a spec is revised after a plan was approved (via cascade or direct), the linked plan approval is automatically revoked. The plan must be updated to match the revised spec and re-approved before any implementation proceeds.
 
+#### Pipeline-Initiated Non-Substantive Revision Exception
+
+Pipeline-initiated non-substantive spec revisions are exempt from the revocation rule. When a pipeline gate (e.g., SC-coherence gate) detects a spec defect and the orchestrator revises the spec to fix it, the linked plan approval is NOT revoked — the plan is auto-updated via `writing-plans --task update` and the pipeline continues without requiring re-authorization.
+
+**Non-substantive** means: changes to evidence types, verification methods, artifact paths, or SC wording that do NOT alter the implementation intent, scope, or success criteria semantics. Substantive changes (new SCs, removed SCs, changed scope, changed implementation approach) still require re-authorization per `approval-gate-006`.
+
 ### Re-implementation Workflow
 
 When `approval-gate-006` fires (spec revision revokes plan approval):
@@ -424,4 +430,19 @@ rules:
       - HALT
       - PROCEED_WITH_GAP_FILL
     source: "010-approval-gate.md §Authorization Scope Model"
+
+  - id: approval-gate-015
+    tier: 2
+    title: "Pipeline-initiated non-substantive spec revisions auto-update plan without re-authorization"
+    conditions:
+      all:
+        - "spec_revised == true"
+        - "revision_source == 'pipeline_gate'"
+        - "revision_classification == 'non_substantive'"
+        - "has_linked_plan == true"
+    actions:
+      - HALT
+      - AUTO_UPDATE_PLAN(writing-plans --task update)
+      - PROCEED
+    source: "010-approval-gate.md §Pipeline-Initiated Non-Substantive Revision Exception"
 ```

--- a/skills/approval-gate/tasks/verify-authorization/spec-to-plan-cascade.md
+++ b/skills/approval-gate/tasks/verify-authorization/spec-to-plan-cascade.md
@@ -57,6 +57,12 @@ elif not plan_files:
 - The spec has been revised — existing revocation rules apply; cascade approval is revoked per Step 6 "Spec Revision Revocation Detection"
 - The plan does not faithfully implement the spec — `plan-fidelity-auditor` catches this during implementation review
 
+### Exception: Pipeline-Initiated Non-Substantive Revisions
+
+Per `approval-gate-015`, pipeline-initiated non-substantive spec revisions do NOT trigger cascade revocation. When a pipeline gate (e.g., SC-coherence gate) detects a non-substantive spec defect and the orchestrator revises the spec to fix it, the linked plan approval is preserved. The plan is auto-updated via `writing-plans --task update` and the pipeline continues without requiring re-authorization.
+
+**Non-substantive** means: changes to evidence types, verification methods, artifact paths, or SC wording that do NOT alter the implementation intent, scope, or success criteria semantics. Substantive changes still trigger standard revocation per Step 6.
+
 **⚠️ Body-Preservation Safeguard:** This task only updates labels (no `body=` parameter in `github_issue_write` calls). Status updates use `github_add_issue_comment`. If any future modification were to use `issue-operations -> update-issue (github_issue_write(method=update, body=...)`, it MUST verify that the new body preserves all original content (len(new_body) >= 0.8 * len(original_body)). See `000-critical-rules.md` → "Critical Violation: Issue Body Erasure" for the project-wide rule. <!-- Routes through issue-operations per SPEC #683 -->
 
 ## 5b.4 Edge Cases

--- a/skills/implementation-pipeline/tasks/pipeline-executor.md
+++ b/skills/implementation-pipeline/tasks/pipeline-executor.md
@@ -169,6 +169,41 @@ solve check --state-path ./tmp/{issue-N}/state/ --contract-path skills/implement
 
 Step results (PASS/FAIL, evidence paths) go into YAML disk artifact — never into solve state. Solve state tracks pipeline **position** only.
 
+## Auto-Revision Routing (Non-Substantive Spec Defects)
+
+When the SC-coherence gate (Step 1) detects a spec defect, the orchestrator classifies the defect as substantive or non-substantive before routing to remediation:
+
+### Non-Substantive Defect Classification
+
+A spec defect is **non-substantive** if it involves only:
+- Evidence type mismatch (e.g., `behavioral` → `string` when the SC is structural)
+- Verification method needs updating
+- Artifact path needs correction
+- SC wording clarification that does NOT alter implementation intent
+
+A spec defect is **substantive** if it involves:
+- New SCs needed (missing from spec)
+- SCs that cannot be implemented as specified
+- Scope or implementation approach changes
+- Contradictory or impossible success criteria
+
+### Non-Substantive Auto-Revision Flow
+
+When the coherence gate finds a non-substantive spec defect:
+
+- [ ] 1. **Orchestrator revises spec** — update the spec issue body with corrected evidence types, verification methods, or artifact paths
+- [ ] 2. **Auto-update plan** — dispatch `writing-plans --task update` with the revised spec issue number
+- [ ] 3. **Continue pipeline** — proceed to Step 2 (pre-red-baseline) without HALT for re-authorization
+- [ ] 4. **No approval revocation** — `approval-gate-015` applies: the linked plan approval is NOT revoked
+
+### Substantive Defect Flow
+
+When the coherence gate finds a substantive spec defect:
+
+- [ ] 1. **HALT** — report the defect to the developer
+- [ ] 2. **No auto-revision** — the orchestrator does NOT revise the spec or plan
+- [ ] 3. **Wait for developer input** — the developer must revise the spec and re-approve
+
 ## Remediation Routing
 
 ### FAIL → Researcher → Remediate Protocol

--- a/skills/writing-plans/SKILL.md
+++ b/skills/writing-plans/SKILL.md
@@ -27,6 +27,7 @@ Transforms approved specs into actionable implementation plans using a 22-step Z
 |---------------------|------|----------|----------------|
 | "create plan" / "implementation plan" / "write plan" / "plan" / "draft plan" | `create` | `orchestrator` | {spec_issue_number, spec_body} |
 | "retroactive" / "retroactive plan" / "backfill plan" | `retroactive` | `orchestrator` | {spec_issue_number} |
+| "update plan" / "plan update" / "auto-update plan" / "revise plan" | `update` | `orchestrator` | {spec_issue_number, plan_issue_number} |
 | completion / workflow end | `completion` | `orchestrator` | {workflow_state} |
 
 ## Programmatic Invocation
@@ -35,6 +36,7 @@ Transforms approved specs into actionable implementation plans using a 22-step Z
 |------|-----------|
 | `create` | Orchestrator reads `tasks/create.md` and executes steps inline |
 | `retroactive` | Orchestrator reads `tasks/retroactive.md` and executes steps inline |
+| `update` | Orchestrator reads `tasks/update.md` and executes steps inline |
 | `completion` | Orchestrator reads `tasks/completion.md` and executes steps inline |
 
 ## Persona
@@ -62,6 +64,7 @@ This skill produces plans by executing a 22-step pipeline at orchestrator level.
 |------|-----------|
 | `create` | Orchestrator reads `tasks/create.md` and executes steps inline |
 | `retroactive` | Orchestrator reads `tasks/retroactive.md` and executes steps inline |
+| `update` | Orchestrator reads `tasks/update.md` and executes steps inline |
 | `completion` | Orchestrator reads `tasks/completion.md` and executes steps inline |
 
 **CLI equivalent (for human TUI use):** `/skill writing-plans --task <task>`

--- a/skills/writing-plans/tasks/update.md
+++ b/skills/writing-plans/tasks/update.md
@@ -1,0 +1,64 @@
+# Task: update — Plan Update for Non-Substantive Spec Revisions
+
+<!-- SPDX-FileCopyrightText: 2026 Michael Conrad -->
+<!-- SPDX-License-Identifier: MIT -->
+<!-- Provenance: AI-generated -->
+
+Co-authored with AI: OpenCode (ollama-cloud/deepseek-v4-flash)
+
+## Purpose
+
+Update an existing implementation plan to reflect a non-substantive spec revision (changes to evidence types, verification methods, artifact paths, or SC wording that do NOT alter implementation intent, scope, or success criteria semantics). Preserves existing approval state — does NOT clear approval markers.
+
+## Entry Criteria
+
+- Spec has been revised (non-substantive revision only)
+- Existing plan file exists at `.issues/{N}/plan.md` or `*/.issues/{N}/plan.md`
+- Plan was previously approved (has approval markers)
+
+## Exit Criteria
+
+- Plan file updated with revised SC verification methods, evidence types, and artifact paths
+- Approval state preserved (approval markers NOT cleared)
+- Result contract returned with `status: DONE` and `finding_summary`
+
+## Procedure
+
+### Step 1: Read Revised Spec
+
+Read the revised spec from the issue body via `github_issue_read(method=get, issue_number=<spec_issue_number>)`. Extract the SC table and identify which SCs have changed (evidence types, verification methods, artifact paths).
+
+### Step 2: Read Existing Plan
+
+Read the existing plan file at `.issues/{N}/plan.md` (or `*/.issues/{N}/plan.md`). Locate the SC sections that correspond to the revised spec SCs.
+
+### Step 3: Diff SCs
+
+Compare the revised spec SCs against the plan's SCs. Identify only the sections that need updating:
+
+- SC verification methods
+- SC evidence types
+- SC artifact paths
+- SC wording (non-substantive only — does not alter intent)
+
+Do NOT update:
+- Phase definitions or concern boundaries
+- Implementation steps or approach
+- Dependency ordering
+- Approval markers or state
+
+### Step 4: Update Plan
+
+Edit the plan file to reflect the revised SC metadata. Only modify the specific sections identified in Step 3. Preserve all existing approval state markers.
+
+### Step 5: Verify
+
+Confirm the plan file is valid YAML/markdown and that approval markers remain intact.
+
+### Step 6: Return Result Contract
+
+```yaml
+status: DONE
+artifact_path: "<path to updated plan file>"
+summary: "Updated plan for spec #{spec_issue_number}: revised {N} SC verification methods/evidence types. Approval state preserved."
+```


### PR DESCRIPTION
## Summary

Adds `approval-gate-015` — a pipeline-initiated non-substantive spec revision exception that allows the pipeline to auto-update the plan and continue without re-authorization when a pipeline gate (e.g., SC-coherence gate) detects a non-substantive spec defect.

## Changes

1. **`guidelines/010-approval-gate.md`** — Added `approval-gate-015` symbolic rule + prose carveout in §Revision Revokes Approval
2. **`skills/writing-plans/SKILL.md`** — Added `update` task to trigger dispatch table and programmatic invocation
3. **`skills/writing-plans/tasks/update.md`** — New task file: plan update procedure that preserves approval state
4. **`skills/implementation-pipeline/tasks/pipeline-executor.md`** — Added Auto-Revision Routing section for non-substantive spec defects
5. **`skills/approval-gate/tasks/verify-authorization/spec-to-plan-cascade.md`** — Added exception note for pipeline-initiated non-substantive revisions

## Success Criteria

| ID | Criterion | Status |
|----|-----------|--------|
| SC-1 | `approval-gate-015` rule in `010-approval-gate.md` | ✅ PASS |
| SC-2 | Prose carveout for pipeline-initiated non-substantive revisions | ✅ PASS |
| SC-3 | `update` task in writing-plans dispatch table | ✅ PASS |
| SC-4 | `writing-plans/tasks/update.md` exists | ✅ PASS |
| SC-5 | Auto-revision routing in pipeline-executor.md | ✅ PASS |
| SC-6 | Exception note in spec-to-plan-cascade.md | ✅ PASS |
| SC-7 | Exactly 5 files changed | ✅ PASS |

Fixes https://github.com/michael-conrad/.opencode/issues/1593

🤖 Co-authored with AI: OpenCode (ollama-cloud/deepseek-v4-flash)