### PR TITLE
gap-fill cascade: state-verification checklist model

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,9 @@ skip it are not "fast" — they produce lower-quality work by definition.
 
 4. **If no skill applies directly: proceed without dispatch, but justify in one sentence.** This is the exception. Treat it like one. The one-sentence justification is the audit trail that proves you considered — and correctly dismissed — the skill deck. Every agent who skips this produces silent bypass. Do not be that agent.
 
+
+**Release PR constraint:** When the context is a release PR (user says "release PR", "release", "is_release", or authorization scope includes release PR), "no skill applies directly" is NOT a valid justification. The agent MUST dispatch at minimum `changelog-generator` and `git-workflow` before proceeding. This constraint is non-waivable.
+
 ### This Gate Fires On
 
 | Trigger | Example User Message |

--- a/guidelines/000-critical-rules.md
+++ b/guidelines/000-critical-rules.md
@@ -890,7 +890,7 @@ See `approval-gate --task verify-closed-issue` and `--task reconcile-issue-graph
 
 
 ### [critical-rules-019] Creating PRs Without Explicit Instruction
-Exception: `for_pr`/`for_pr_only` scope authorizes PR creation.
+Exception: `for_pr` scope authorizes PR creation.
 
 
 ### [critical-rules-018] Ignoring Spec-to-Plan Approval Cascade

--- a/guidelines/010-approval-gate.md
+++ b/guidelines/010-approval-gate.md
@@ -20,7 +20,7 @@ load_when: sub-agent
 | 6 | Human-only merge | approval-gate-005 | GitHub branch protection |
 | 7 | Silent halt — no prompts | — | `000-critical-rules.md` |
 | 8 | Search before halt (no spec found) | — | `000-critical-rules.md` §Silent Halt |
-| 9 | PR requires explicit instruction (except `for_pr`/`for_pr_only`) | critical-rules-019 | `pr-creation-workflow` skill |
+| 9 | PR requires explicit instruction (except `for_pr` scope) | critical-rules-019 | `pr-creation-workflow` skill |
 | 10 | Close issues only after PR merge confirmed | critical-rules-013 | `git-workflow cleanup` |
 | 11 | Spec-to-Plan cascade (auto-approve faithful plan) | approval-gate-001a-cascade | `approval-gate` skill |
 | 12 | Pipeline-scoped authorization with hard HALT at boundary | approval-gate-010/011 | `approval-gate` skill |
@@ -35,6 +35,7 @@ load_when: sub-agent
 - **Explicit authorization:** "approved" or "go" — implicit, rhetorical, or complaint-based authorization is invalid
 - **Label application:** Apply `approved-for-*` label on authorization
 - **Human-only merge:** Agent never merges PRs
+- **Release PR gate:** When `authorization_scope >= for_pr` and context is a release PR, agent MUST evaluate the skill deck before any action.
 
 ### Issue Creation Is Reporting, Not Implementation (CRITICAL)
 
@@ -110,16 +111,15 @@ Defines where the pipeline halts after a given authorization scope, what gap-fil
 
 #### Key Scope Values
 
-| Scope | HALT After | Gap-Fill | PR Strategy |
-|-------|-----------|----------|-------------|
-| `for_review_prep` | review-prep | None | none |
-| `for_spec` | spec_created | None | none |
-| `for_plan` | plan_created | auto-create spec | none |
-| `for_implementation` | verification_complete | auto-create spec+plan+auto-approve | none |
-| `for_pr` | pr_created | auto-create spec+plan+auto-approve+auto-PR | stacked |
-| `for_pr_only` | pr_created | None | stacked |
-| `for_review_only` | code_review_ready | None | none |
-| `for_analysis` | analysis_complete | None | none |
+| Scope | HALT After | PR Strategy |
+|-------|-----------|-------------|
+| `for_review_prep` | review-prep | none |
+| `for_spec` | spec_created | none |
+| `for_plan` | plan_created | none |
+| `for_implementation` | verification_complete | none |
+| `for_pr` | pr_created | stacked |
+| `for_release_pr` | pr_created | stacked |
+| `for_analysis` | analysis_complete | none |
 
 
 #### Scope-Dependent PR Strategy
@@ -129,11 +129,7 @@ Defines where the pipeline halts after a given authorization scope, what gap-fil
 
 #### Gap-Fill Cascade
 
-When scope includes gap-fill, the agent auto-creates missing artifacts:
-
-1. `for_plan` scope: auto-create spec before plan
-2. `for_implementation` scope: auto-create spec → auto-create plan → auto-approve
-3. `for_pr` scope: auto-create spec → auto-create plan → auto-approve → auto-create PR
+Authorization always triggers dispatch of `gap-fill-cascade`, which reads the scope and walks its per-scope state-verification checklist. The checklist verifies each state sequentially and reports the first missing state or that all states are verified. See `skills/approval-gate/tasks/gap-fill-cascade.md` for the dispatcher and `skills/approval-gate/tasks/gap-fill-cascade/` for per-scope checklist files.
 
 ### Multi-Task Plan Authorization (CRITICAL)
 
@@ -201,7 +197,7 @@ Non-substantive GitHub Issue body formatting fixes found during deliberately-inv
 | Create feature branch (`feature/*`, `spec/*`) | Yes (requires `for_implementation` or above) |
 | Create investigation branch (`observe/*`) | No (must discard before HALT under `for_analysis`) |
 | Write code, modify files | Yes |
-| Create PR | Yes (except `for_pr`/`for_pr_only` scope) |
+| Create PR | Yes (except `for_pr` scope) |
 | Merge PR | No — human-only |
 | Close issues | Yes (after PR merge confirmed) |
 | Delete branches | Yes |

--- a/guidelines/020-go-prohibitions.md
+++ b/guidelines/020-go-prohibitions.md
@@ -242,7 +242,7 @@ The verb-prefix parsing table in `approval-gate` skill → Authorization Scope M
 | -- | -- |
 | Parse scope from verb-prefix table, proceed with pipeline chain | Ask user "should I proceed with the full workflow?" |
 | Accept unambiguous authorization at face value | Treat authorization as needing confirmation |
-| Resolve `for_pr`, `for_plan`, `for_implementation`, `for_spec`, `for_review_only` autonomously | Ask "is this approved to PR or just to implementation?" |
+| Resolve `for_pr`, `for_plan`, `for_implementation`, `for_spec` autonomously | Ask "is this approved to PR or just to implementation?" |
 
 **See `approval-gate` skill → "Authorization Scope Model" for the complete verb-prefix parsing table. See `000-critical-rules.md` §Pushing Agent Intelligence Decisions for the autonomous resolution mandate. See `000-critical-rules.md` → "Structural Decision Solicitation Under for_pr Scope" for the complete enforcement, including the `question` tool prohibition under `for_pr` scope.** **AUTHORITY: `000-critical-rules.md` §Structural Decision Solicitation Under for_pr Scope** (this line is a reference only)
 

--- a/guidelines/080-code-standards.md
+++ b/guidelines/080-code-standards.md
@@ -762,6 +762,17 @@ See `process_data()` in `file.py` for the function definition.
 See `"Cross-Reference Standards"` section in `guidelines.md` for the rule.
 ```
 
+## YAML Standard for LLM-to-LLM Data Transfers
+
+All structured data exchanged between AI agents (result contracts, work state files, task context, evidence artifacts) MUST use YAML format. JSON is prohibited for LLM-to-LLM communication.
+
+**Exceptions:**
+- External API calls (GitHub API, GitBucket API)
+- Configuration files that require JSON (`opencode.jsonc`)
+- Data interchange with non-LLM systems
+
+**Rationale:** YAML is more readable for AI agents in multi-line contexts. JSON is error-prone when embedded in agent prompts due to brace/quote escaping issues.
+
 ## Mandatory Triple Co-Application
 
 ### Scope

--- a/skills/approval-gate/SKILL.md
+++ b/skills/approval-gate/SKILL.md
@@ -22,13 +22,12 @@ This skill operates in the main repo directory (direct-branch mode). When `WORKT
 
 Sub-Agent Task Context Audit
 
-All tasks run via `task(subagent_type="general")`. Standard context: `{ issue_number, worktree.path, github.owner, github.repo, authorization_scope, halt_at, pr_strategy, pipeline_phase }`. Auditor tasks use subagent_type from resolve-models result contract (auditor_1/auditor_2) — NOT `general`. Include audit_phase in task context when routing auditors. See audit SKILL.md §DISPATCH_GATE. `screen-issue` receives issue body + authorization context + pipeline_phase. `pre-implementation-analysis` receives all issue numbers + authorization context + pipeline_phase. `pre-analysis` receives only `{ issue_number, task_description, pipeline_phase, authorization_scope, halt_at, pr_strategy, github.owner, github.repo }` with zero file paths. No inline work — all tasks use sub-agents. If a sub-agent returns empty, re-task with original scoped context only (max 2 retries). Result contracts return `status` (DONE/BLOCKED/OVERFLOW) + task-specific fields per `enforcement/` result contract schemas. `DONE_WITH_CONCERNS` is coerced to FAIL per the bright-line coercion rule in the implementation-pipeline SKILL.md Trigger Dispatch Table.
+All tasks run via `task(subagent_type="general")`. Standard context: `{ issue_number, worktree.path, github.owner, github.repo, authorization_scope, halt_at, pipeline_phase }`. Auditor tasks use subagent_type from resolve-models result contract (auditor_1/auditor_2) — NOT `general`. Include audit_phase in task context when routing auditors. See audit SKILL.md §DISPATCH_GATE. `screen-issue` receives issue body + authorization context + pipeline_phase. `pre-implementation-analysis` receives all issue numbers + authorization context + pipeline_phase. `pre-analysis` receives only `{ issue_number, task_description, pipeline_phase, authorization_scope, halt_at, github.owner, github.repo }` with zero file paths. No inline work — all tasks use sub-agents. If a sub-agent returns empty, re-task with original scoped context only (max 2 retries). Result contracts return `status` (DONE/BLOCKED/OVERFLOW) + task-specific fields per `enforcement/` result contract schemas. `DONE_WITH_CONCERNS` is coerced to FAIL per the bright-line coercion rule in the implementation-pipeline SKILL.md Trigger Dispatch Table.
 
 ### Authorization Context Template
 ```
-authorization_scope: <for_analysis|for_spec|for_plan|for_implementation|for_review_prep|for_pr|for_pr_only|for_review_only>
+authorization_scope: <for_analysis|for_spec|for_plan|for_implementation|for_review_prep|for_pr>
 halt_at: <analysis_complete|spec_created|plan_created|verification_complete|review_prep|pr_created>
-pr_strategy: <none|stacked>
 pipeline_phase: <current_phase_name>
 authorization_source: "User approved #N on YYYY-MM-DD"
 ```
@@ -103,7 +102,6 @@ Every `task()` call MUST include only:
 - `github.repo`
 - `authorization_scope`
 - `halt_at`
-- `pr_strategy`
 - `pipeline_phase`
 
 Plus skill-specific fields per the `## Sub-Agent Routing` section above.
@@ -157,6 +155,7 @@ After loading this skill and reading the Trigger Dispatch Table, the orchestrato
 | "bug discovery" / "bug found during implementation" | `bug-discovery-protocol` | `sub-task` | {issue_number, bug_description} |
 | "verify plan pipeline" / "check pipeline completeness" | `verify-plan-pipeline` | `sub-task` | {issue_number} |
 | completion / workflow end | `completion` | `sub-task` | {workflow_state} |
+| "release PR" / "release authorization" | `verify-authorization` | `sub-task` | {issue_number, authorization_scope, is_release: true} |
 
 Skills: `git-workflow`, `pr-creation-workflow`, `issue-review`, `implementation-pipeline`, `writing-plans`, `executing-plans`, `pre-analysis`. Guidelines: `010-approval-gate.md`, `000-critical-rules.md`, `065-verification-honesty.md`.
 

--- a/skills/approval-gate/enforcement/auto-dispatch-table.md
+++ b/skills/approval-gate/enforcement/auto-dispatch-table.md
@@ -24,8 +24,7 @@ When a spec is approved, the auto-route chain determines which downstream action
 | `for_plan` | Auto-create spec (gap-fill), HALT after plan_created |
 | `for_implementation` | Auto-create spec+plan (gap-fill), auto-approve, proceed through implementation |
 | `for_pr` | Auto-create spec+plan, auto-approve, proceed through PR creation, stacked PR |
-| `for_pr_only` | Skip to PR creation, stacked PR |
-| `for_review_only` | Skip to code review readiness |
+
 
 ## Dispatch Order (Mandatory)
 

--- a/skills/approval-gate/enforcement/scope-parsing.md
+++ b/skills/approval-gate/enforcement/scope-parsing.md
@@ -12,8 +12,6 @@ Authorization phrases carry implicit scope — the pipeline stage the developer 
 | `"approved #N for plan"` or `"#N approved for plan"` | for_plan | plan_created | auto-create spec | none |
 | `"approved #N for implementation"` or `"#N approved for implementation"` | for_implementation | verification_complete | auto-create spec+plan, auto-approve | none |
 | `"approved #N to PR"` or `"#N approved to PR"` | for_pr | pr_created | auto-create spec+plan, auto-approve, auto-PR | stacked |
-| `"approved #N pr only"` or `"#N approved for pr only"` | for_pr_only | pr_created | None | stacked |
-| `"approved #N for review"` or `"#N approved for review only"` | for_review_only | code_review_ready | None | none |
 | `"approved for next phase"` or `"approved #N for next phase"` | for_next_phase | next_phase_complete | auto-approve next phase | none |
 | `"approved for phase N"` or `"approved #N for phase N"` | for_phase_N | phase_N_complete | auto-approve up to phase N | none |
 
@@ -86,7 +84,5 @@ def resolve_phase_n(phase_number, total_phases):
 | for_plan | none |
 | for_implementation | none |
 | for_pr | stacked |
-| for_pr_only | stacked |
-| for_review_only | none |
 | for_next_phase | none |
 | for_phase_N | none |

--- a/skills/approval-gate/tasks/gap-fill-cascade.md
+++ b/skills/approval-gate/tasks/gap-fill-cascade.md
@@ -1,0 +1,65 @@
+<!-- SPDX-FileCopyrightText: 2026 Michael Conrad -->
+<!-- SPDX-License-Identifier: MIT -->
+<!-- Provenance: AI-generated -->
+
+# Task: Gap-Fill Cascade Dispatcher
+
+## Purpose
+
+Routing dispatcher for the gap-fill state-verification checklist model. Reads `authorization_scope` from context, loads the corresponding per-scope checklist file, walks items sequentially, and reports the first missing state or that all states are verified.
+
+## Context Received
+
+```yaml
+authorization_scope: <scope_value>
+issue_number: <N>
+github.owner: <owner>
+github.repo: <repo>
+```
+
+## Scope-to-Checklist Mapping
+
+| Scope | Checklist File | Behavior |
+|-------|---------------|----------|
+| `for_pr` | `gap-fill-cascade/for-pr.md` | 5-item checklist (spec → plan → approval → implementation → PR) |
+| `for_implementation` | `gap-fill-cascade/for-implementation.md` | 4-item checklist (spec → plan → approval → implementation) |
+| `for_plan` | `gap-fill-cascade/for-plan.md` | 2-item checklist (spec → plan) |
+| `for_spec` | None | Report all states verified immediately — spec is the target |
+| `for_analysis` | None | Report all states verified immediately — read-only investigation |
+| `for_review_prep` | None | Report all states verified immediately — all artifacts must pre-exist |
+
+## Procedure
+
+1. Read `authorization_scope` from context
+2. If scope has a checklist file (for_pr, for_implementation, for_plan):
+   a. Load the corresponding checklist file from `gap-fill-cascade/{scope-file}.md`
+   b. Walk items sequentially — process each item's verify step
+   c. On first FAIL: report `next_action` with reason, stop walking
+   d. If all items PASS: report `all_states_verified: true`
+3. If scope has no checklist (for_spec, for_analysis, for_review_prep):
+   a. Report `all_states_verified: true` immediately
+
+## Result Contract
+
+```yaml
+status: DONE|BLOCKED
+all_states_verified: true|false
+next_action: <skill-name>|null
+reason: "<explanation if blocked or next_action set>"
+checklist_progress:
+  items_checked: <N>
+  items_passed: <N>
+  first_fail_item: <item-name>|null
+```
+
+## Orchestrator Loop Integration
+
+After this task returns, the orchestrator:
+
+- If `all_states_verified: true`: proceed to the halt boundary
+- If `next_action` is set: dispatch that action, then re-dispatch this task
+- If BLOCKED with no `next_action`: HALT with blocker report
+
+---
+
+Co-authored with AI: OpenCode (deepseek-v4-flash)

--- a/skills/approval-gate/tasks/gap-fill-cascade/for-implementation.md
+++ b/skills/approval-gate/tasks/gap-fill-cascade/for-implementation.md
@@ -1,0 +1,45 @@
+<!-- SPDX-FileCopyrightText: 2026 Michael Conrad -->
+<!-- SPDX-License-Identifier: MIT -->
+<!-- Provenance: AI-generated -->
+
+# Gap-Fill Checklist: `for_implementation` Scope
+
+**Purpose:** State-verification checklist for `for_implementation` authorization scope. Walk items sequentially. Report the first missing state or that all states are verified.
+
+**Context received:** `{ authorization_scope, issue_number, github.owner, github.repo }`
+
+---
+
+## Checklist Items
+
+### Item 1: Spec exists and is approved
+
+- **State:** Spec issue exists with `[SPEC]` label
+- **Verify:** Read issue `{issue_number}` — check for `[SPEC]` label
+- **If PASS:** Proceed to Item 2
+- **If FAIL:** Report `next_action: spec-creation` with reason "No approved spec found for issue {issue_number}"
+
+### Item 2: Plan exists and is faithful to spec
+
+- **State:** Plan file exists at `*/.issues/{issue_number}/plan.md`
+- **Verify:** Check if `*/.issues/{issue_number}/plan.md` exists and is non-empty
+- **If PASS:** Proceed to Item 3
+- **If FAIL:** Report `next_action: writing-plans` with reason "No plan found for issue {issue_number}"
+
+### Item 3: Plan is approved
+
+- **State:** Issue has `approved-for-plan` label (or scope >= `for_plan` auto-approves)
+- **Verify:** Read issue `{issue_number}` — check for `approved-for-plan` label
+- **If PASS:** Proceed to Item 4
+- **If FAIL:** Report `next_action: apply-label` with reason "Plan for issue {issue_number} needs approval label"
+
+### Item 4: Implementation complete (all SCs verified PASS)
+
+- **State:** Verification artifacts exist for all SCs in spec
+- **Verify:** Check `{project_root}/tmp/{issue_number}/artifacts/` for SC verification evidence
+- **If PASS:** Report `all_states_verified: true` with summary "All states verified for for_implementation scope"
+- **If FAIL:** Report `next_action: implementation-pipeline` with reason "Implementation not complete for issue {issue_number}"
+
+---
+
+Co-authored with AI: OpenCode (deepseek-v4-flash)

--- a/skills/approval-gate/tasks/gap-fill-cascade/for-plan.md
+++ b/skills/approval-gate/tasks/gap-fill-cascade/for-plan.md
@@ -1,0 +1,31 @@
+<!-- SPDX-FileCopyrightText: 2026 Michael Conrad -->
+<!-- SPDX-License-Identifier: MIT -->
+<!-- Provenance: AI-generated -->
+
+# Gap-Fill Checklist: `for_plan` Scope
+
+**Purpose:** State-verification checklist for `for_plan` authorization scope. Walk items sequentially. Report the first missing state or that all states are verified.
+
+**Context received:** `{ authorization_scope, issue_number, github.owner, github.repo }`
+
+---
+
+## Checklist Items
+
+### Item 1: Spec exists and is approved
+
+- **State:** Spec issue exists with `[SPEC]` label
+- **Verify:** Read issue `{issue_number}` — check for `[SPEC]` label
+- **If PASS:** Proceed to Item 2
+- **If FAIL:** Report `next_action: spec-creation` with reason "No approved spec found for issue {issue_number}"
+
+### Item 2: Plan exists and is faithful to spec
+
+- **State:** Plan file exists at `*/.issues/{issue_number}/plan.md`
+- **Verify:** Check if `*/.issues/{issue_number}/plan.md` exists and is non-empty
+- **If PASS:** Report `all_states_verified: true` with summary "All states verified for for_plan scope"
+- **If FAIL:** Report `next_action: writing-plans` with reason "No plan found for issue {issue_number}"
+
+---
+
+Co-authored with AI: OpenCode (deepseek-v4-flash)

--- a/skills/approval-gate/tasks/gap-fill-cascade/for-pr.md
+++ b/skills/approval-gate/tasks/gap-fill-cascade/for-pr.md
@@ -1,0 +1,52 @@
+<!-- SPDX-FileCopyrightText: 2026 Michael Conrad -->
+<!-- SPDX-License-Identifier: MIT -->
+<!-- Provenance: AI-generated -->
+
+# Gap-Fill Checklist: `for_pr` Scope
+
+**Purpose:** State-verification checklist for `for_pr` authorization scope. Walk items sequentially. Report the first missing state or that all states are verified.
+
+**Context received:** `{ authorization_scope, issue_number, github.owner, github.repo }`
+
+---
+
+## Checklist Items
+
+### Item 1: Spec exists and is approved
+
+- **State:** Spec issue exists with `[SPEC]` label
+- **Verify:** Read issue `{issue_number}` — check for `[SPEC]` label
+- **If PASS:** Proceed to Item 2
+- **If FAIL:** Report `next_action: spec-creation` with reason "No approved spec found for issue {issue_number}"
+
+### Item 2: Plan exists and is faithful to spec
+
+- **State:** Plan file exists at `*/.issues/{issue_number}/plan.md`
+- **Verify:** Check if `*/.issues/{issue_number}/plan.md` exists and is non-empty
+- **If PASS:** Proceed to Item 3
+- **If FAIL:** Report `next_action: writing-plans` with reason "No plan found for issue {issue_number}"
+
+### Item 3: Plan is approved
+
+- **State:** Issue has `approved-for-plan` label (or scope >= `for_plan` auto-approves)
+- **Verify:** Read issue `{issue_number}` — check for `approved-for-plan` label
+- **If PASS:** Proceed to Item 4
+- **If FAIL:** Report `next_action: apply-label` with reason "Plan for issue {issue_number} needs approval label"
+
+### Item 4: Implementation complete (all SCs verified PASS)
+
+- **State:** Verification artifacts exist for all SCs in spec
+- **Verify:** Check `{project_root}/tmp/{issue_number}/artifacts/` for SC verification evidence
+- **If PASS:** Proceed to Item 5
+- **If FAIL:** Report `next_action: implementation-pipeline` with reason "Implementation not complete for issue {issue_number}"
+
+### Item 5: PR exists
+
+- **State:** Open PR for this branch exists
+- **Verify:** Check for open PR on the current feature branch
+- **If PASS:** Report `all_states_verified: true` with summary "All states verified for for_pr scope"
+- **If FAIL:** Report `next_action: git-workflow` with reason "PR not yet created for issue {issue_number}"
+
+---
+
+Co-authored with AI: OpenCode (deepseek-v4-flash)

--- a/skills/approval-gate/tasks/pre-impl/collect-screening-results.md
+++ b/skills/approval-gate/tasks/pre-impl/collect-screening-results.md
@@ -2,4 +2,4 @@ Sub-Agent Task Context Audit
 
 | Scope of Context | Exclusions | Pre-Analysis Contract | Includes Inline Work? |
 |---|---|---|---|
-| `issue_number`, `work_peers`, `authorization_scope`, `halt_at`, `pr_strategy`, `github.owner`, `github.repo`, `dev.name`, `dev.email`, `worktree.path` | Issue bodies (never read into orchestrator context), orchestrator reasoning, prior screening results | N/A — screen-issue sub-agents receive full task context directly | NO |
+| `issue_number`, `work_peers`, `authorization_scope`, `halt_at`, `github.owner`, `github.repo`, `dev.name`, `dev.email`, `worktree.path` | Issue bodies (never read into orchestrator context), orchestrator reasoning, prior screening results | N/A — screen-issue sub-agents receive full task context directly | NO |

--- a/skills/approval-gate/tasks/verify-authorization.md
+++ b/skills/approval-gate/tasks/verify-authorization.md
@@ -24,7 +24,7 @@ This task delegates to atomic sub-tasks. Each sub-task reads inputs from the wor
 | Step | Sub-Task | Purpose |
 |------|----------|---------|
 | 0 | Re-task guard | If sub-agent returns empty, re-task with original scoped context (max 2 retries); on exhaustion, fall through to double-failure protocol |
-| 0.5 | `verify-authorization/scope-auto-resolve` | Parse authorization text, resolve scope/halt_at/pr_strategy/gap_fill |
+| 0.5 | `verify-authorization/scope-auto-resolve` | Parse authorization text, resolve scope/halt_at/gap_fill |
 | 1 | `verify-authorization/verify-explicit-authorization` | Check for "approved"/"go" + author identity + currency |
 | 2 | Label write (advisory-only, asynchronous) | Write authorization-scope label after work state file is written; labels are visibility markers, not gates. Remove prior scope and `needs-approval` labels as advisory cleanup. |
 | 3 | Authorization decision (inline) | Route based on authorization result |
@@ -84,10 +84,9 @@ gates_passed: [gate_name]
 blocking_reason: <reason|null>
 cascade_type: plan_cascade | output_lineage_cascade | none
 cascade_parent: <issue_number | null>
-authorization_scope: for_review_prep | for_spec | for_analysis | for_plan | for_implementation | for_pr | for_pr_only | for_review_only
+authorization_scope: for_review_prep | for_spec | for_analysis | for_plan | for_implementation | for_pr
 scope_source: parsed | default
 halt_at: <pipeline_stage>
-pr_strategy: stacked | none
 gap_fill_actions: [<action_list>]
 pipeline_phase: <current_phase_name>
 ```

