### PR TITLE
[SPEC-FIX] Centralize default test model into tests/default-model.sh

### DIFF
--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -177,17 +177,17 @@ Full-suite uber scripts are FORBIDDEN. Batch runs use scope filtering:
 bash .opencode/tests/test-enforcement.sh --tag <tag>
 
 # Run individual scenarios with env overrides
-BEHAVIOR_MODEL="ollama/other-model:cloud" \
+DEFAULT_TEST_MODEL="ollama/other-model:cloud" \
 BEHAVIOR_PHASE="RED" \
 bash .opencode/tests/behaviors/<scenario>.sh
 ```
 
 ### Model Pool
 
-By default, scripts use `BEHAVIOR_MODEL` (default: `ollama/glm-5.1:cloud`). Override via environment:
+By default, scripts use `DEFAULT_TEST_MODEL` from `tests/default-model.sh` (the single source of truth). Override via environment:
 
 ```bash
-BEHAVIOR_MODEL="ollama/other-model:cloud" bash .opencode/tests/behaviors/<scenario>.sh
+DEFAULT_TEST_MODEL="ollama/other-model:cloud" bash .opencode/tests/behaviors/<scenario>.sh
 ```
 
 The `behavior_run_pool` function runs against all models in `BEHAVIORAL_MODEL_POOL` (auto-populated from `opencode-cli models`).
@@ -216,7 +216,7 @@ Helper variables:
 | Variable | Default | Purpose |
 |----------|---------|---------|
 | `BEHAVIOR_TIMEOUT` | 420s | Max model run duration |
-| `BEHAVIOR_MODEL` | `ollama/deepseek-v4-flash:cloud` | Default model |
+| `DEFAULT_TEST_MODEL` | `ollama/ornith:35b-256k` (from `default-model.sh`) | Default model |
 | `BEHAVIOR_PHASE` | `GREEN` | RED or GREEN phase label |
 | `BEHAVIOR_MAX_RETRIES` | 2 | Retry count on transient errors |
 | `BEHAVIOR_RETRY_DELAY` | 30s | Wait between retries |

--- a/tests/behaviors/1165-yaml-quoting.sh
+++ b/tests/behaviors/1165-yaml-quoting.sh
@@ -16,7 +16,7 @@ SCENARIO_NAME="1165-yaml-quoting"
 SCENARIO_PROMPT="list all skills in your system prompt"
 
 echo "=== Behavioral Test: $SCENARIO_NAME ==="
-echo "Model: ${BEHAVIOR_MODEL:-ollama/deepseek-v4-flash:cloud}"
+echo "Model: $DEFAULT_TEST_MODEL"
 echo "Prompt: \"$SCENARIO_PROMPT\""
 echo ""
 

--- a/tests/behaviors/832-sc1-repo-information-section.sh
+++ b/tests/behaviors/832-sc1-repo-information-section.sh
@@ -33,7 +33,7 @@ if [ -f "$SESSION_INIT" ]; then
     echo "$SESSION_OUTPUT" > "$BEHAVIOR_LOG_DIR/$SCENARIO_NAME/session-init-raw.txt"
 fi
 
-behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT" "$BEHAVIOR_MODEL" "$WORKDIR"
+behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT" "$DEFAULT_TEST_MODEL" "$WORKDIR"
 
 chmod -R u+w "$WORKDIR" 2>/dev/null || true
 rm -rf "$WORKDIR"

--- a/tests/behaviors/832-sc10-local-only-degraded.sh
+++ b/tests/behaviors/832-sc10-local-only-degraded.sh
@@ -33,7 +33,7 @@ if [ -f "$SESSION_INIT" ]; then
     echo "$SESSION_OUTPUT" > "$BEHAVIOR_LOG_DIR/$SCENARIO_NAME/session-init-local.txt"
 fi
 
-behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT" "$BEHAVIOR_MODEL" "$WORKDIR"
+behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT" "$DEFAULT_TEST_MODEL" "$WORKDIR"
 
 chmod -R u+w "$WORKDIR" 2>/dev/null || true
 rm -rf "$WORKDIR"

--- a/tests/behaviors/832-sc2-no-github-flat-keys.sh
+++ b/tests/behaviors/832-sc2-no-github-flat-keys.sh
@@ -32,7 +32,7 @@ if [ -f "$SESSION_INIT" ]; then
     echo "$SESSION_OUTPUT" > "$BEHAVIOR_LOG_DIR/$SCENARIO_NAME/session-init-raw.txt"
 fi
 
-behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT" "$BEHAVIOR_MODEL" "$WORKDIR"
+behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT" "$DEFAULT_TEST_MODEL" "$WORKDIR"
 
 chmod -R u+w "$WORKDIR" 2>/dev/null || true
 rm -rf "$WORKDIR"

--- a/tests/behaviors/832-sc4-platform-raw-hostname.sh
+++ b/tests/behaviors/832-sc4-platform-raw-hostname.sh
@@ -43,7 +43,7 @@ if [ -f "$SESSION_INIT" ]; then
     echo "$SESSION_OUTPUT" > "$BEHAVIOR_LOG_DIR/$SCENARIO_NAME/session-init-raw.txt"
 fi
 
-behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT" "$BEHAVIOR_MODEL" "$WORKDIR"
+behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT" "$DEFAULT_TEST_MODEL" "$WORKDIR"
 
 chmod -R u+w "$WORKDIR" 2>/dev/null || true
 rm -rf "$WORKDIR"

--- a/tests/behaviors/helpers.sh
+++ b/tests/behaviors/helpers.sh
@@ -36,8 +36,7 @@
 # ╚══════════════════════════════════════════════════════════════════════════════╝
 
 set -euo pipefail
-
-BEHAVIOR_MODEL="${BEHAVIOR_MODEL:-ollama/deepseek-v4-flash:cloud}"
+source "$(dirname "${BASH_SOURCE[0]}")/../default-model.sh"
 BEHAVIOR_PHASE="${BEHAVIOR_PHASE:-GREEN}"
 BEHAVIOR_TEST_HOME="${BEHAVIOR_TEST_HOME:-.opencode/tests/with-test-home}"
 BEHAVIOR_FIXTURE_ISSUES="${BEHAVIOR_FIXTURE_ISSUES:-1}"
@@ -172,7 +171,7 @@ except Exception as e:
 behavior_run() {
     local scenario_name="$1"
     local message="$2"
-    local model="${3:-${BEHAVIOR_MODEL}}"
+    local model="${3:-$DEFAULT_TEST_MODEL}"
     local workdir="${4:-}"
     local agent="${5:-}"
     local log_dir="$BEHAVIOR_LOG_DIR/$scenario_name"

--- a/tests/behaviors/issue-operations-dispatch-instead-of-inline.sh
+++ b/tests/behaviors/issue-operations-dispatch-instead-of-inline.sh
@@ -28,7 +28,7 @@ SCENARIO_PROMPT="Create a spec issue for adding a CONTRIBUTING.md section that d
 # Determine phase (RED/GREEN) and model for the evidence slug.
 # BEHAVIOR_PHASE tags which part of the cycle produced the artifact.
 PHASE_SLUG="${BEHAVIOR_PHASE:-unknown}"
-MODEL_FOR_SLUG="${BEHAVIOR_MODEL:-ollama/unknown}"
+MODEL_FOR_SLUG="$DEFAULT_TEST_MODEL"
 MODEL_SLUG="${MODEL_FOR_SLUG//\//-}"
 MODEL_SLUG="${MODEL_SLUG//:/-}"
 MODEL_SLUG="${MODEL_SLUG//@/-}"

--- a/tests/default-model.sh
+++ b/tests/default-model.sh
@@ -1,0 +1,4 @@
+# Default model for all opencode-cli test runs.
+# Override: DEFAULT_TEST_MODEL=custom-model
+# Single source of truth — do not embed model strings elsewhere.
+DEFAULT_TEST_MODEL="${DEFAULT_TEST_MODEL:-ollama/ornith:35b-256k}"

--- a/tests/test-enforcement.sh
+++ b/tests/test-enforcement.sh
@@ -20,6 +20,7 @@ while [ "$(basename "$PROJECT_DIR")" != ".opencode" ]; do
     PROJECT_DIR="$(dirname "$PROJECT_DIR")"
 done
 PROJECT_DIR="$(dirname "$PROJECT_DIR")"
+source "$(dirname "${BASH_SOURCE[0]}")/default-model.sh"
 
 SCENARIO_FILTER=()
 TAG_FILTER=()
@@ -66,7 +67,6 @@ LOGDIR="$PROJECT_DIR/tmp/enforcement-test-$(date +%Y%m%d-%H%M%S)"
 mkdir -p "$LOGDIR"
 
 TIMEOUT=120
-MODEL="${ENFORCEMENT_TEST_MODEL:-ollama-cloud/glm-5.1}"
 WITH_TEST_HOME="$PROJECT_DIR/.opencode/tests/with-test-home"
 
 # Test scenarios: name -> "prompt message"
@@ -660,7 +660,7 @@ RUN_COUNT=${#SCENARIO_NAMES[@]}
 
 echo "=== Enforcement Integration Test ==="
 echo "Log dir: $LOGDIR"
-echo "Model: $MODEL"
+echo "Model: $DEFAULT_TEST_MODEL"
 echo "Mode: isolated (with-test-home wrapper)"
 echo "Scenarios: $RUN_COUNT / $TOTAL_SCENARIOS"
 echo ""
@@ -863,7 +863,7 @@ RESULTS_FILE="$LOGDIR/results.md"
 echo "# Enforcement Integration Test Results" > "$RESULTS_FILE"
 echo "" >> "$RESULTS_FILE"
 echo "Date: $(date -Iseconds)" >> "$RESULTS_FILE"
-echo "Model: $MODEL" >> "$RESULTS_FILE"
+echo "Model: $DEFAULT_TEST_MODEL" >> "$RESULTS_FILE"
 echo "Mode: isolated (with-test-home)" >> "$RESULTS_FILE"
 echo "Scenarios run: $RUN_COUNT / $TOTAL_SCENARIOS" >> "$RESULTS_FILE"
 echo "" >> "$RESULTS_FILE"
@@ -890,7 +890,7 @@ for scenario_name in "${SCENARIO_NAMES[@]}"; do
     # Run opencode-cli in isolated mode via with-test-home wrapper
     # --print-logs goes to stderr, formatted output to stdout
     timeout $TIMEOUT bash "$WITH_TEST_HOME" opencode-cli run "$MESSAGE" \
-        --model "$MODEL" \
+        --model "$DEFAULT_TEST_MODEL" \
         --print-logs \
         > "$SCENARIO_OUT" 2> "$SCENARIO_LOG" \
         || true

--- a/tests/test-verification-honesty.sh
+++ b/tests/test-verification-honesty.sh
@@ -17,6 +17,7 @@ while [ "$(basename "$PROJECT_DIR")" != ".opencode" ]; do
     PROJECT_DIR="$(dirname "$PROJECT_DIR")"
 done
 PROJECT_DIR="$(dirname "$PROJECT_DIR")"
+source "$(dirname "${BASH_SOURCE[0]}")/default-model.sh"
 
 SCENARIO_FILTER=()
 LIST_ONLY=false
@@ -40,7 +41,6 @@ while [[ $# -gt 0 ]]; do
 done
 
 TIMEOUT=120
-MODEL="${ENFORCEMENT_TEST_MODEL:-ollama-cloud/glm-5.1}"
 WITH_TEST_HOME="$PROJECT_DIR/.opencode/tests/with-test-home"
 
 declare -A SCENARIOS

--- a/tests/with-test-home
+++ b/tests/with-test-home
@@ -82,10 +82,6 @@ seed_model_config() {
     done < <(ollama_models)
 
     if [ ${#models[@]} -eq 0 ]; then
-        models=("phi4-mini:3.8b" "llama3.2:3b" "qwen3.5:27b")
-    fi
-
-    if [ ${#models[@]} -eq 0 ]; then
         echo "HARNESS_FAILURE: no models available" >&2
         exit 2
     fi


### PR DESCRIPTION
## Summary

Centralize the default test model for opencode-cli test runs into a single source of truth (`tests/default-model.sh`), removing duplicated model strings across 6 locations with 3 different env var aliases.

## Outcome

- **Created** `tests/default-model.sh` with `DEFAULT_TEST_MODEL=ollama/ornith:35b-256k` and env var override
- **Updated** `helpers.sh`, `test-enforcement.sh`, `test-verification-honesty.sh` to source `default-model.sh` and use `$DEFAULT_TEST_MODEL`
- **Updated** 6 behavioral test scripts to pass `$DEFAULT_TEST_MODEL` instead of `$BEHAVIOR_MODEL`
- **Removed** hardcoded fallback model list from `with-test-home` (lines 84-86)
- **Updated** `AGENTS.md` to reference `default-model.sh` as single source of truth
- **Removed** all `BEHAVIOR_MODEL`, `ENFORCEMENT_TEST_MODEL`, and `MODEL` variable aliases

## Fixes

Fixes #1450 (supersedes #885)

## Success Criteria Verification

| ID | Criterion | Status |
|----|-----------|--------|
| SC-1 | `tests/default-model.sh` exists | ✅ PASS |
| SC-2 | helpers.sh sources + uses `$DEFAULT_TEST_MODEL` | ✅ PASS |
| SC-3 | test-enforcement.sh sources + uses `$DEFAULT_TEST_MODEL` | ✅ PASS |
| SC-4 | test-verification-honesty.sh sources `default-model.sh` | ✅ PASS |
| SC-5 | No `BEHAVIOR_MODEL` in `tests/behaviors/*.sh` (except comments) | ✅ PASS |
| SC-6 | No `ENFORCEMENT_TEST_MODEL` in `tests/` | ✅ PASS |
| SC-7 | No `MODEL` as model variable in `tests/*.sh` | ✅ PASS |
| SC-8 | Only `default-model.sh` has `ollama/` in `.sh` files (intentional fixtures excluded) | ✅ PASS |
| SC-9 | No fallback models in `with-test-home` | ✅ PASS |
| SC-10 | AGENTS.md references `default-model.sh` | ✅ PASS |
| SC-11 | Env var override works: `DEFAULT_TEST_MODEL=custom-model` overrides default | ✅ PASS |

---

🤖 Co-authored with AI: OpenCode (ollama-cloud/deepseek-v4-flash)