### PR TITLE
[SPEC-FIX] #1588 — Add gap-fill dispatch triggers to writing-plans dispatch table

### DIFF
--- a/skills/writing-plans/SKILL.md
+++ b/skills/writing-plans/SKILL.md
@@ -28,7 +28,7 @@ This skill operates in the main repo directory (direct-branch mode). When `WORKT
 
 | User says / Context | Task | Dispatch | Context passed |
 |---------------------|------|----------|----------------|
-| "create plan" / "implementation plan" / "write plan" / "plan" / "draft plan" | `create` | `orchestrator` | {spec_issue_number, spec_body} |
+| "create plan" / "implementation plan" / "write plan" / "plan" / "draft plan" / "auto-create plan" / "gap-fill plan" | `create` | `orchestrator` | {spec_issue_number, spec_body} |
 | "retroactive" / "retroactive plan" / "backfill plan" | `retroactive` | `orchestrator` | {spec_issue_number} |
 | "update plan" / "plan update" / "auto-update plan" / "revise plan" | `update` | `orchestrator` | {spec_issue_number, plan_issue_number} |
 | completion / workflow end | `completion` | `orchestrator` | {workflow_state} |

--- a/tests/behaviors/gap-fill-dispatch.sh
+++ b/tests/behaviors/gap-fill-dispatch.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# Behavioral test: gap-fill-dispatch
+# See .opencode/tests/AGENTS.md for the test harness specification and paradigm.
+# This script is an artifact-only generator — it does NOT evaluate model output.
+#
+# SC-4: Behavioral test — "approved for PR" triggers dispatch to writing-plans --task create
+#
+# RED phase: The writing-plans/SKILL.md Trigger Dispatch Table does NOT include
+# "auto-create plan" or "gap-fill plan" as triggers. When the agent receives
+# "approved for PR: .opencode#1579", it MUST NOT dispatch to writing-plans --task create
+# because the dispatch table lacks the trigger phrases. The test MUST FAIL at this point.
+#
+# GREEN phase: After the dispatch table is updated with the trigger phrases,
+# the same prompt MUST cause the agent to dispatch to writing-plans --task create.
+#
+# Authority: .opencode#1588 SC-4
+# Co-authored with AI: OpenCode (deepseek-v4-flash)
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/helpers.sh"
+
+SCENARIO_NAME="gap-fill-dispatch"
+SCENARIO_PROMPT="approved for PR: .opencode#1579"
+
+echo "=== Behavioral Test: $SCENARIO_NAME ==="
+
+behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT"
+
+# Artifact-only generator — exit 0 unconditionally.
+# Evaluation is performed by the orchestrator via clean-room sub-agents.
+exit 0


### PR DESCRIPTION
## Summary

Added `"auto-create plan"` / `"gap-fill plan"` triggers to the `writing-plans/SKILL.md` Trigger Dispatch Table so the orchestrator routes to `--task create` when the approval-gate gap-fill cascade triggers plan creation — preventing the orchestrator from falling through to inline execution.

## Outcome

- **SC-1**: `writing-plans/SKILL.md` Trigger Dispatch Table now includes `"auto-create plan"` / `"gap-fill plan"` as triggers for the `create` task
- **SC-4**: Behavioral enforcement test at `tests/behaviors/gap-fill-dispatch.sh` verifies `"approved for PR"` → dispatches to `writing-plans --task create`

## Changes

1. `skills/writing-plans/SKILL.md` — Added `"auto-create plan"` / `"gap-fill plan"` to the Trigger Dispatch Table `create` row
2. `tests/behaviors/gap-fill-dispatch.sh` — New behavioral enforcement test (artifact-only generator per AGENTS.md paradigm)

## Fixes

Fixes https://github.com/michael-conrad/.opencode/issues/1588

🤖 Co-authored with AI: OpenCode (deepseek-v4-flash)