--- a/skills/approval-gate/tasks/verify-authorization/auto-dispatch.md
+++ b/skills/approval-gate/tasks/verify-authorization/auto-dispatch.md
@@ -7,9 +7,8 @@ After all verification gates (Steps 1-5) pass, determine the approval context an
 ## Authorization Context
 
 ```
-authorization_scope: <for_analysis|for_spec|for_plan|for_implementation|for_review_prep|for_pr|for_pr_only|for_review_only>
+authorization_scope: <for_analysis|for_spec|for_plan|for_implementation|for_review_prep|for_pr>
 halt_at: <analysis_complete|spec_created|plan_created|verification_complete|review_prep|pr_created>
-pr_strategy: <none|stacked>
 pipeline_phase: <current_phase_name>
 authorization_source: "User approved #N on YYYY-MM-DD"
 ```
@@ -72,16 +71,16 @@ When `authorization_scope == "for_analysis"`:
    - Issue title format: `[SPEC` prefix = spec approval
    - Labels: presence of `spec` label
    - Plan detection is via local file existence at `.issues/{N}/plan.md` or `{project_root}/{path}/.issues/{N}/plan.md` (NOT via GitHub Issue labels or title prefixes)
-2. Determine scope from Step 2.0 result (`authorization_scope`, `halt_at`, `pr_strategy`)
+2. Determine scope from Step 2.0 result (`authorization_scope`, `halt_at`)
 3. Execute gap-fill from Step 5c if scope >= `for_plan`
 5. **If spec approval:** Invoke `writing-plans --task create` with context:
    - `spec_issue=#N` (the approved spec issue number)
