### PR TITLE
fix(#1732): prevent routing-bypass on "pr merged" trigger

### DIFF
--- a/guidelines/000-critical-rules.md
+++ b/guidelines/000-critical-rules.md
@@ -934,6 +934,8 @@ No `question` tool for structural decisions when `halt_at >= pr_created`.
 
 Creating a PR whose sole purpose is to update a submodule pointer during the cleanup pipeline stage. See `git-workflow cleanup` task Step 1.7 for the complete prohibition and correct behavior (leave dirty pointer untouched).
 
+**Scope clarification:** This prohibition applies to PR creation only. It does NOT exempt the agent from dispatching `git-workflow --task cleanup` on "pr merged" triggers. The cleanup sub-agent independently determines which cleanup actions apply — including whether to leave the submodule pointer dirty. Using this prohibition as a rationalization to skip the entire cleanup workflow is a routing-bypass self-authorization violation (critical-rules-006).
+
 
 ### [critical-rules-039] Parent Issue Left Open After All Children Closed
 See verify-already-implemented Step 6, cleanup Step 2.8.

--- a/guidelines/020-go-prohibitions.md
+++ b/guidelines/020-go-prohibitions.md
@@ -219,6 +219,7 @@ These branches are NOT for implementation — they are ephemeral scratch space. 
   - 🚫 FORBIDDEN: Any PR whose only changed files are submodule pointer updates (regardless of submodule count)
   - 🚫 FORBIDDEN: Committing dirty pointer(s) to dev
   - 🚫 FORBIDDEN: Rationalizing "this is just a pointer update, not real code"
+  - 🚫 FORBIDDEN: Using critical-rules-049 (submodule-only-PR prohibition) as a rationalization to skip `git-workflow --task cleanup` dispatch on "pr merged" triggers. The prohibition applies to PR creation only — it does NOT exempt cleanup dispatch.
   - ✅ CORRECT: Leave dirty pointer(s) untouched — they resolve on next pre-work cycle
 
 ## 1.5 Soliciting Authorization for Already-Authorized Phrases — CRITICAL VIOLATION

--- a/tests/behaviors/pr-merged-routes-to-cleanup.sh
+++ b/tests/behaviors/pr-merged-routes-to-cleanup.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# Behavioral test: pr-merged-routes-to-cleanup
+# See .opencode/tests/AGENTS.md for the test harness specification and paradigm.
+# This script is an artifact-only generator — it does NOT evaluate model output.
+# Behavioral Enforcement Test: "pr merged" routes to git-workflow cleanup
+#
+# Verifies that when an agent receives "pr merged" input, it
+# dispatches git-workflow skill and routes to cleanup rather than
+# inline-analyzing git state and constructing a carveout justification.
+#
+# Evidence type: behavioral — verified by clean-room semantic inspection.
+# Per 080-code-standards.md §Rule 5, grep/string assertions on agent output
+# prose are EVIDENCE_TYPE_MISMATCH for behavioral SCs.
+#
+# Co-authored with AI: OpenCode (ollama-cloud/deepseek-v4-flash)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/helpers.sh"
+
+SCENARIO_NAME="pr-merged-routes-to-cleanup"
+SCENARIO_PROMPT="pr merged"
+
+echo "=== Behavioral Test: $SCENARIO_NAME ==="
+echo "SC-3: Agent dispatches git-workflow cleanup on 'pr merged' trigger"
+echo "SC-4: Agent does NOT inline-analyze git state on 'pr merged'"
+
+behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT"
+
+# Artifact-only generator — exit 0 unconditionally.
+# Evaluation is performed by clean-room sub-agents reading the artifacts.
+exit 0


### PR DESCRIPTION
## Summary

Prevent agents from using the critical-rules-049 submodule-only-PR prohibition as a rationalization to skip `git-workflow --task cleanup` dispatch on "pr merged" triggers.

## Success Criteria

| ID | Criterion | Evidence Type | Status |
|----|-----------|---------------|--------|
| SC-1 | critical-rules-049 explicitly states it does NOT exempt cleanup dispatch | `string` | ✅ `grep -n "does NOT exempt"` → line 937 |
| SC-2 | 020-go-prohibitions.md has explicit prohibition against using critical-rules-049 to skip cleanup | `string` | ✅ `grep -n "rationalization"` → line 222 |
| SC-3 | Agent dispatches git-workflow cleanup on "pr merged" trigger | `behavioral` | ✅ Artifacts at `tmp/behavioral-evidence-pr-merged-routes-to-cleanup-GREEN-ollama-ornith-35b-256k/` — stderr shows `Skill "git-workflow"` + `Dispatch check-pr task for "pr merged" trigger` |
| SC-4 | Agent does NOT inline-analyze git state on "pr merged" | `behavioral` | ✅ Same artifacts — no inline `git status`/`git log`/`github_list_pull_requests` in orchestrator context; agent dispatched to sub-agent |

## Files Changed

- **000-critical-rules.md**: Clarified critical-rules-049 scope — prohibition applies to PR creation only, does NOT exempt cleanup dispatch
- **020-go-prohibitions.md**: Added explicit prohibition against using critical-rules-049 as rationalization to skip cleanup
- **tests/behaviors/pr-merged-routes-to-cleanup.sh**: Behavioral enforcement test (SC-3, SC-4) — artifact-only generator, verified via model run

## Fixes

Closes #1732

🤖 Co-authored with AI: OpenCode (ollama-cloud/deepseek-v4-flash)