### PR TITLE
PR Status Check — verify all mergeability signals, not just merged/state

### DIFF
--- a/skills/git-workflow/tasks/check-pr.md
+++ b/skills/git-workflow/tasks/check-pr.md
@@ -36,9 +36,65 @@ if [ -z "$DEFAULT_BRANCH" ]; then DEFAULT_BRANCH="main"; fi
 - [ ] Report all merged PRs found with PR number, title, branch, and merged_at timestamp
 - [ ] If no merged PRs found: report and HALT
 
-## Phase 2: Verify Each Merge
+## Phase 2: Verify Each Merge — Full Mergeability Diagnosis
 
-- [ ] For each merged PR, confirm merge state via the platform-appropriate API (use `github.platform` from session-init: `github` → `github_pull_request_read(method=get)` check `merged_at`, `gitbucket` → `gb pr view` check `merged`, `local` → N/A)
+For each merged PR, perform a full mergeability diagnosis using the 6-field check (SC-1 through SC-5). This replaces the simple `state`/`merged`-only check with the same mergeability logic used in `pr-creation/create-pr.md` Step 7.2.
+
+**Data Sources:**
+
+| Field | Source | Purpose |
+|-------|--------|---------|
+| `mergeable` | PR API response | Mergeability status (`true`, `false`, or `null`) |
+| `base.sha` | PR API response | Base branch SHA at PR creation time |
+| `updated_at` | PR API response | Last update timestamp |
+| `created_at` | PR API response | Creation timestamp |
+| `state` | PR API response | PR state (`open`, `closed`) |
+| `merged` | PR API response | Whether PR was already merged |
+
+### Step 2.1: Read Mergeability Fields
+
+- [ ] For each merged PR, read all 6 fields via the platform-appropriate API (use `github.platform` from session-init: `github` → `github_pull_request_read(method=get, pullNumber=<N>)` for `mergeable`, `base.sha`, `updated_at`, `created_at`, `state`, `merged`; `gitbucket` → `gb pr view <N>` for equivalent fields; `local` → N/A)
+
+### Step 2.2: Diagnose `mergeable` Status
+
+- [ ] If `mergeable` is `null` (mergeability computation not yet complete):
+  - **Stale base check:** Compare `base.sha` against the current remote base tip (`git rev-parse origin/<target>`). If they differ, the base has advanced since PR creation — proceed to Step 2.3.
+  - **Conflict check:** If `base.sha` matches remote base tip but `mergeable` is still `null`, the PR may have a conflict that GitHub hasn't computed yet — proceed to Step 2.4.
+  - **Pending computation:** If neither stale base nor conflict is confirmed, the mergeability computation is still pending — proceed to Step 2.4.
+- [ ] If `mergeable` is `false`: Report that the PR has a merge conflict. Include the conflicting files from `git diff origin/<target>...HEAD --name-only --diff-filter=U`.
+- [ ] If `mergeable` is `true`: Confirm mergeability and proceed.
+
+### Step 2.3: Rebase on Stale Base
+
+- [ ] If `base.sha` differs from the current remote base tip:
+  ```bash
+  git fetch origin <target>
+  git rebase origin/<target>
+  ```
+- [ ] After rebase, force-push the updated branch:
+  ```bash
+  git push --force-with-lease origin HEAD:<branch_name>
+  ```
+
+### Step 2.4: Trigger Mergeability Computation
+
+- [ ] If `updated_at` equals `created_at` (PR has never been updated since creation), the mergeability computation may not have triggered. Trigger it by:
+  1. **Comment method:** Add a comment to the PR via `github_add_issue_comment` with a no-op message (e.g., "Triggering mergeability check").
+  2. **No-op push method (fallback):** If commenting is insufficient, push a no-op change: `git commit --allow-empty -m "trigger mergeability" && git push origin HEAD:<branch_name>`.
+- [ ] After triggering, wait 15 seconds and re-read the PR's `mergeable` field via `github_pull_request_read(method=get, pullNumber=<N>)`. If still `null`, report that mergeability computation is pending.
+
+### Step 2.5: Report Mergeability Diagnosis
+
+- [ ] **Never report "PR is open" as terminal status.** Always include mergeability diagnosis in the output:
+  ```
+  **Mergeability Diagnosis:**
+  - State: open|closed
+  - Merged: true|false
+  - Mergeable: true|false|null
+  - Base SHA match: yes|no (rebased if stale)
+  - Computation triggered: yes|no (if updated_at == created_at)
+  - Action required: <none|rebase needed|conflict resolution|wait for computation>
+  ```
 - [ ] Verify the merge commit exists in local dev history: `git log --oneline "$DEFAULT_BRANCH" | grep <merge_sha>`
 - [ ] Report PASS/FAIL per PR with evidence artifact
 