-   - `authorization_scope=<scope>`, `halt_at=<stage>`, `pr_strategy=<strategy>`, `pipeline_phase=<phase>`
+   - `authorization_scope=<scope>`, `halt_at=<stage>`, `pipeline_phase=<phase>`
    - `<github.owner>`, `<github.repo>`, `<worktree.path>` from session
 5. **If plan approval:** Invoke `executing-plans --task start` with context:
    - `plan_issue=#N` (the approved plan issue number)
    - `spec_issue=#M` (extracted from plan body — the spec reference)
-   - `authorization_scope=<scope>`, `halt_at=<stage>`, `pr_strategy=<strategy>`, `pipeline_phase=<phase>`
+   - `authorization_scope=<scope>`, `halt_at=<stage>`, `pipeline_phase=<phase>`
    - `<github.owner>`, `<github.repo>`, `<worktree.path>` from session
 6. **Chat output:** Clearly indicate the transition and scope:
    - Spec approval: "Verification passed → Creating implementation plan (scope: <scope>)"
@@ -104,7 +103,7 @@ Numeric format: `STATUS: 1.1 (REVISED - NEEDS APPROVAL)`
 - **Multi-task plan with missing sub-issues:** Step 5 sub-issue verification gate fails → HALT, no dispatch
 - **Authorization set dispatch:** Each plan in the work set gets its own dispatch cycle after work state is established
 - **Scope requires gap-fill but artifact exists:** Skip gap-fill for that artifact (check before creating)
-- **`for_pr_only` or `for_review_only` scope with no existing branch/PR:** HALT and report — these scopes assume existing work
+
 
 ## Authorization Cascade by Output Lineage (Step 2.1)
 
@@ -134,7 +133,7 @@ When cascade does NOT apply (conditions not met):
 
 Before routing to the implementation-pipeline per the SKILL.md Trigger Dispatch Table, verify that the orchestrator context is not bloated with non-routing data:
 
-1. **Verify routing-only dispatch:** Confirm the orchestrator holds only routing metadata (worktree.path, github.owner, github.repo, authorization_scope, halt_at, pr_strategy, pipeline_phase, pipeline_history). Any cached analysis artifacts, task file contents, or prior sub-agent reasoning traces indicate context bloat.
+1. **Verify routing-only dispatch:** Confirm the orchestrator holds only routing metadata (worktree.path, github.owner, github.repo, authorization_scope, halt_at, pipeline_phase, pipeline_history). Any cached analysis artifacts, task file contents, or prior sub-agent reasoning traces indicate context bloat.
 2. **If context bloat detected:** Do NOT proceed to dispatch. The orchestrator must task a clean sub-agent from the current pipeline phase — do NOT attempt recovery via state cleanup.
 3. **Evidence artifact:** Before dispatch, the halt message must include: "Orchestrator context discipline verified: routing-only data held, no task file content cached, no prior sub-agent reasoning retained."
 

--- a/skills/approval-gate/tasks/verify-authorization/gap-fill-cascade.md
+++ b/skills/approval-gate/tasks/verify-authorization/gap-fill-cascade.md
@@ -14,8 +14,7 @@ SCOPE_HORIZON = {
     "for_plan":         "plan_created",
     "for_implementation": "verification_complete",
     "for_pr":           "pr_created",
-    "for_pr_only":      "pr_created",
-    "for_review_only":  "code_review_ready",
+
 }
 
 # From Step 2.0 result
@@ -32,8 +31,7 @@ GAP_FILL = {
     "for_plan": ["auto_create_spec"],  # Missing spec is gap-filled
     "for_implementation": ["auto_create_spec", "auto_create_plan", "auto_approve_plan"],
     "for_pr": ["auto_create_spec", "auto_create_plan", "auto_approve_plan", "auto_create_pr"],
-    "for_pr_only": [],  # Assumes branch exists; no gap-fill
-    "for_review_only": [],  # Assumes code exists; no gap-fill
+
     "for_review_prep": [],  # No gap-fill; all artifacts must pre-exist
 }
 ```

--- a/skills/approval-gate/tasks/verify-authorization/scope-auto-resolve.md
+++ b/skills/approval-gate/tasks/verify-authorization/scope-auto-resolve.md
@@ -27,13 +27,13 @@ If a qualifier matches, set `authorization_scope` to the corresponding scope val
 
 If the message does NOT contain authorization language (question, bug report, factual claim, investigation request), set `authorization_scope = "for_analysis"` with `scope_source = "self-assigned"`. This is the ONLY scope the agent may self-assign.
 
-Derive `halt_at`, `pr_strategy`, and `gap_fill_actions` from the resolved scope per the Auto-Dispatch Table Module (`enforcement/auto-dispatch-table.md`).
+Derive `halt_at` and `gap_fill_actions` from the resolved scope per the Auto-Dispatch Table Module (`enforcement/auto-dispatch-table.md`).
 
 Record the parsed result as an evidence artifact — no human input is solicited.
 
 ## Evidence Artifact
 
-The parsed authorization text, matched regex pattern (or default fallback), and resulting `(authorization_scope, scope_source, halt_at, pr_strategy, gap_fill_actions)` tuple MUST be recorded in the verification report without soliciting human input.
+The parsed authorization text, matched regex pattern (or default fallback), and resulting `(authorization_scope, scope_source, halt_at, gap_fill_actions)` tuple MUST be recorded in the verification report without soliciting human input.
 
 ## Work State I/O
 

--- a/skills/brainstorming/SKILL.md
+++ b/skills/brainstorming/SKILL.md
@@ -111,7 +111,6 @@ Every `task()` call MUST include only:
 - `github.repo`
 - `authorization_scope`
 - `halt_at`
-- `pr_strategy`
 - `pipeline_phase`
 
 Plus skill-specific fields per the `## Sub-Agent Routing` section above.

--- a/skills/changelog-generator/SKILL.md
+++ b/skills/changelog-generator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: changelog-generator
-description: "Use when creating release notes, documenting changes between versions, or preparing a changelog. Also use when comparing diffs between releases or generating structured version history. Invoke for: release note creation, changelog generation, version diff analysis, release documentation. Changelog generation is REQUIRED before every release — not optional. Trigger phrases: create changelog, generate release notes, document changes, version history, release diff."
+description: "Use when creating release notes, documenting changes between versions, or preparing a changelog. Also use when comparing diffs between releases or generating structured version history. Invoke for: release note creation, changelog generation, version diff analysis, release documentation. Changelog generation is REQUIRED before every release — not optional. Trigger phrases: create changelog, generate release notes, document changes, version history, release diff, release PR, release notes."
 license: MIT
 compatibility: opencode
 ---
