### PR TITLE
[SPEC-FIX] #1582 — Add behavioral enforcement tests for spec writer, plan writer, and auditor skill defects

### DIFF
--- a/tests/behaviors/1582-sc1-either-or-rejection.sh
+++ b/tests/behaviors/1582-sc1-either-or-rejection.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Behavioral test: 1582-sc1-either-or-rejection
+# SC-1: Spec writer rejects either/or in Required Actions
+# See .opencode/tests/AGENTS.md for the test harness specification and paradigm.
+# This script is an artifact-only generator — it does NOT evaluate model output.
+#
+# PROMPT CONSTRUCTION GUIDANCE:
+# Real-domain task: triggers spec-creation with an either/or requirement.
+# The agent should reject the ambiguity and resolve to a single outcome.
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/helpers.sh"
+
+SCENARIO_NAME="1582-sc1-either-or-rejection"
+SCENARIO_PROMPT="Create a spec for a new feature: the system should log errors to a file OR to stdout. The requirement is: 'Error logging target: file or stdout — pick one.' Write the spec with success criteria."
+
+behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT"
+exit 0

--- a/tests/behaviors/1582-sc2-delegation-concretization.sh
+++ b/tests/behaviors/1582-sc2-delegation-concretization.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Behavioral test: 1582-sc2-delegation-concretization
+# SC-2: Spec writer requires concrete delegation targets
+# See .opencode/tests/AGENTS.md for the test harness specification and paradigm.
+# This script is an artifact-only generator — it does NOT evaluate model output.
+#
+# PROMPT CONSTRUCTION GUIDANCE:
+# Real-domain task: triggers spec-creation with a vague "delegate to" reference.
+# The agent should require concrete file changes, routing updates, and capability migration.
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/helpers.sh"
+
+SCENARIO_NAME="1582-sc2-delegation-concretization"
+SCENARIO_PROMPT="Create a spec that delegates the user authentication module to a new centralized auth service. The requirement says: 'Delegate login, logout, and session management to the auth service.' Write the spec with concrete file changes, routing table updates, and capability migration details."
+
+behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT"
+exit 0

--- a/tests/behaviors/1582-sc3-spec-auditor-ambiguity.sh
+++ b/tests/behaviors/1582-sc3-spec-auditor-ambiguity.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Behavioral test: 1582-sc3-spec-auditor-ambiguity
+# SC-3: Spec-auditor detects either/or in Required Actions
+# See .opencode/tests/AGENTS.md for the test harness specification and paradigm.
+# This script is an artifact-only generator — it does NOT evaluate model output.
+#
+# PROMPT CONSTRUCTION GUIDANCE:
+# Real-domain task: triggers spec-audit on a spec with an either/or requirement.
+# The auditor should flag the ambiguity via SC-DET-AMBIGUITY.
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/helpers.sh"
+
+SCENARIO_NAME="1582-sc3-spec-auditor-ambiguity"
+SCENARIO_PROMPT="Audit this spec for quality defects. The spec says: 'The system MUST cache results in Redis OR Memcached — pick one during implementation.' Check for either/or ambiguity in Required Actions."
+
+behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT"
+exit 0

--- a/tests/behaviors/1582-sc4-plan-fidelity-delegation.sh
+++ b/tests/behaviors/1582-sc4-plan-fidelity-delegation.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Behavioral test: 1582-sc4-plan-fidelity-delegation
+# SC-4: Plan-fidelity auditor detects undefined delegation targets
+# See .opencode/tests/AGENTS.md for the test harness specification and paradigm.
+# This script is an artifact-only generator — it does NOT evaluate model output.
+#
+# PROMPT CONSTRUCTION GUIDANCE:
+# Real-domain task: triggers plan-fidelity audit on a plan with a vague delegation reference.
+# The auditor should flag the missing concrete definitions via PF-DELEGATION.
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/helpers.sh"
+
+SCENARIO_NAME="1582-sc4-plan-fidelity-delegation"
+SCENARIO_PROMPT="Check the fidelity of this plan against its spec. The spec says: 'Delegate notification sending to the notification service.' The plan says: 'Phase 2: delegate to notification service.' Verify the plan has concrete definitions for what 'delegate to notification service' means — file changes, routing updates, capability migration."
+
+behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT"
+exit 0

--- a/tests/behaviors/1582-sc5-concern-separation-routing.sh
+++ b/tests/behaviors/1582-sc5-concern-separation-routing.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Behavioral test: 1582-sc5-concern-separation-routing
+# SC-5: Concern-separation auditor detects missing routing table changes
+# See .opencode/tests/AGENTS.md for the test harness specification and paradigm.
+# This script is an artifact-only generator — it does NOT evaluate model output.
+#
+# PROMPT CONSTRUCTION GUIDANCE:
+# Real-domain task: triggers concern-separation audit on a spec that removes a task file
+# with a routing/dispatch table but doesn't update the routing table.
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/helpers.sh"
+
+SCENARIO_NAME="1582-sc5-concern-separation-routing"
+SCENARIO_PROMPT="Audit the concern separation of this spec. The spec removes the 'legacy-task.md' file which has a routing/dispatch table that dispatches to 3 different handlers. The spec does not mention updating the routing table. Check for CS-ROUTING: missing routing table changes when a task file is removed."
+
+behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT"
+exit 0


### PR DESCRIPTION
## Summary

Adds 5 behavioral enforcement tests (artifact-only generators) for the systemic defects identified in #1582. The code changes (Step 23a, 23b in spec-creation, SC-DET-AMBIGUITY in spec-audit, PF-DELEGATION in plan-fidelity, CS-ROUTING in concern-separation) were already implemented as part of the parent #1540 work, but no behavioral enforcement tests were created to verify the agent actually follows these rules.

## Outcome

All 5 tests ran successfully against `opencode/deepseek-v4-flash-free`, producing complete artifact directories with `exit_code=0`.

## Files Changed

| File | Purpose |
|------|---------|
| `tests/behaviors/1582-sc1-either-or-rejection.sh` | SC-1: Spec writer rejects either/or in Required Actions |
| `tests/behaviors/1582-sc2-delegation-concretization.sh` | SC-2: Spec writer requires concrete delegation targets |
| `tests/behaviors/1582-sc3-spec-auditor-ambiguity.sh` | SC-3: Spec-auditor detects either/or ambiguity (SC-DET-AMBIGUITY) |
| `tests/behaviors/1582-sc4-plan-fidelity-delegation.sh` | SC-4: Plan-fidelity auditor detects undefined delegation targets (PF-DELEGATION) |
| `tests/behaviors/1582-sc5-concern-separation-routing.sh` | SC-5: Concern-separation auditor detects missing routing table changes (CS-ROUTING) |

Fixes #1582

🤖 Co-authored with AI: OpenCode (deepseek-v4-flash)