### PR TITLE
fix(#1440): add mandatory submodule sync verification to implementation pipeline entry point

### DIFF
--- a/skills/implementation-pipeline/SKILL.md
+++ b/skills/implementation-pipeline/SKILL.md
@@ -103,7 +103,8 @@ Before the pipeline dispatches to `sc-coherence-gate`, the orchestrator MUST run
 
 - [ ] 1. **Plan-to-pipeline handoff:** Execute `implementation-pipeline --task pre-flight-handoff` — validates RED checkpoints, SC-ID traceability, approval cascade state, verification gate preservation, and manifest writes at `./tmp/{issue-N}/artifacts/plan-to-pipeline-handoff-*.yaml`
 - [ ] 2. **Handoff-consistency check:** Reads both `spec-to-plan-handoff-*.yaml` and `plan-to-pipeline-handoff-*.yaml` manifests and compares shared variables (SC coverage total, decomposition classification, phase count). BLOCKs on mismatch.
-- [ ] 3. **Pre-flight PASS required:** The pipeline MUST NOT proceed to `sc-coherence-gate` (step 1) if pre-flight returns BLOCKED. This is a hard gate — no bypass path.
+- [ ] 3. **Submodule state check:** Resolve default branch via `git remote show origin | sed -n 's/.*HEAD branch: //p'`, then verify `git submodule status` shows submodules at that branch's tip. If submodules are stale, BLOCK and report `SUBMODULE-DRIFT`.
+- [ ] 4. **Pre-flight PASS required:** The pipeline MUST NOT proceed to `sc-coherence-gate` (step 1) if pre-flight returns BLOCKED. This is a hard gate — no bypass path.
 
 ## Step Labels (for #932 naming convention)
 

--- a/skills/implementation-pipeline/tasks/assemble-work.md
+++ b/skills/implementation-pipeline/tasks/assemble-work.md
@@ -36,9 +36,10 @@ This is the **mandatory entry point** — the orchestrator MUST dispatch here af
 - [ ] 1. Read plan index from `{N}/plan.md` for phase table, then read current phase file from `{N}/plan-{NN}-*.md` — extract phases, items, SCs, dependencies. **→ SC-5**
 - [ ] 2. Read work state file from `./tmp/{N}/work.md` — extract current progress, completed items, blocked items.
 - [ ] 3. Verify pre-flight conditions:
-   - Feature branch exists (or create via `git-workflow --task pre-work`)
+   - Feature branch exists (MUST have been created via `git-workflow --task pre-work`)
    - Working tree is clean (`git status --porcelain` returns empty)
    - Authorization scope covers the current pipeline phase
+   - Submodule state is current — resolve default branch via `git remote show origin | sed -n 's/.*HEAD branch: //p'`, then verify `git submodule status` shows submodules at that branch's tip
 - [ ] 4. Create Step 1.5 entry proof marker — write `./tmp/{N}/artifacts/entry-proof-{timestamp}.yaml` with:
    ```yaml
    step: 1.5

--- a/skills/implementation-pipeline/tasks/pipeline-executor.md
+++ b/skills/implementation-pipeline/tasks/pipeline-executor.md
@@ -40,6 +40,7 @@ A status of `DONE_WITH_CONCERNS` is coerced to FAIL — caveats are defects, not
 
 | Step # | Step Label | Dispatches To | Artifact Produced | YAML Contract Schema |
 |--------|------------|---------------|-------------------|---------------------|
+| 0 | `submodule-verify` | `git-workflow --task pre-work` (submodule state verification — resolve default branch via `git remote show origin \| sed -n 's/.*HEAD branch: //p'`, then `git submodule status` against that branch's tip) | `./tmp/{issue-N}/artifacts/pipeline-submodule-verify-{STATUS}-{timestamp}.yaml` | single-criterion |
 | 1 | `sc-coherence-gate` | `adversarial-audit --task coherence-extraction` (evidence-type uplift + substrate classification) | `./tmp/{issue-N}/artifacts/pipeline-sc-coherence-gate-{STATUS}-{timestamp}.yaml` | `per_criterion[]` from #932 |
 | 2 | `pre-red-baseline` | `implementation-pipeline --task pre-red-baseline` (doc-source-currency + SC-ID cross-ref traceability) | `./tmp/{issue-N}/state/state.yaml` + `./tmp/{issue-N}/artifacts/` YAML | pipeline state file |
 | 3 | `red-phase` | `test-driven-development --task red` | `./tmp/{issue-N}/artifacts/pipeline-red-phase-{STATUS}-{timestamp}.yaml` | `per_criterion[]` |

--- a/skills/implementation-pipeline/tasks/pre-red-baseline.md
+++ b/skills/implementation-pipeline/tasks/pre-red-baseline.md
@@ -41,8 +41,10 @@ Initialize pipeline state and verify document source currency before RED phase b
 - [ ] 5. For each referenced file path, check if the file has been modified since the plan was created
 - [ ] 6. Flag missing files as `MISSING-FILE`
 - [ ] 7. Flag modified files as `SOURCE-DRIFT`
-- [ ] 8. Check the plan's creation timestamp against the spec's last revision timestamp
-- [ ] 9. Flag if spec was revised after plan creation as `SPEC-REVISED-AFTER-PLAN`
+- [ ] 8. Check submodule state: resolve default branch via `git remote show origin | sed -n 's/.*HEAD branch: //p'`, then run `git submodule status` and verify submodules are at that branch's tip
+- [ ] 9. Flag stale submodules as `SUBMODULE-DRIFT`
+- [ ] 10. Check the plan's creation timestamp against the spec's last revision timestamp
+- [ ] 11. Flag if spec was revised after plan creation as `SPEC-REVISED-AFTER-PLAN`
 
 ### Step 3: SC-ID Cross-Reference Traceability
 
@@ -76,15 +78,19 @@ checks:
   - check_id: DOCUMENT_SOURCE_CURRENCY
     result: PASS | FAIL
     detail: "..."
+  - check_id: SUBMODULE_STATE
+    result: PASS | FAIL
+    detail: "..."
   - check_id: SC_ID_TRACEABILITY
     result: PASS | FAIL
     detail: "..."
 summary:
-  total_checks: 3
+  total_checks: 4
   pass: <count>
   fail: <count>
   missing_files: <list>
   source_drift: <list>
+  submodule_drift: <list>
   scope_creep: <list>
   missing_traceability: <list>
   missing_test_steps: <list>


### PR DESCRIPTION
## Summary

Adds mandatory submodule state verification at the implementation pipeline entry point. The pipeline previously assumed submodules were current without verification, allowing execution with stale submodules.

## Changes

- **`assemble-work.md`**: Added submodule state check to pre-flight conditions; changed "or create via" to "MUST have been created via" to make pre-work mandatory
- **`pipeline-executor.md`**: Added `submodule-verify` as step 0 in the dispatch table
- **`SKILL.md`**: Added submodule state check to Pre-Flight section
- **`pre-red-baseline.md`**: Added submodule state verification to document source currency check with `SUBMODULE-DRIFT` flag

## Fixes

Fixes #1440

🤖 Co-authored with AI: OpenCode (ollama-cloud/deepseek-v4-flash)