@@ -31,6 +31,7 @@ This skill operates in the main repo directory (direct-branch mode). When `WORKT
 | User says / Context | Task | Dispatch | Context passed |
 |---------------------|------|----------|----------------|
 | "changelog" / "since last release" | `since-last-release` | `sub-task` | {date_range} |
+| "release PR" / "release notes" | `since-last-release` | `sub-task` | {date_range} |
 | "changelog date range" / "changes between dates" | `date-range` | `sub-task` | {from_date, to_date} |
 | "backfill changelog" | `backfill` | `sub-task` | {date_range} |
 | completion / workflow end | `completion` | `sub-task` | {workflow_state} |
@@ -86,7 +87,6 @@ Every `task()` call MUST include only:
 - `github.repo`
 - `authorization_scope`
 - `halt_at`
-- `pr_strategy`
 - `pipeline_phase`
 
 Plus skill-specific fields per the `## Sub-Agent Routing` section above.

--- a/skills/completeness-gate/SKILL.md
+++ b/skills/completeness-gate/SKILL.md
@@ -67,7 +67,6 @@ Every `task()` call MUST include only:
 - `github.repo`
 - `authorization_scope`
 - `halt_at`
-- `pr_strategy`
 - `pipeline_phase`
 
 Plus skill-specific fields per the `## Sub-Agent Routing` section above.

--- a/skills/completeness-gate/tasks/check.md
+++ b/skills/completeness-gate/tasks/check.md
@@ -14,7 +14,6 @@ Completeness check after RED/GREEN sub-agent returns. Verifies the deliverable a
 ```
 authorization_scope: <for_analysis|for_spec|for_plan|for_implementation|for_review_prep|for_pr|for_pr_only|for_review_only>
 halt_at: <analysis_complete|spec_created|plan_created|verification_complete|review_prep|pr_created>
-pr_strategy: <none|stacked>
 pipeline_phase: <current_phase_name>
 authorization_source: "User approved #N on YYYY-MM-DD"
 spec_local_dir: <path> | [<path>, ...]     # REQUIRED — local issue directories

--- a/skills/completion-core/SKILL.md
+++ b/skills/completion-core/SKILL.md
@@ -152,7 +152,6 @@ Every `task()` call MUST include only:
 - `github.repo`
 - `authorization_scope`
 - `halt_at`
-- `pr_strategy`
 - `pipeline_phase`
 
 Plus skill-specific fields per the `## Sub-Agent Routing` section above.

--- a/skills/completion-core/tasks/completion.md
+++ b/skills/completion-core/tasks/completion.md
@@ -22,7 +22,6 @@ if [ -z "$DEFAULT_BRANCH" ]; then DEFAULT_BRANCH="main"; fi
 ```
 authorization_scope: <for_analysis|for_spec|for_plan|for_implementation|for_review_prep|for_pr|for_pr_only|for_review_only>
 halt_at: <analysis_complete|spec_created|plan_created|verification_complete|review_prep|pr_created>
-pr_strategy: <none|stacked>
 pipeline_phase: <current_phase_name>
 ```
 

--- a/skills/conflict-resolution/SKILL.md
+++ b/skills/conflict-resolution/SKILL.md
@@ -54,13 +54,12 @@ Automatic from `git-workflow` when conflicts detected. Manual invocation:
 
 ## Sub-Agent Routing
 
-Sub-agents run via `task(subagent_type="general")` with `{ conflict_files, branch_context, worktree.path, github.owner, github.repo, authorization_scope, halt_at, pr_strategy, pipeline_phase }`. Exclusions: implementation context, agent memory. `pre-analysis` receives only `{ issue_number, task_description, audit_phase, pipeline_phase, authorization_scope, halt_at, pr_strategy, github.owner, github.repo }`. No inline work.
+Sub-agents run via `task(subagent_type="general")` with `{ conflict_files, branch_context, worktree.path, github.owner, github.repo, authorization_scope, halt_at, pipeline_phase }`. Exclusions: implementation context, agent memory. `pre-analysis` receives only `{ issue_number, task_description, audit_phase, pipeline_phase, authorization_scope, halt_at, github.owner, github.repo }`. No inline work.
 
 ### Authorization Context
 ```
 authorization_scope: <for_analysis|for_spec|for_plan|for_implementation|for_review_prep|for_pr|for_pr_only|for_review_only>
 halt_at: <analysis_complete|spec_created|plan_created|verification_complete|review_prep|pr_created>
-pr_strategy: <none|stacked>
 pipeline_phase: <current_phase_name>
 authorization_source: "User approved #N on YYYY-MM-DD"
 ```
@@ -95,7 +94,6 @@ Every `task()` call MUST include only:
 - `github.repo`
 - `authorization_scope`
 - `halt_at`
-- `pr_strategy`
 - `pipeline_phase`
 
 Plus skill-specific fields per the `## Sub-Agent Routing` section above.

--- a/skills/correspondence/SKILL.md
+++ b/skills/correspondence/SKILL.md
@@ -93,7 +93,6 @@ Every `task()` call MUST include only:
 - `github.repo`
 - `authorization_scope`
 - `halt_at`
-- `pr_strategy`
 - `pipeline_phase`
 
 Plus skill-specific fields per the `## Sub-Agent Routing` section above.

--- a/skills/engineering-approach/SKILL.md
+++ b/skills/engineering-approach/SKILL.md
@@ -96,7 +96,6 @@ Every `task()` call MUST include only:
 - `github.repo`
 - `authorization_scope`
 - `halt_at`
-- `pr_strategy`
 - `pipeline_phase`
 
 Plus skill-specific fields per the `## Sub-Agent Routing` section above.

--- a/skills/executing-plans/SKILL.md
+++ b/skills/executing-plans/SKILL.md
@@ -62,17 +62,16 @@ This skill operates in the main repo directory (direct-branch mode). When `WORKT
 
 ## Received Context
 
-From approval-gate: `{ plan_issue, spec_issue, authorization_scope, halt_at, pr_strategy, worktree.path, phase_progress, github.owner, github.repo }`.
+From approval-gate: `{ plan_issue, spec_issue, authorization_scope, halt_at, worktree.path, phase_progress, github.owner, github.repo }`.
 
 ## Sub-Agent Routing
 
-Sub-agents run via `task(subagent_type="general")`. `execute` receives plan context + session vars. Auditor tasks use subagent_type from resolve-models result contract (auditor_1/auditor_2) — NOT `general`. Include audit_phase in task context when routing auditors. See audit SKILL.md §DISPATCH_GATE. Exclusions: implementation context, agent memory. `pre-analysis` receives only `{ issue_number, task_description, pipeline_phase, authorization_scope, halt_at, pr_strategy, github.owner, github.repo }`. No inline work.
+Sub-agents run via `task(subagent_type="general")`. `execute` receives plan context + session vars. Auditor tasks use subagent_type from resolve-models result contract (auditor_1/auditor_2) — NOT `general`. Include audit_phase in task context when routing auditors. See audit SKILL.md §DISPATCH_GATE. Exclusions: implementation context, agent memory. `pre-analysis` receives only `{ issue_number, task_description, pipeline_phase, authorization_scope, halt_at, github.owner, github.repo }`. No inline work.
 
 ### Authorization Context
 ```
 authorization_scope: <for_analysis|for_spec|for_plan|for_implementation|for_review_prep|for_pr|for_pr_only|for_review_only>
 halt_at: <analysis_complete|spec_created|plan_created|verification_complete|review_prep|pr_created>
-pr_strategy: <none|stacked>
 pipeline_phase: <current_phase_name>
 authorization_source: "User approved #N on YYYY-MM-DD"
 ```
@@ -107,7 +106,6 @@ Every `task()` call MUST include only:
 - `github.repo`
 - `authorization_scope`
 - `halt_at`
-- `pr_strategy`
 - `pipeline_phase`
 
 Plus skill-specific fields per the `## Sub-Agent Routing` section above.

--- a/skills/executing-plans/tasks/start.md
+++ b/skills/executing-plans/tasks/start.md
@@ -41,13 +41,12 @@ This makes the implementation phase resilient to branch switching, worktree recr
 `skill({name: "implementation-pipeline"})` then dispatch per the SKILL.md Trigger Dispatch Table
 ```
 
-When task()ing, pass `authorization_scope`, `halt_at`, `pr_strategy`, and `pipeline_phase` alongside `plan_issue`, `spec_issue`, `<github.owner>`, `<github.repo>`, and `<worktree.path>`. The implementation-pipeline uses these fields for scope-aware task() boundary enforcement per the SKILL.md Trigger Dispatch Table.
+When task()ing, pass `authorization_scope`, `halt_at`, and `pipeline_phase` alongside `plan_issue`, `spec_issue`, `<github.owner>`, `<github.repo>`, and `<worktree.path>`. The implementation-pipeline uses these fields for scope-aware task() boundary enforcement per the SKILL.md Trigger Dispatch Table.
 
 **Authorization context:**
 ```
 authorization_scope: <for_analysis|for_spec|for_plan|for_implementation|for_review_prep|for_pr|for_pr_only|for_review_only>
 halt_at: <analysis_complete|spec_created|plan_created|verification_complete|review_prep|pr_created>
-pr_strategy: <none|stacked>
 pipeline_phase: <current_phase_name>
 authorization_source: "User approved #N on YYYY-MM-DD"
 ```

--- a/skills/finishing-a-development-branch/SKILL.md
+++ b/skills/finishing-a-development-branch/SKILL.md
@@ -98,7 +98,6 @@ Every `task()` call MUST include only:
 - `github.repo`
 - `authorization_scope`
 - `halt_at`
-- `pr_strategy`
 - `pipeline_phase`
 
 Plus skill-specific fields per the `## Sub-Agent Routing` section above.

--- a/skills/git-workflow/SKILL.md
+++ b/skills/git-workflow/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: git-workflow
-description: "Use when creating a branch, committing, pushing, or creating a PR. Also use when handling rebase/merge conflicts (invoke conflict-resolution), checking PR state and cleanup, or running provenance tracking. Invoke for: branch creation, commit, push, PR creation, rebase, merge, conflict resolution dispatch, PR state verification, cleanup, provenance tracking, submodule sync. Branch-and-PR discipline is REQUIRED — always follow the workflow. Trigger phrases: create branch, commit, push, create PR, rebase, merge, check pr, check prs, check merged prs, pr merged, provenance, sync submodules."
+description: "Use when creating a branch, committing, pushing, or creating a PR. Also use when handling rebase/merge conflicts (invoke conflict-resolution), checking PR state and cleanup, or running provenance tracking. Invoke for: branch creation, commit, push, PR creation, rebase, merge, conflict resolution dispatch, PR state verification, cleanup, provenance tracking, submodule sync. Branch-and-PR discipline is REQUIRED — always follow the workflow. Trigger phrases: create branch, commit, push, create PR, rebase, merge, check pr, check prs, check merged prs, pr merged, provenance, sync submodules, release PR."
 license: MIT
 compatibility: opencode
 ---
