### PR TITLE
Add filesystem-root guards to 26 walk-up scripts [.opencode#317]

### DIFF
--- a/scripts/session_context_triggers.py
+++ b/scripts/session_context_triggers.py
@@ -51,7 +51,10 @@ def get_current_branch() -> str | None:
 def get_root_dir() -> str:
     _path = Path(__file__).resolve().parent
     while _path.name != ".opencode":
-        _path = _path.parent
+        parent = _path.parent
+        if parent == _path:
+            raise RuntimeError("Could not find .opencode/ directory")
+        _path = parent
     return str(_path.parent)
 
 def is_pair_mode_branch() -> tuple[bool, str | None]:

--- a/skills/issue-operations/platforms/gitbucket-api/tests/test_pr_idempotency.py
+++ b/skills/issue-operations/platforms/gitbucket-api/tests/test_pr_idempotency.py
@@ -17,7 +17,10 @@ import sys
 
 _path = Path(__file__).resolve().parent
 while _path.name != ".opencode":
-    _path = _path.parent
+    parent = _path.parent
+    if parent == _path:
+        raise RuntimeError("Could not find .opencode/ directory")
+    _path = parent
 sys.path.insert(0, str(_path / "tools"))
 
 from gitbucket_api import GitBucketAPI

--- a/skills/issue-operations/platforms/gitbucket-api/tests/verify_api.py
+++ b/skills/issue-operations/platforms/gitbucket-api/tests/verify_api.py
@@ -191,7 +191,10 @@ def verify_openapi_spec() -> bool:
     print("\n=== Verifying OpenAPI Specification ===")
     _path = Path(__file__).resolve().parent
     while _path.name != ".opencode":
-        _path = _path.parent
+        parent = _path.parent
+        if parent == _path:
+            raise RuntimeError("Could not find .opencode/ directory")
+        _path = parent
     spec_path = (
         _path
         / "skills"

--- a/tests/regressions/regression-91-verify-structure.py
+++ b/tests/regressions/regression-91-verify-structure.py
@@ -19,7 +19,10 @@ from pathlib import Path
 
 _path = Path(__file__).resolve().parent
 while _path.name != ".opencode":
-    _path = _path.parent
+    parent = _path.parent
+    if parent == _path:
+        raise RuntimeError("Could not find .opencode/ directory")
+    _path = parent
 OPENCODE_DIR = _path
 PROJECT_ROOT = _path.parent
 

--- a/tools/detect-secrets-wrapper.sh
+++ b/tools/detect-secrets-wrapper.sh
@@ -9,7 +9,12 @@ fi
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_DIR="$SCRIPT_DIR"
 while [ "$(basename "$PROJECT_DIR")" != ".opencode" ]; do
-    PROJECT_DIR="$(dirname "$PROJECT_DIR")"
+    PARENT="$(dirname "$PROJECT_DIR")"
+    if [ "$PARENT" = "$PROJECT_DIR" ]; then
+        echo "FATAL: Could not find .opencode/ directory" >&2
+        exit 1
+    fi
+    PROJECT_DIR="$PARENT"
 done
 PROJECT_DIR="$(dirname "$PROJECT_DIR")"
 test -f "$PROJECT_DIR/.secrets.baseline" || exit 0

--- a/tools/ensure-node
+++ b/tools/ensure-node
@@ -9,7 +9,12 @@ fi
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$SCRIPT_DIR"
 while [ "$(basename "$REPO_ROOT")" != ".opencode" ]; do
-    REPO_ROOT="$(dirname "$REPO_ROOT")"
+    PARENT="$(dirname "$REPO_ROOT")"
+    if [ "$PARENT" = "$REPO_ROOT" ]; then
+        echo "FATAL: Could not find .opencode/ directory" >&2
+        exit 1
+    fi
+    REPO_ROOT="$PARENT"
 done
 REPO_ROOT="$(dirname "$REPO_ROOT")"
 NODE_DIR="${REPO_ROOT}/.opencode/.node"

--- a/tools/file-exists
+++ b/tools/file-exists
@@ -18,7 +18,10 @@ from pathlib import Path
 
 _path = Path(__file__).resolve().parent
 while _path.name != ".opencode":
-    _path = _path.parent
+    parent = _path.parent
+    if parent == _path:
+        raise RuntimeError("Could not find .opencode/ directory")
+    _path = parent
 PROJECT_ROOT = _path.parent
 
 def main() -> None:

--- a/tools/guidelines
+++ b/tools/guidelines
@@ -20,7 +20,10 @@ from pathlib import Path
 
 _path = Path(__file__).resolve().parent
 while _path.name != ".opencode":
-    _path = _path.parent
+    parent = _path.parent
+    if parent == _path:
+        raise RuntimeError("Could not find .opencode/ directory")
+    _path = parent
 PROJECT_ROOT = _path.parent
 
 ACTIONS = {

--- a/tools/help
+++ b/tools/help
@@ -20,7 +20,10 @@ from pathlib import Path
 
 _path = Path(__file__).resolve().parent
 while _path.name != ".opencode":
-    _path = _path.parent
+    parent = _path.parent
+    if parent == _path:
+        raise RuntimeError("Could not find .opencode/ directory")
+    _path = parent
 PROJECT_ROOT = _path.parent
 TOOLS_DIR = Path(__file__).resolve().parent
 

--- a/tools/impl/guidelines-edit
+++ b/tools/impl/guidelines-edit
@@ -40,7 +40,10 @@ from pathlib import Path
 
 _path = Path(__file__).resolve().parent
 while _path.name != ".opencode":
-    _path = _path.parent
+    parent = _path.parent
+    if parent == _path:
+        raise RuntimeError("Could not find .opencode/ directory")
+    _path = parent
 PROJECT_ROOT = _path.parent
 GUIDELINES_DIR = PROJECT_ROOT / ".opencode" / "guidelines"
 

--- a/tools/impl/guidelines-read
+++ b/tools/impl/guidelines-read
@@ -28,7 +28,10 @@ from pathlib import Path
 
 _path = Path(__file__).resolve().parent
 while _path.name != ".opencode":
-    _path = _path.parent
+    parent = _path.parent
+    if parent == _path:
+        raise RuntimeError("Could not find .opencode/ directory")
+    _path = parent
 PROJECT_ROOT = _path.parent
 GUIDELINES_DIR = PROJECT_ROOT / ".opencode" / "guidelines"
 SKILLS_DIR = PROJECT_ROOT / ".opencode" / "skills"

--- a/tools/impl/guidelines-search
+++ b/tools/impl/guidelines-search
@@ -42,7 +42,10 @@ from pathlib import Path
 
 _path = Path(__file__).resolve().parent
 while _path.name != ".opencode":
-    _path = _path.parent
+    parent = _path.parent
+    if parent == _path:
+        raise RuntimeError("Could not find .opencode/ directory")
+    _path = parent
 PROJECT_ROOT = _path.parent
 GUIDELINES_DIR = PROJECT_ROOT / ".opencode" / "guidelines"
 

--- a/tools/impl/guidelines-show
+++ b/tools/impl/guidelines-show
@@ -28,7 +28,10 @@ from pathlib import Path
 
 _path = Path(__file__).resolve().parent
 while _path.name != ".opencode":
-    _path = _path.parent
+    parent = _path.parent
+    if parent == _path:
+        raise RuntimeError("Could not find .opencode/ directory")
+    _path = parent
 PROJECT_ROOT = _path.parent
 OPENCODE_DIR = PROJECT_ROOT / ".opencode"
 GUIDELINES_DIR = OPENCODE_DIR / "guidelines"

--- a/tools/impl/jupyter-start
+++ b/tools/impl/jupyter-start
@@ -29,7 +29,10 @@ from pathlib import Path
 
 _path = Path(__file__).resolve().parent
 while _path.name != ".opencode":
-    _path = _path.parent
+    parent = _path.parent
+    if parent == _path:
+        raise RuntimeError("Could not find .opencode/ directory")
+    _path = parent
 PROJECT_ROOT = _path.parent
 PORT = 18888
 LOG_FILE = PROJECT_ROOT / "tmp" / "jupyter.log"

--- a/tools/impl/jupyter-stop
+++ b/tools/impl/jupyter-stop
@@ -29,7 +29,10 @@ from pathlib import Path
 
 _path = Path(__file__).resolve().parent
 while _path.name != ".opencode":
-    _path = _path.parent
+    parent = _path.parent
+    if parent == _path:
+        raise RuntimeError("Could not find .opencode/ directory")
+    _path = parent
 PROJECT_ROOT = _path.parent
 PORT = 18888
 

--- a/tools/impl/py-ls
+++ b/tools/impl/py-ls
@@ -27,7 +27,10 @@ from pathlib import Path
 
 _path = Path(__file__).resolve().parent
 while _path.name != ".opencode":
-    _path = _path.parent
+    parent = _path.parent
+    if parent == _path:
+        raise RuntimeError("Could not find .opencode/ directory")
+    _path = parent
 PROJECT_ROOT = _path.parent
 
 def is_package(p: Path) -> bool:

--- a/tools/impl/py-mkpkg
+++ b/tools/impl/py-mkpkg
@@ -24,7 +24,10 @@ from pathlib import Path
 
 _path = Path(__file__).resolve().parent
 while _path.name != ".opencode":
-    _path = _path.parent
+    parent = _path.parent
+    if parent == _path:
+        raise RuntimeError("Could not find .opencode/ directory")
+    _path = parent
 PROJECT_ROOT = _path.parent
 
 def make_package(rel_path: str) -> None:

--- a/tools/jupyter
+++ b/tools/jupyter
@@ -20,7 +20,10 @@ from pathlib import Path
 
 _path = Path(__file__).resolve().parent
 while _path.name != ".opencode":
-    _path = _path.parent
+    parent = _path.parent
+    if parent == _path:
+        raise RuntimeError("Could not find .opencode/ directory")
+    _path = parent
 PROJECT_ROOT = _path.parent
 
 ACTIONS = {

--- a/tools/jupyter-start
+++ b/tools/jupyter-start
@@ -23,7 +23,10 @@ from pathlib import Path
 
 _path = Path(__file__).resolve().parent
 while _path.name != ".opencode":
-    _path = _path.parent
+    parent = _path.parent
+    if parent == _path:
+        raise RuntimeError("Could not find .opencode/ directory")
+    _path = parent
 PROJECT_ROOT = _path.parent
 PORT = 18888
 LOG_FILE = PROJECT_ROOT / "tmp" / "jupyter.log"

--- a/tools/jupyter-stop
+++ b/tools/jupyter-stop
@@ -23,7 +23,10 @@ from pathlib import Path
 
 _path = Path(__file__).resolve().parent
 while _path.name != ".opencode":
-    _path = _path.parent
+    parent = _path.parent
+    if parent == _path:
+        raise RuntimeError("Could not find .opencode/ directory")
+    _path = parent
 PROJECT_ROOT = _path.parent
 PORT = 18888
 

--- a/tools/md
+++ b/tools/md
@@ -20,7 +20,10 @@ from pathlib import Path
 
 _path = Path(__file__).resolve().parent
 while _path.name != ".opencode":
-    _path = _path.parent
+    parent = _path.parent
+    if parent == _path:
+        raise RuntimeError("Could not find .opencode/ directory")
+    _path = parent
 PROJECT_ROOT = _path.parent
 
 ACTIONS = {

--- a/tools/plan
+++ b/tools/plan
@@ -55,7 +55,10 @@ import yaml
 
 _path = Path(__file__).resolve().parent
 while _path.name != ".opencode":
-    _path = _path.parent
+    parent = _path.parent
+    if parent == _path:
+        raise RuntimeError("Could not find .opencode/ directory")
+    _path = parent
 PROJECT_ROOT = _path.parent
 
 

--- a/tools/py
+++ b/tools/py
@@ -21,7 +21,10 @@ from pathlib import Path
 
 _path = Path(__file__).resolve().parent
 while _path.name != ".opencode":
-    _path = _path.parent
+    parent = _path.parent
+    if parent == _path:
+        raise RuntimeError("Could not find .opencode/ directory")
+    _path = parent
 PROJECT_ROOT = _path.parent
 
 ACTIONS = {

--- a/tools/session-init
+++ b/tools/session-init
@@ -56,7 +56,10 @@ NETWORK_TIMEOUT = 5
 
 _path = Path(__file__).resolve().parent
 while _path.name != ".opencode":
-    _path = _path.parent
+    parent = _path.parent
+    if parent == _path:
+        raise RuntimeError("Could not find .opencode/ directory")
+    _path = parent
 PROJECT_ROOT = _path.parent
 
 

--- a/tools/skildeck
+++ b/tools/skildeck
@@ -30,7 +30,10 @@ from pathlib import Path
 BASE_DIR = Path(__file__).resolve().parent
 _path = Path(__file__).resolve().parent
 while _path.name != ".opencode":
-    _path = _path.parent
+    parent = _path.parent
+    if parent == _path:
+        raise RuntimeError("Could not find .opencode/ directory")
+    _path = parent
 PROJECT_ROOT = _path.parent
 IMPL_DIR = BASE_DIR / "impl" / "skildeck"
 SYM_DIR = BASE_DIR / "impl"

--- a/tools/solve
+++ b/tools/solve
@@ -37,7 +37,10 @@ import z3
 
 _path = Path(__file__).resolve().parent
 while _path.name != ".opencode":
-    _path = _path.parent
+    parent = _path.parent
+    if parent == _path:
+        raise RuntimeError("Could not find .opencode/ directory")
+    _path = parent
 PROJECT_ROOT = _path.parent
 
 


### PR DESCRIPTION
## Summary

Add filesystem-root guard to all 26 scripts with canonical walk-up-to-`.opencode` pattern, preventing infinite loop when `.opencode/` is unreachable.

## Changes

**G1 — 2 bash scripts:**
- `tools/detect-secrets-wrapper.sh`
- `tools/ensure-node`

**G2 — 12 Python PEP 723 tools:**
- `tools/guidelines`, `tools/md`, `tools/py`, `tools/file-exists`, `tools/session-init`, `tools/help`, `tools/jupyter`, `tools/jupyter-start`, `tools/jupyter-stop`, `tools/skildeck`, `tools/plan`, `tools/solve`

**G3 — 8 Python PEP 723 impl scripts:**
- `tools/impl/guidelines-read`, `tools/impl/guidelines-show`, `tools/impl/guidelines-search`, `tools/impl/guidelines-edit`, `tools/impl/jupyter-start`, `tools/impl/jupyter-stop`, `tools/impl/py-ls`, `tools/impl/py-mkpkg`

**G4 — 4 Python scripts:**
- `scripts/session_context_triggers.py`
- `skills/issue-operations/platforms/gitbucket-api/tests/verify_api.py`
- `skills/issue-operations/platforms/gitbucket-api/tests/test_pr_idempotency.py`
- `tests/regressions/regression-91-verify-structure.py`

## Guard Pattern

**Shell:** `if [ "$PARENT" = "$PROJECT_DIR" ]; then echo "FATAL: Could not find .opencode/ directory" >&2; exit 1; fi`

**Python:** `if parent == _path: raise RuntimeError("Could not find .opencode/ directory")`

## Verification

- All 26 files confirmed lacking root-guard before changes
- All 26 files confirmed having root-guard after changes
- `tools/local-issues` existing guard verified unchanged (SC-5)
- 4 checkpoint commits (one per group)

Fixes #317 (Phase 1)

🤖 Co-authored with AI: OpenCode (ollama-cloud/deepseek-v4-flash)