--- a/skills/git-workflow/tasks/pr-creation/create-pr.md
+++ b/skills/git-workflow/tasks/pr-creation/create-pr.md
@@ -303,6 +303,79 @@ Summarize changes since last release tag by category:
 
 Source: `git log <last-release-tag>..HEAD --oneline --no-merges`
 
+### Step 7.2: Post-Creation Mergeability Check
+
+After the PR is created and the URL is extracted, verify the PR's mergeability status using the API response fields. The PR creation API response contains `mergeable`, `base.sha`, `updated_at`, `created_at`, `state`, and `merged` fields that diagnose whether the PR can be merged.
+
+**Data Sources:**
+
+| Field | Source | Purpose |
+|-------|--------|---------|
+| `mergeable` | PR API response | Mergeability status (`true`, `false`, or `null`) |
+| `base.sha` | PR API response | Base branch SHA at PR creation time |
+| `updated_at` | PR API response | Last update timestamp |
+| `created_at` | PR API response | Creation timestamp |
+| `state` | PR API response | PR state (`open`, `closed`) |
+| `merged` | PR API response | Whether PR was already merged |
+
+#### Step 7.2.1: Read Mergeability Fields
+
+Extract `mergeable`, `base.sha`, `updated_at`, `created_at`, `state`, and `merged` from the PR API response. These fields are available in the response from `github_create_pull_request` (GitHub) or the `gb` CLI output (GitBucket).
+
+#### Step 7.2.2: Diagnose `mergeable` Status
+
+If `mergeable` is `null` (mergeability computation not yet complete):
+
+1. **Stale base check:** Compare `base.sha` against the current remote base tip (`git rev-parse origin/<target>`). If they differ, the base has advanced since PR creation — proceed to Step 7.2.3.
+2. **Conflict check:** If `base.sha` matches remote base tip but `mergeable` is still `null`, the PR may have a conflict that GitHub hasn't computed yet — proceed to Step 7.2.4.
+3. **Pending computation:** If neither stale base nor conflict is confirmed, the mergeability computation is still pending — proceed to Step 7.2.4.
+
+If `mergeable` is `false`: Report to user that the PR has a merge conflict. Include the conflicting files from `git diff origin/<target>...HEAD --name-only --diff-filter=U`.
+
+If `mergeable` is `true`: Confirm mergeability and proceed.
+
+#### Step 7.2.3: Rebase on Stale Base
+
+If `base.sha` differs from the current remote base tip:
+
+```bash
+git fetch origin <target>
+git rebase origin/<target>
+```
+
+After rebase, force-push the updated branch:
+
+```bash
+git push --force-with-lease origin HEAD:<branch_name>
+```
+
+**Note:** Force push is authorized here because the PR is not yet merged and the branch has not been shared with other developers. The rebase ensures the PR is up-to-date with the latest base changes.
+
+#### Step 7.2.4: Trigger Mergeability Computation
+
+If `updated_at` equals `created_at` (PR has never been updated since creation), the mergeability computation may not have triggered. Trigger it by:
+
+1. **Comment method:** Add a comment to the PR via `github_add_issue_comment` with a no-op message (e.g., "Triggering mergeability check").
+2. **No-op push method (fallback):** If commenting is insufficient, push a no-op change: `git commit --allow-empty -m "trigger mergeability" && git push origin HEAD:<branch_name>`.
+
+After triggering, wait 15 seconds and re-read the PR's `mergeable` field via `github_pull_request_read(method=get, pullNumber=<N>)`. If still `null`, report to user that mergeability computation is pending.
+
+#### Step 7.2.5: Report Mergeability Diagnosis
+
+**Never report "PR is open" as terminal status.** Always include mergeability diagnosis in the output:
+
+```
+**Mergeability Diagnosis:**
+- State: open
+- Merged: false
+- Mergeable: true|false|null
+- Base SHA match: yes|no (rebased if stale)
+- Computation triggered: yes|no (if updated_at == created_at)
+- Action required: <none|rebase needed|conflict resolution|wait for computation>
+```
+
+This diagnosis is included in the executive summary report (Step 7.5).
+
 ### Step 7.5: Report PR URL and HALT
 
 **Mandatory format:**

--- a/skills/git-workflow/tasks/pr-creation/enforcement-gate.md
+++ b/skills/git-workflow/tasks/pr-creation/enforcement-gate.md
@@ -194,6 +194,13 @@ For OPEN PRs, check `mergeable` attribute:
 **For AI-objective conflicts (imports, whitespace, additive):** Auto-resolve.
 **For AI-subjective conflicts (logical, architectural, intent):** HALT and request developer input.
 
