### PR TITLE
fix: remove slug padding from .issues/ naming + PR recovery fix

### DIFF
--- a/guidelines/140-planning-spec-creation.md
+++ b/guidelines/140-planning-spec-creation.md
@@ -11,7 +11,7 @@ load_when: sub-agent
 AI agents MUST follow the **Spec-Driven Development** (Gated Workflow) approach with the **Plan-Bridge Hierarchy**:
 
 1. **Specify Phase**: Define **What & Why**. Kick off with a high-level vision (product brief), then expand it into a detailed specification focusing on user journeys, experiences, and success criteria.
-2. **Plan Phase** (Bridge): Define **How**. Create a local plan index at `{N}/plan.md` with phase table, plus phase files at `{N}/plan-{NN}-{slug}.md` (one per phase). The plan bridges spec → tasks. **Spec approval authorizes plan creation; plan approval authorizes implementation.**
+2. **Plan Phase** (Bridge): Define **How**. Create a local plan index at `{N}/plan.md` with phase table, plus phase files at `{N}/plan-{NN}.md` (one per phase). The plan bridges spec → tasks. **Spec approval authorizes plan creation; plan approval authorizes implementation.**
 3. **Tasks Phase**: Break the plan into **small, reviewable chunks** (sub-issues under the plan, not the spec) that can be implemented and tested in isolation.
 4. **Implement Phase**: **Execute** tasks and **verify** results.
 
@@ -33,10 +33,10 @@ ______________________________________________________________________
 ## Terminology: Spec vs. Plan vs. Guideline Files
 
 - **"Create a new spec"** = Create a GitHub Issue with `[SPEC]` prefix (Mandatory when GitHub MCP available)
-- **"Create a plan"** = Create a local plan index at `{N}/plan.md` with phase table, plus phase files at `{N}/plan-{NN}-{slug}.md` (one per phase), referencing the spec via body linked reference
+- **"Create a plan"** = Create a local plan index at `{N}/plan.md` with phase table, plus phase files at `{N}/plan-{NN}.md` (one per phase), referencing the spec via body linked reference
 - **"Create a guideline file"** = Create/modify files in `.opencode/guidelines/` (Implementation task)
 - **SPEC = GitHub Issue** — Specs are planning/tracking artifacts, not file system artifacts
-- **PLAN = local files** — Plans are local artifacts: index at `{N}/plan.md` with phase table, plus phase files at `{N}/plan-{NN}-{slug}.md` (one per phase). They bridge specs to implementation sub-issues; sub-issues are children of the plan's spec issue, not the spec itself
+- **PLAN = local files** — Plans are local artifacts: index at `{N}/plan.md` with phase table, plus phase files at `{N}/plan-{NN}.md` (one per phase). They bridge specs to implementation sub-issues; sub-issues are children of the plan's spec issue, not the spec itself
 
 ______________________________________________________________________
 

--- a/skills/git-workflow/tasks/pr-creation/enforcement-gate.md
+++ b/skills/git-workflow/tasks/pr-creation/enforcement-gate.md
@@ -154,18 +154,35 @@ ls {project_root}/tmp/{issue-N}/work.md 2>/dev/null
 
 ### Step 1.5: Check Existing PR State
 
-Query GitHub API for existing PRs on this branch:
+Query GitHub API for **open** PRs on this branch using `state=open` filter:
 
-- **Open PR:** Update existing PR (push new commits)
-- **Closed PR (not merged):** Check reason, proceed with caution
-- **Merged PR:** Rebase branch on dev, check for remaining changes
+```bash
+# Query ONLY open PRs — never query all PRs
+gh pr list --head <branch_name> --state open --json number,html_url
+```
 
-If branch already merged (no remaining changes):
-```
-✅ BRANCH ALREADY MERGED
-The branch '{branch_name}' has already been merged via PR #{pr_number}.
-No new PR needed.
-```
+**If an OPEN PR exists on this branch:**
+- Update existing PR (push new commits)
+- This is the correct behavior — an open PR is in-flight work
+
+**If NO open PR exists (but a closed PR exists on the branch):**
+- **Do NOT re-open the closed PR.**
+- **Create a new PR.**
+- A closed (unmerged) PR is an indicator that the previous attempt was defective — the developer closed it. Do not re-use defective code.
+- The developer must explicitly say "use the closed PR" for it to be considered.
+
+**If a MERGED PR exists on this branch:**
+- Rebase branch on dev, check for remaining changes
+- If branch already merged (no remaining changes):
+  ```
+  ✅ BRANCH ALREADY MERGED
+  The branch '{branch_name}' has already been merged via PR #{pr_number}.
+  No new PR needed.
+  ```
+
+**Developer override:**
+- If the developer explicitly says "use the closed PR" or equivalent, consider the closed PR.
+- Without explicit instruction, always create a new PR when no open PR exists.
 
 ### Step 1.5d: Merge Conflict Detection
 

