### PR TITLE
1587: add pipeline re-priming block, dispatch-gate-rejection ref, and orchestrator-MUST-NOT-read-task-file-content enforcement

### DIFF
--- a/skills/approval-gate/SKILL.md
+++ b/skills/approval-gate/SKILL.md
@@ -132,6 +132,7 @@ After loading this skill and reading the Trigger Dispatch Table, the orchestrato
 - Use the exact `task(..., prompt: "...")` string from the table
 - NOT write a custom prompt with preloaded context
 - NOT add orchestrator reasoning, file paths, step sequences, or expected outcomes
+- The orchestrator MUST NOT read task file content — it only receives result contracts from sub-agents
 - If the canonical dispatch produces an empty result: re-task clean-room with the same canonical string (max 2 retries)
 
 ## Cross-References

--- a/skills/implementation-pipeline/SKILL.md
+++ b/skills/implementation-pipeline/SKILL.md
@@ -215,6 +215,17 @@ A sub-agent receiving a `task()` prompt MUST reject it if the prompt contains:
 
 Return `status: BLOCKED` with `reason: PRELOADED_CONTEXT_REJECTED`.
 
+**Behavioral enforcement test:** `dispatch-gate-rejection.sh` verifies sub-agents reject preloaded context with `PRELOADED_CONTEXT_REJECTED`.
+
+#### Pipeline Re-Priming Enforcement Block
+
+At every pipeline stage transition (pre-work → assemble-work → verification-before-completion → finishing-checklist → review-prep), the orchestrator re-encounters this enforcement block restating procedural discipline:
+
+- Sub-agents execute — orchestrators route
+- No inline work — all file modifications, analysis, and decisions go through clean-room sub-agents
+- The orchestrator holds routing metadata only — task file contents, analysis artifacts, and verification results go to sub-agents or disk
+- Every stage transition is a re-encounter of this discipline — context degrades between gates, and re-priming prevents drift
+
 #### Orchestrator Entry Criteria
 
 After loading this skill and reading the Trigger Dispatch Table, the orchestrator MUST:


### PR DESCRIPTION
## Summary

Three string-level text additions to two SKILL.md files enforcing canonical dispatch and preventing the orchestrator read-then-inline pattern.

## Changes

| SC | Change | File |
|----|--------|------|
| SC-1 | Add pipeline re-priming enforcement block after Sub-Agent Entry Criteria | `skills/implementation-pipeline/SKILL.md` |
| SC-2 | Add `dispatch-gate-rejection.sh` reference to Sub-Agent Entry Criteria | `skills/implementation-pipeline/SKILL.md` |
| SC-3 | Add "orchestrator MUST NOT read task file content" to Orchestrator Entry Criteria | `skills/approval-gate/SKILL.md` |

## Verification

All 3 SCs verified via grep:

- `grep "Pipeline Re-Priming" skills/implementation-pipeline/SKILL.md` → match at line 220
- `grep "dispatch-gate-rejection" skills/implementation-pipeline/SKILL.md` → match at line 218
- `grep "orchestrator MUST NOT read task file content" skills/approval-gate/SKILL.md` → match at line 135

Fixes https://github.com/michael-conrad/.opencode/issues/1587

Co-authored with AI: OpenCode (ollama-cloud/deepseek-v4-flash)