@@ -35,6 +35,8 @@ This skill operates in the main repo directory (direct-branch mode). When `WORKT
 | "check pr" / "check prs" / "check merged prs" / "pr merged" | `check-pr` | `sub-task` | {branch_name} |
 | "provenance" / "provenance check" | `provenance` | `sub-task` | {submodule_path} |
 | "sync submodules" / "update submodules" | `submodule-sync` | `sub-task` | {submodule_paths} |
+| "release" / "release/v" | `pre-work` | `sub-task` | {branch_name: release/v{semver}} |
+| "release PR" / "is_release" | `pr-creation` | `sub-task` | {branch_name, spec_summary, is_release: true} |
 | "pre-commit-pointer-check" / "check submodule pointers" | `pre-commit-pointer-check` | `sub-task` | {branch_name} |
 | completion / workflow end | `completion` | `sub-task` | {workflow_state} |
 
@@ -98,8 +100,9 @@ Git Workflow Enforcer. Focus: trunk-based development workflow, block AI on prot
 - [ ] 6. **Submodule repos:** git ops from inside submodule dir. No `--recursive`.
 - [ ] 7. **Pair mode:** `pair-*` branches use WIP-commit switching, not worktrees.
 - [ ] 8. **Adversarial-audit call:** after issue closure, before branch cleanup, call `audit --task closure-verification --pr <N>` with `audit_phase: post_merge`.
-- [ ] 9. **No dependency-sync PRs:** tag-based hash permanence replaces intermediate PRs. Submodule SHAs are preserved via parent-repo-prefixed tags. See AGENTS.md §Tag Layers.
-- [ ] 10. **Correctness over speed.** Every code path with runtime behavior requires live-wire testing against real systems. A slow correct answer is strictly better than a fast incorrect one. Static analysis alone is NOT acceptable verification — behavioral compliance requires actual execution with cross-validated PASS verdict.
+- [ ] 9. **Release branches:** use `release/v{semver}` naming convention. Release PRs use `compare/main...<target>` compare URL.
+- [ ] 10. **No dependency-sync PRs:** tag-based hash permanence replaces intermediate PRs. Submodule SHAs are preserved via parent-repo-prefixed tags. See AGENTS.md §Tag Layers.
+- [ ] 11. **Correctness over speed.** Every code path with runtime behavior requires live-wire testing against real systems. A slow correct answer is strictly better than a fast incorrect one. Static analysis alone is NOT acceptable verification — behavioral compliance requires actual execution with cross-validated PASS verdict.
 
 ### Tag Convention (Canonical)
 
@@ -165,7 +168,6 @@ Every `task()` call MUST include only:
 - `github.repo`
 - `authorization_scope`
 - `halt_at`
-- `pr_strategy`
 - `pipeline_phase`
 
 Plus skill-specific fields per the `## Sub-Agent Routing` section above.

--- a/skills/git-workflow/enforcement/halt-conditions.md
+++ b/skills/git-workflow/enforcement/halt-conditions.md
@@ -40,7 +40,6 @@ If the agent detects it is on a `feature/` or `spec/` branch without `for_implem
 ```
 authorization_scope: <for_analysis|for_spec|for_plan|for_implementation|for_review_prep|for_pr|for_pr_only|for_review_only>
 halt_at: <analysis_complete|spec_created|plan_created|verification_complete|review_prep|pr_created>
-pr_strategy: <none|stacked>
 pipeline_phase: <current_phase_name>
 authorization_source: "User approved #N on YYYY-MM-DD"
 ```

--- a/skills/git-workflow/tasks/cleanup.md
+++ b/skills/git-workflow/tasks/cleanup.md
@@ -90,6 +90,15 @@ Before any cleanup operations, detect and build routing context for submodules u
 
 Verifies PR merge via GitHub API, runs SC-verification gate, phase-completion gate, and rebase pending PRs.
 
+
+### Step 1.5: Post-Merge Release Detection
+
+If the merged PR was a release PR (detected via branch name pattern `release/` or PR label), dispatch release-promoter tasks:
+
+- [ ] 1. Check if merged branch name starts with `release/` or PR has a `release` label
+- [ ] 2. If release PR detected: dispatch `release-promoter --task tag` then `release-promoter --task create-release`
+- [ ] 3. If not a release PR: proceed normally (no release promotion)
+
 ### Step 2: Hierarchical Issue Closure
 
 **Route to:** `cleanup/issue-closure`

--- a/skills/git-workflow/tasks/cleanup/branch-cleanup.md
+++ b/skills/git-workflow/tasks/cleanup/branch-cleanup.md
@@ -49,7 +49,7 @@ blocked_reason: "Spec issue #N not closed after PR merge"  # if BLOCKED
 
 | Element | Value |
 |---------|-------|
-| `must_receive` | `github.owner`, `github.repo`, PR number, `audit_phase: post_merge`, `spec_local_dir`, `authorization_scope`, `halt_at`, `pr_strategy`, `pipeline_phase` |
+| `must_receive` | `github.owner`, `github.repo`, PR number, `audit_phase: post_merge`, `spec_local_dir`, `authorization_scope`, `halt_at`, `pipeline_phase` |
 | `must_not_receive` | Orchestrator reasoning, expected verdicts, pre-determined findings, cached git state, inline file paths to task files |
 
 **🚫 CRITICAL: If closure-verification returns BLOCKED (issue not closed or SCs unverified), do NOT proceed to branch deletion. HALT and report findings for remediation.**

--- a/skills/git-workflow/tasks/pr-creation.md
+++ b/skills/git-workflow/tasks/pr-creation.md
@@ -23,6 +23,7 @@ if [ -z "$DEFAULT_BRANCH" ]; then DEFAULT_BRANCH="main"; fi
 - User says "create a PR", "make a PR", "push and create PR", or similar
 - Implementation is complete
 - Developer has reviewed changes via compare URL
+- Pre-Response Gate evaluation completed (skill deck evaluated against current context)
 
 ## Exit Criteria
 

--- a/skills/git-workflow/tasks/pr-creation/squash-push.md
+++ b/skills/git-workflow/tasks/pr-creation/squash-push.md
@@ -18,6 +18,17 @@ Squash implementation commits or verify existing commit structure for all branch
 
 ## Procedure
 
+### Step 1: Pre-Response Gate — Skill Deck Evaluation (MANDATORY)
+
+Before proceeding to changelog generation, evaluate ALL available skills against the current context per `.opencode/AGENTS.md` §Universal Skill Dispatch Gate.
+
+1. Read the `<available_skills>` list from the system prompt
+2. Evaluate each skill's description and trigger phrases against the current context (release PR creation)
+3. If one or more skills match: call `skill({name: "..."})` before proceeding
+4. If no skill applies directly: provide a one-sentence justification in chat
+
+**Release PR context:** When `{is_release: true}` or the context is a release PR, the agent MUST dispatch at minimum `changelog-generator` and `git-workflow` before proceeding. "No skill applies directly" is NOT a valid justification for release PR contexts.
+
 ### Step 2: Changelog Generation (MANDATORY)
 
 Check for `[skip changelog]` in last commit message or PR title. If present, skip.

--- a/skills/git-workflow/tasks/pre-work.md
+++ b/skills/git-workflow/tasks/pre-work.md
@@ -420,7 +420,6 @@ If the agent attempts to create a `feature/` or `spec/` branch under `for_analys
 ```
 authorization_scope: <for_analysis|for_spec|for_plan|for_implementation|for_review_prep|for_pr|for_pr_only|for_review_only>
 halt_at: <analysis_complete|spec_created|plan_created|verification_complete|review_prep|pr_created>
-pr_strategy: <none|stacked>
 pipeline_phase: <current_phase_name>
 authorization_source: "User approved #N on YYYY-MM-DD"
 ```

--- a/skills/implementation-pipeline/SKILL.md
+++ b/skills/implementation-pipeline/SKILL.md
@@ -37,7 +37,7 @@ This skill operates in the main repo directory (direct-branch mode). When `WORKT
 
 | User says / Context | Task | Dispatches To | Dispatch | Context passed |
 |---------------------|------|---------------|----------|----------------|
-| "execute plan" / "implement spec" / "run pipeline" / "assemble work" | `assemble-work` | Orchestrator entry — reads plan, creates branches, dispatches sub-agents | `orchestrator` | {issue_number, plan_path, authorization_scope, halt_at, pr_strategy} |
+| "execute plan" / "implement spec" / "run pipeline" / "assemble work" | `assemble-work` | Orchestrator entry — reads plan, creates branches, dispatches sub-agents | `orchestrator` | {issue_number, plan_path, authorization_scope, halt_at} |
 | "sc-coherence-gate" / "coherence gate" | `sc-coherence-gate` | `audit --task coherence-extraction` | `sub-task` | {issue_number} |
 | "pre-red-baseline" / "baseline check" | `pre-red-baseline` | `implementation-pipeline --task pre-red-baseline` | `sub-task` | {issue_number} |
 | "red-phase" / "write failing test" | `red-phase` | `test-driven-development --task red` | `sub-task` | {issue_number} |
@@ -124,7 +124,6 @@ Every task context MUST include the authorization context block:
 ```yaml
 authorization_scope: <for_analysis|for_spec|for_plan|for_implementation|for_review_prep|for_pr|for_pr_only|for_review_only>
 halt_at: <analysis_complete|spec_created|plan_created|verification_complete|review_prep|pr_created>
-pr_strategy: <none|stacked>
 pipeline_phase: <current_phase_name>
 authorization_source: "User approved #N on YYYY-MM-DD"
 ```
@@ -178,7 +177,6 @@ Every `task()` call MUST include only:
 - `github.repo`
 - `authorization_scope`
 - `halt_at`
-- `pr_strategy`
 - `pipeline_phase`
 
 Plus skill-specific fields per the `## Sub-Agent Routing` section above.

--- a/skills/implementation-pipeline/enforcement/context-passing.md
+++ b/skills/implementation-pipeline/enforcement/context-passing.md
@@ -22,7 +22,6 @@ Reference document for yield-back context patterns between subtasks in the imple
 ```yaml
 authorization_scope: <for_analysis|for_spec|for_plan|for_implementation|for_review_prep|for_pr|for_pr_only|for_review_only>
 halt_at: <analysis_complete|spec_created|plan_created|verification_complete|review_prep|pr_created>
-pr_strategy: <none|stacked>
 pipeline_phase: <current_phase_name>
 authorization_source: "User approved #N on YYYY-MM-DD"
 issue_number: int

--- a/skills/issue-operations/SKILL.md
+++ b/skills/issue-operations/SKILL.md
@@ -159,7 +159,6 @@ Every `task()` call MUST include only:
 - `github.repo`
 - `authorization_scope`
 - `halt_at`
-- `pr_strategy`
 - `pipeline_phase`
 
 Plus skill-specific fields per the `## Sub-Agent Routing` section above.

--- a/skills/issue-operations/tasks/body-edit.md
+++ b/skills/issue-operations/tasks/body-edit.md
@@ -192,7 +192,6 @@ gb issue edit <issue-number> -R <github.owner>/<github.repo> --body "<remote_md_
 ```
 authorization_scope: <for_analysis|for_spec|for_plan|for_implementation|for_review_prep|for_pr|for_pr_only|for_review_only>
 halt_at: <analysis_complete|spec_created|plan_created|verification_complete|review_prep|pr_created>
-pr_strategy: <none|stacked>
 pipeline_phase: <current_phase_name>
 authorization_source: "User approved #N on YYYY-MM-DD"
 ```

--- a/skills/issue-operations/tasks/comment.md
+++ b/skills/issue-operations/tasks/comment.md
@@ -212,7 +212,6 @@ Route to `platforms/local/tasks/comment.md` via task(). Pass: `{issue_number: N,
 ```
 authorization_scope: <for_analysis|for_spec|for_plan|for_implementation|for_review_prep|for_pr|for_pr_only|for_review_only>
 halt_at: <analysis_complete|spec_created|plan_created|verification_complete|review_prep|pr_created>
-pr_strategy: <none|stacked>
 pipeline_phase: <current_phase_name>
 authorization_source: "User approved #N on YYYY-MM-DD"
 ```

--- a/skills/issue-operations/tasks/completion.md
+++ b/skills/issue-operations/tasks/completion.md
@@ -5,7 +5,6 @@
 ```
 authorization_scope: <for_analysis|for_spec|for_plan|for_implementation|for_review_prep|for_pr|for_pr_only|for_review_only>
 halt_at: <analysis_complete|spec_created|plan_created|verification_complete|review_prep|pr_created>
