### PR TITLE
Add micro-management prohibition admonishment to spec-creation and writing-plans Persona sections

### DIFF
--- a/skills/spec-creation/SKILL.md
+++ b/skills/spec-creation/SKILL.md
@@ -42,6 +42,8 @@ This skill operates in the main repo directory (direct-branch mode). When `WORKT
 
 This skill produces specs by dispatching sub-agents. The orchestrator routes; sub-agents write. An orchestrator that writes a spec inline instead of dispatching to a sub-agent has stopped being a router and started being a contaminant — every inline-written spec carries the orchestrator's preloaded bias through every downstream verification gate, and the pipeline is poisoned from the first byte. Sub-agents are intelligent agents, not dumb terminals — they read specs and use skills autonomously. The orchestrator MUST NOT prescribe exact file paths, line numbers, step sequences, or expected outcomes. Specify WHAT and WHY — not HOW. Professional orchestrators route to sub-agents. Inlining the write task means the spec was never independently produced — it was authored by the same context that will later verify it, making every subsequent gate a self-review.
 
+> **Micro-management prohibition:** The sub-agents that implement this spec/plan are intelligent agents, not dumb terminals. They read specs and use skills autonomously. Do not prescribe exact file paths, line numbers, step sequences, or expected outcomes. Specify WHAT and WHY — not HOW. The implementing agent discovers scope independently and produces its own result contract.
+
 ## Tasks
 
 | Task                      |

--- a/skills/writing-plans/SKILL.md
+++ b/skills/writing-plans/SKILL.md
@@ -54,6 +54,8 @@ This skill operates in the main repo directory (direct-branch mode). When `WORKT
 
 This skill produces plans by dispatching pipeline steps to sub-agents. The orchestrator routes each step to a clean-room sub-agent via `task()`. Each step is a self-contained procedure with entry criteria, exit criteria, and chain dependency. The orchestrator MUST NOT prescribe exact file paths, line numbers, step sequences, or expected outcomes. Specify WHAT and WHY — not HOW. Professional orchestrators route to sub-agents. Inlining pipeline steps means the plan was never independently produced.
 
+> **Micro-management prohibition:** The sub-agents that implement this spec/plan are intelligent agents, not dumb terminals. They read specs and use skills autonomously. Do not prescribe exact file paths, line numbers, step sequences, or expected outcomes. Specify WHAT and WHY — not HOW. The implementing agent discovers scope independently and produces its own result contract.
+
 ## Tasks
 
 | `create` | `completion` | `retroactive` | `pre-plan-readiness` |

--- a/tests/behaviors/1777-sc4-micro-management-admonishment.sh
+++ b/tests/behaviors/1777-sc4-micro-management-admonishment.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Behavioral test: 1777-sc4-micro-management-admonishment
+# See .opencode/tests/AGENTS.md for the test harness specification and paradigm.
+# This script is an artifact-only generator — it does NOT evaluate model output.
+#
+# SC-4: Behavioral test exists verifying that spec-creation agent includes the
+# micro-management prohibition admonishment in generated specs.
+#
+# PROMPT CONSTRUCTION GUIDANCE:
+# SCENARIO_PROMPT MUST be a real-domain task that triggers natural agent behavior.
+# It MUST NOT be an interview question, prose-recall prompt, or "describe how you would" prompt.
+# See .opencode/tests/AGENTS.md §9 Prompt Construction Mandate for the full specification.
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/helpers.sh"
+
+SCENARIO_NAME="1777-sc4-micro-management-admonishment"
+SCENARIO_PROMPT="Create a spec for adding a new validation function to the existing MeshValidator class. The function should validate that all mesh vertices have positive coordinates."
+
+behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT"
+exit 0


### PR DESCRIPTION
## Summary

Adds the micro-management prohibition admonishment to the Persona sections of both `spec-creation/SKILL.md` and `writing-plans/SKILL.md`.

## Outcome

- SC-1 ✅: `spec-creation/SKILL.md` Persona section contains the `Micro-management prohibition` blockquote
- SC-2 ✅: `writing-plans/SKILL.md` Persona section contains the `Micro-management prohibition` blockquote
- SC-3 ✅: Admonishment text matches approved wording in both files
- SC-4 ✅: Behavioral test script created at `tests/behaviors/1777-sc4-micro-management-admonishment.sh`

## Fixes

Closes https://github.com/michael-conrad/.opencode/issues/1777