--- a/skills/writing-plans/SKILL.md
+++ b/skills/writing-plans/SKILL.md
@@ -63,12 +63,12 @@ This skill produces plans by dispatching pipeline steps to sub-agents. The orche
 **All plans are local artifacts.** Plans use a split file convention:
 
 - **Index file:** `{N}/plan.md` — contains Goal, Architecture, Files, Phase table, Exit criteria, all admonishments, and self-review evidence. No implementation steps.
-- **Phase files:** `{N}/plan-{NN}-{short-slug}.md` — one per phase, with full step-by-step instructions, dispatch indicators, RED/GREEN chains, Z3 checks, VbC blocks, phase completion block, and concern transition.
+- **Phase files:** `{N}/plan-{NN}.md` — one per phase, with full step-by-step instructions, dispatch indicators, RED/GREEN chains, Z3 checks, VbC blocks, phase completion block, and concern transition.
 
 **Numbering rules:**
 - Steps are globally sequential across all phase files
 - Phase 2's first step continues from Phase 1's last step
-- Phase file naming: `plan-{NN}-{short-slug}.md` where NN is zero-padded phase number
+- Phase file naming: `plan-{NN}.md` where NN is zero-padded phase number
 
 **Single-task plans** (one phase) use `{N}/plan.md` as the sole file (no split needed).
 

--- a/skills/writing-plans/tasks/create.md
+++ b/skills/writing-plans/tasks/create.md
@@ -127,7 +127,7 @@ Each item is tagged with dispatch scope and chain dependency.
 ## Exit Criteria
 
 - Plan index stored at `{N}/plan.md` with phase table
-- Phase files stored at `{N}/plan-{NN}-{slug}.md` (one per phase)
+- Phase files stored at `{N}/plan-{NN}.md` (one per phase)
 - All validation passed
 - Plan reported in chat with `{N}/plan.md` path
 - Approval cascade applied (auto-approval for pipeline scope)

--- a/skills/writing-plans/tasks/write.md
+++ b/skills/writing-plans/tasks/write.md
@@ -65,9 +65,8 @@ Plans use a split file format:
   - All admonishments (compliance, one-step-at-a-time, step status, self-remediation)
   - Self-review evidence section
 
-- **`{N}/plan-{NN}-{slug}.md`** — Phase files (one per phase)
+- **`{N}/plan-{NN}.md`** — Phase files (one per phase)
   - `{NN}` is zero-padded phase number (01, 02, ...)
-  - `{slug}` is short kebab-case descriptor (e.g., `frontmatter`, `farmage`)
   - Phase metadata (Concern, Files, SCs, Dependencies, Entry/Exit conditions)
   - Full step-by-step with globally sequential numbering
   - Dispatch indicators, RED/GREEN chains, Z3 checks, VbC blocks

--- a/tests/test_local_issues.py
+++ b/tests/test_local_issues.py
@@ -39,7 +39,7 @@ def _read_frontmatter(tmpdir, number, status="open"):
     import yaml
     open_dir = os.path.join(tmpdir, ".issues", status)
     for entry in os.listdir(open_dir):
-        if entry.startswith(f"{number:03d}-"):
+        if entry == str(number):
             spec_path = os.path.join(open_dir, entry, "spec.md")
             with open(spec_path) as f:
                 content = f.read()

--- a/tools/local-issues
+++ b/tools/local-issues
@@ -91,12 +91,7 @@ def get_issue_path(
     dir_path = _find_issue_dir(number, repo_path)
     if dir_path is not None:
         return dir_path
-    name = f"{number}"
-    if title:
-        slug = _slug(title)
-        if slug:
-            name = f"{name}-{slug}"
-    return (repo_path or PROJECT_DIR) / ISSUES_DIR / name
+    return (repo_path or PROJECT_DIR) / ISSUES_DIR / str(number)
 
 
 def read_file(path: Path) -> str:
@@ -1315,7 +1310,7 @@ def cmd_delete(args: argparse.Namespace) -> None:
 
 
 def _parse_number(entry: Path) -> int | None:
-    """Extract issue number from directory name (NNN or NNN-slug)."""
+    """Extract issue number from directory name (NNN)."""
     if not entry.is_dir():
         return None
     parts = entry.name.split("-", 1)


### PR DESCRIPTION
## Summary

Two fixes in a single stacked PR:

### #1156 — Remove slug padding from .issues/ directory naming
- `get_issue_path()` no longer appends `-{slug}` suffix — creates `.issues/NNN/` directories
- `_parse_number()` docstring updated to reflect bare-number format
- Test file updated: `entry.startswith(f"{number:03d}-")` → `entry == str(number)`
- Skill/guideline files updated: `plan-{NN}-{slug}.md` → `plan-{NN}.md`
- Legacy slug detection preserved as warning for AI agent remediation

### #1712 — PR creation re-uses closed PRs
- `enforcement-gate.md` Step 1.5: added `state=open` filter to PR queries
- Explicit rule: closed (unmerged) PRs are NOT re-opened — create a fresh PR
- Developer must explicitly say "use the closed PR" for it to be considered

## Outcome
- Closes #1156
- Closes #1712

🤖 Co-authored with AI: OpenCode (ollama-cloud/deepseek-v4-flash)