### PR TITLE
[#327] Add content dispatch exclusion to orchestrator context lean table

### DIFF
--- a/guidelines/020-go-prohibitions.md
+++ b/guidelines/020-go-prohibitions.md
@@ -102,6 +102,7 @@ Everything else goes to a sub-agent:
 | Cached verification results | Sub-agent → disk → evidence artifacts |
 | Previous sub-agent reasoning traces | Discarded with sub-agent context |
 | Full file contents | Disk only |
+| Pre-composed content, prose, or text intended for API posting (comments, issue bodies, PR descriptions) | Sub-agent context — sub-agent composes autonomously |
 
 #### 2. Sub-Agent Context Generosity
 


### PR DESCRIPTION
## Summary

Closes the rationalization loophole where "it's just a comment, not code" bypasses clean-room protocol. The orchestrator context lean table in `020-go-prohibitions.md` §1.1 now explicitly excludes pre-composed content intended for API posting.

## Outcome

One row added to the exclusion table:

```
| Pre-composed content, prose, or text intended for API posting (comments, issue bodies, PR descriptions) | Sub-agent context — sub-agent composes autonomously |
```

## Fixes

Fixes #327

## Background

The original spec proposed a token-exact detection mechanism (dispatch-to-output overlap >80%). That approach was rejected during review: detection scripts are bypassable by the same agent that writes them. The structural rule is the only durable fix — content is not routing metadata, the orchestrator does not hold it.

Co-authored with AI: OpenCode (deepseek-v4-flash)
