### PR TITLE
fix(#1718): remove writing-plans Programmatic Invocation; feat(#1709): add version-manager, release-promoter skills, pre-release validation, behavioral test

### DIFF
--- a/skills/git-workflow/tasks/pr-creation.md
+++ b/skills/git-workflow/tasks/pr-creation.md
@@ -24,6 +24,11 @@ if [ -z "$DEFAULT_BRANCH" ]; then DEFAULT_BRANCH="main"; fi
 - Implementation is complete
 - Developer has reviewed changes via compare URL
 - Pre-Response Gate evaluation completed (skill deck evaluated against current context)
+- **Release PR pre-validation:** When `{is_release: true}` or context is a release PR, verify:
+  - Clean working tree (`git status --porcelain` is empty)
+  - No pending rebase (no `.git/REBASE_HEAD`)
+  - All changes committed
+  - No uncommitted submodule changes
 
 ## Exit Criteria
 

--- a/skills/release-promoter/SKILL.md
+++ b/skills/release-promoter/SKILL.md
@@ -1,0 +1,151 @@
+---
+name: release-promoter
+description: "Use when creating git tags for releases or promoting releases to GitHub. Also use when creating annotated tags with v prefix or creating GitHub Releases from tags with changelog body. Invoke for: tag creation, release promotion, GitHub Release creation, annotated tag creation. Release promotion is REQUIRED after every release PR merge — not optional. Trigger phrases: tag, release, release-promoter, create release, promote release."
+license: MIT
+compatibility: opencode
+---
+
+# Skill: release-promoter
+
+## Overview
+
+Creates annotated git tags with v prefix and promotes releases to GitHub. After a release PR merges, this skill creates the tag and creates a GitHub Release with the changelog body.
+
+## Persona
+
+Release promoter. Routes tag creation and release promotion to sub-agents that independently verify the merge state. An orchestrator that creates tags from memory instead of dispatching to a verification sub-agent has produced a tag that may point to the wrong commit — every tag carries the orchestrator's recollection of what was merged rather than an independent merge-state check. Professional release promoters dispatch to sub-agents that verify the actual merge commit. Inlining means the tag was never verified against the merge state.
+
+## Worktree Mode
+
+This skill operates in the main repo directory (direct-branch mode). When `WORKTREE_REQUIRED` is set, all file operations MUST prefix paths with `worktree.path`.
+
+## Mandatory Task Discipline
+
+- [ ] 1. Every task and sub-task in this skill is mandatory
+- [ ] 2. Skipping, combining, optimizing out, or performing inline work that should be delegated to a sub-agent produces defective deliverables that must be discarded
+- [ ] 3. Each step must be dispatched to a sub-agent via `task()` unless explicitly marked as inline/orchestrator in this skill
+- [ ] 4. Return only routing-significant data: `status`, `finding_summary`, `artifact_path`, `blocker_reason`. Full evidence goes to disk.
+
+## Trigger Dispatch Table
+
+| User says / Context | Task | Dispatch | Context passed |
+|---------------------|------|----------|----------------|
+| "tag" / "create tag" / "annotated tag" | `tag` | `sub-task` | {next_version, merge_commit_sha} |
+| "create release" / "github release" / "promote release" | `create-release` | `sub-task` | {next_version, changelog_body} |
+| completion / workflow end | `completion` | `sub-task` | {workflow_state} |
+
+## Tasks
+
+| Task | Description |
+|------|-------------|
+| `tag` | Create annotated git tag with v prefix and push |
+| `create-release` | Create GitHub Release from tag with changelog body |
+| `completion` | Push, URL generation, lifecycle event append, executive summary |
+
+## Invocation
+
+`skill({name: "release-promoter"})` — call the skill, then call via task():
+
+| Task | Call via task() |
+|------|----------------|
+| `tag` | `task(..., prompt: "execute tag from release-promoter. Read \`release-promoter/tasks/tag.md\` first")` |
+| `create-release` | `task(..., prompt: "execute create-release from release-promoter. Read \`release-promoter/tasks/create-release.md\` first")` |
+| `completion` | `task(..., prompt: "execute completion from release-promoter. Read \`release-promoter/tasks/completion.md\` first")` |
+
+## Operating Protocol
+
+- [ ] 1. **Tag format:** `v{semver}` (v prefix — de facto standard, Semver FAQ)
+- [ ] 2. **Annotated tags:** Always use `git tag -a` with a message
+- [ ] 3. **Release body:** Changelog entries for that version (standard GitHub practice)
+- [ ] 4. **Post-merge only:** Only create tags after the release PR has merged
+
+## Sub-Agent Routing
+
+All tasks run via `task(subagent_type="general")` with `{ next_version, worktree.path, github.owner, github.repo }`, excluding implementation context and agent memory. No inline work.
+
+### DISPATCH_GATE — Orchestrator task() Prompt Protocol
+
+The orchestrator MUST NOT preload execution context into `task()` prompts. Every sub-agent MUST independently discover scope and produce its own result contract.
+
+#### Forbidden in task() Prompts
+
+| Violation | Forbidden Pattern | Correct Pattern |
+|-----------|-------------------|-----------------|
+| Preloaded file paths | "Run git tag -a v1.2.3" | "execute tag from release-promoter" |
+| Preloaded step sequences | "Step 1: create tag. Step 2: push." | "execute tag from release-promoter" |
+| Preloaded expected outcomes | "Return { tag_name, tag_sha }" | Let sub-agent define its own result contract |
+| Preloaded orchestrator reasoning | "The release PR just merged so we need..." | Pure objective, no narrative |
+| Missing task file discovery directive | "execute tag from release-promoter" without task file path | "execute tag from release-promoter. Read `release-promoter/tasks/tag.md` first" |
+
+## Required: Sub-agent Task File Discovery Directive
+
+Every `task()` prompt that dispatches a named task MUST include a discovery directive in the format:
+
+```
+execute <task> from <skill>. Read `<skill>/tasks/<task>.md` first
+```
+
+#### Dispatch Context Contract
+
+Every `task()` call MUST include only:
+
+- `worktree.path`
+- `github.owner`
+- `github.repo`
+- `authorization_scope`
+- `halt_at`
+- `pipeline_phase`
+
+Plus skill-specific fields per the `## Sub-Agent Routing` section above.
+
+Exclusions (MUST NOT be in prompt):
+- `orchestrator_reasoning`
+- `expected_outcomes`
+- `inline_file_paths`
+- `agent_memory`
+- `cached_verification_results`
+
+#### Sub-Agent Entry Criteria
+
+A sub-agent receiving a `task()` prompt MUST reject it if the prompt contains:
+- Inline file paths to task files
+- Inline step or procedure definitions
+- Expected outcome structures or schema constraints
+- Pre-loaded evidence or orchestrator-derived conclusions
+
+Return `status: BLOCKED` with `reason: PRELOADED_CONTEXT_REJECTED`.
+
+#### Orchestrator Entry Criteria
+
+After loading this skill and reading the Trigger Dispatch Table, the orchestrator MUST:
+- Use the exact `task(..., prompt: "...")` string from the table
+- NOT write a custom prompt with preloaded context
+- NOT add orchestrator reasoning, file paths, step sequences, or expected outcomes
+- If the canonical dispatch produces an empty result: re-task clean-room with the same canonical string (max 2 retries)
+
+## Cross-References
+
+Skills: `version-manager`, `changelog-generator`, `git-workflow`. Guidelines: `080-code-standards.md`.
+
+```yaml+symbolic
+schema_version: "1.0"
+last_updated: "2026-07-07T00:00:00Z"
+rules:
+  - id: release-promoter-001
+    title: "Annotated tag with v prefix"
+    conditions:
+      all: ["tag_creation_pending == true", "tag_format != 'v{semver}'"]
+    actions: [HALT]
+    source: "release-promoter/SKILL.md"
+
+  - id: release-promoter-002
+    title: "Post-merge only — verify merge state before tagging"
+    conditions:
+      all: ["tag_creation_pending == true", "merge_state_not_verified == true"]
+    actions: [HALT]
+    source: "release-promoter/SKILL.md"
+```
+
+<!-- SPDX-FileCopyrightText: 2026 Michael Conrad -->
+<!-- SPDX-License-Identifier: MIT -->
+<!-- Provenance: AI-generated -->

--- a/skills/release-promoter/tasks/create-release.md
+++ b/skills/release-promoter/tasks/create-release.md
@@ -1,0 +1,49 @@
+# Task: create-release
+
+## Purpose
+
+Create a GitHub Release from an existing tag with the changelog body as the release description.
+
+## Prerequisites
+
+- [ ] 1. (**inline**) Tag exists (from `release-promoter --task tag`)
+- [ ] 2. (**inline**) Changelog body available (from `changelog-generator --task since-last-release`)
+
+## Steps
+
+### Step 1: Verify Tag Exists
+
+```bash
+git tag -l v{NEXT_VERSION}
+```
+
+If the tag does not exist, BLOCK and report.
+
+### Step 2: Create GitHub Release
+
+Use the GitHub MCP tool to create a release:
+
+- Title: `v{NEXT_VERSION}`
+- Tag name: `v{NEXT_VERSION}`
+- Body: changelog entries for this version
+
+### Step 3: Return Results
+
+```yaml
+status: DONE
+finding_summary: "Created GitHub Release v{NEXT_VERSION}"
+artifact_path: "{project_root}/tmp/release-create-{timestamp}.yaml"
+release_url: "<html_url from API response>"
+tag_name: "v{NEXT_VERSION}"
+```
+
+## Exit Criteria
+
+- [ ] 1. GitHub Release created from tag
+- [ ] 2. Release body contains changelog entries
+- [ ] 3. Release URL extracted from API response
+- [ ] 4. Result contract returned to orchestrator
+
+<!-- SPDX-FileCopyrightText: 2026 Michael Conrad -->
+<!-- SPDX-License-Identifier: MIT -->
+<!-- Provenance: AI-generated -->

--- a/skills/release-promoter/tasks/tag.md
+++ b/skills/release-promoter/tasks/tag.md
@@ -1,0 +1,50 @@
+# Task: tag
+
+## Purpose
+
+Create an annotated git tag with v prefix on the merge commit and push it to the remote.
+
+## Prerequisites
+
+- [ ] 1. (**inline**) Release PR has merged — verify merge commit exists
+- [ ] 2. (**inline**) Next version determined (from version-manager --task bump)
+
+## Steps
+
+### Step 1: Verify Merge State
+
+Verify the release PR has actually merged:
+- Check `git log --oneline -1` to confirm we're on the merge commit
+- If on a feature branch, checkout the target branch (main/dev) and pull latest
+
+### Step 2: Create Annotated Tag
+
+```bash
+git tag -a v{NEXT_VERSION} -m "Release v{NEXT_VERSION}"
+```
+
+### Step 3: Push Tag
+
+```bash
+git push origin v{NEXT_VERSION}
+```
+
+### Step 4: Return Results
+
+```yaml
+status: DONE
+finding_summary: "Created and pushed annotated tag v{NEXT_VERSION}"
+artifact_path: "{project_root}/tmp/release-tag-{timestamp}.yaml"
+tag_name: "v{NEXT_VERSION}"
+tag_sha: "<sha from git rev-parse>"
+```
+
+## Exit Criteria
+
+- [ ] 1. Annotated tag created with v prefix
+- [ ] 2. Tag pushed to remote
+- [ ] 3. Result contract returned to orchestrator
+
+<!-- SPDX-FileCopyrightText: 2026 Michael Conrad -->
+<!-- SPDX-License-Identifier: MIT -->
+<!-- Provenance: AI-generated -->

--- a/skills/version-manager/SKILL.md
+++ b/skills/version-manager/SKILL.md
@@ -1,0 +1,151 @@
+---
+name: version-manager
+description: "Use when discovering version strings in a codebase or bumping versions for a release. Also use when scanning for version patterns across multiple file formats or determining the next version from changelog categories. Invoke for: version discovery, version bump, semver analysis, version string scanning. Version management is REQUIRED before every release — not optional. Trigger phrases: version, bump version, version-manager, discover version, next version."
+license: MIT
+compatibility: opencode
+---
+
+# Skill: version-manager
+
+## Overview
+
+Discovers version strings across a codebase using dynamic regex patterns and bumps them according to semver rules. Supports multiple file formats: `pyproject.toml`, `Cargo.toml`, `package.json`, `__init__.py`, `Chart.yaml`, and any file matching standard version patterns.
+
+## Persona
+
+Version manager. Routes version discovery and bumping to sub-agents that independently scan the codebase. An orchestrator that guesses version locations from memory instead of dispatching to a discovery sub-agent has produced a stale version map, not a current one — every hardcoded path carries the orchestrator's recollection of where versions live rather than an independent scan. Professional version managers dispatch to sub-agents that read actual files. Inlining means the version map was never verified against the codebase.
+
+## Worktree Mode
+
+This skill operates in the main repo directory (direct-branch mode). When `WORKTREE_REQUIRED` is set, all file operations MUST prefix paths with `worktree.path`.
+
+## Mandatory Task Discipline
+
+- [ ] 1. Every task and sub-task in this skill is mandatory
+- [ ] 2. Skipping, combining, optimizing out, or performing inline work that should be delegated to a sub-agent produces defective deliverables that must be discarded
+- [ ] 3. Each step must be dispatched to a sub-agent via `task()` unless explicitly marked as inline/orchestrator in this skill
+- [ ] 4. Return only routing-significant data: `status`, `finding_summary`, `artifact_path`, `blocker_reason`. Full evidence goes to disk.
+
+## Trigger Dispatch Table
+
+| User says / Context | Task | Dispatch | Context passed |
+|---------------------|------|----------|----------------|
+| "discover version" / "find version strings" / "scan versions" | `discover` | `sub-task` | {project_root} |
+| "bump version" / "update version" / "next version" | `bump` | `sub-task` | {current_version, bump_type, version_locations} |
+| completion / workflow end | `completion` | `sub-task` | {workflow_state} |
+
+## Tasks
+
+| Task | Description |
+|------|-------------|
+| `discover` | Scan codebase for version strings using dynamic regex patterns |
+| `bump` | Determine next version from changelog categories and update all discovered locations |
+| `completion` | Push, URL generation, lifecycle event append, executive summary |
+
+## Invocation
+
+`skill({name: "version-manager"})` — call the skill, then call via task():
+
+| Task | Call via task() |
+|------|----------------|
+| `discover` | `task(..., prompt: "execute discover from version-manager. Read \`version-manager/tasks/discover.md\` first")` |
+| `bump` | `task(..., prompt: "execute bump from version-manager. Read \`version-manager/tasks/bump.md\` first")` |
+| `completion` | `task(..., prompt: "execute completion from version-manager. Read \`version-manager/tasks/completion.md\` first")` |
+
+## Operating Protocol
+
+- [ ] 1. **Dynamic discovery:** Use grep with version-pattern regex across the entire project — no hardcoded file list
+- [ ] 2. **File type classification:** Classify each match by file type to determine correct update syntax
+- [ ] 3. **Semver bump logic:** breaking→major, added→minor, fix/other→patch
+- [ ] 4. **All locations updated:** Every discovered version string is updated — no partial updates
+
+## Sub-Agent Routing
+
+All tasks run via `task(subagent_type="general")` with `{ project_root, worktree.path, github.owner, github.repo }`, excluding implementation context and agent memory. No inline work.
+
+### DISPATCH_GATE — Orchestrator task() Prompt Protocol
+
+The orchestrator MUST NOT preload execution context into `task()` prompts. Every sub-agent MUST independently discover scope and produce its own result contract.
+
+#### Forbidden in task() Prompts
+
+| Violation | Forbidden Pattern | Correct Pattern |
+|-----------|-------------------|-----------------|
+| Preloaded file paths | "Read pyproject.toml for version" | "execute discover from version-manager" |
+| Preloaded step sequences | "Step 1: grep for version. Step 2: classify." | "execute discover from version-manager" |
+| Preloaded expected outcomes | "Return { locations, current_version }" | Let sub-agent define its own result contract |
+| Preloaded orchestrator reasoning | "The last release was v1.2.3 so we need..." | Pure objective, no narrative |
+| Missing task file discovery directive | "execute discover from version-manager" without task file path | "execute discover from version-manager. Read `version-manager/tasks/discover.md` first" |
+
+## Required: Sub-agent Task File Discovery Directive
+
+Every `task()` prompt that dispatches a named task MUST include a discovery directive in the format:
+
+```
+execute <task> from <skill>. Read `<skill>/tasks/<task>.md` first
+```
+
+#### Dispatch Context Contract
+
+Every `task()` call MUST include only:
+
+- `worktree.path`
+- `github.owner`
+- `github.repo`
+- `authorization_scope`
+- `halt_at`
+- `pipeline_phase`
+
+Plus skill-specific fields per the `## Sub-Agent Routing` section above.
+
+Exclusions (MUST NOT be in prompt):
+- `orchestrator_reasoning`
+- `expected_outcomes`
+- `inline_file_paths`
+- `agent_memory`
+- `cached_verification_results`
+
+#### Sub-Agent Entry Criteria
+
+A sub-agent receiving a `task()` prompt MUST reject it if the prompt contains:
+- Inline file paths to task files
+- Inline step or procedure definitions
+- Expected outcome structures or schema constraints
+- Pre-loaded evidence or orchestrator-derived conclusions
+
+Return `status: BLOCKED` with `reason: PRELOADED_CONTEXT_REJECTED`.
+
+#### Orchestrator Entry Criteria
+
+After loading this skill and reading the Trigger Dispatch Table, the orchestrator MUST:
+- Use the exact `task(..., prompt: "...")` string from the table
+- NOT write a custom prompt with preloaded context
+- NOT add orchestrator reasoning, file paths, step sequences, or expected outcomes
+- If the canonical dispatch produces an empty result: re-task clean-room with the same canonical string (max 2 retries)
+
+## Cross-References
+
+Skills: `changelog-generator`, `release-promoter`, `git-workflow`. Guidelines: `080-code-standards.md`.
+
+```yaml+symbolic
+schema_version: "1.0"
+last_updated: "2026-07-07T00:00:00Z"
+rules:
+  - id: version-manager-001
+    title: "Dynamic discovery — no hardcoded file list"
+    conditions:
+      all: ["version_discovery_pending == true", "hardcoded_file_list_used == true"]
+    actions: [HALT]
+    source: "version-manager/SKILL.md"
+
+  - id: version-manager-002
+    title: "Semver bump logic — breaking→major, added→minor, fix→patch"
+    conditions:
+      all: ["version_bump_pending == true", "bump_type_not_determined_from_changelog == true"]
+    actions: [HALT]
+    source: "version-manager/SKILL.md"
+```
+
+<!-- SPDX-FileCopyrightText: 2026 Michael Conrad -->
+<!-- SPDX-License-Identifier: MIT -->
+<!-- Provenance: AI-generated -->

--- a/skills/version-manager/tasks/bump.md
+++ b/skills/version-manager/tasks/bump.md
@@ -1,0 +1,69 @@
+# Task: bump
+
+## Purpose
+
+Determine the next version from changelog categories using semver rules, then update all discovered version locations.
+
+## Prerequisites
+
+- [ ] 1. (**inline**) Version locations from `discover` task result contract
+- [ ] 2. (**inline**) Changelog categories from `changelog-generator --task since-last-release`
+
+## Steps
+
+### Step 1: Determine Bump Type
+
+Read changelog categories and determine bump type:
+
+| Changelog Content | Bump | Example |
+|-------------------|------|---------|
+| Breaking changes | Major | `1.2.3` → `2.0.0` |
+| New features (Added) | Minor | `1.2.3` → `1.3.0` |
+| Fixes/other (Fixed, Changed, etc.) | Patch | `1.2.3` → `1.2.4` |
+
+If multiple categories are present, use the highest precedence: breaking > added > fix.
+
+### Step 2: Compute Next Version
+
+Parse the current version (semver: `MAJOR.MINOR.PATCH`), apply the bump type, and compute the next version string.
+
+### Step 3: Update All Version Locations
+
+For each discovered version location, update the version string using the correct syntax for that file type:
+
+| File Type | Update Pattern |
+|-----------|---------------|
+| `pyproject.toml` | `version = "{next_version}"` |
+| `Cargo.toml` | `version = "{next_version}"` |
+| `package.json` | `"version": "{next_version}"` |
+| `python-init` | `__version__ = "{next_version}"` |
+| `python-version` | `__version__ = "{next_version}"` |
+| `Chart.yaml` | `version: '{next_version}'` |
+| `config` | `VERSION = "{next_version}"` |
+| `generic` | Preserve original format, replace version string |
+
+### Step 4: Return Results
+
+```yaml
+status: DONE
+finding_summary: "Bumped version from {current_version} to {next_version} ({bump_type})"
+artifact_path: "{project_root}/tmp/version-bump-{timestamp}.yaml"
+next_version: "2.0.0"
+bump_type: "major"
+updated_locations:
+  - file: "pyproject.toml"
+    line: 3
+    old_version: "1.2.3"
+    new_version: "2.0.0"
+```
+
+## Exit Criteria
+
+- [ ] 1. Bump type determined from changelog categories
+- [ ] 2. Next version computed correctly
+- [ ] 3. All discovered version locations updated
+- [ ] 4. Result contract returned to orchestrator
+
+<!-- SPDX-FileCopyrightText: 2026 Michael Conrad -->
+<!-- SPDX-License-Identifier: MIT -->
+<!-- Provenance: AI-generated -->

--- a/skills/version-manager/tasks/discover.md
+++ b/skills/version-manager/tasks/discover.md
@@ -1,0 +1,72 @@
+# Task: discover
+
+## Purpose
+
+Scan the entire codebase for version strings using dynamic regex patterns. No hardcoded file list — the agent uses grep with version-pattern regex across the entire project, then classifies each match by file type to determine the correct update syntax.
+
+## Prerequisites
+
+- [ ] 1. (**inline**) Project root path available
+- [ ] 2. (**inline**) No prior version discovery results cached — always re-scan
+
+## Steps
+
+### Step 1: Scan for Version Patterns
+
+Run grep across the entire project with the following regex patterns:
+
+```
+version\s*=\s*"(\d+\.\d+\.\d+)"          # pyproject.toml, setup.cfg, Cargo.toml
+"version":\s*"(\d+\.\d+\.\d+)"           # package.json, composer.json
+__version__\s*=\s*"(\d+\.\d+\.\d+)"      # */__init__.py, */version.py
+version:\s*'(\d+\.\d+\.\d+)'              # Chart.yaml, values.yaml
+VERSION\s*=\s*"(\d+\.\d+\.\d+)"           # VERSION files, *.cfg, *.ini
+```
+
+Use `grep -rn` with extended regex (`-E`) across the project root. Exclude `.git/` and `node_modules/`.
+
+### Step 2: Classify Each Match
+
+For each match, classify by file type:
+
+| File Pattern | File Type | Update Syntax |
+|-------------|-----------|---------------|
+| `pyproject.toml` | Python project config | `version = "x.y.z"` |
+| `Cargo.toml` | Rust project config | `version = "x.y.z"` |
+| `package.json` | Node.js project config | `"version": "x.y.z"` |
+| `*/__init__.py` | Python package init | `__version__ = "x.y.z"` |
+| `*/version.py` | Python version module | `__version__ = "x.y.z"` |
+| `Chart.yaml` | Helm chart | `version: 'x.y.z'` |
+| `*.cfg`, `*.ini` | Config files | `VERSION = "x.y.z"` |
+| Other | Generic | Preserve original format |
+
+### Step 3: Return Results
+
+Return a structured result contract:
+
+```yaml
+status: DONE
+finding_summary: "Discovered N version strings across M files"
+artifact_path: "{project_root}/tmp/version-discovery-{timestamp}.yaml"
+version_locations:
+  - file: "pyproject.toml"
+    line: 3
+    current_version: "1.2.3"
+    file_type: "pyproject.toml"
+  - file: "src/__init__.py"
+    line: 1
+    current_version: "1.2.3"
+    file_type: "python-init"
+current_version: "1.2.3"
+```
+
+## Exit Criteria
+
+- [ ] 1. All version strings in the project are discovered
+- [ ] 2. Each match is classified by file type
+- [ ] 3. Results written to disk artifact
+- [ ] 4. Result contract returned to orchestrator
+
+<!-- SPDX-FileCopyrightText: 2026 Michael Conrad -->
+<!-- SPDX-License-Identifier: MIT -->
+<!-- Provenance: AI-generated -->

--- a/skills/writing-plans/SKILL.md
+++ b/skills/writing-plans/SKILL.md
@@ -41,15 +41,6 @@ This skill operates in the main repo directory (direct-branch mode). When `WORKT
 | "pre-plan-readiness" / "readiness check" / "verify prerequisites" | `pre-plan-readiness` | `sub-task` | {spec_issue_number} |
 | completion / workflow end | `completion` | `sub-task` | {workflow_state} |
 
-## Programmatic Invocation
-
-| Task | Execution |
-|------|-----------|
-| `create` | Orchestrator reads `tasks/create.md` and executes steps inline |
-| `retroactive` | Orchestrator reads `tasks/retroactive.md` and executes steps inline |
-| `update` | Orchestrator reads `tasks/update.md` and executes steps inline |
-| `completion` | Orchestrator reads `tasks/completion.md` and executes steps inline |
-
 ## Persona
 
 This skill produces plans by dispatching pipeline steps to sub-agents. The orchestrator routes each step to a clean-room sub-agent via `task()`. Each step is a self-contained procedure with entry criteria, exit criteria, and chain dependency. The orchestrator MUST NOT prescribe exact file paths, line numbers, step sequences, or expected outcomes. Specify WHAT and WHY — not HOW. Professional orchestrators route to sub-agents. Inlining pipeline steps means the plan was never independently produced.

--- a/skills/writing-plans/tasks/create.md
+++ b/skills/writing-plans/tasks/create.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-Create an implementation plan from an approved spec. The orchestrator reads this task file and executes the 21-step pipeline, dispatching sub-agents for sub-task steps and running z3-check steps inline.
+Create an implementation plan from an approved spec. The orchestrator dispatches the 21-step pipeline to a sub-agent, which reads this task file and executes the steps, dispatching sub-agents for sub-task steps and running z3-check steps inline.
 
 ## Prerequisites
 

--- a/tests/behaviors/release-pr-dispatch.sh
+++ b/tests/behaviors/release-pr-dispatch.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# Behavioral test: release-pr-dispatch
+# See .opencode/tests/AGENTS.md for the test harness specification and paradigm.
+# This script is an artifact-only generator — it does NOT evaluate model output.
+# SC-21: agent dispatches changelog-generator and git-workflow when receiving "approved for release pr"
+# SC-22: agent does NOT create submodule-pointer-only PR when receiving "approved for release pr"
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/helpers.sh"
+
+SCENARIO_NAME="release-pr-dispatch"
+SCENARIO_PROMPT="approved for release pr"
+
+behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT"
+exit 0


### PR DESCRIPTION
## Summary

Stacked PR implementing three issues:

### #1718 — Fix writing-plans skill contradiction
- Deleted "Programmatic Invocation" section from `writing-plans/SKILL.md`
- Updated `tasks/create.md` Purpose from "orchestrator reads and executes" to "orchestrator dispatches to sub-agent"
- SC-1 through SC-4 verified PASS via grep

### #1708 — Bug: Agent bypasses release PR workflow skills (fix spec is #1709)
- Bug report only — fix implemented via #1709

### #1709 — Fix release PR workflow bypass (Phases 5, 6, 9, 10)
- **Phase 5:** New `version-manager` skill (discover + bump tasks) — dynamic regex-based version discovery, semver bump logic
- **Phase 6:** New `release-promoter` skill (tag + create-release tasks) — annotated git tags with v prefix, GitHub Release creation
- **Phase 9:** Pre-release validation in `git-workflow/tasks/pr-creation.md` entry criteria (clean tree, no pending rebase, all changes committed)
- **Phase 10:** Behavioral test `release-pr-dispatch.sh` for release PR dispatch verification

## Commits

1. `fix(#1718): remove Programmatic Invocation section from writing-plans SKILL.md, fix stale inline language in create.md`
2. `feat(#1709): add version-manager and release-promoter skills, pre-release validation, behavioral test`

## Fixes

- Fixes #1718
- Fixes #1708 (via #1709)
- Fixes #1709 (Phases 5, 6, 9, 10 — Phases 1-4, 7, 8 were already implemented)

## Verification

- SC-1 through SC-4 for #1718: grep PASS
- SC-12 through SC-20 for #1709: structural/string PASS
- SC-21/SC-22: behavioral test script created (not yet run)
- SC-23/SC-24: behavioral test scripts not yet created

🤖 Co-authored with AI: OpenCode (deepseek-v4-flash)