### PR TITLE
feat(#361): append correctness-over-speed line to all SKILL.md Operating Protocol sections

### DIFF
--- a/skills/brainstorming/SKILL.md
+++ b/skills/brainstorming/SKILL.md
@@ -67,6 +67,7 @@ Requirements Explorer. Focus: understand what user wants through natural convers
 - [ ] 3. **Pre-spec inspection mandatory** (code inspection checklist) before proposing approach.
 - [ ] 4. **Autonomous structural classification:** classify single vs multi-task without asking.
 - [ ] 5. **Terminal state** invokes `spec-creation`.
+- [ ] 6. **Correctness over speed.** Every code path with runtime behavior requires live-wire testing against real systems. A slow correct answer is strictly better than a fast incorrect one. Static analysis alone is NOT acceptable verification — behavioral compliance requires actual execution with cross-validated PASS verdict.
 
 ## Sub-Agent Routing
 

--- a/skills/completeness-gate/SKILL.md
+++ b/skills/completeness-gate/SKILL.md
@@ -117,6 +117,7 @@ After loading this skill and reading the Trigger Dispatch Table, the orchestrato
 - [ ] 2. **Single pass:** The check runs once per handoff — no internal loop, no re-checking
 - [ ] 3. **Read-only:** No remediation, no routing advice, no fix suggestions
 - [ ] 4. **Evidence-based:** All findings require tool-call evidence from live sources
+- [ ] 5. **Correctness over speed.** Every code path with runtime behavior requires live-wire testing against real systems. A slow correct answer is strictly better than a fast incorrect one. Static analysis alone is NOT acceptable verification — behavioral compliance requires actual execution with cross-validated PASS verdict.
 
 ## Routing Decision
 

--- a/skills/correspondence/SKILL.md
+++ b/skills/correspondence/SKILL.md
@@ -62,6 +62,7 @@ This skill operates in the main repo directory (direct-branch mode). When `WORKT
 - [ ] 6. **AI byline mandatory** in all correspondence.
 - [ ] 7. **Content-type propagation:** match source email format (inspect Content-Type header).
 - [ ] 8. **Attribution verification:** no role-proximity inference — only evidence-backed attribution.
+- [ ] 9. **Correctness over speed.** Every code path with runtime behavior requires live-wire testing against real systems. A slow correct answer is strictly better than a fast incorrect one. Static analysis alone is NOT acceptable verification — behavioral compliance requires actual execution with cross-validated PASS verdict.
 
 ## Sub-Agent Routing
 

--- a/skills/engineering-approach/SKILL.md
+++ b/skills/engineering-approach/SKILL.md
@@ -65,6 +65,7 @@ This skill operates in the main repo directory (direct-branch mode). When `WORKT
 - [ ] 3. **Verify before complete:** run tests manually, check edge cases, validate success criteria.
 - [ ] 4. **No scope creep:** implement ONLY what's in the approved spec.
 - [ ] 5. **Pre-implementation verification:** verify API signatures, env vars, config formats against live docs.
+- [ ] 6. **Correctness over speed.** Every code path with runtime behavior requires live-wire testing against real systems. A slow correct answer is strictly better than a fast incorrect one. Static analysis alone is NOT acceptable verification — behavioral compliance requires actual execution with cross-validated PASS verdict.
 
 ## Sub-Agent Routing
 

--- a/skills/executing-plans/SKILL.md
+++ b/skills/executing-plans/SKILL.md
@@ -60,6 +60,7 @@ This skill operates in the main repo directory (direct-branch mode). When `WORKT
 - [ ] 2. **Route to implementation-pipeline** with full context.
 - [ ] 3. **Track phase progress** against plan sub-issues.
 - [ ] 4. **Unified path:** no single-task exemption.
+- [ ] 5. **Correctness over speed.** Every code path with runtime behavior requires live-wire testing against real systems. A slow correct answer is strictly better than a fast incorrect one. Static analysis alone is NOT acceptable verification — behavioral compliance requires actual execution with cross-validated PASS verdict.
 
 ## Received Context
 

--- a/skills/finishing-a-development-branch/SKILL.md
+++ b/skills/finishing-a-development-branch/SKILL.md
@@ -67,6 +67,7 @@ This skill operates in the main repo directory (direct-branch mode). When `WORKT
 - [ ] 4. **Type check:** `uvx pyright` clean.
 - [ ] 5. **Branch pushed:** up to date with remote.
 - [ ] 6. **Plan sub-issue closure verification:** matched against implementation.
+- [ ] 7. **Correctness over speed.** Every code path with runtime behavior requires live-wire testing against real systems. A slow correct answer is strictly better than a fast incorrect one. Static analysis alone is NOT acceptable verification — behavioral compliance requires actual execution with cross-validated PASS verdict.
 
 ## Sub-Agent Routing
 

--- a/skills/git-workflow/SKILL.md
+++ b/skills/git-workflow/SKILL.md
@@ -109,6 +109,7 @@ Git Workflow Enforcer. Focus: trunk-based development workflow, block AI on prot
 - [ ] 7. **Pair mode:** `pair-*` branches use WIP-commit switching, not worktrees.
 - [ ] 8. **Adversarial-audit call:** after issue closure, before branch cleanup, call `adversarial-audit --task closure-verification --pr <N>` with `audit_phase: post_merge`.
 - [ ] 9. **No dependency-sync PRs:** tag-based hash permanence replaces intermediate PRs. Submodule SHAs are preserved via parent-repo-prefixed tags. See AGENTS.md §Tag Layers.
+- [ ] 10. **Correctness over speed.** Every code path with runtime behavior requires live-wire testing against real systems. A slow correct answer is strictly better than a fast incorrect one. Static analysis alone is NOT acceptable verification — behavioral compliance requires actual execution with cross-validated PASS verdict.
 
 ### Tag Convention (Canonical)
 

--- a/skills/issue-operations/SKILL.md
+++ b/skills/issue-operations/SKILL.md
@@ -115,6 +115,7 @@ Issue Operations Router. Focus: spec-first workflow, validation, labeling, platf
 - [ ] 4. **Byline mandatory:** AI-authored comments must include `🤖 Co-authored with AI: <AgentName> (<ModelId>)`.
 - [ ] 5. **Issue creation = no auth needed** per `010-approval-gate.md`.
 - [ ] 6. **Adversarial-audit call:** after sub-issue creation, call `adversarial-audit --task concern-separation --issue <N>` with `audit_phase: sub_issue_creation`.
+- [ ] 7. **Correctness over speed.** Every code path with runtime behavior requires live-wire testing against real systems. A slow correct answer is strictly better than a fast incorrect one. Static analysis alone is NOT acceptable verification — behavioral compliance requires actual execution with cross-validated PASS verdict.
 
 ## Sub-Agent Routing
 

--- a/skills/issue-operations/platforms/gitbucket-api/SKILL.md
+++ b/skills/issue-operations/platforms/gitbucket-api/SKILL.md
@@ -192,6 +192,7 @@ All `list` endpoints return arrays, NOT objects. Use `--json --no-pager` flags f
 - [ ] 8. Use comment-based linking for sub-issues
 - [ ] 9. Use iterative listing for search operations
 - [ ] 10. Follow error recovery procedures in `tasks/error-recovery.md`
+- [ ] 11. **Correctness over speed.** Every code path with runtime behavior requires live-wire testing against real systems. A slow correct answer is strictly better than a fast incorrect one. Static analysis alone is NOT acceptable verification — behavioral compliance requires actual execution with cross-validated PASS verdict.
 
 ## Cross-References
 

--- a/skills/issue-review/SKILL.md
+++ b/skills/issue-review/SKILL.md
@@ -71,6 +71,7 @@ Issue Review Orchestrator. Focus: gather context, classify path, delegate to cor
 - [ ] 3. **Bug discovery ≠ authorization:** findings reported as bug issues; no code edits during analysis.
 - [ ] 4. **Fix spec must target root cause, not symptom** per `000-critical-rules.md`.
 - [ ] 5. **Audit findings are internal** — posted to chat, not GitHub comments.
+- [ ] 6. **Correctness over speed.** Every code path with runtime behavior requires live-wire testing against real systems. A slow correct answer is strictly better than a fast incorrect one. Static analysis alone is NOT acceptable verification — behavioral compliance requires actual execution with cross-validated PASS verdict.
 
 ## Sub-Agent Routing
 

--- a/skills/pr-creation-workflow/SKILL.md
+++ b/skills/pr-creation-workflow/SKILL.md
@@ -66,6 +66,7 @@ This skill operates in the main repo directory (direct-branch mode). When `WORKT
 - [ ] 6. **No agent merge** — human-only operation.
 - [ ] 7. **Work branch guard:** no individual PRs during work execution (single stacked PR).
 - [ ] 8. **Submodule-bump-only PR block (MANDATORY — parent repo context):** Before creating any PR, check whether the diff contains changes outside `.opencode/`. In a parent repo with `.gitmodules`, a PR that only changes `.opencode/` (submodule pointer bump) is BLOCKED by enforcement gate `pr-workflow-003`. The agent MUST NOT create, propose, or assist in creating a submodule-bump-only PR. This is a CRITICAL GUIDELINE VIOLATION — bypassing this gate results in a HALT.
+- [ ] 9. **Correctness over speed.** Every code path with runtime behavior requires live-wire testing against real systems. A slow correct answer is strictly better than a fast incorrect one. Static analysis alone is NOT acceptable verification — behavioral compliance requires actual execution with cross-validated PASS verdict.
 
 ## Sub-Agent Routing
 

--- a/skills/pre-analysis/SKILL.md
+++ b/skills/pre-analysis/SKILL.md
@@ -125,6 +125,7 @@ After loading this skill and reading the Trigger Dispatch Table, the orchestrato
 - [ ] 2. **Minimal context:** Pre-analysis sub-agents receive only `{ issue_number, task_description, pipeline_phase, authorization_scope, halt_at, pr_strategy, github.owner, github.repo }`
 - [ ] 3. **Autonomous discovery:** Independently search the codebase to discover affected files
 - [ ] 4. **Return task plan:** Return a structured plan with task partitions and file scope
+- [ ] 5. **Correctness over speed.** Every code path with runtime behavior requires live-wire testing against real systems. A slow correct answer is strictly better than a fast incorrect one. Static analysis alone is NOT acceptable verification — behavioral compliance requires actual execution with cross-validated PASS verdict.
 
 ## Worktree Mode
 

--- a/skills/skill-creator/SKILL.md
+++ b/skills/skill-creator/SKILL.md
@@ -72,6 +72,7 @@ This skill operates in the main repo directory (direct-branch mode). When `WORKT
 - [ ] 7. **Required frontmatter:** name, description, type, license, provenance, compatibility.
 - [ ] 8. **Session-init variable alignment:** use canonical dotted-name format.
 - [ ] 9. **Fragment discipline:** master copy is single source of truth — never edit copies directly. Registry at `.opencode/.guidelines/registry.yaml`.
+- [ ] 10. **Correctness over speed.** Every code path with runtime behavior requires live-wire testing against real systems. A slow correct answer is strictly better than a fast incorrect one. Static analysis alone is NOT acceptable verification — behavioral compliance requires actual execution with cross-validated PASS verdict.
 
 ## Sub-Agent Routing
 

--- a/skills/spec-creation/SKILL.md
+++ b/skills/spec-creation/SKILL.md
@@ -66,6 +66,7 @@ This skill produces specs by dispatching sub-agents. The orchestrator routes; su
 - [ ] 9. [inline] Invoke `plan plan` for phase solvability validation — chain: `step_8`
 - [ ] 10. [sub-task: write] `task(..., prompt: "execute write task from spec-creation")` — input: `./tmp/{N}/contracts/write-input.yaml`, output: `./tmp/{N}/contracts/write-output.yaml`, template: `.opencode/skills/spec-creation/contracts/write-input-template.yaml`, chain: `step_6, step_9`
 - [ ] 11. [sub-task: completion] `task(..., prompt: "execute completion task from spec-creation")` — input: `./tmp/{N}/contracts/completion-input.yaml`, output: `./tmp/{N}/contracts/completion-output.yaml`, template: `.opencode/skills/spec-creation/contracts/write-output-template.yaml` (shared), chain: `step_10`
+- [ ] 12. **Correctness over speed.** Every code path with runtime behavior requires live-wire testing against real systems. A slow correct answer is strictly better than a fast incorrect one. Static analysis alone is NOT acceptable verification — behavioral compliance requires actual execution with cross-validated PASS verdict.
 
 ## Sub-Agent Routing
 

--- a/skills/sre-runbook/SKILL.md
+++ b/skills/sre-runbook/SKILL.md
@@ -64,6 +64,7 @@ SRE-oriented operator writing runbooks for sysops under pressure. Runbooks are o
 - [ ] 6. **Live-verification:** every CLI/GUI/API claim verified against live docs before inclusion. All sources fail → HALT with VERIFICATION-GAP.
 - [ ] 7. **Exact-match verification:** row-by-row comparison template. No "functionally equivalent" soft-passes.
 - [ ] 8. **DNS-specific validation:** RFC 1034 compliance (CNAME at apex invalid), provider-specific reference data.
+- [ ] 9. **Correctness over speed.** Every code path with runtime behavior requires live-wire testing against real systems. A slow correct answer is strictly better than a fast incorrect one. Static analysis alone is NOT acceptable verification — behavioral compliance requires actual execution with cross-validated PASS verdict.
 
 ## Sub-Agent Routing
 

--- a/skills/systematic-debugging/SKILL.md
+++ b/skills/systematic-debugging/SKILL.md
@@ -62,6 +62,7 @@ This skill operates in the main repo directory (direct-branch mode). When `WORKT
 - [ ] 4. **Fix targets root cause, not symptoms.**
 - [ ] 5. **Fix requires authorization** per `approval-gate`.
 - [ ] 6. **No scope creep:** fix only what diagnosis identified.
+- [ ] 7. **Correctness over speed.** Every code path with runtime behavior requires live-wire testing against real systems. A slow correct answer is strictly better than a fast incorrect one. Static analysis alone is NOT acceptable verification — behavioral compliance requires actual execution with cross-validated PASS verdict.
 
 ## Sub-Agent Routing
 

--- a/skills/using-git-worktrees/SKILL.md
+++ b/skills/using-git-worktrees/SKILL.md
@@ -63,6 +63,7 @@ Worktree Setup Specialist. Focus: creating safe, isolated git worktrees for para
 - [ ] 1. **Opt-in only** — created when `WORKTREE_REQUIRED` or developer requests.
 - [ ] 2. **Safety verification:** confirm git worktree add succeeded, verify path is writable.
 - [ ] 3. **Path resolution:** `worktree.path` set; all file ops prefix paths.
+- [ ] 4. **Correctness over speed.** Every code path with runtime behavior requires live-wire testing against real systems. A slow correct answer is strictly better than a fast incorrect one. Static analysis alone is NOT acceptable verification — behavioral compliance requires actual execution with cross-validated PASS verdict.
 
 ## Sub-Agent Routing
 

--- a/skills/verification-before-completion/SKILL.md
+++ b/skills/verification-before-completion/SKILL.md
@@ -69,6 +69,7 @@ Verification Gatekeeper. Focus: no completion claim without verified evidence. E
 - [ ] 4. **Exact comparison:** external verifications use exact mode. No "functionally equivalent" soft-passes.
 - [ ] 5. **Live-source only:** evidence from memory/training data is FORBIDDEN. Tool-call artifact required.
 - [ ] 6. **Clean-room routing:** verification sub-agents receive ONLY spec SC list + file paths. No implementation context, no prior results.
+- [ ] 7. **Correctness over speed.** Every code path with runtime behavior requires live-wire testing against real systems. A slow correct answer is strictly better than a fast incorrect one. Static analysis alone is NOT acceptable verification — behavioral compliance requires actual execution with cross-validated PASS verdict.
 
 ## Sub-Agent Routing
 

--- a/skills/verification-enforcement/SKILL.md
+++ b/skills/verification-enforcement/SKILL.md
@@ -66,6 +66,7 @@ Verification Gatekeeper. Not the content author — the evidence collector runni
 - [ ] 3. **Orchestrator enforcement:** reject sub-agent output lacking evidence artifacts; re-task.
 - [ ] 4. **Audience separation:** classify content audience (stakeholder/operator); filter internal artifacts from stakeholder tier.
 - [ ] 5. **All factual claims require live-source verification.**
+- [ ] 6. **Correctness over speed.** Every code path with runtime behavior requires live-wire testing against real systems. A slow correct answer is strictly better than a fast incorrect one. Static analysis alone is NOT acceptable verification — behavioral compliance requires actual execution with cross-validated PASS verdict.
 
 ## Sub-Agent Routing
 

--- a/skills/writing-plans/SKILL.md
+++ b/skills/writing-plans/SKILL.md
@@ -84,6 +84,7 @@ This skill produces plans by executing a 22-step pipeline at orchestrator level.
 **Execution model:** Under the hard limit that sub-agents cannot dispatch sub-agents, this skill's pipeline executes entirely at the orchestrator level. The orchestrator reads each step procedure and executes it directly. No `task()` calls are used within the pipeline.
 
 Each item is tagged with chain dependency and contract paths.
+- [ ] 0. **Correctness over speed.** Every code path with runtime behavior requires live-wire testing against real systems. A slow correct answer is strictly better than a fast incorrect one. Static analysis alone is NOT acceptable verification — behavioral compliance requires actual execution with cross-validated PASS verdict.
 
 ### Pipeline Steps
 


### PR DESCRIPTION
## Summary

Appends the uniform correctness-over-speed reinforcement line to all 20 SKILL.md files that have an Operating Protocol section.

**Revised from LLM-specific to engineering-universal language:**
- "live-wire testing against real systems" replaces "two different cloud models"
- "static analysis alone" replaces "static grep"
- Applies to any code path with runtime behavior — integration tests, e2e suites, canary deployments, or dual-auditor LLM evaluation are all valid mechanisms

## Outcome

20 files changed, 20 insertions. Content-verification: all 20 files confirmed.

## Fixes

- #361

---

🤖 Co-authored with AI: OpenCode (deepseek-v4-flash)