### PR TITLE
[SPEC-FIX] #1623 — Replace set notation with plain English in auto-dispatch-table.md

### DIFF
--- a/skills/approval-gate/enforcement/auto-dispatch-table.md
+++ b/skills/approval-gate/enforcement/auto-dispatch-table.md
@@ -46,7 +46,7 @@ Three chain-of-responsibility paths route through verify-authorization sub-tasks
 | Path | Criteria | Skips |
 |------|----------|-------|
 | fast-path | 1 issue, `for_review_prep` scope, 0 sub-issues, explicit auth | needs-approval-label check, item-decomposition, sc-traceability, sub-issue-verification, spec-to-plan-cascade, gap-fill-cascade, screen-issue, pre-implementation-analysis |
-| gap-fill-path | 1 issue + scope ∈ {for_pr, for_implementation, for_plan, for_analysis} + 0 sub-issues | screen-issue, pre-implementation-analysis, sub-issue-verification, spec-to-plan-cascade, item-decomposition, sc-traceability, verify-codebase, verify-blockers, verify-closed-issue-main, verify-already-implemented |
+| gap-fill-path | 1 issue, 0 sub-issues, scope is one of: `for_pr`, `for_implementation`, `for_plan`, `for_analysis` | screen-issue, pre-implementation-analysis, sub-issue-verification, spec-to-plan-cascade, item-decomposition, sc-traceability, verify-codebase, verify-blockers, verify-closed-issue-main, verify-already-implemented |
 | medium-path | 1 issue + sub-issues OR plan with phases | screen-issue (single issue), pre-implementation-analysis (no dependency graph needed) |
 | full-path | Multi-issue authorization set | None — all steps executed |
 | analysis-path | `for_analysis` scope (self-assigned, no authorization) | All gates — only read/dispatch operations permitted |


### PR DESCRIPTION
## Summary

PR #1622 introduced a `gap-fill-path` entry to `auto-dispatch-table.md` using mathematical set notation (`scope ∈ {for_pr, for_implementation, for_plan, for_analysis}`). LLMs do not natively parse this notation — some treat it as a literal string, others misinterpret the braces. Replaced with plain English: `scope is one of: for_pr, for_implementation, for_plan, for_analysis`.

## Outcome

- **SC-1**: `auto-dispatch-table.md` gap-fill-path criteria uses plain English, no set notation

## Changes

1. `skills/approval-gate/enforcement/auto-dispatch-table.md` — Replaced `scope ∈ {for_pr, ...}` with `scope is one of: for_pr, ...`

## Fixes

Fixes https://github.com/michael-conrad/.opencode/issues/1623

🤖 Co-authored with AI: OpenCode (deepseek-v4-flash)