### PR TITLE
Move submodule-pointer-only gate from pre-commit to pre-push

### DIFF
--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -80,82 +80,8 @@ GATE_EXIT_CODES+=($?)
 )
 GATE_EXIT_CODES+=($?)
 
-# --- Gate 4: Submodule-pointer-only commit blocker ---
-(
-  if [ ! -f ".gitmodules" ]; then
-    exit 0
-  fi
-
-  SUBMODULE_PATHS=$(git submodule status | awk '{print $2}')
-  STAGED_FILES_G4=$(git diff --cached --name-only 2>/dev/null)
-
-  if [ -z "$STAGED_FILES_G4" ] || [ -z "$SUBMODULE_PATHS" ]; then
-    exit 0
-  fi
-
-  ALL_SUBMODULE_POINTERS=1
-  for f in $STAGED_FILES_G4; do
-    IS_SUBMODULE=0
-    for sp in $SUBMODULE_PATHS; do
-      if [ "$f" = "$sp" ]; then
-        IS_SUBMODULE=1
-        break
-      fi
-    done
-    if [ "$IS_SUBMODULE" -eq 0 ]; then
-      ALL_SUBMODULE_POINTERS=0
-      break
-    fi
-  done
-
-  if [ "$ALL_SUBMODULE_POINTERS" = "1" ]; then
-    # Check if there are uncommitted non-submodule changes in the working tree
-    UNCOMMITTED_NON_SUBMODULE=0
-    UNSTAGED_FILES=$(git diff --name-only 2>/dev/null)
-    for f in $UNSTAGED_FILES; do
-      IS_SUBMODULE=0
-      for sp in $SUBMODULE_PATHS; do
-        if [ "$f" = "$sp" ]; then
-          IS_SUBMODULE=1
-          break
-        fi
-      done
-      if [ "$IS_SUBMODULE" -eq 0 ]; then
-        UNCOMMITTED_NON_SUBMODULE=1
-        break
-      fi
-    done
-
-    if [ "$UNCOMMITTED_NON_SUBMODULE" = "1" ]; then
-      # Non-submodule changes exist in working tree — allow the commit
-      echo "  ⚠ Submodule pointer-only staged, but non-submodule changes exist in working tree."
-      echo "  Allowing commit — submodule pointers will accompany the next non-submodule commit."
-      exit 0
-    fi
-
-    echo ""
-    echo "ERROR: Submodule-pointer-only commit blocked."
-    echo ""
-    echo "Changed paths:"
-    for f in $STAGED_FILES_G4; do
-      echo "  $f"
-    done
-    echo ""
-    echo "Submodule-only bump PRs are against policy and will be rejected upstream."
-    echo ""
-    echo "Changes to submodule pointers belong in the submodule's own feature branch"
-    echo "and PR. The parent repo pointer is synced when the submodule PR merges to"
-    echo "dev and the parent updates via a normal feature commit (not a pointer-only"
-    echo "commit)."
-    echo ""
-    exit 1
-  fi
-  exit 0
-)
-GATE_EXIT_CODES+=($?)
-
 # Report per-gate status
-GATE_NAMES=("Gate 1 (branch protection)" "Gate 3 (submodule bump)" "Gate 4 (submodule pointer)")
+GATE_NAMES=("Gate 1 (branch protection)" "Gate 3 (submodule bump)")
 ANY_FAILED=0
 for i in "${!GATE_EXIT_CODES[@]}"; do
   if [ "${GATE_EXIT_CODES[$i]}" -ne 0 ]; then

--- a/hooks/pre-push
+++ b/hooks/pre-push
@@ -107,6 +107,82 @@ while read LOCAL_REF LOCAL_SHA REMOTE_REF REMOTE_SHA; do
             fi
         fi
     fi