-pr_strategy: <none|stacked>
 pipeline_phase: <current_phase_name>
 authorization_source: "User approved #N on YYYY-MM-DD"
 ```

--- a/skills/issue-operations/tasks/creation.md
+++ b/skills/issue-operations/tasks/creation.md
@@ -323,7 +323,6 @@ The body must contain the following 6 sections in order:
 ```
 authorization_scope: <for_analysis|for_spec|for_plan|for_implementation|for_review_prep|for_pr|for_pr_only|for_review_only>
 halt_at: <analysis_complete|spec_created|plan_created|verification_complete|review_prep|pr_created>
-pr_strategy: <none|stacked>
 pipeline_phase: <current_phase_name>
 authorization_source: "User approved #N on YYYY-MM-DD"
 ```

--- a/skills/issue-operations/tasks/list-issues.md
+++ b/skills/issue-operations/tasks/list-issues.md
@@ -69,7 +69,6 @@ Return the issue list to the calling task. Used for:
 ```
 authorization_scope: <for_analysis|for_spec|for_plan|for_implementation|for_review_prep|for_pr|for_pr_only|for_review_only>
 halt_at: <analysis_complete|spec_created|plan_created|verification_complete|review_prep|pr_created>
-pr_strategy: <none|stacked>
 pipeline_phase: <current_phase_name>
 authorization_source: "User approved #N on YYYY-MM-DD"
 ```

--- a/skills/issue-operations/tasks/read-comments.md
+++ b/skills/issue-operations/tasks/read-comments.md
@@ -68,7 +68,6 @@ This task exists because `067-context-completeness.md` mandates reading ALL comm
 ```
 authorization_scope: <for_analysis|for_spec|for_plan|for_implementation|for_review_prep|for_pr|for_pr_only|for_review_only>
 halt_at: <analysis_complete|spec_created|plan_created|verification_complete|review_prep|pr_created>
-pr_strategy: <none|stacked>
 pipeline_phase: <current_phase_name>
 authorization_source: "User approved #N on YYYY-MM-DD"
 ```

--- a/skills/issue-operations/tasks/read-issue.md
+++ b/skills/issue-operations/tasks/read-issue.md
@@ -63,7 +63,6 @@ Return the issue data to the calling task. Do NOT interpret or modify the data â
 ```
 authorization_scope: <for_analysis|for_spec|for_plan|for_implementation|for_review_prep|for_pr|for_pr_only|for_review_only>
 halt_at: <analysis_complete|spec_created|plan_created|verification_complete|review_prep|pr_created>
-pr_strategy: <none|stacked>
 pipeline_phase: <current_phase_name>
 authorization_source: "User approved #N on YYYY-MM-DD"
 ```

--- a/skills/issue-operations/tasks/read-labels.md
+++ b/skills/issue-operations/tasks/read-labels.md
@@ -63,7 +63,6 @@ Return label data to the calling task. Labels are used for authorization scope v
 ```
 authorization_scope: <for_analysis|for_spec|for_plan|for_implementation|for_review_prep|for_pr|for_pr_only|for_review_only>
 halt_at: <analysis_complete|spec_created|plan_created|verification_complete|review_prep|pr_created>
-pr_strategy: <none|stacked>
 pipeline_phase: <current_phase_name>
 authorization_source: "User approved #N on YYYY-MM-DD"
 ```

--- a/skills/issue-operations/tasks/read-sub-issues.md
+++ b/skills/issue-operations/tasks/read-sub-issues.md
@@ -68,7 +68,6 @@ Return sub-issue data to the calling task. Used for:
 ```
 authorization_scope: <for_analysis|for_spec|for_plan|for_implementation|for_review_prep|for_pr|for_pr_only|for_review_only>
 halt_at: <analysis_complete|spec_created|plan_created|verification_complete|review_prep|pr_created>
-pr_strategy: <none|stacked>
 pipeline_phase: <current_phase_name>
 authorization_source: "User approved #N on YYYY-MM-DD"
 ```

--- a/skills/issue-operations/tasks/search-issues.md
+++ b/skills/issue-operations/tasks/search-issues.md
@@ -66,7 +66,6 @@ Return search results to the calling task. Used for:
 ```
 authorization_scope: <for_analysis|for_spec|for_plan|for_implementation|for_review_prep|for_pr|for_pr_only|for_review_only>
 halt_at: <analysis_complete|spec_created|plan_created|verification_complete|review_prep|pr_created>
-pr_strategy: <none|stacked>
 pipeline_phase: <current_phase_name>
 authorization_source: "User approved #N on YYYY-MM-DD"
 ```

--- a/skills/issue-operations/tasks/update-issue.md
+++ b/skills/issue-operations/tasks/update-issue.md
@@ -81,7 +81,6 @@ Return the update confirmation to the calling task.
 ```
 authorization_scope: <for_analysis|for_spec|for_plan|for_implementation|for_review_prep|for_pr|for_pr_only|for_review_only>
 halt_at: <analysis_complete|spec_created|plan_created|verification_complete|review_prep|pr_created>
-pr_strategy: <none|stacked>
 pipeline_phase: <current_phase_name>
 authorization_source: "User approved #N on YYYY-MM-DD"
 ```

--- a/skills/issue-review/SKILL.md
+++ b/skills/issue-review/SKILL.md
@@ -102,7 +102,6 @@ Every `task()` call MUST include only:
 - `github.repo`
 - `authorization_scope`
 - `halt_at`
-- `pr_strategy`
 - `pipeline_phase`
 
 Plus skill-specific fields per the `## Sub-Agent Routing` section above.

--- a/skills/mcp-tool-usage/SKILL.md
+++ b/skills/mcp-tool-usage/SKILL.md
@@ -73,7 +73,6 @@ Every `task()` call MUST include only:
 - `github.repo`
 - `authorization_scope`
 - `halt_at`
-- `pr_strategy`
 - `pipeline_phase`
 
 Plus skill-specific fields per the `## Sub-Agent Routing` section above.

--- a/skills/multimodal-dispatch/SKILL.md
+++ b/skills/multimodal-dispatch/SKILL.md
@@ -87,7 +87,6 @@ Every `task()` call MUST include only:
 - `github.repo`
 - `authorization_scope`
 - `halt_at`
-- `pr_strategy`
 - `pipeline_phase`
 
 Plus skill-specific fields per the `## Sub-Agent Routing` section above.

--- a/skills/plan-creation-pipeline/SKILL.md
+++ b/skills/plan-creation-pipeline/SKILL.md
@@ -67,7 +67,6 @@ Every task context MUST include the authorization context block:
 ```yaml
 authorization_scope: <for_analysis|for_spec|for_plan|for_implementation|for_review_prep|for_pr|for_pr_only|for_review_only>
 halt_at: <analysis_complete|spec_created|plan_created|verification_complete|review_prep|pr_created>
-pr_strategy: <none|stacked>
 pipeline_phase: <current_phase_name>
 authorization_source: "User approved #N on YYYY-MM-DD"
 ```
@@ -110,7 +109,6 @@ Every `task()` call MUST include only:
 - `github.repo`
 - `authorization_scope`
 - `halt_at`
-- `pr_strategy`
 - `pipeline_phase`
 
 Plus skill-specific fields per the `## Sub-Agent Routing` section above.

--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -75,7 +75,6 @@ Every `task()` call MUST include only:
 - `github.repo`
 - `authorization_scope`
 - `halt_at`
-- `pr_strategy`
 - `pipeline_phase`
 
 Plus skill-specific fields per the task context above.

--- a/skills/pr-creation-workflow/SKILL.md
+++ b/skills/pr-creation-workflow/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pr-creation-workflow
-description: "Use when asking about when to create a PR or whether PR creation is authorized. Also use when verifying PR authorization scope, preparing PR body, or determining PR strategy. Invoke for: PR authorization check, PR readiness verification, PR body preparation, PR strategy determination, PR creation decision. Every PR MUST be an authorized, intentional delivery. Trigger phrases: create PR, PR authorized, ready for PR, PR strategy, when to create PR."
+description: "Use when asking about when to create a PR or whether PR creation is authorized. Also use when verifying PR authorization scope, preparing PR body, or determining PR strategy. Invoke for: PR authorization check, PR readiness verification, PR body preparation, PR strategy determination, PR creation decision. Every PR MUST be an authorized, intentional delivery. Trigger phrases: create PR, PR authorized, ready for PR, PR strategy, when to create PR, release PR, release."
 license: MIT
 compatibility: opencode
 ---
@@ -33,6 +33,7 @@ This skill operates in the main repo directory (direct-branch mode). When `WORKT
 | User says / Context | Task | Dispatch | Context passed |
 |---------------------|------|----------|----------------|
 | "pre-pr-checklist" / "PR checklist" | `pre-pr-checklist` | `sub-task` | {branch_name} |
+| "release PR" / "release" | `pre-pr-checklist` | `sub-task` | {branch_name, is_release: true} |
 | "sub-issue-collection" / "collect sub-issues" | `sub-issue-collection` | `sub-task` | {issue_number} |
 | completion / workflow end | `completion` | `sub-task` | {workflow_state} |
 
@@ -66,16 +67,16 @@ This skill operates in the main repo directory (direct-branch mode). When `WORKT
 - [ ] 7. **Work branch guard:** no individual PRs during work execution (single stacked PR).
 - [ ] 8. **Submodule-bump-only PR block (MANDATORY — parent repo context):** Before creating any PR, check whether the diff contains changes outside `.opencode/`. In a parent repo with `.gitmodules`, a PR that only changes `.opencode/` (submodule pointer bump) is BLOCKED by enforcement gate `pr-workflow-003`. The agent MUST NOT create, propose, or assist in creating a submodule-bump-only PR. This is a CRITICAL GUIDELINE VIOLATION — bypassing this gate results in a HALT.
 - [ ] 9. **Correctness over speed.** Every code path with runtime behavior requires live-wire testing against real systems. A slow correct answer is strictly better than a fast incorrect one. Static analysis alone is NOT acceptable verification — behavioral compliance requires actual execution with cross-validated PASS verdict.
+- [ ] 10. **Release PR body format:** version summary line + changelog entries + compare link.
 
 ## Sub-Agent Routing
 
-Sub-agents run via `task(subagent_type="general")` with `{ branch_name, worktree.path, github.owner, github.repo, authorization_scope, halt_at, pr_strategy, pipeline_phase }`. Auditor tasks use subagent_type from resolve-models result contract (auditor_1/auditor_2) — NOT `general`. Include audit_phase in task context when routing auditors. See audit SKILL.md §DISPATCH_GATE. Exclusions: implementation context, agent memory. `pre-analysis` receives only `{ issue_number, task_description, pipeline_phase, authorization_scope, halt_at, pr_strategy, github.owner, github.repo }`. No inline work.
+Sub-agents run via `task(subagent_type="general")` with `{ branch_name, worktree.path, github.owner, github.repo, authorization_scope, halt_at, pipeline_phase }`. Auditor tasks use subagent_type from resolve-models result contract (auditor_1/auditor_2) — NOT `general`. Include audit_phase in task context when routing auditors. See audit SKILL.md §DISPATCH_GATE. Exclusions: implementation context, agent memory. `pre-analysis` receives only `{ issue_number, task_description, pipeline_phase, authorization_scope, halt_at, github.owner, github.repo }`. No inline work.
 
 ### Authorization Context
 ```
 authorization_scope: <for_analysis|for_spec|for_plan|for_implementation|for_review_prep|for_pr|for_pr_only|for_review_only>
 halt_at: <analysis_complete|spec_created|plan_created|verification_complete|review_prep|pr_created>
-pr_strategy: <none|stacked>
 pipeline_phase: <current_phase_name>
 authorization_source: "User approved #N on YYYY-MM-DD"
 ```
