### PR TITLE
feat(#393): document Ollama/Ollama-Cloud dependency in README and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,42 @@ This repository provides a comprehensive framework for configuring and extending
 - **Verification Gates** - Evidence-based completion verification
 - **Fragment Registry** - Synchronized content blocks across skills
 
+## Runtime Dependencies
+
+### Model Provider: Ollama / Ollama-Cloud
+
+The entire skilldeck is hard-wired to use **Ollama** as its model provider — both locally (via the `ollama` CLI) and via **ollama-cloud** (Ollama's cloud-hosting service). There is no abstraction layer or alternate provider. If Ollama is not installed and ollama-cloud is not accessible, the skilldeck cannot dispatch agents.
+
+| Layer | Ollama Footprint |
+|---|---|
+| **Agent definitions** (`agents/auditor-*.md`) | All 4 auditor agents hard-code `model: ollama/:cloud` |
+| **Behavioral tests** (`tests/behaviors/`) | Default test model: `ollama/ornith:35b-256k`; `helpers.sh` sources `default-model.sh` |
+| **Content-verification tests** (`test-enforcement.sh`) | Default model: `ollama/ornith:35b-256k` |
+| **Auditor pool** (`tests/qualification/qualified-auditor-pool.sh`) | 4 audited models, all `:cloud`-suffixed via Ollama |
+| **Adversarial audit** (`skills/adversarial-audit/`) | Cross-family cross-validation dispatches dual Ollama models per audit via `resolve-models` |
+| **Tooling** (`tools/ollama-probe`, `tools/resolve-models`) | Dedicated tools for probing local Ollama server and resolving auditor model pairs |
+| **Guidelines** (`020-go-prohibitions.md`) | References `ollama-probe hw` as mandatory hardware assessment step |
+
+### Prerequisites
+
+| Requirement | Minimum | Recommended |
+|---|---|---|
+| **Ollama** (local) | Installed, reachable at `localhost:11434` | `curl -fsSL https://ollama.com/install.sh \| sh` |
+| **ollama-cloud** | Token configured (via `ollama login` or env) for cloud model access | Verified via `ollama list` — cloud models show SIZE of `"-"` |
+| **VRAM** (for local models) | 8 GB for a ≥7B model | 16 GB+ for multiple concurrent models |
+| **Hardware probe** | `ollama-probe hw` must return VRAM ≥ 8 GB | Run at session start to validate capacity |
+
+## Model Configuration
+
+| Setting | Mechanism | Default |
+|---|---|---|
+| **Default test model** | `DEFAULT_TEST_MODEL` env var (sourced from `tests/default-model.sh`) | `ollama/ornith:35b-256k` |
+| **Auditor agent models** | `model:` field in `agents/auditor-*.md` YAML frontmatter | Per-card (e.g., `ollama/deepseek-v4-flash:cloud`) |
+| **Qualified auditor pool** | `tests/qualification/qualified-auditor-pool.sh` | 4 models (deepseek-v4-flash, gemma4, mistral-large-3, qwen3.5) |
+| **Auditor pair resolution** | `tools/resolve-models` scans cards + pool | Selects 2 auditors from different families |
+
+Model name convention: `ollama/:cloud` (agent definitions, test helpers) and `ollama-cloud/` (content-verification tests) both resolve to the same Ollama cloud model namespace.
+
 ## Directory Structure
 
 ```

--- a/docs/model-dependency.md
+++ b/docs/model-dependency.md
@@ -1,0 +1,50 @@
+<!-- SPDX-FileCopyrightText: 2026 Michael Conrad -->
+<!-- SPDX-License-Identifier: MIT -->
+<!-- Provenance: AI-generated -->
+
+# Model Dependency: Ollama / Ollama-Cloud
+
+The `.opencode` skilldeck is hard-wired to use **Ollama** as its model provider — both locally (via the `ollama` CLI) and via **ollama-cloud** (Ollama's cloud-hosting service). There is no abstraction layer or alternate provider. If Ollama is not installed and ollama-cloud is not accessible, the skilldeck cannot dispatch agents.
+
+## Touchpoints
+
+| Layer | Ollama Footprint |
+|---|---|
+| **Agent definitions** (`agents/auditor-*.md`) | All 4 auditor agents hard-code `model: ollama/:cloud` |
+| **Behavioral tests** (`tests/behaviors/`) | Default test model: `ollama/ornith:35b-256k`; `helpers.sh` sources `default-model.sh` |
+| **Content-verification tests** (`test-enforcement.sh`) | Default model: `ollama/ornith:35b-256k` |
+| **Auditor pool** (`tests/qualification/qualified-auditor-pool.sh`) | 4 audited models, all `:cloud`-suffixed via Ollama |
+| **Adversarial audit** (`skills/adversarial-audit/`) | Cross-family cross-validation dispatches dual Ollama models per audit via `resolve-models` |
+| **Tooling** (`tools/ollama-probe`, `tools/resolve-models`) | Dedicated tools for probing local Ollama server and resolving auditor model pairs |
+| **Guidelines** (`020-go-prohibitions.md`) | References `ollama-probe hw` as mandatory hardware assessment step |
+
+## Prerequisites
+
+| Requirement | Minimum | Recommended |
+|---|---|---|
+| **Ollama** (local) | Installed, reachable at `localhost:11434` | `curl -fsSL https://ollama.com/install.sh \| sh` |
+| **ollama-cloud** | Token configured (via `ollama login` or env) for cloud model access | Verified via `ollama list` — cloud models show SIZE of `"-"` |
+| **VRAM** (for local models) | 8 GB for a ≥7B model | 16 GB+ for multiple concurrent models |
+| **Hardware probe** | `ollama-probe hw` must return VRAM ≥ 8 GB | Run at session start to validate capacity |
+
+## Configuration Points
+
+| Setting | Mechanism | Default |
+|---|---|---|
+| **Default test model** | `DEFAULT_TEST_MODEL` env var (sourced from `tests/default-model.sh`) | `ollama/ornith:35b-256k` |
+| **Auditor agent models** | `model:` field in `agents/auditor-*.md` YAML frontmatter | Per-card (e.g., `ollama/deepseek-v4-flash:cloud`) |
+| **Qualified auditor pool** | `tests/qualification/qualified-auditor-pool.sh` | 4 models (deepseek-v4-flash, gemma4, mistral-large-3, qwen3.5) |
+| **Auditor pair resolution** | `tools/resolve-models` scans cards + pool | Selects 2 auditors from different families |
+
+## Model Name Convention
+
+Two formats are used interchangeably:
+
+- `ollama/:cloud` — used in agent definitions and behavioral test helpers
+- `ollama-cloud/` — used in content-verification tests and guideline examples
+
+Both resolve to the same Ollama cloud model namespace.
+
+---
+
+Co-authored with AI: OpenCode (ollama-cloud/deepseek-v4-flash)

--- a/skills/adversarial-audit/SKILL.md
+++ b/skills/adversarial-audit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: adversarial-audit
-description: "Use when running adversarial audits of specs, plans, or code. Also use when verifying spec fidelity, checking plan coherence, detecting drift, or cross-validating verification results. Invoke for: spec audit, plan fidelity, concern separation, coherence extraction, coherence maintenance, guideline audit, drift detection, spec summary, closure verification, test quality audit, verification audit, resolve models, cross-validate. Audits are not optional — dispatch is MANDATORY. Trigger phrases: audit spec, audit plan, check fidelity, verify coherence, detect drift, cross-validate, audit guidelines, verify closure, audit tests, verify verification, resolve auditor models."
+description: "Use when running adversarial audits of specs, plans, code, or generated content. Also use when verifying spec fidelity, checking plan coherence, detecting drift, cross-validating verification results, or auditing factual claims in generated content. Invoke for: spec audit, plan fidelity, concern separation, coherence extraction, coherence maintenance, guideline audit, drift detection, spec summary, closure verification, test quality audit, verification audit, content audit, resolve models, cross-validate. Audits are not optional — dispatch is MANDATORY. Trigger phrases: audit spec, audit plan, check fidelity, verify coherence, detect drift, cross-validate, audit guidelines, verify closure, audit tests, verify verification, content audit, resolve auditor models."
 license: MIT
 compatibility: opencode
 ---
@@ -45,6 +45,7 @@ This skill operates in the main repo directory (direct-branch mode). When `WORKT
 | "closure verification" / "post-merge audit" | `closure-verification` | `sub-task` | {pr_number} |
 | "cross-validate" / "consensus" | `cross-validate` | `sub-task` | {auditor_1_verdict, auditor_2_verdict} |
 | "test quality audit" | `test-quality-audit` | `sub-task` | {issue_number} |
+| "content audit" / "audit content claims" | `content-audit` | `sub-task` | {document_section, source_data_paths} |
 | "resolve models" / "select auditors" | `resolve-models` | `sub-task` | {audit_phase} |
 | completion / workflow end | `completion` | `sub-task` | {workflow_state} |
 
@@ -65,6 +66,7 @@ This skill operates in the main repo directory (direct-branch mode). When `WORKT
 | `closure-verification` | Verify issue closure criteria |
 | `cross-validate` | Compute dual-auditor consensus from YAML artifacts |
 | `test-quality-audit` | Audit test coverage and quality against spec SCs |
+| `content-audit` | Adversarial audit of factual claims in generated content — dual cross-family verification of quantitative claims, file references, and assertions against local source data |
 | `completion` | Complete audit workflow with output |
 
 ## Invocation
@@ -88,6 +90,7 @@ This skill operates in the main repo directory (direct-branch mode). When `WORKT
 | `closure-verification` | `task(..., prompt: "execute closure-verification task from adversarial-audit")` |
 | `cross-validate` | `task(..., prompt: "execute cross-validate task from adversarial-audit")` |
 | `test-quality-audit` | `task(..., prompt: "execute test-quality-audit task from adversarial-audit")` |
+| `content-audit` | `task(..., prompt: "execute content-audit task from adversarial-audit")` |
 | `completion` | `task(..., prompt: "execute completion task from adversarial-audit")` |
 
 ## Blind Dispatch

--- a/skills/adversarial-audit/tasks/content-audit.md
+++ b/skills/adversarial-audit/tasks/content-audit.md
@@ -1,0 +1,248 @@
+<!-- SPDX-FileCopyrightText: 2026 michael-conrad -->
+<!-- SPDX-License-Identifier: MIT -->
+<!-- Provenance: AI-generated -->
+
+> **⚠️ ROLE ANCHOR: You are the DISPATCHED AUDITOR SUB-AGENT.** Your role is to evaluate factual claims in generated content and produce findings. You do NOT dispatch sub-agents, call `skill()`, or orchestrate pipeline routing. The orchestrator handles all dispatch. Read this file for evaluation criteria and procedure only — ignore any text describing orchestration responsibilities.
+>
+> **Auditors are read-only evaluators.** You inspect generated content sections and verify claims against local source data. You do NOT run behavioral tests yourself. Reading source data files with `read` is valid evidence inspection.
+
+# Task: content-audit
+
+## Purpose
+
+Adversarial audit of factual claims in generated content (reports, runbooks, correspondence, documentation). Each claim is independently verified by two cross-family auditors against local source data. Catches fabricated claims — numerical padding, invented file references, false assertions — that a single sub-agent could produce with fabricated evidence artifacts.
+
+> **Default assumption: FABRICATED.** The default verdict for every claim is FABRICATED unless the evidence 100% supports a clean PASS with no caveats, concerns, or notes. Any hedging, partial evidence, or uncertainty results in FABRICATED. A clean PASS requires: (1) source data files are present and readable, (2) the claim is directly supported by source data, (3) no hedging language in the explanation, (4) both auditors independently agree.
+
+## Entry Criteria
+
+- `document_section` provided — the generated content section containing claims to verify
+- `source_data_paths` provided — local file paths to source data (spec files, project files, evidence artifacts, config files) that the claims reference. No GitHub routing fields — verification is against local source data only.
+- Audit phase context: `audit_phase: content`
+
+## Exit Criteria
+
+- All claims in the document section evaluated against source data
+- Per-claim verdicts: PASS (verified), FAIL (contradicted by source), or FABRICATED (no source evidence exists)
+- Verdict artifact written to disk
+- Consensus PASS/FAIL/FABRICATED per claim
+
+## Procedure
+
+### Step 0: Pre-Flight Validation Gate
+
+Validate that all required inputs are present before proceeding with the audit:
+
+- [ ] 1. Verify `document_section` is present and non-empty — if missing, return BLOCKED:
+
+```yaml
+status: BLOCKED
+error: MISSING_REQUIRED_INPUT
+missing: "document_section"
+remediation: "document_section is required for content-audit. The orchestrator must provide the generated content section containing claims to verify."
+```
+
+- [ ] 2. Verify `source_data_paths` is present — if missing, return BLOCKED:
+
+```yaml
+status: BLOCKED
+error: MISSING_REQUIRED_INPUT
+missing: "source_data_paths"
+remediation: "source_data_paths is required for content-audit. The orchestrator must provide local file paths to source data that the claims reference."
+```
+
+- [ ] 3. Verify no GitHub routing fields (`github.owner`, `github.repo`) are present in context — if present, return BLOCKED:
+
+```yaml
+status: BLOCKED
+error: PRELOADED_CONTEXT_REJECTED
+reason: "content-audit verifies against local source data only. GitHub routing fields are not permitted in content-audit context."
+```
+
+### Step 1: Load Document Section
+
+Read the generated content section and extract all factual claims:
+
+- [ ] 1. Read `document_section` — identify all quantitative claims (counts, percentages, durations, sizes), file references, and factual assertions
+- [ ] 2. Classify each claim by domain: numerical, file-reference, config-value, code-behavior, docs-claim
+- [ ] 3. Build a claim list with the exact assertion text for verification
+
+### Step 2: Load Source Data
+
+Read source data files from `source_data_paths`:
+
+- [ ] 1. Glob `**/*` in each `source_data_paths` directory via `glob` tool
+- [ ] 2. Read relevant files — spec files, project files, evidence artifacts, config files
+- [ ] 3. If a referenced source file does not exist, record that as evidence of FABRICATED
+
+### Step 3: Verify Each Claim
+
+For each claim in the document section, verify against source data:
+
+| Claim Type | Verification Method | PASS | FAIL | FABRICATED |
+|------------|---------------------|------|------|------------|
+| Numerical | Count/measure from source data | Exact match | Contradicted by source | No source data supports the number |
+| File reference | `glob` or `ls` for the file path | File exists | File exists but content doesn't match | File does not exist |
+| Config value | `read` the config file | Value matches | Value differs | Config file doesn't contain the field |
+| Code behavior | `srclight_get_signature` or `read` source | Behavior matches | Behavior differs | No code path supports the claim |
+| Docs claim | `read` the referenced doc | Docs support claim | Docs contradict claim | No doc supports the claim |
+
+Record PASS/FAIL/FABRICATED per claim with tool-call evidence.
+
+### Step 4: Generate Findings
+
+For each claim, produce a finding with evidence reference:
+
+```yaml
+- claim_id: "C-1"
+  claim_text: "12 models were tested"
+  domain: "numerical"
+  result: "FABRICATED"
+  evidence: "<tool-call reference to source data inspection>"
+  explanation: "Source data shows only 8 models were tested. The claim of 12 is unsupported."
+  remediation: "Correct the count to match source data, or add the missing 4 models to the test run."
+  next_step: "remediate"
+```
+
+### Step 5: Write Verdict Artifact to Disk
+
+Write the full YAML verdict artifact to `./tmp/{issue-N}/artifacts/pipeline-audit-content-audit-{STATUS}-{timestamp}.yaml`:
+
+```yaml
+audit_phase: content
+auditor_type: content-audit
+family: <family>
+issue_number: <N>
+generated_at: "<timestamp>"
+orchestrator_model: "<model>"
+summary:
+  total_claims: N
+  pass: N
+  fail: N
+  fabricated: N
+per_claim:
+  - claim_id: "C-1"
+    claim_text: "<exact assertion from document>"
+    domain: "numerical"
+    result: "PASS"
+    evidence: "<tool-call reference>"
+    explanation: "<reasoning>"
+    remediation: ""
+    next_step: "proceed"
+all_claims_verified: false
+mandatory_remediation: "Remit for mandatory remediation. Any FABRICATED or FAIL claim requires remediation before content ships. Default assumption is FABRICATED unless 100% clean PASS with no caveats, concerns, or notes."
+```
+
+### Step 6: Return Frugal Result Contract
+
+```yaml
+status: DONE
+artifact_path: "./tmp/{issue-N}/artifacts/pipeline-audit-content-audit-PASS-{timestamp}.yaml"
+summary: "N claims evaluated. X PASS, Y FAIL, Z FABRICATED."
+all_claims_verified: false
+mandatory_remediation: "Remit for mandatory remediation. Any FABRICATED or FAIL claim requires remediation before content ships. Default assumption is FABRICATED unless 100% clean PASS with no caveats, concerns, or notes."
+```
+
+## Clean-Room Protocol
+
+- **Dual cross-family auditors**: Dispatched via `resolve-models`. Each auditor is a clean-room sub-agent from a different model family. No single model family can dominate the verdict.
+- **No orchestrator preload**: Auditors receive only `{ document_section, source_data_paths }`. No orchestrator reasoning, expected outcomes, pre-loaded evidence, or cached verification results.
+- **Sub-agent entry criteria**: If the orchestrator preloads context (inline file paths, step definitions, expected outcomes, orchestrator-derived conclusions), the auditor MUST return `status: BLOCKED` with `reason: PRELOADED_CONTEXT_REJECTED`.
+- **Independent verification**: Each auditor independently runs tool calls against source data to verify claims. The two auditors do not share context, reasoning, or intermediate results.
+- **Cross-validation**: After both auditors return verdicts, `cross-validate` computes consensus. Disagreement (PASS vs FAIL/FABRICATED) blocks the claim from shipping and escalates to the developer.
+- **Evidence artifacts on disk**: Each auditor writes full evidence artifacts to disk. The result contract carries only routing-significant data (`status`, `finding_summary`, `artifact_path`, `blocker_reason`).
+
+## Completion Dependency Chain
+
+Every step in this task is a mandatory dependency. Skipping any step produces an INVALID result:
+
+- [ ] 0. Pre-Flight Validation Gate → INVALID if skipped
+- [ ] 1. Load document section → INVALID if skipped
+- [ ] 2. Load source data → INVALID if skipped
+- [ ] 3. Verify each claim → INVALID if skipped
+- [ ] 4. Generate findings → INVALID if skipped
+- [ ] 5. Write verdict artifact → INVALID if skipped
+- [ ] 6. Return result contract → INVALID if skipped
+
+## Next Pipeline Step (MANDATORY CONTINUATION)
+
+After content-audit completes:
+- If consensus PASS on all claims: proceed to `cross-validate` or next pipeline step
+- If any claim is FAIL or FABRICATED: remediate findings, then re-run content-audit
+
+## Error Handling
+
+| Error | Action |
+|-------|--------|
+| `document_section` absent | Return BLOCKED with MISSING_REQUIRED_INPUT |
+| `source_data_paths` absent | Return BLOCKED with MISSING_REQUIRED_INPUT |
+| GitHub routing fields present | Return BLOCKED with PRELOADED_CONTEXT_REJECTED |
+| Source data file not found | Record as FABRICATED evidence for affected claims |
+| Cross-validate fails | Return OVERFLOW, log error |
+| Auditor unavailable | Use fallback chain per multimodal-dispatch |
+
+## Cross-References
+
+- `tasks/cross-validate.md` — consensus computation with pre-resolved verdicts
+- `tasks/resolve-models.md` — cross-family selection
+- `verification-enforcement/tasks/verify.md` — pre-generation verification gate that dispatches content-audit
+- `verification-enforcement/tasks/revisit.md` — post-generation resolution of UNVERIFIED markers
+- `000-critical-rules.md` — behavioral evidence mandate, clean-room protocol
+
+```yaml+symbolic
+schema_version: "2.0"
+last_updated: "2026-07-01T00:00:00Z"
+rules:
+  - id: content-audit-001
+    title: "document_section required — BLOCK on absent input"
+    conditions:
+      all: ["document_section_absent == true"]
+    actions: [BLOCKED(MISSING_REQUIRED_INPUT)]
+    source: "content-audit.md §Step 0"
+
+  - id: content-audit-002
+    title: "source_data_paths required — BLOCK on absent input"
+    conditions:
+      all: ["source_data_paths_absent == true"]
+    actions: [BLOCKED(MISSING_REQUIRED_INPUT)]
+    source: "content-audit.md §Step 0"
+
+  - id: content-audit-003
+    title: "No GitHub routing fields — BLOCK on PRELOADED_CONTEXT_REJECTED"
+    conditions:
+      all: ["github_routing_fields_present == true"]
+    actions: [BLOCKED(PRELOADED_CONTEXT_REJECTED)]
+    source: "content-audit.md §Step 0"
+
+  - id: content-audit-004
+    title: "Dual auditors required — no single-auditor evaluation"
+    conditions:
+      all: ["auditor_count < 2"]
+    actions: [HALT, RESOLVE_SECOND_AUDITOR]
+    source: "content-audit.md §Clean-Room Protocol"
+
+  - id: content-audit-005
+    title: "Clean-room task() — no orchestrator reasoning leaked to auditors"
+    conditions:
+      all: ["auditor_context contains 'expected' OR 'should' OR 'correct'"]
+    actions: [HALT, STRIP_BIASED_CONTEXT]
+    source: "content-audit.md §Clean-Room Protocol"
+
+  - id: content-audit-006
+    title: "next_step MUST be 'remediate' when result is 'FAIL' or 'FABRICATED', 'proceed' when result is 'PASS'"
+    conditions:
+      any:
+        - "per_claim[].result in ['FAIL', 'FABRICATED'] AND per_claim[].next_step != 'remediate'"
+        - "per_claim[].result == 'PASS' AND per_claim[].next_step != 'proceed'"
+    actions: [HALT, REQUIRE_CORRECT_NEXT_STEP]
+    source: "content-audit.md §Step 5 — conditional next_step enforcement"
+
+  - id: content-audit-007
+    title: "all_claims_verified MUST be true when every claim result is 'PASS', false otherwise"
+    conditions:
+      any:
+        - "all(claim.result == 'PASS' for claim in per_claim) AND all_claims_verified != true"
+        - "any(claim.result in ['FAIL', 'FABRICATED'] for claim in per_claim) AND all_claims_verified != false"
+    actions: [HALT, REQUIRE_CORRECT_ALL_CLAIMS_VERIFIED]
+    source: "content-audit.md §Step 5 — all_claims_verified enforcement"
+```

--- a/skills/verification-enforcement/tasks/verify.md
+++ b/skills/verification-enforcement/tasks/verify.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-Run the pre-generation verification gate. Before a content-generating skill produces any output, this task collects evidence artifacts for every factual claim the agent intends to make. The agent declares its intended claims, tasks sub-agents to verify each content section against live sources, and assembles the results. Claims that cannot be verified are marked for later resolution.
+Run the pre-generation verification gate. Before a content-generating skill produces any output, this task dispatches adversarial content audits for every factual claim the agent intends to make. The agent declares its intended claims, dispatches dual cross-family adversarial auditors to verify each content section against local source data, and assembles the results. Claims that cannot be verified are marked for later resolution.
 
 ## Entry Criteria
 
@@ -16,22 +16,26 @@ Evidence artifacts have been collected for all claims, or unverifiable claims ha
 
 The orchestrator begins by identifying the content sections that the generating skill intends to produce. These sections correspond to the natural divisions of the output — for a spec, this might be objectives, constraints, success criteria, and affected files; for a runbook, this might be environment context, diagnosis, mitigation steps, and verification criteria. The orchestrator does not need to know the exact content yet — it needs to know the claims that will be made, broadly categorized.
 
-For each content section, the orchestrator tasks one sub-agent with a focused mission: verify all factual claims that will appear in this section against live sources and return evidence artifacts. The sub-agent receives the section context, the claim types expected, and the verification domains that apply. Each sub-agent uses domain-appropriate tools: `srclight_get_signature` for API claims, `read` for config and source code claims, `srclight_get_symbol` for code behavior claims, bash commands for CLI tool verification, and web fetches for external documentation claims.
+For each content section, the orchestrator dispatches an adversarial content audit via `adversarial-audit --task content-audit`. This replaces the previous single-sub-agent approach with dual cross-family adversarial verification:
 
-Each sub-agent classifies every claim it encounters into the appropriate verification domain, selects the evidence tool, collects the evidence, and returns a structured evidence artifact for each claim. Claims that the sub-agent cannot verify against any live source are marked with `⚠️ UNVERIFIED` and the specific reason verification failed is recorded.
+1. The orchestrator calls `skill({name: "adversarial-audit"})` then tasks `content-audit` with `{ document_section, source_data_paths }` — clean-room, no orchestrator preload, no GitHub routing fields
+2. The `content-audit` task dispatches two cross-family auditors (via `resolve-models`) who independently verify every numerical claim, file reference, and factual assertion against local source data
+3. Each auditor returns per-claim verdicts: PASS (verified), FAIL (contradicted by source), or FABRICATED (no source evidence exists)
+4. The two auditor verdicts are cross-validated for consensus
+5. The result contract returns per-claim verdicts and evidence artifact paths
 
 The evidence artifact format is:
 
 ```
 Claim: <what the content asserts>
-Domain: <verification domain — API, config, code behavior, docs, CLI>
+Domain: <verification domain — numerical, file-reference, config-value, code-behavior, docs-claim>
 Source: <tool call or document that provided the evidence>
 Verified: <yes|no>
 Marker: <if no, ⚠️ UNVERIFIED>
 Reason: <if no, why verification failed>
 ```
 
-The orchestrator assembles the evidence artifacts from all sub-agents. If every claim has a `Verified: yes` artifact, the generation proceeds with full confidence. If some claims are marked `⚠️ UNVERIFIED`, the generation proceeds — but the unverified claims must be marked with `⚠️ UNVERIFIED` in the generated content so the revisit pass can find and attempt to resolve them.
+The orchestrator assembles the evidence artifacts from all content-audit dispatches. If every claim has a `Verified: yes` artifact, the generation proceeds with full confidence. If some claims are marked `⚠️ UNVERIFIED`, the generation proceeds — but the unverified claims must be marked with `⚠️ UNVERIFIED` in the generated content so the revisit pass can find and attempt to resolve them.
 
 No claim appears in generated content without an evidence artifact. If the agent has no tool call to support a claim, it must not assert the claim as verified. This is the core principle: no tool call means no claim, and no evidence means no assertion.
 
@@ -40,3 +44,4 @@ No claim appears in generated content without an evidence artifact. If the agent
 - Invoked by: content-generating skills as their first substantive step
 - Followed by: the content generation steps of the invoking skill
 - Related tasks: `revisit` (post-generation resolution), `enforce` (orchestrator gate)
+- Related skills: `adversarial-audit --task content-audit` (adversarial verification of claims)

--- a/tests/behaviors/content-audit-fabricated-claim.sh
+++ b/tests/behaviors/content-audit-fabricated-claim.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Behavioral test: content-audit-fabricated-claim
+# See .opencode/tests/AGENTS.md for the test harness specification and paradigm.
+# This script is an artifact-only generator — it does NOT evaluate model output.
+#
+# SC-9: Behavioral enforcement test: auditor catches fabricated numerical claim.
+# Uses the trigger phrase "content audit" from the adversarial-audit dispatch table
+# to dispatch the content-audit task. The document section claims 12 models were
+# tested but source data only lists 8. Dual cross-family auditors should detect
+# the fabricated count and return FABRICATED.
+#
+# BEHAVIOR_SUBMODULE_COMMIT must be set to the feature branch commit containing the
+# content-audit task. Run with:
+#   BEHAVIOR_SUBMODULE_COMMIT=9efd03dce73497e5adca7760d9fc16b39dde39ae \
+#   bash .opencode/tests/behaviors/content-audit-fabricated-claim.sh
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/helpers.sh"
+
+SCENARIO_NAME="content-audit-fabricated-claim"
+SCENARIO_PROMPT="content audit document_section: '12 models were tested on this system. 8 were available, 4 were unavailable.' source_data_paths: ./tmp/test-source-data/"
+
+behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT"
+exit 0

--- a/tools/ollama-probe
+++ b/tools/ollama-probe
@@ -22,6 +22,30 @@ if [[ "${1:-}" == "--description" ]]; then
     exit 0
 fi
 
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+    cat <<EOF
+Usage: ollama-probe <subcommand>
+
+Subcommands:
+  list    — List installed models with name, size, quantization (JSON output)
+  ps      — Show running models with RAM/VRAM allocation (JSON output)
+  hw      — Report CPU cores, RAM, GPU specs (JSON output)
+  remote  — Query online Ollama models DB (JSON output)
+
+Options:
+  remote --capability enforcement  — Filter for enforcement-capable models
+
+Environment:
+  OLLAMA_HOST  — Ollama server URL (default: http://localhost:11434)
+
+Examples:
+  MODEL_INFO=\$(.opencode/tools/ollama-probe list)
+  HW_INFO=\$(.opencode/tools/ollama-probe hw)
+  REMOTE_MODELS=\$(.opencode/tools/ollama-probe remote --capability enforcement)
+EOF
+    exit 0
+fi
+
 OLLAMA_HOST="${OLLAMA_HOST:-http://localhost:11434}"
 
 json_escape() {

--- a/tools/resolve-models
+++ b/tools/resolve-models
@@ -28,6 +28,33 @@ if [[ "${1:-}" == "--description" ]]; then
     exit 0
 fi
 
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+    cat <<EOF
+Usage: resolve-models --orchestrator-model <model> [options]
+
+Select 2 auditors from different families for adversarial audit.
+
+Required:
+  --orchestrator-model <model>  — Model identifier of the orchestrator (e.g., ollama/deepseek-v4-flash:cloud)
+
+Options:
+  --excluded-pair <fam1>,<fam2>  — Exclude specific families from selection
+  --re-task                       — Re-run selection (no-op flag for pipeline compatibility)
+  --test-insufficient-families    — Test mode: force insufficient-families error
+
+Output (YAML):
+  auditor_1: <card-name>
+  auditor_2: <card-name>
+  family_1: <family>
+  family_2: <family>
+
+Examples:
+  tools/resolve-models --orchestrator-model "ollama/deepseek-v4-flash:cloud"
+  tools/resolve-models --orchestrator-model "ollama/deepseek-v4-flash:cloud" --excluded-pair deepseek,mistral
+EOF
+    exit 0
+fi
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 AGENTS_DIR="$SCRIPT_DIR/../agents"
 POOL_SCRIPT="$SCRIPT_DIR/../tests/qualification/qualified-auditor-pool.sh"


### PR DESCRIPTION
## Summary

Two stacked issues on this branch:

### #393 — Document Ollama/Ollama-Cloud Dependency

Document the hard-wired Ollama/Ollama-Cloud dependency that was previously undocumented. A user pulling this repo as a submodule had no upfront signal that Ollama is mandatory infrastructure.

- **README.md**: Added `## Runtime Dependencies` section with touchpoint table (7 rows) and prerequisites; added `## Model Configuration` section documenting `DEFAULT_TEST_MODEL`, auditor agent cards, and qualified pool
- **tools/ollama-probe**: Added `--help`/`-h` flag (previously only showed usage on no-arg invocation)
- **tools/resolve-models**: Added `--help`/`-h` flag (previously returned `UNKNOWN_FLAG` error)
- **docs/model-dependency.md**: Created comprehensive dependency documentation with touchpoint table, prerequisites, configuration points, and model name convention

### #364 — Content-Audit Task for Adversarial Audit

Add content-audit task to adversarial-audit skill for dual cross-family verification of factual claims in generated content.

- **skills/adversarial-audit/SKILL.md**: Added content-audit to dispatch table and invocation
- **skills/adversarial-audit/tasks/content-audit.md**: New task file (248 lines) with dual cross-family auditors, per-claim PASS/FAIL/FABRICATED verdicts, clean-room protocol
- **skills/verification-enforcement/tasks/verify.md**: Updated to dispatch adversarial-audit --task content-audit instead of single sub-agents
- **tests/behaviors/content-audit-fabricated-claim.sh**: New behavioral enforcement test

## Fixes

https://github.com/michael-conrad/.opencode/issues/393
https://github.com/michael-conrad/.opencode/issues/364

---

🤖 Co-authored with AI: OpenCode (ollama-cloud/deepseek-v4-flash)