### PR TITLE
[SPEC] Derivation Provenance — Tier 2 rule for anti-cargo-cult discipline

### DIFF
--- a/guidelines/000-critical-rules.md
+++ b/guidelines/000-critical-rules.md
@@ -828,7 +828,6 @@ When a sub-agent returns a defective deliverable, the orchestrator MUST NOT atte
 | Inline-fixing defective deliverable | Bypasses pipeline quality gates, produces defective output |
 | Direct mutation of issue body | Lacks spec-creation context, produces inconsistent results |
 
-### Tier 3 — Workflow-Standard (FLAG — Convention/Consistency)
 
 ### [critical-rules-XXX] Derivation Provenance — every element must have a consumer or first-principles justification
 
@@ -867,6 +866,8 @@ When a derivation-provenance violation is detected (by the agent during self-rev
 | Applying template structure without evaluation | Every artifact looks the same regardless of problem shape — misses domain-specific concerns |
 
 Rules that prevent **inconsistency or tech debt**: naming conventions, numbering, comment style, tool selection. Violations are flagged but do not halt.
+### Tier 3 — Workflow-Standard (FLAG — Convention/Consistency)
+
 ### [critical-rules-005] Direct-Branch Default — feature branch without worktree is the norm
 Default: `git checkout -b feature/X` in main repo. Worktree opt-in when `WORKTREE_REQUIRED` set. See `git-workflow --task pre-work`.
 


### PR DESCRIPTION
## Summary

Moves the existing Derivation Provenance rule from Tier 3 (Workflow-Standard) to Tier 2 (Process-Integrity) in `000-critical-rules.md`. The rule requires every element in agent output to trace to a specific consumer or first-principles justification — "because it's there in the other location" is not valid.

## Changes

- **`.opencode/guidelines/000-critical-rules.md`**: Moved `[critical-rules-XXX] Derivation Provenance` from Tier 3 to Tier 2 section. Rule text, artifact type table, remediation protocol, and Why This Matters table preserved as-is.

## SC Verification

| SC | Criterion | Status |
|----|-----------|--------|
| SC-1 | Tier 2 rule titled "Derivation Provenance" in 000-critical-rules.md | ✅ PASS |
| SC-2 | Rule lists all artifact types (code, specs, plans, contracts, routing tables, config) | ✅ PASS |
| SC-3 | Rule requires consumer or first-principles derivation | ✅ PASS |
| SC-4 | "Because it's there" is NOT a valid justification | ✅ PASS |
| SC-5 | Remediation section present | ✅ PASS |
| SC-6 | Behavioral test: consumer verification gate | ✅ Test exists at `tests/behaviors/derivation-provenance-sc6-consumer-gate.sh` |
| SC-7 | Behavioral test: Java parameter derivation | ✅ Test exists at `tests/behaviors/derivation-provenance-sc7-parameter-derivation.sh` |
| SC-8 | Behavioral test: routing scope dead weight | ✅ Test exists at `tests/behaviors/derivation-provenance-sc8-routing-dead-weight.sh` |
| SC-9 | Cross-reference in 080-code-standards.md Design Principles | ✅ PASS |

## Behavioral Tests

All 3 behavioral test scripts already exist as artifact-only generators per the test harness specification.

## Fixes

Closes #1794

🤖 OpenCode (deepseek-v4-flash)