@@ -110,7 +111,6 @@ Every `task()` call MUST include only:
 - `github.repo`
 - `authorization_scope`
 - `halt_at`
-- `pr_strategy`
 - `pipeline_phase`
 
 Plus skill-specific fields per the `## Sub-Agent Routing` section above.

--- a/skills/pr-creation-workflow/tasks/pre-pr-checklist.md
+++ b/skills/pr-creation-workflow/tasks/pre-pr-checklist.md
@@ -34,7 +34,7 @@ if [ -z "$DEFAULT_BRANCH" ]; then DEFAULT_BRANCH="main"; fi
 ls {project_root}/tmp/{issue-N}/work.md 2>/dev/null
 
 # Read scope fields from work state file if present
-# authorization_scope, halt_at, pr_strategy
+# authorization_scope, halt_at
 
 # Check commit count between dev and HEAD
 git log origin/"$DEFAULT_BRANCH"..HEAD --oneline
@@ -52,13 +52,12 @@ git log origin/"$DEFAULT_BRANCH"..HEAD --oneline | wc -l
 
 **If commit count mismatch → SQUASH NOW (single-issue) or VERIFY NOW (work branch).** This is a CRITICAL GUIDELINE VIOLATION per `000-critical-rules.md` §Un-Squashed PR — creating a PR with incorrect commit count is forbidden.
 
-**Scope check:** If `pr_strategy == none` or `halt_at < pr_created`, HALT — PR creation is not authorized by the current scope. The scope boundary is a hard wall.
+**Scope check:** If `halt_at < pr_created`, HALT — PR creation is not authorized by the current scope. The scope boundary is a hard wall.
 
 **Authorization context:**
 ```
 authorization_scope: <for_analysis|for_spec|for_plan|for_implementation|for_review_prep|for_pr|for_pr_only|for_review_only>
 halt_at: <analysis_complete|spec_created|plan_created|verification_complete|review_prep|pr_created>
-pr_strategy: <none|stacked>
 pipeline_phase: <current_phase_name>
 authorization_source: "User approved #N on YYYY-MM-DD"
 ```

--- a/skills/pre-analysis/SKILL.md
+++ b/skills/pre-analysis/SKILL.md
@@ -46,7 +46,7 @@ You are a Pre-Analysis Gatekeeper. Your focus is independently discovering scope
 
 | Sub-Agent Task | Trigger Condition | Scope of Context | Exclusions | Inline Work? |
 |---|---|---|---|---|
-| `analyze` | Before any sub-agent routing | Issue number, task description, audit_phase, pipeline_phase, authorization_scope, halt_at, pr_strategy, github.owner, github.repo | File paths, line numbers, expected outcomes, orchestrator reasoning | NO |
+| `analyze` | Before any sub-agent routing | Issue number, task description, audit_phase, pipeline_phase, authorization_scope, halt_at, github.owner, github.repo | File paths, line numbers, expected outcomes, orchestrator reasoning | NO |
 | `completion` | When workflow halts at any point | Workflow state, authorization_scope, halt_at | Implementation context, agent memory | NO |
 
 ### DISPATCH_GATE — Orchestrator task() Prompt Protocol
@@ -75,7 +75,6 @@ Every `task()` call MUST include only:
 - `github.repo`
 - `authorization_scope`
 - `halt_at`
-- `pr_strategy`
 - `pipeline_phase`
 
 Plus skill-specific fields per the `## Sub-Agent Routing` section above.
@@ -121,7 +120,7 @@ After loading this skill and reading the Trigger Dispatch Table, the orchestrato
 ## Operating Protocol
 
 - [ ] 1. **Mandatory call:** The orchestrator MUST call this skill before ANY sub-agent routing
-- [ ] 2. **Minimal context:** Pre-analysis sub-agents receive only `{ issue_number, task_description, pipeline_phase, authorization_scope, halt_at, pr_strategy, github.owner, github.repo }`
+- [ ] 2. **Minimal context:** Pre-analysis sub-agents receive only `{ issue_number, task_description, pipeline_phase, authorization_scope, halt_at, github.owner, github.repo }`
 - [ ] 3. **Autonomous discovery:** Independently search the codebase to discover affected files
 - [ ] 4. **Return task plan:** Return a structured plan with task partitions and file scope
 - [ ] 5. **Correctness over speed.** Every code path with runtime behavior requires live-wire testing against real systems. A slow correct answer is strictly better than a fast incorrect one. Static analysis alone is NOT acceptable verification — behavioral compliance requires actual execution with cross-validated PASS verdict.

--- a/skills/pre-analysis/tasks/analyze.md
+++ b/skills/pre-analysis/tasks/analyze.md
@@ -15,7 +15,6 @@ Independently discover the full scope of work needed for a given task. This sub-
 ```
 authorization_scope: <for_analysis|for_spec|for_plan|for_implementation|for_review_prep|for_pr|for_pr_only|for_review_only>
 halt_at: <analysis_complete|spec_created|plan_created|verification_complete|review_prep|pr_created>
-pr_strategy: <none|stacked>
 pipeline_phase: <current_phase_name>
 authorization_source: "User approved #N on YYYY-MM-DD"
 ```

--- a/skills/programming-principles/SKILL.md
+++ b/skills/programming-principles/SKILL.md
@@ -89,7 +89,6 @@ Every `task()` call MUST include only:
 - `github.repo`
 - `authorization_scope`
 - `halt_at`
-- `pr_strategy`
 - `pipeline_phase`
 
 Plus skill-specific fields per the `## Sub-Agent Routing` section above.

--- a/skills/receiving-code-review/SKILL.md
+++ b/skills/receiving-code-review/SKILL.md
@@ -55,13 +55,12 @@ This skill operates in the main repo directory (direct-branch mode). When `WORKT
 
 ## Sub-Agent Routing
 
-Sub-agents run via `task(subagent_type="general")` with `{ pr_number, review_comments, worktree.path, github.owner, github.repo, authorization_scope, halt_at, pr_strategy, pipeline_phase }`. Exclusions: implementation context, agent memory. `pre-analysis` receives only `{ issue_number, task_description, audit_phase, pipeline_phase, authorization_scope, halt_at, pr_strategy, github.owner, github.repo }`. No inline work.
+Sub-agents run via `task(subagent_type="general")` with `{ pr_number, review_comments, worktree.path, github.owner, github.repo, authorization_scope, halt_at, pipeline_phase }`. Exclusions: implementation context, agent memory. `pre-analysis` receives only `{ issue_number, task_description, audit_phase, pipeline_phase, authorization_scope, halt_at, github.owner, github.repo }`. No inline work.
 
 ### Authorization Context
 ```
 authorization_scope: <for_analysis|for_spec|for_plan|for_implementation|for_review_prep|for_pr|for_pr_only|for_review_only>
 halt_at: <analysis_complete|spec_created|plan_created|verification_complete|review_prep|pr_created>
-pr_strategy: <none|stacked>
 pipeline_phase: <current_phase_name>
 authorization_source: "User approved #N on YYYY-MM-DD"
 ```
@@ -96,7 +95,6 @@ Every `task()` call MUST include only:
 - `github.repo`
 - `authorization_scope`
 - `halt_at`
-- `pr_strategy`
 - `pipeline_phase`
 
 Plus skill-specific fields per the `## Sub-Agent Routing` section above.

--- a/skills/requesting-code-review/SKILL.md
+++ b/skills/requesting-code-review/SKILL.md
@@ -80,7 +80,6 @@ Every `task()` call MUST include only:
 - `github.repo`
 - `authorization_scope`
 - `halt_at`
-- `pr_strategy`
 - `pipeline_phase`
 
 Plus skill-specific fields per the `## Sub-Agent Routing` section above.

--- a/skills/research/SKILL.md
+++ b/skills/research/SKILL.md
@@ -84,7 +84,6 @@ Every `task()` call MUST include only:
 - `github.repo`
 - `authorization_scope`
 - `halt_at`
-- `pr_strategy`
 - `pipeline_phase`
 
 Plus skill-specific fields per the `## Sub-Agent Routing` section above.

--- a/skills/skill-creator/SKILL.md
+++ b/skills/skill-creator/SKILL.md
@@ -103,7 +103,6 @@ Every `task()` call MUST include only:
 - `github.repo`
 - `authorization_scope`
 - `halt_at`
-- `pr_strategy`
 - `pipeline_phase`
 
 Plus skill-specific fields per the `## Sub-Agent Routing` section above.

--- a/skills/skill-creator/reference/routing-only-template.md
+++ b/skills/skill-creator/reference/routing-only-template.md
@@ -74,7 +74,7 @@ provenance: AI-generated
 
 [Routing rules: what context fields to pass, what to exclude, any special dispatch instructions.]
 
-- Standard context: `{worktree.path, github.owner, github.repo, authorization_scope, halt_at, pr_strategy, pipeline_phase}`
+- Standard context: `{worktree.path, github.owner, github.repo, authorization_scope, halt_at, pipeline_phase}`
 - Exclusions: orchestrator reasoning, expected outcomes, inline file paths, agent memory, cached verification results
 - Auditor tasks use subagent_type from `resolve-models` result contract — NOT `general`
 - `pre-analysis` receives only `{issue_number, task_description, github.owner, github.repo}`

--- a/skills/skill-creator/scripts/init_skill.py
+++ b/skills/skill-creator/scripts/init_skill.py
@@ -64,7 +64,7 @@ provenance: AI-generated
 
 ## Sub-Agent Routing
 
-- Standard context: `{{worktree.path, github.owner, github.repo, authorization_scope, halt_at, pr_strategy, pipeline_phase}}`
+- Standard context: `{{worktree.path, github.owner, github.repo, authorization_scope, halt_at, pipeline_phase}}`
 - Exclusions: orchestrator reasoning, expected outcomes, inline file paths, agent memory, cached verification results
 - Auditor tasks use subagent_type from `resolve-models` result contract — NOT `general`
 - `pre-analysis` receives only `{{issue_number, task_description, github.owner, github.repo}}`

--- a/skills/spec-creation/SKILL.md
+++ b/skills/spec-creation/SKILL.md
@@ -120,7 +120,6 @@ Every `task()` call MUST include only:
 - `github.repo`
 - `authorization_scope`
 - `halt_at`
-- `pr_strategy`
 - `pipeline_phase`
 
 Plus skill-specific fields per the `## Sub-Agent Routing` section above.

--- a/skills/sre-runbook/SKILL.md
+++ b/skills/sre-runbook/SKILL.md
@@ -95,7 +95,6 @@ Every `task()` call MUST include only:
 - `github.repo`
 - `authorization_scope`
 - `halt_at`
-- `pr_strategy`
 - `pipeline_phase`
 
 Plus skill-specific fields per the `## Sub-Agent Routing` section above.

--- a/skills/sync-guidelines/SKILL.md
+++ b/skills/sync-guidelines/SKILL.md
@@ -89,7 +89,6 @@ Every `task()` call MUST include only:
 - `github.repo`
 - `authorization_scope`
 - `halt_at`
-- `pr_strategy`
 - `pipeline_phase`
 
 Plus skill-specific fields per the `## Sub-Agent Routing` section above.

