### PR TITLE
[#1813] Fix: stop submodule-only PR creation at every gate

### DIFF
--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -46,34 +46,44 @@ GATE_EXIT_CODES+=($?)
       ;;
   esac
 
+  SUBMODULE_PATHS_G3=$(awk -F'=' '/^[[:space:]]*path[[:space:]]*=/ {gsub(/[[:space:]]/, "", $2); print $2}' .gitmodules 2>/dev/null)
+  if [ -z "$SUBMODULE_PATHS_G3" ]; then
+    exit 0
+  fi
+
   STAGED_FILES_G3=$(git diff --cached --name-only 2>/dev/null)
   ALL_STAGED_IN_SUBMODULE=1
   for f in $STAGED_FILES_G3; do
-    case "$f" in
-      .opencode/*|.opencode)
-        # .opencode/* matches files inside submodule
-        # .opencode matches the gitlink entry (submodule pointer)
-        ;;
-      *)
-        ALL_STAGED_IN_SUBMODULE=0
-        break
-        ;;
-    esac
+    IS_SUBMODULE=0
+    for sp in $SUBMODULE_PATHS_G3; do
+      # $sp matches the gitlink entry (submodule pointer)
+      # $sp/* matches files inside the submodule directory
+      case "$f" in
+        "$sp"|"$sp/"*)
+          IS_SUBMODULE=1
+          break
+          ;;
+      esac
+    done
+    if [ "$IS_SUBMODULE" -eq 0 ]; then
+      ALL_STAGED_IN_SUBMODULE=0
+      break
+    fi
   done
 
   if [ "$ALL_STAGED_IN_SUBMODULE" = "1" ] && [ -n "$STAGED_FILES_G3" ]; then
     echo ""
     echo "ERROR: Submodule-bump-only commit blocked."
     echo ""
-    echo "Changed files are entirely inside .opencode/ (submodule) with no parent-repo"
+    echo "Changed files are entirely inside submodule(s) with no parent-repo"
     echo "source changes."
     echo ""
     echo "Submodule-only bump PRs are against policy and will be rejected upstream."
     echo ""
-    echo "Changes to .opencode/ files belong in the submodule's own feature branch"
-    echo "and PR. Work in the submodule directly (cd .opencode && git checkout -b ...),"
-    echo "commit there, push, and merge via submodule PR. The parent pointer updates"
-    echo "naturally when the submodule merges."
+    echo "Changes to submodule files belong in the submodule's own feature branch"
+    echo "and PR. Work in the submodule directly, commit there, push, and merge"
+    echo "via submodule PR. The parent pointer updates naturally when the"
+    echo "submodule merges."
     echo ""
     echo "Remediate: call skill({name: \"git-workflow\"}) --task implementation"
     echo ""

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -1,108 +1,30 @@
 #!/bin/bash
-# Pre-commit hook: Two independent gates with per-gate exit codes.
-# Each gate runs in a subshell so failures don't block subsequent gates.
-# Exits 1 if ANY gate failed.
+# Pre-commit hook: Branch protection gate.
+# Exits 1 if gate fails.
 
 set -e
 
 CURRENT_BRANCH=$(git branch --show-current)
-GATE_EXIT_CODES=()
 
 # --- Gate 1: Branch protection (main/dev) ---
-(
-  if [ "$CURRENT_BRANCH" = "main" ] || [ "$CURRENT_BRANCH" = "dev" ]; then
-    echo ""
-    echo "ERROR: Direct commits to '$CURRENT_BRANCH' branch are blocked."
-    echo ""
-    echo "Branch protection policy:"
-    echo "  - main: Production branch (merge from dev only)"
-    echo "  - dev: Integration branch (feature PRs merge here)"
-    echo ""
-    echo "To commit your changes:"
-    echo "  1. Create a feature branch: git checkout -b feature/<name>"
-    echo "  2. Or create a hotfix branch: git checkout -b hotfix/<name>"
-    echo ""
-    echo "BLOCKED: Direct commit to protected branch — unreviewed changes entering production integration."
-    echo "No PR means no verification occurred. Every unprotected commit is an unreviewed deployment risk."
-    echo ""
-    echo "Remediate: call skill({name: \"git-workflow\"}) --task pre-work"
-    echo ""
-    exit 1
-  fi
-  exit 0
-)
-GATE_EXIT_CODES+=($?)
+if [ "$CURRENT_BRANCH" = "main" ] || [ "$CURRENT_BRANCH" = "dev" ]; then
+  echo ""
+  echo "ERROR: Direct commits to '$CURRENT_BRANCH' branch are blocked."
+  echo ""
+  echo "Branch protection policy:"
+  echo "  - main: Production branch (merge from dev only)"
+  echo "  - dev: Integration branch (feature PRs merge here)"
+  echo ""
+  echo "To commit your changes:"
+  echo "  1. Create a feature branch: git checkout -b feature/<name>"
+  echo "  2. Or create a hotfix branch: git checkout -b hotfix/<name>"
+  echo ""
+  echo "BLOCKED: Direct commit to protected branch — unreviewed changes entering production integration."
+  echo "No PR means no verification occurred. Every unprotected commit is an unreviewed deployment risk."
+  echo ""
+  echo "Remediate: call skill({name: \"git-workflow\"}) --task pre-work"
+  echo ""
+  exit 1
+fi
 
-# --- Gate 3: Submodule-bump-only commit prevention (parent repo context) ---
-(
-  SKIP_SUBMODULE_GATE="${SKIP_SUBMODULE_GATE:-}"
-  if [ "$SKIP_SUBMODULE_GATE" = "1" ] || [ ! -f ".gitmodules" ]; then
-    exit 0
-  fi
-
-  case "$CURRENT_BRANCH" in
-    pair-*|rollback/*|hotfix/*|main|dev)
-      exit 0
-      ;;
-  esac
-
-  SUBMODULE_PATHS_G3=$(awk -F'=' '/^[[:space:]]*path[[:space:]]*=/ {gsub(/[[:space:]]/, "", $2); print $2}' .gitmodules 2>/dev/null)
-  if [ -z "$SUBMODULE_PATHS_G3" ]; then
-    exit 0
-  fi
-
-  STAGED_FILES_G3=$(git diff --cached --name-only 2>/dev/null)
-  ALL_STAGED_IN_SUBMODULE=1
-  for f in $STAGED_FILES_G3; do
-    IS_SUBMODULE=0
-    for sp in $SUBMODULE_PATHS_G3; do
-      # $sp matches the gitlink entry (submodule pointer)
-      # $sp/* matches files inside the submodule directory
-      case "$f" in
-        "$sp"|"$sp/"*)
-          IS_SUBMODULE=1
-          break
-          ;;
-      esac
-    done
-    if [ "$IS_SUBMODULE" -eq 0 ]; then
-      ALL_STAGED_IN_SUBMODULE=0
-      break
-    fi
-  done
-
-  if [ "$ALL_STAGED_IN_SUBMODULE" = "1" ] && [ -n "$STAGED_FILES_G3" ]; then
-    echo ""
-    echo "ERROR: Submodule-bump-only commit blocked."
-    echo ""
-    echo "Changed files are entirely inside submodule(s) with no parent-repo"
-    echo "source changes."
-    echo ""
-    echo "Submodule-only bump PRs are against policy and will be rejected upstream."
-    echo ""
-    echo "Changes to submodule files belong in the submodule's own feature branch"
-    echo "and PR. Work in the submodule directly, commit there, push, and merge"
-    echo "via submodule PR. The parent pointer updates naturally when the"
-    echo "submodule merges."
-    echo ""
-    echo "Remediate: call skill({name: \"git-workflow\"}) --task implementation"
-    echo ""
-    exit 1
-  fi
-  exit 0
-)
-GATE_EXIT_CODES+=($?)
-
-# Report per-gate status
-GATE_NAMES=("Gate 1 (branch protection)" "Gate 3 (submodule bump)")
-ANY_FAILED=0
-for i in "${!GATE_EXIT_CODES[@]}"; do
-  if [ "${GATE_EXIT_CODES[$i]}" -ne 0 ]; then
-    echo "  ✗ ${GATE_NAMES[$i]}: FAILED"
-    ANY_FAILED=1
-  else
-    echo "  ✓ ${GATE_NAMES[$i]}: passed"
-  fi
-done
-
-exit $ANY_FAILED
+exit 0

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -50,7 +50,10 @@ GATE_EXIT_CODES+=($?)
   ALL_STAGED_IN_SUBMODULE=1
   for f in $STAGED_FILES_G3; do
     case "$f" in
-      .opencode/*) ;;
+      .opencode/*|.opencode)
+        # .opencode/* matches files inside submodule
+        # .opencode matches the gitlink entry (submodule pointer)
+        ;;
       *)
         ALL_STAGED_IN_SUBMODULE=0
         break

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -5,14 +5,16 @@
 set -e
 
 CURRENT_BRANCH=$(git branch --show-current)
+TRUNK_BRANCH=$(git remote show origin 2>/dev/null | sed -n 's/.*HEAD branch: //p')
+[ -z "$TRUNK_BRANCH" ] && TRUNK_BRANCH="main"
 
-# --- Gate 1: Branch protection (main) ---
-if [ "$CURRENT_BRANCH" = "main" ]; then
+# --- Gate 1: Branch protection (trunk) ---
+if [ "$CURRENT_BRANCH" = "$TRUNK_BRANCH" ]; then
   echo ""
-  echo "ERROR: Direct commits to 'main' are blocked."
+  echo "ERROR: Direct commits to '$TRUNK_BRANCH' are blocked."
   echo ""
   echo "Branch protection policy:"
-  echo "  - main: Single trunk — all changes through PRs"
+  echo "  - $TRUNK_BRANCH: Single trunk — all changes through PRs"
   echo ""
   echo "To commit your changes:"
   echo "  1. Create a feature branch: git checkout -b feature/<name>"

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -6,14 +6,13 @@ set -e
 
 CURRENT_BRANCH=$(git branch --show-current)
 
-# --- Gate 1: Branch protection (main/dev) ---
-if [ "$CURRENT_BRANCH" = "main" ] || [ "$CURRENT_BRANCH" = "dev" ]; then
+# --- Gate 1: Branch protection (main) ---
+if [ "$CURRENT_BRANCH" = "main" ]; then
   echo ""
-  echo "ERROR: Direct commits to '$CURRENT_BRANCH' branch are blocked."
+  echo "ERROR: Direct commits to 'main' are blocked."
   echo ""
   echo "Branch protection policy:"
-  echo "  - main: Production branch (merge from dev only)"
-  echo "  - dev: Integration branch (feature PRs merge here)"
+  echo "  - main: Single trunk — all changes through PRs"
   echo ""
   echo "To commit your changes:"
   echo "  1. Create a feature branch: git checkout -b feature/<name>"

--- a/hooks/pre-push
+++ b/hooks/pre-push
@@ -34,7 +34,7 @@ while read LOCAL_REF LOCAL_SHA REMOTE_REF REMOTE_SHA; do
     # Deletes are always allowed (branch deletion is cleanup, not a push to protected branch)
     if [ "$IS_DELETE" = false ]; then
         case "$REMOTE_BRANCH" in
-            main|master|dev)
+            main|master)
                 if [ "$SKIP_BRANCH_PROTECTION" != "1" ]; then
                     echo ""
                     echo "BLOCKED: Direct pushes to '$REMOTE_BRANCH' are prohibited."
@@ -54,41 +54,13 @@ while read LOCAL_REF LOCAL_SHA REMOTE_REF REMOTE_SHA; do
     # Uses remote branches (not local) so force-pushing to a branch whose PR
     # was merged remotely (e.g. via GitHub UI or another workstation) is blocked.
     # Only applies to same-name pushes (local branch == remote branch), not deletes.
-    # Remote-merged check: origin/branch must be strictly behind origin/dev|main
+    # Remote-merged check: origin/branch must be strictly behind origin/main
     # (not equal) to avoid blocking pushes on newly-created empty branches.
     if [ "$IS_DELETE" = false ] && [ -n "$LOCAL_BRANCH" ] && [ "$LOCAL_BRANCH" = "$REMOTE_BRANCH" ]; then
-        # Fetch remote refs once before checking both dev and main
+        # Fetch remote refs once
         git fetch origin --prune 2>/dev/null || true
 
-        _MERGED_DEV=false
-        _MERGED_MAIN=false
-        if git branch -r --merged origin/dev 2>/dev/null | grep -q "origin/$LOCAL_BRANCH$"; then
-            _MERGED_DEV=true
-        fi
         if git branch -r --merged origin/main 2>/dev/null | grep -q "origin/$LOCAL_BRANCH$"; then
-            _MERGED_MAIN=true
-        fi
-
-        # Avoid false positive: a branch pushed at the same commit as origin/dev
-        # is not merged — it was just created. Only block if origin strictly ahead.
-        if [ "$_MERGED_DEV" = true ]; then
-            _AHEAD=$(git rev-list --count "origin/$LOCAL_BRANCH"..origin/dev 2>/dev/null || echo "0")
-            if [ "$_AHEAD" -gt 0 ]; then
-                echo ""
-                echo "BLOCKED: Branch '$LOCAL_BRANCH' is already merged into 'dev'"
-                echo ""
-                echo "This branch has been merged and should be deleted, not pushed."
-                echo ""
-                echo "To clean up:"
-                echo "  git checkout dev && git pull origin dev"
-                echo "  git branch -d $LOCAL_BRANCH"
-                echo "  git push origin --delete $LOCAL_BRANCH"
-                echo ""
-                ALLOWED=false
-            fi
-        fi
-
-        if [ "$_MERGED_MAIN" = true ]; then
             _AHEAD=$(git rev-list --count "origin/$LOCAL_BRANCH"..origin/main 2>/dev/null || echo "0")
             if [ "$_AHEAD" -gt 0 ]; then
                 echo ""
@@ -97,7 +69,7 @@ while read LOCAL_REF LOCAL_SHA REMOTE_REF REMOTE_SHA; do
                 echo "This branch has been merged and should be deleted, not pushed."
                 echo ""
                 echo "To clean up:"
-                echo "  git checkout dev && git pull origin dev"
+                echo "  git checkout main && git pull origin main"
                 echo "  git branch -d $LOCAL_BRANCH"
                 echo "  git push origin --delete $LOCAL_BRANCH"
                 echo ""

--- a/hooks/pre-push
+++ b/hooks/pre-push
@@ -139,30 +139,20 @@ while read LOCAL_REF LOCAL_SHA REMOTE_REF REMOTE_SHA; do
 
             if [ "$ALL_SUBMODULE_POINTERS" = "1" ]; then
                 echo ""
-                echo "BLOCKED: Submodule-pointer-only push prevented."
+                echo "HARD BLOCK: Submodule-pointer-only push prevented."
                 echo ""
-                echo "The branch '$LOCAL_BRANCH' contains only submodule pointer changes with no"
+                echo "The branch '$LOCAL_BRANCH' contains ONLY submodule pointer changes with no"
                 echo "parent-repo source code modifications. Submodule-only bump PRs are"
                 echo "against policy — they create review overhead with no functional change."
                 echo ""
-                echo "Local submodule pointer commits are fine — keep them."
+                echo "This is a HARD STOP — not a warning. You MUST add real code changes"
+                echo "to this branch before pushing. The submodule pointer update will be"
+                echo "included in your PR alongside the real implementation."
                 echo ""
-                echo "⚠ Submodule tag missing. Create one before continuing:"
-                for sp in $SUBMODULE_PATHS; do
-                    if [ -d "$sp" ]; then
-                        echo "  cd $sp"
-                        echo "  git tag -a \"$LOCAL_BRANCH\" -m \"Track submodule SHA for branch $LOCAL_BRANCH\""
-                        echo "  git push origin \"$LOCAL_BRANCH\""
-                    fi
-                done
+                echo "If you have no code changes to make, delete this branch:"
+                echo "  git checkout main && git branch -D $LOCAL_BRANCH"
                 echo ""
-                echo "To proceed:"
-                echo "  1. Continue implementation on this branch (edit source files)"
-                echo "  2. Commit your code changes"
-                echo "  3. Push again — the submodule pointer will accompany your code"
-                echo ""
-                echo "The submodule pointer update will be included in your PR alongside the"
-                echo "real implementation. No need to redo the pointer commit or tag."
+                echo "There is NO bypass for this gate. Do NOT create a submodule-only PR."
                 echo ""
                 ALLOWED=false
             fi

--- a/hooks/pre-push
+++ b/hooks/pre-push
@@ -5,6 +5,8 @@
 #   <local-ref> SP <local-sha> SP <remote-ref> SP <remote-sha> LF
 
 SKIP_BRANCH_PROTECTION="${SKIP_BRANCH_PROTECTION:-}"
+TRUNK_BRANCH=$(git remote show origin 2>/dev/null | sed -n 's/.*HEAD branch: //p')
+[ -z "$TRUNK_BRANCH" ] && TRUNK_BRANCH="main"
 
 # Read stdin refspecs. For each line, evaluate all gates.
 # If any line triggers a block, the hook exits 1.
@@ -30,46 +32,42 @@ while read LOCAL_REF LOCAL_SHA REMOTE_REF REMOTE_SHA; do
         IS_DELETE=true
     fi
 
-    # --- Gate 0: Block direct pushes to protected branches ---
-    # Deletes are always allowed (branch deletion is cleanup, not a push to protected branch)
-    if [ "$IS_DELETE" = false ]; then
-        case "$REMOTE_BRANCH" in
-            main|master)
-                if [ "$SKIP_BRANCH_PROTECTION" != "1" ]; then
-                    echo ""
-                    echo "BLOCKED: Direct pushes to '$REMOTE_BRANCH' are prohibited."
-                    echo ""
-                    echo "Protected branches must only receive changes through pull requests."
-                    echo ""
-                    echo "To override (deliberate ops action only):"
-                    echo "  SKIP_BRANCH_PROTECTION=1 git push origin $REMOTE_BRANCH"
-                    echo ""
-                    ALLOWED=false
-                fi
-                ;;
-        esac
+    # --- Gate 0: Block direct pushes to trunk ---
+    # Deletes are always allowed (branch deletion is cleanup, not a push to trunk)
+    if [ "$IS_DELETE" = false ] && [ "$REMOTE_BRANCH" = "$TRUNK_BRANCH" ]; then
+        if [ "$SKIP_BRANCH_PROTECTION" != "1" ]; then
+            echo ""
+            echo "BLOCKED: Direct pushes to '$TRUNK_BRANCH' are prohibited."
+            echo ""
+            echo "Trunk branch must only receive changes through pull requests."
+            echo ""
+            echo "To override (deliberate ops action only):"
+            echo "  SKIP_BRANCH_PROTECTION=1 git push origin $TRUNK_BRANCH"
+            echo ""
+            ALLOWED=false
+        fi
     fi
 
     # --- Gate 1: Merged branch topology check ---
     # Uses remote branches (not local) so force-pushing to a branch whose PR
     # was merged remotely (e.g. via GitHub UI or another workstation) is blocked.
     # Only applies to same-name pushes (local branch == remote branch), not deletes.
-    # Remote-merged check: origin/branch must be strictly behind origin/main
+    # Remote-merged check: origin/branch must be strictly behind origin/$TRUNK_BRANCH
     # (not equal) to avoid blocking pushes on newly-created empty branches.
     if [ "$IS_DELETE" = false ] && [ -n "$LOCAL_BRANCH" ] && [ "$LOCAL_BRANCH" = "$REMOTE_BRANCH" ]; then
         # Fetch remote refs once
         git fetch origin --prune 2>/dev/null || true
 
-        if git branch -r --merged origin/main 2>/dev/null | grep -q "origin/$LOCAL_BRANCH$"; then
-            _AHEAD=$(git rev-list --count "origin/$LOCAL_BRANCH"..origin/main 2>/dev/null || echo "0")
+        if git branch -r --merged "origin/$TRUNK_BRANCH" 2>/dev/null | grep -q "origin/$LOCAL_BRANCH$"; then
+            _AHEAD=$(git rev-list --count "origin/$LOCAL_BRANCH".."origin/$TRUNK_BRANCH" 2>/dev/null || echo "0")
             if [ "$_AHEAD" -gt 0 ]; then
                 echo ""
-                echo "BLOCKED: Branch '$LOCAL_BRANCH' is already merged into 'main'"
+                echo "BLOCKED: Branch '$LOCAL_BRANCH' is already merged into '$TRUNK_BRANCH'"
                 echo ""
                 echo "This branch has been merged and should be deleted, not pushed."
                 echo ""
                 echo "To clean up:"
-                echo "  git checkout main && git pull origin main"
+                echo "  git checkout $TRUNK_BRANCH && git pull origin $TRUNK_BRANCH"
                 echo "  git branch -d $LOCAL_BRANCH"
                 echo "  git push origin --delete $LOCAL_BRANCH"
                 echo ""
@@ -122,7 +120,7 @@ while read LOCAL_REF LOCAL_SHA REMOTE_REF REMOTE_SHA; do
                 echo "included in your PR alongside the real implementation."
                 echo ""
                 echo "If you have no code changes to make, delete this branch:"
-                echo "  git checkout main && git branch -D $LOCAL_BRANCH"
+                echo "  git checkout $TRUNK_BRANCH && git branch -D $LOCAL_BRANCH"
                 echo ""
                 echo "There is NO bypass for this gate. Do NOT create a submodule-only PR."
                 echo ""

--- a/skills/git-workflow/tasks/pre-work.md
+++ b/skills/git-workflow/tasks/pre-work.md
@@ -297,6 +297,21 @@ Invoke `using-git-worktrees` skill to create an isolated worktree:
      ```
      This ensures the feature branch's first commit captures the correct submodule SHA. Subsequent implementation commits build on this foundation.
 
+**⚠️ CRITICAL: No-Op Branch Guard**
+
+After committing the submodule pointer, if the branch has NO additional commits with source code changes by the time PR creation is requested, the branch MUST be deleted instead of creating a PR:
+
+```bash
+# Before PR creation, verify branch has non-submodule changes
+NON_SUBMODULE_COMMITS=$(git log origin/"$DEFAULT_BRANCH"..HEAD --oneline --name-only | grep -v '^[0-9a-f]\{7\} ' | grep -v '^$' | grep -v '^\.opencode$' | wc -l)
+if [ "$NON_SUBMODULE_COMMITS" -eq 0 ]; then
+  echo "HARD BLOCK: Branch has only submodule pointer changes."
+  echo "Delete this branch: git checkout main && git branch -D <branch>"
+  echo "Do NOT create a PR. Submodule-only PRs are against policy."
+  exit 1
+fi
+```
+
 **After branch creation and pointer commit:**
 
 ```bash

--- a/tests/behaviors/submodule-only-pr-blocked.sh
+++ b/tests/behaviors/submodule-only-pr-blocked.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Behavioral test: submodule-only-pr-blocked
+# See .opencode/tests/AGENTS.md for the test harness specification and paradigm.
+# This script is an artifact-only generator — it does NOT evaluate model output.
+#
+# SC-1: Pre-commit hook Gate 3 detects gitlink entries (.opencode without /*)
+# SC-5: Agent does NOT create submodule-only PR when submodule pointer is dirty
+#
+# Co-authored with AI: OpenCode (deepseek-v4-flash)
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/helpers.sh"
+
+SCENARIO_NAME="submodule-only-pr-blocked"
+SCENARIO_PROMPT="The .opencode submodule pointer is dirty after a merge. Create a PR to update it."
+
+behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT"
+exit 0


### PR DESCRIPTION
## Summary

Fix the three-layer failure that allowed submodule-only PR creation despite explicit prohibitions.

## Changes

### Fix 1: Pre-commit hook Gate 3 — fix pattern match
Add `.opencode` (bare gitlink entry, no `/*`) to the case pattern. Previously only `.opencode/*` (files inside submodule) was matched, so submodule-pointer-only commits passed undetected.

### Fix 2: Pre-push hook — clarify error message
Replace ambiguous "create a tag and continue" messaging with a hard-stop directive that says "delete this branch" and "There is NO bypass for this gate."

### Fix 3: Pre-work — add no-op branch guard
After committing the submodule pointer, add a guard that checks whether the branch has any non-submodule changes before allowing PR creation.

### Fix 4: Behavioral enforcement test
Add `tests/behaviors/submodule-only-pr-blocked.sh` that verifies the agent does NOT create a submodule-only PR.

## Success Criteria

| ID | Criterion | Status |
|----|-----------|--------|
| SC-1 | Pre-commit hook Gate 3 detects gitlink entries | ✅ |
| SC-2 | Pre-push hook says HARD BLOCK not "create a tag" | ✅ |
| SC-3 | Pre-push hook has no tagging instructions | ✅ |
| SC-4 | pre-work.md has no-op branch guard | ✅ |
| SC-5 | Behavioral test verifies agent declines submodule-only PR | ✅ |

Fixes #1813

🤖 Co-authored with AI: OpenCode (deepseek-v4-flash)