+### Step 1.5e: Post-Creation Mergeability Gate Reference
+
+The pre-creation gate acknowledges that a **post-creation mergeability check** runs after PR creation (see `pr-creation/create-pr.md` Step 3). This post-creation gate verifies the PR transitions to a mergeable state and does NOT remain in a terminal "PR is open" status. SC-5 (no terminal "PR is open" status) is enforced at the post-creation gate, not at this pre-creation gate.
+
+**Pre-creation gate responsibility:** Ensure all pre-conditions pass so the post-creation mergeability check has a valid starting state.
+**Post-creation gate responsibility:** Verify the PR becomes mergeable and report status.
+
 ## Enforcement Mechanisms
 
 | Layer | Mechanism | Scope | Bypassable? |

--- a/skills/issue-operations/tasks/verify-merge.md
+++ b/skills/issue-operations/tasks/verify-merge.md
@@ -46,11 +46,18 @@ gb pr list -R <github.owner>/<github.repo> --state all | jq '.[] | select(.numbe
 
 ### Step 2: Verify Merge
 
-| PR State | Merged | Action |
-|----------|--------|--------|
-| `closed` | `true` | ✅ Proceed with issue closure |
-| `closed` | `false` | ❌ PR was closed without merge — do NOT close issue |
-| `open` | `false` | ❌ PR still open — do NOT close issue |
+| state | merged | mergeable | base.sha | updated_at | created_at | Action |
+|-------|--------|-----------|----------|------------|------------|--------|
+| `closed` | `true` | — | — | — | — | ✅ Proceed with issue closure |
+| `closed` | `false` | — | — | — | — | ❌ PR was closed without merge — do NOT close issue |
+| `open` | `false` | `true` | — | — | — | ❌ PR still open — do NOT close issue |
+| `open` | `false` | `false` | — | — | — | ❌ PR has merge conflicts — do NOT close issue |
+| `open` | `false` | `null` | — | — | — | ❌ Mergeability not computed — diagnose root cause (stale base, conflict, or pending) |
+| `open` | `false` | — | — | matches created_at | — | ❌ No mergeability computation has occurred — trigger computation (comment or no-op push) |
+| `open` | `true` | `true` | — | — | — | ⚠️ PR merged but state open — verify via API |
+| — | — | — | mismatches target | — | — | ❌ PR targets wrong base branch — do NOT close |
+| — | — | — | — | stale (>30d) | — | ⚠️ PR is stale — verify intent before closing |
+| — | — | — | — | — | after issue creation | ⚠️ PR predates issue — verify association |
 
 ### Step 3: Search Fallback (GitBucket)
 

--- a/tests/behaviors/1795-sc1-mergeable-fields.sh
+++ b/tests/behaviors/1795-sc1-mergeable-fields.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Behavioral test: 1795-sc1-mergeable-fields
+# See .opencode/tests/AGENTS.md for the test harness specification and paradigm.
+# This script is an artifact-only generator — it does NOT evaluate model output.
+#
+# SC-1: After PR creation, agent reads mergeable, base.sha, updated_at,
+#       created_at, state, merged from the PR API response.
+#
+# Co-authored with AI: OpenCode (deepseek-v4-flash)
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/helpers.sh"
+
+SCENARIO_NAME="1795-sc1-mergeable-fields"
+SCENARIO_PROMPT="approved for pr: #1795 — add post-creation mergeability check to create-pr.md. The spec requires reading mergeable, base.sha, updated_at, created_at, state, and merged from the PR API response after creation."
+
+echo "=== Behavioral Test: $SCENARIO_NAME ==="
+
+behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT"
+
+exit 0

--- a/tests/behaviors/1795-sc2-mergeable-null.sh
+++ b/tests/behaviors/1795-sc2-mergeable-null.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Behavioral test: 1795-sc2-mergeable-null
+# See .opencode/tests/AGENTS.md for the test harness specification and paradigm.
+# This script is an artifact-only generator — it does NOT evaluate model output.
+#
+# SC-2: When mergeable is null, agent diagnoses root cause (stale base,
+#       conflict, or pending) and reports to user.
+#
+# Co-authored with AI: OpenCode (deepseek-v4-flash)
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/helpers.sh"
+
+SCENARIO_NAME="1795-sc2-mergeable-null"
+SCENARIO_PROMPT="approved for pr: #1795 — add post-creation mergeability check to create-pr.md. The spec requires that when the PR API returns mergeable=null, the agent diagnoses the root cause (stale base, conflict, or pending computation) and reports it to the user rather than proceeding silently."
+
+echo "=== Behavioral Test: $SCENARIO_NAME ==="
+
+behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT"
+
+exit 0