--- a/skills/systematic-debugging/SKILL.md
+++ b/skills/systematic-debugging/SKILL.md
@@ -93,7 +93,6 @@ Every `task()` call MUST include only:
 - `github.repo`
 - `authorization_scope`
 - `halt_at`
-- `pr_strategy`
 - `pipeline_phase`
 
 Plus skill-specific fields per the `## Sub-Agent Routing` section above.

--- a/skills/test-driven-development/SKILL.md
+++ b/skills/test-driven-development/SKILL.md
@@ -169,7 +169,7 @@ If at ANY point within RED/GREEN/REFACTOR a step exceeds its timing target (30s 
 
 ## Sub-Agent Routing
 
-Sub-agents run via `task(subagent_type="general")` with `{ spec_context, test_path, worktree.path, github.owner, github.repo, authorization_scope, halt_at, pr_strategy, pipeline_phase }`. Exclusions: implementation context, agent memory, prior test results. `pre-analysis` receives only `{ issue_number, task_description, audit_phase, pipeline_phase, authorization_scope, halt_at, pr_strategy, github.owner, github.repo }`. No inline work.
+Sub-agents run via `task(subagent_type="general")` with `{ spec_context, test_path, worktree.path, github.owner, github.repo, authorization_scope, halt_at, pipeline_phase }`. Exclusions: implementation context, agent memory, prior test results. `pre-analysis` receives only `{ issue_number, task_description, audit_phase, pipeline_phase, authorization_scope, halt_at, github.owner, github.repo }`. No inline work.
 
 ### DISPATCH_GATE — Orchestrator task() Prompt Protocol
 
@@ -197,7 +197,6 @@ Every `task()` call MUST include only:
 - `github.repo`
 - `authorization_scope`
 - `halt_at`
-- `pr_strategy`
 - `pipeline_phase`
 
 Plus skill-specific fields per the `## Sub-Agent Routing` section above.
@@ -231,7 +230,6 @@ After loading this skill and reading the Trigger Dispatch Table, the orchestrato
 ```
 authorization_scope: <for_analysis|for_spec|for_plan|for_implementation|for_review_prep|for_pr|for_pr_only|for_review_only>
 halt_at: <analysis_complete|spec_created|plan_created|verification_complete|review_prep|pr_created>
-pr_strategy: <none|stacked>
 pipeline_phase: <current_phase_name>
 authorization_source: "User approved #N on YYYY-MM-DD"
 ```

--- a/skills/using-git-worktrees/SKILL.md
+++ b/skills/using-git-worktrees/SKILL.md
@@ -94,7 +94,6 @@ Every `task()` call MUST include only:
 - `github.repo`
 - `authorization_scope`
 - `halt_at`
-- `pr_strategy`
 - `pipeline_phase`
 
 Plus skill-specific fields per the `## Sub-Agent Routing` section above.

--- a/skills/verification-before-completion/SKILL.md
+++ b/skills/verification-before-completion/SKILL.md
@@ -76,13 +76,12 @@ Verification Gatekeeper. Focus: no completion claim without verified evidence. E
 
 ## Sub-Agent Routing
 
-All tasks run via `task(subagent_type="general")` with `{ spec_sc_list, file_paths, worktree.path, github.owner, github.repo, authorization_scope, halt_at, pr_strategy, pipeline_phase }`. Auditor tasks use subagent_type from resolve-models result contract (auditor_1/auditor_2) — NOT `general`. Include audit_phase in task context when routing auditors. See audit SKILL.md §DISPATCH_GATE. Exclusions: implementation context, agent memory, prior verification results. `structural-verify` receives spec structure. `pre-analysis` receives only `{ issue_number, task_description, pipeline_phase, authorization_scope, halt_at, pr_strategy, github.owner, github.repo }`. No inline work.
+All tasks run via `task(subagent_type="general")` with `{ spec_sc_list, file_paths, worktree.path, github.owner, github.repo, authorization_scope, halt_at, pipeline_phase }`. Auditor tasks use subagent_type from resolve-models result contract (auditor_1/auditor_2) — NOT `general`. Include audit_phase in task context when routing auditors. See audit SKILL.md §DISPATCH_GATE. Exclusions: implementation context, agent memory, prior verification results. `structural-verify` receives spec structure. `pre-analysis` receives only `{ issue_number, task_description, pipeline_phase, authorization_scope, halt_at, github.owner, github.repo }`. No inline work.
 
 ### Authorization Context
 ```
 authorization_scope: <for_analysis|for_spec|for_plan|for_implementation|for_review_prep|for_pr|for_pr_only|for_review_only>
 halt_at: <analysis_complete|spec_created|plan_created|verification_complete|review_prep|pr_created>
-pr_strategy: <none|stacked>
 pipeline_phase: <current_phase_name>
 authorization_source: "User approved #N on YYYY-MM-DD"
 ```
@@ -130,7 +129,6 @@ Every `task()` call MUST include only:
 - `github.repo`
 - `authorization_scope`
 - `halt_at`
-- `pr_strategy`
 - `pipeline_phase`
 
 Plus skill-specific fields per the `## Sub-Agent Routing` section above.

--- a/skills/verification-before-completion/tasks/structural-verify.md
+++ b/skills/verification-before-completion/tasks/structural-verify.md
@@ -122,7 +122,6 @@ required_components: [<component_list>]
 vbc_artifact_path: <path_to_vbc_artifacts>
 authorization_scope: <scope_value>
 halt_at: <pipeline_stage>
-pr_strategy: stacked | none
 pipeline_phase: <current_phase_name>
 ```
 

--- a/skills/verification-before-completion/tasks/verify.md
+++ b/skills/verification-before-completion/tasks/verify.md
@@ -45,7 +45,6 @@ if [ -z "$DEFAULT_BRANCH" ]; then DEFAULT_BRANCH="main"; fi
 ```
 authorization_scope: <for_analysis|for_spec|for_plan|for_implementation|for_review_prep|for_pr|for_pr_only|for_review_only>
 halt_at: <analysis_complete|spec_created|plan_created|verification_complete|review_prep|pr_created>
-pr_strategy: <none|stacked>
 pipeline_phase: <current_phase_name>
 authorization_source: "User approved #N on YYYY-MM-DD"
 spec_local_dir: <path> | [<path>, ...]     # REQUIRED — one or more local issue directories containing spec.md

--- a/skills/verification-enforcement/SKILL.md
+++ b/skills/verification-enforcement/SKILL.md
@@ -97,7 +97,6 @@ Every `task()` call MUST include only:
 - `github.repo`
 - `authorization_scope`
 - `halt_at`
-- `pr_strategy`
 - `pipeline_phase`
 
 Plus skill-specific fields per the `## Sub-Agent Routing` section above.

--- a/skills/verification/SKILL.md
+++ b/skills/verification/SKILL.md
@@ -84,7 +84,6 @@ Every `task()` call MUST include only:
 - `github.repo`
 - `authorization_scope`
 - `halt_at`
-- `pr_strategy`
 - `pipeline_phase`
 
 Plus skill-specific fields per the `## Sub-Agent Routing` section above.

--- a/skills/writing-plans/tasks/create.md
+++ b/skills/writing-plans/tasks/create.md
@@ -156,7 +156,6 @@ The write sub-agent produces the plan per the format specification in `write.md`
 ```
 authorization_scope: <for_analysis|for_spec|for_plan|for_implementation|for_review_prep|for_pr|for_pr_only|for_review_only>
 halt_at: <analysis_complete|spec_created|plan_created|verification_complete|review_prep|pr_created>
-pr_strategy: <none|stacked>
 pipeline_phase: <current_phase_name>
 authorization_source: "User approved #N on YYYY-MM-DD"
 ```

--- a/tests/behaviors/gap-fill-cascade-for-pr.sh
+++ b/tests/behaviors/gap-fill-cascade-for-pr.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# Behavioral test: gap-fill-cascade-for-pr
+# See .opencode/tests/AGENTS.md for the test harness specification and paradigm.
+# This script is an artifact-only generator — it does NOT evaluate model output.
+#
+# SC-8: Behavioral test — agent with for_pr scope and existing spec+plan
+# dispatches gap-fill-cascade, routes through implementation-pipeline
+# — does NOT skip to PR creation.
+#
+# RED phase: The gap-fill cascade is a flat action list. When the agent
+# receives "approved for PR" with existing spec+plan, it skips to PR
+# creation without dispatching gap-fill-cascade or implementation-pipeline.
+# The test MUST FAIL at this point.
+#
+# GREEN phase: After gap-fill cascade is restructured as state-verification
+# checklist, the same prompt MUST cause the agent to dispatch
+# gap-fill-cascade and route through implementation-pipeline.
+#
+# Authority: .opencode#1421 SC-8
+# Co-authored with AI: OpenCode (deepseek-v4-flash)
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/helpers.sh"
+
+SCENARIO_NAME="gap-fill-cascade-for-pr"
+SCENARIO_PROMPT="approved for PR: .opencode#1421"
+
+echo "=== Behavioral Test: $SCENARIO_NAME ==="
+
+behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT"
+
+# Artifact-only generator — exit 0 unconditionally.
+# Evaluation is performed by the orchestrator via clean-room sub-agents.
+exit 0

--- a/tests/behaviors/gap-fill-cascade-missing-plan.sh
+++ b/tests/behaviors/gap-fill-cascade-missing-plan.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# Behavioral test: gap-fill-cascade-missing-plan
+# See .opencode/tests/AGENTS.md for the test harness specification and paradigm.
+# This script is an artifact-only generator — it does NOT evaluate model output.
+#
+# SC-9: Behavioral test — agent with for_pr scope and missing plan
+# dispatches writing-plans via next_action routing from the gap-fill
+# state-verification checklist.
+#
+# RED phase: The gap-fill cascade is a flat action list. When the agent
+# receives "approved for PR" with missing plan, it skips to PR creation
+# without dispatching writing-plans. The test MUST FAIL at this point.
+#
+# GREEN phase: After gap-fill cascade is restructured as state-verification
+# checklist, the same prompt MUST cause the agent to dispatch writing-plans
+# via the checklist's FAIL routing (next_action).
+#
+# Authority: .opencode#1421 SC-9
+# Co-authored with AI: OpenCode (deepseek-v4-flash)
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/helpers.sh"
+
+SCENARIO_NAME="gap-fill-cascade-missing-plan"
+SCENARIO_PROMPT="approved for PR: .opencode#9999"
+
+echo "=== Behavioral Test: $SCENARIO_NAME ==="
+
+behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT"
+
+# Artifact-only generator — exit 0 unconditionally.
+# Evaluation is performed by the orchestrator via clean-room sub-agents.
+exit 0


### PR DESCRIPTION
## Summary

Replace the gap-fill cascade with a routing dispatcher that loads per-scope state-verification checklist files. Each item verifies a state and reports the next action if missing.

### Changes

- **New**: `gap-fill-cascade/for-pr.md`, `for-implementation.md`, `for-plan.md` — per-scope state-verification checklists
- **New**: `gap-fill-cascade.md` as routing dispatcher
- **Remove**: `for_pr_only` and `for_review_only` from all scope-parsing files
- **Remove**: gap-fill column from `010-approval-gate.md` scope table
- **Add**: YAML-only rule for LLM-to-LLM data transfers in `080-code-standards.md`
- **Remove**: `pr_strategy` from ~69 authorization_scope template blocks across all skill files
- **New**: Behavioral enforcement tests for SC-8 (for_pr with existing spec+plan) and SC-9 (for_pr with missing plan)

### Fixes

Closes #1421, #1735, #1736, #1737

🤖 Co-authored with AI: OpenCode (deepseek-v4-flash)