+
+    # --- Gate 2: Submodule-pointer-only push blocker ---
+    # Blocks pushes where ALL changed files are submodule pointer updates.
+    # Submodule-only bump PRs are against policy — they create review overhead
+    # with no functional change. Local submodule pointer commits are fine.
+    if [ "$IS_DELETE" = false ] && [ -f ".gitmodules" ]; then
+        CHANGED_FILES=$(git diff --name-only "$REMOTE_SHA".."$LOCAL_SHA" 2>/dev/null || true)
+        SUBMODULE_PATHS=$(git submodule status | awk '{print $2}')
+
+        if [ -n "$CHANGED_FILES" ] && [ -n "$SUBMODULE_PATHS" ]; then
+            ALL_SUBMODULE_POINTERS=1
+            for f in $CHANGED_FILES; do
+                IS_SUBMODULE=0
+                for sp in $SUBMODULE_PATHS; do
+                    if [ "$f" = "$sp" ]; then
+                        IS_SUBMODULE=1
+                        break
+                    fi
+                done
+                if [ "$IS_SUBMODULE" -eq 0 ]; then
+                    ALL_SUBMODULE_POINTERS=0
+                    break
+                fi
+            done
+
+            if [ "$ALL_SUBMODULE_POINTERS" = "1" ]; then
+                ISSUE_NUM=$(echo "$LOCAL_BRANCH" | grep -oP '^\w+/\K\d+')
+                TAG=""
+                TAG_MSG=""
+                for sp in $SUBMODULE_PATHS; do
+                    if [ -d "$sp" ]; then
+                        _TAG=$(cd "$sp" && git tag -l "*/$ISSUE_NUM" --sort=-version:refname 2>/dev/null | head -1)
+                        if [ -n "$_TAG" ]; then
+                            TAG="$_TAG"
+                            TAG_MSG="The submodule SHA is already tracked via tag '$_TAG' on the submodule remote. Nothing is lost."
+                            break
+                        fi
+                    fi
+                done
+
+                echo ""
+                echo "BLOCKED: Submodule-pointer-only push prevented."
+                echo ""
+                echo "The branch '$LOCAL_BRANCH' contains only submodule pointer changes with no"
+                echo "parent-repo source code modifications. Submodule-only bump PRs are"
+                echo "against policy — they create review overhead with no functional change."
+                echo ""
+                echo "Local submodule pointer commits are fine — keep them."
+                echo ""
+
+                if [ -n "$TAG" ]; then
+                    echo "$TAG_MSG"
+                else
+                    echo "⚠ Submodule tag missing. Create one before continuing:"
+                    for sp in $SUBMODULE_PATHS; do
+                        if [ -d "$sp" ]; then
+                            echo "  cd $sp"
+                            echo "  git tag -a \"$LOCAL_BRANCH/$ISSUE_NUM\" -m \"Track submodule SHA for issue $ISSUE_NUM\""
+                            echo "  git push origin \"$LOCAL_BRANCH/$ISSUE_NUM\""
+                        fi
+                    done
+                fi
+
+                echo ""
+                echo "To proceed:"
+                echo "  1. Continue implementation on this branch (edit source files)"
+                echo "  2. Commit your code changes"
+                echo "  3. Push again — the submodule pointer will accompany your code"
+                echo ""
+                echo "The submodule pointer update will be included in your PR alongside the"
+                echo "real implementation. No need to redo the pointer commit or tag."
+                echo ""
+                ALLOWED=false
+            fi
+        fi
+    fi
 done
 
 if [ "$ALLOWED" = false ]; then


### PR DESCRIPTION
## Summary

Move the submodule-pointer-only check from `hooks/pre-commit` (Gate 4) to `hooks/pre-push` (new Gate 2). The pre-commit layer was the wrong enforcement point — the pre-work workflow legitimately requires committing the submodule pointer as the first commit on a feature branch.

## Changes

- **`hooks/pre-commit`**: Removed Gate 4 (lines 83-155) and its GATE_EXIT_CODES entry. Updated gate names array from 3 to 2 gates.
- **`hooks/pre-push`**: Added Gate 2 — submodule-pointer-only push blocker inside the existing `while read` loop.

## How the new push gate works

1. Computes `CHANGED_FILES` via `git diff --name-only $REMOTE_SHA..$LOCAL_SHA`
2. Gets submodule paths from `git submodule status`
3. Checks if ALL changed files are submodule pointers
4. If submodule-only: extracts issue number from branch name, checks for existing tag on submodule
5. If tag exists: references it in the error message
6. If tag missing: instructs tag creation
7. Blocks the push with actionable error message

## Verification

- [x] Gate 4 removed from pre-commit — confirmed by file read
- [x] Gate 2 added to pre-push — confirmed by file read
- [x] No branch exemptions — check applies universally
- [x] Error message handles both tag-present and tag-missing cases

Fixes https://github.com/michael-conrad/.opencode/issues/1714

🤖 Co-authored with AI: opencode (deepseek-v4-flash)