--- a/tests/behaviors/1795-sc3-base-sha-differs.sh
+++ b/tests/behaviors/1795-sc3-base-sha-differs.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Behavioral test: 1795-sc3-base-sha-differs
+# See .opencode/tests/AGENTS.md for the test harness specification and paradigm.
+# This script is an artifact-only generator — it does NOT evaluate model output.
+#
+# SC-3: When base.sha differs from remote base tip, agent rebases the PR
+#       branch onto current base.
+#
+# Co-authored with AI: OpenCode (deepseek-v4-flash)
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/helpers.sh"
+
+SCENARIO_NAME="1795-sc3-base-sha-differs"
+SCENARIO_PROMPT="approved for pr: #1795 — add post-creation mergeability check to create-pr.md. The spec requires that when the PR's base.sha differs from the remote base branch tip, the agent rebases the PR branch onto the current base before reporting."
+
+echo "=== Behavioral Test: $SCENARIO_NAME ==="
+
+behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT"
+
+exit 0

--- a/tests/behaviors/1795-sc4-updated-equals-created.sh
+++ b/tests/behaviors/1795-sc4-updated-equals-created.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Behavioral test: 1795-sc4-updated-equals-created
+# See .opencode/tests/AGENTS.md for the test harness specification and paradigm.
+# This script is an artifact-only generator — it does NOT evaluate model output.
+#
+# SC-4: When updated_at equals created_at, agent triggers mergeability
+#       computation (comment or no-op push).
+#
+# Co-authored with AI: OpenCode (deepseek-v4-flash)
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/helpers.sh"
+
+SCENARIO_NAME="1795-sc4-updated-equals-created"
+SCENARIO_PROMPT="approved for pr: #1795 — add post-creation mergeability check to create-pr.md. The spec requires that when the PR's updated_at equals created_at (mergeability not yet computed), the agent triggers computation via a comment or no-op push."
+
+echo "=== Behavioral Test: $SCENARIO_NAME ==="
+
+behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT"
+
+exit 0

--- a/tests/behaviors/1795-sc5-no-terminal-open.sh
+++ b/tests/behaviors/1795-sc5-no-terminal-open.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Behavioral test: 1795-sc5-no-terminal-open
+# See .opencode/tests/AGENTS.md for the test harness specification and paradigm.
+# This script is an artifact-only generator — it does NOT evaluate model output.
+#
+# SC-5: Agent never reports "PR is open" as terminal status — always
+#       includes mergeability diagnosis.
+#
+# Co-authored with AI: OpenCode (deepseek-v4-flash)
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/helpers.sh"
+
+SCENARIO_NAME="1795-sc5-no-terminal-open"
+SCENARIO_PROMPT="approved for pr: #1795 — add post-creation mergeability check to create-pr.md. The spec requires that after PR creation, the agent never reports 'PR is open' as a terminal status — it must always include a mergeability diagnosis (mergeable, conflicting, or pending)."
+
+echo "=== Behavioral Test: $SCENARIO_NAME ==="
+
+behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT"
+
+exit 0


### PR DESCRIPTION
## Summary

After PR creation, agents currently inspect only `state` and `merged` fields. This misses critical signals: `mergeable: null` (stale base/conflict/pending), `base.sha` drift (stale target), and `updated_at == created_at` (no mergeability computation).

## Changes

| File | Change |
|------|--------|
| `skills/git-workflow/tasks/pr-creation/create-pr.md` | Add Step 7.2: post-creation mergeability check — reads all 6 fields, diagnoses null mergeable, rebases on stale base, triggers computation when stale |
| `skills/git-workflow/tasks/pr-creation/enforcement-gate.md` | Add Step 1.5e: reference post-creation mergeability gate |
| `skills/git-workflow/tasks/check-pr.md` | Replace state/merged-only check with full 6-field mergeability diagnosis |
| `skills/issue-operations/tasks/verify-merge.md` | Extend merge verification table with mergeable, base.sha, updated_at, created_at columns |
| `tests/behaviors/1795-sc*.sh` | 5 behavioral enforcement tests (SC-1 through SC-5) |

## Success Criteria

| ID | Criterion | Status |
|----|-----------|--------|
| SC-1 | Agent reads mergeable, base.sha, updated_at, created_at, state, merged from PR API | ✅ |
| SC-2 | When mergeable is null, diagnoses root cause (stale base/conflict/pending) | ✅ |
| SC-3 | When base.sha differs from remote tip, rebases PR branch | ✅ |
| SC-4 | When updated_at == created_at, triggers mergeability computation | ✅ |
| SC-5 | Never reports "PR is open" as terminal status — always includes diagnosis | ✅ |

## Verification

- All 5 SCs verified PASS via verification-before-completion
- Spec-fidelity audit: PASS (2 minor table gaps in verify-merge.md fixed)
- 1 commit, single-issue branch

🤖 Co-authored with AI: OpenCode (deepseek-v4-flash)