### PR TITLE
fix: route 'PR created' to Chat only, not Issue comment

### DIFF
--- a/guidelines/000-critical-rules.md
+++ b/guidelines/000-critical-rules.md
@@ -1014,7 +1014,7 @@ All references to "context budget", "context cost", and "context awareness" must
 | Progress executive summaries | Chat only |
 | Review-prep / verification status | Chat only |
 | Substantive spec revision | Chat + Issue comment |
-| PR created | Issue comment |
+| PR created | Chat only |
 | Issue blocked | Issue comment |
 | Bug discovered during implementation | Issue comment |
 | User question response | Issue comment |


### PR DESCRIPTION
## Summary

Channel-Routing Table in `000-critical-rules.md` told agents to post "PR created: #NNN" as a GitHub Issue comment. This is noise — the PR URL is already in chat output and GitHub auto-links via `Closes #N` in the PR body. The user has to delete the comment.

## Changes

- `000-critical-rules.md` line 1017: `| PR created | Issue comment |` → `| PR created | Chat only |`

## SC Verification

| ID | Criterion | Result |
|----|-----------|--------|
| SC-1 | Channel-Routing Table routes "PR created" to Chat only | ✅ PASS |

Closes #1705

🤖 Co-authored with AI: OpenCode (deepseek-v4-flash)