### PR TITLE
fix: per-issue spec_path in _search_in_repo and _list_issues_in_repo (#1439)

### DIFF
--- a/tests/behaviors/1439-sc1-sc2-spec-path-per-issue.sh
+++ b/tests/behaviors/1439-sc1-sc2-spec-path-per-issue.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Behavioral test: 1439-sc1-sc2-spec-path-per-issue
+# See .opencode/tests/AGENTS.md for the test harness specification and paradigm.
+# This script is an artifact-only generator — it does NOT evaluate model output.
+#
+# SC-1: local-issues list prints spec_path=.issues/N (not .issues) for each issue
+# SC-2: local-issues search prints spec_path=.issues/N (not .issues) for each result
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../helpers.sh"
+
+SCENARIO_NAME="1439-sc1-sc2-spec-path-per-issue"
+SCENARIO_PROMPT="Run \`local-issues list\` and \`local-issues search --query spec_path\` and check whether each issue shows \`spec_path=.issues/N\` (e.g. \`spec_path=.issues/1439\`) or the incorrect \`spec_path=.issues\`."
+
+behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT"
+exit 0

--- a/tools/local-issues
+++ b/tools/local-issues
@@ -1316,10 +1316,6 @@ def _search_in_repo(
     repo_issues_dir = repo_path / ISSUES_DIR
     if not repo_issues_dir.is_dir():
         return []
-    try:
-        spec_path = str(repo_issues_dir.relative_to(current_cwd))
-    except ValueError:
-        spec_path = str(repo_issues_dir)
     results: list[tuple[str, str, str, str, str]] = []
     seen: set[int] = set()
     for entry in sorted(repo_issues_dir.iterdir()):
@@ -1327,6 +1323,7 @@ def _search_in_repo(
         if num is None or num in seen:
             continue
         seen.add(num)
+        spec_path = _spec_path_for_issue(num, repo_path)
         data = _read_issue_data_in_repo(num, repo_path)
         if not data:
             continue
@@ -1389,10 +1386,6 @@ def _list_issues_in_repo(
     repo_issues_dir = repo_path / ISSUES_DIR
     if not repo_issues_dir.is_dir():
         return []
-    try:
-        spec_path = str(repo_issues_dir.relative_to(cwd))
-    except ValueError:
-        spec_path = str(repo_issues_dir)
     seen: set[int] = set()
     entries: list[tuple[int, str, str, str, str, str, int]] = []
     for entry in sorted(repo_issues_dir.iterdir()):
@@ -1400,6 +1393,7 @@ def _list_issues_in_repo(
         if num is None or num in seen:
             continue
         seen.add(num)
+        spec_path = _spec_path_for_issue(num, repo_path)
         title, status = _read_issue_title_status(entry)
         entries.append(
             (sort_prio, repo_name, f"{repo_name}#{num}", status, title, spec_path, num)


### PR DESCRIPTION
## Summary

Fix `local-issues list` and `local-issues search` printing `spec_path=.issues` (directory-level) instead of `spec_path=.issues/N` (per-issue).

## Changes

| File | Change |
|------|--------|
| `tools/local-issues` | `_search_in_repo()` and `_list_issues_in_repo()` now compute `spec_path` per-issue via `_spec_path_for_issue()` inside the loop |
| `tests/behaviors/1439-sc1-sc2-spec-path-per-issue.sh` | Behavioral enforcement test for SC-1 and SC-2 |

## Outcome

| SC | Criterion | Status |
|----|-----------|--------|
| SC-1 | `list` prints `spec_path=.issues/N` per issue | ✅ |
| SC-2 | `search` prints `spec_path=.issues/N` per result | ✅ |
| SC-3 | `read` continues to print correct `spec_path=.issues/N` | ✅ |
| SC-4 | No other callers of `_spec_path_for_issue()` affected | ✅ |

Fixes #1439

🤖 Co-authored with AI: OpenCode (deepseek-v4-flash)