### PR TITLE
fix: remove stale 'gap-fill actions' reference from 010-approval-gate.md scope model (#1421)

### DIFF
--- a/guidelines/010-approval-gate.md
+++ b/guidelines/010-approval-gate.md
@@ -107,7 +107,7 @@ Authorization scope determines what the agent is authorized to do between approv
 
 ### Authorization Scope Model (CRITICAL)
 
-Defines where the pipeline halts after a given authorization scope, what gap-fill actions to auto-perform, and the PR strategy.
+Defines where the pipeline halts after a given authorization scope and the PR strategy.
 
 #### Key Scope Values
 


### PR DESCRIPTION
## Summary

Removes the phrase "what gap-fill actions to auto-perform" from the Authorization Scope Model description in `010-approval-gate.md`. The gap-fill column was already removed from the scope table in the merged PR #1741, but this prose line was missed.

## Changes

- **`guidelines/010-approval-gate.md`**: Line 110 — remove "what gap-fill actions to auto-perform" from scope model description

## Verification

All 11 SCs from spec #1421 verified PASS against `main` — the gap-fill cascade restructuring was already complete. This is the only remaining cleanup.

## Fixes

Closes #1421, #1735, #1736, #1737

🤖 Co-authored with AI: OpenCode (deepseek-v4-flash)