### PR TITLE
[#1696] Upgrade viewport-editor MCP plugin to v0.3.4, rename key to "editor"

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -275,9 +275,9 @@ When parent issue has sub-issues, authorization cascades to ALL sub-issues:
 
 ---
 
-## viewport-editor MCP Plugin
+## editor MCP Plugin
 
-This repo uses [viewport-editor](https://github.com/michael-conrad/viewport-editor) as its editing MCP server.
+This repo uses [editor](https://github.com/michael-conrad/viewport-editor) as its editing MCP server.
 
 **11-tool surface** (see README for full action lists):
 

--- a/opencode.jsonc
+++ b/opencode.jsonc
@@ -128,9 +128,9 @@
         "OLLAMA_BASE_URL": "http://localhost:11434"
       }
     },
-    "viewport-editor": {
+    "editor": {
       "type": "local",
-      "command": ["uvx", "--from", "git+https://github.com/michael-conrad/viewport-editor@v0.3.3", "viewport-editor"],
+      "command": ["uvx", "--from", "git+https://github.com/michael-conrad/viewport-editor@v0.3.4", "viewport-editor"],
       "enabled": true
     }
   }


### PR DESCRIPTION
## Summary

Upgrades the viewport-editor MCP plugin from v0.3.3 to v0.3.4 and adopts the new config key `"editor"`.

## Changes

- **`opencode.jsonc`**: Renamed MCP server key from `"viewport-editor"` to `"editor"`, bumped version pin from `@v0.3.3` to `@v0.3.4`
- **`AGENTS.md`**: Updated section heading from `## viewport-editor MCP Plugin` to `## editor MCP Plugin`, updated link text

## Verification

All 5 SCs verified PASS:
- SC-1: `"editor": {` key present in opencode.jsonc ✅
- SC-2: `@v0.3.4` in git URL ✅
- SC-3: `## editor MCP Plugin` heading in AGENTS.md ✅
- SC-4: `[editor](https://github.com/michael-conrad/viewport-editor)` link text ✅
- SC-5: Only 1 occurrence of `"viewport-editor"` (the binary name in command array) ✅

Fixes #1696

---

🤖 Co-authored with AI: OpenCode (deepseek-v4-flash)