### PR TITLE
fix(#1729): pre-push Gate 2 fails on new branch pushes — REMOTE_SHA is all zeros

### DIFF
--- a/hooks/pre-push
+++ b/hooks/pre-push
@@ -113,7 +113,14 @@ while read LOCAL_REF LOCAL_SHA REMOTE_REF REMOTE_SHA; do
     # Submodule-only bump PRs are against policy — they create review overhead
     # with no functional change. Local submodule pointer commits are fine.
     if [ "$IS_DELETE" = false ] && [ -f ".gitmodules" ]; then
-        CHANGED_FILES=$(git diff --name-only "$REMOTE_SHA".."$LOCAL_SHA" 2>/dev/null || true)
+        # On first push of a new branch, REMOTE_SHA is 0000... (all zeros).
+        # Compare against default branch tip instead to get the full diff.
+        if echo "$REMOTE_SHA" | grep -q '^0\{40\}$'; then
+            DEFAULT_BRANCH=$(git remote show origin 2>/dev/null | sed -n 's/.*HEAD branch: //p')
+            CHANGED_FILES=$(git diff --name-only "origin/$DEFAULT_BRANCH".."$LOCAL_SHA" 2>/dev/null || true)
+        else
+            CHANGED_FILES=$(git diff --name-only "$REMOTE_SHA".."$LOCAL_SHA" 2>/dev/null || true)
+        fi
         SUBMODULE_PATHS=$(git submodule status | awk '{print $2}')
 
         if [ -n "$CHANGED_FILES" ] && [ -n "$SUBMODULE_PATHS" ]; then


### PR DESCRIPTION
## Summary

Fixes pre-push hook Gate 2 (submodule-pointer-only push blocker) which silently skips on the first push of a new branch.

## Root Cause

When a branch has never been pushed, `$REMOTE_SHA` is `0000...` (all zeros per git pre-push protocol). The command `git diff --name-only "$REMOTE_SHA".."$LOCAL_SHA"` fails because `0000...` is not a valid commit. `$CHANGED_FILES` is empty, so the gate silently exits without blocking.

## Fix

When `$REMOTE_SHA` is all zeros (new branch), compare against `origin/<default-branch>` tip instead to get the full branch diff. Existing branch pushes continue to use `$REMOTE_SHA` for the diff.

## SCs

| ID | Criterion | Evidence Type |
|----|-----------|---------------|
| SC-1 | Gate 2 uses default branch tip for diff when REMOTE_SHA is all zeros | `string` |
| SC-2 | Gate 2 still uses REMOTE_SHA for existing branch pushes | `string` |

🤖 Co-authored with AI: OpenCode (ollama-cloud/deepseek-v4-flash)