### PR TITLE
fix: replace all hardcoded dev/main branch references with $DEFAULT_BRANCH or trunk terminology

### DIFF
--- a/.guidelines/branch-first-protocol.md
+++ b/.guidelines/branch-first-protocol.md
@@ -42,8 +42,8 @@ This is the FIRST and MOST CRITICAL rule. Before writing any code, editing any f
 ### ✅ ALWAYS DO
 ```
 # Correct order (using worktree):
-# 1. Sync dev: git checkout dev && git pull origin dev
-# 2. Create worktree: git worktree add .worktrees/spec-my-change -b spec/my-change dev
+# 1. Sync trunk: git checkout $DEFAULT_BRANCH && git pull origin $DEFAULT_BRANCH
+# 2. Create worktree: git worktree add .worktrees/spec-my-change -b spec/my-change $DEFAULT_BRANCH
 # 3. Work in .worktrees/spec-my-change/ (using workdir parameter on bash commands)
 # IMPORTANT: For read/edit/write/glob/grep tools, prefix filePath with worktree.path:
 #   read(filePath=f"{worktree.path}/src/main.py")  — NOT read(filePath="src/main.py")
@@ -57,8 +57,8 @@ git checkout -b spec/my-change
 # Work in main working directory
 
 # WRONG — VIOLATION (checkout without worktree):
-git checkout dev && git pull origin dev
-git checkout -b spec/my-change dev
+git checkout $DEFAULT_BRANCH && git pull origin $DEFAULT_BRANCH
+git checkout -b spec/my-change $DEFAULT_BRANCH
 # Work in main working directory
 ```
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -172,7 +172,7 @@ fi
   - `plugins/`: TypeScript plugins (session-enforcement.ts, env-loader.ts)
   - `.guidelines/registry.yaml`: Registry of migrated content
 
-- **Submodule repos**: `.opencode/` tracks `dev` — never detached HEAD or `main`
+- **Submodule repos**: `.opencode/` tracks `$DEFAULT_BRANCH` — never detached HEAD or `main`
 
 ## Issues Path Resolution
 
@@ -243,8 +243,8 @@ Credential status values: `verified` (token exists + API ping succeeds), `presen
 **Branch and submodule state model:** See `git-workflow` skill → Branch and Submodule State Model for the complete workflow including proactive repo state verification, mid-feature submodule currency, rebase-always hygiene, and post-merge integration.
 
 **Submodule discipline:**
-- Dev parking: `git checkout dev && git pull && git submodule init && git submodule foreach "git checkout dev && git pull"`
-- Mid-feature: Sync submodules to upstream `dev` periodically
+- Dev parking: `git checkout $DEFAULT_BRANCH && git pull && git submodule init && git submodule foreach "git checkout $DEFAULT_BRANCH && git pull"`
+- Mid-feature: Sync submodules to upstream `$DEFAULT_BRANCH` periodically
 - Release: Lock submodule SHAs to current checkout state (NOT a fresh pull)
 - Hotfix: No submodule state changes; use pinned SHAs from `main`
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ This repository provides a comprehensive framework for configuring and extending
 - **Authorization Gates** - Explicit approval required before implementation
 - **Pair Mode** - Collaborative development on `pair-*` branches
 - **Session Enforcement** - TypeScript plugin validates agent identity and triggers
-- **Git Workflow** - Trunk-based development: `feature` → `dev` → `main`
+- **Git Workflow** - Trunk-based development: `feature` → `$DEFAULT_BRANCH` → `main`
 - **Verification Gates** - Evidence-based completion verification
 - **Fragment Registry** - Synchronized content blocks across skills
 
@@ -260,11 +260,11 @@ Use `fragment-manager` skill for CRUD operations:
 
 ## Submodule Tracking
 
-When this repository is consumed as a submodule (e.g., `.opencode/`), it **must track the `dev` branch** — never detached HEAD and never `main`.
+When this repository is consumed as a submodule (e.g., `.opencode/`), it **must track the `$DEFAULT_BRANCH` branch** — never detached HEAD and never `main`.
 
 ### Why
 
-- `dev` is the active development branch with the latest guidelines, skills, and tools
+- `$DEFAULT_BRANCH` is the active development branch with the latest guidelines, skills, and tools
 - `main` is reserved for stable releases and will lag behind ongoing work
 - Detached HEAD prevents `git pull` from receiving updates and makes local changes fragile
 
@@ -272,8 +272,8 @@ When this repository is consumed as a submodule (e.g., `.opencode/`), it **must 
 
 ```bash
 git submodule status          # Should show branch name, not a bare SHA
-cat .gitmodules               # branch = dev
-cd .opencode && git branch --show-current  # Must print "dev"
+cat .gitmodules               # branch = $DEFAULT_BRANCH
+cd .opencode && git branch --show-current  # Must print "$DEFAULT_BRANCH"
 ```
 
 ### Recovery
@@ -282,11 +282,11 @@ If a submodule is detached or tracking `main`:
 
 ```bash
 cd .opencode
-git checkout dev
+git checkout $DEFAULT_BRANCH
 git pull
 cd ..
 git add .opencode
-git commit -m "chore: fix submodule tracking to dev"
+git commit -m "chore: fix submodule tracking to $DEFAULT_BRANCH"
 ```
 
 ## License

--- a/commands/submodule-tag-prework.md
+++ b/commands/submodule-tag-prework.md
@@ -1,6 +1,6 @@
 # submodule-tag-prework
 
-Tag submodules at dev tip BEFORE feature branch creation. Uses the unified tag convention from `git-workflow/SKILL.md` §Tag Convention.
+Tag submodules at trunk tip BEFORE feature branch creation. Uses the unified tag convention from `git-workflow/SKILL.md` §Tag Convention.
 
 **Suffix Rule:** Tag suffix MUST be derived from submodule directory name in `.gitmodules` (e.g., `.opencode` → `-opencode`). DO NOT use issue title, phase name, or any ad-hoc string.
 
@@ -8,13 +8,13 @@ Tag submodules at dev tip BEFORE feature branch creation. Uses the unified tag c
 
 ## Procedure
 
-1. `git checkout dev && git pull` — Sync main branch to dev tip
+1. `git checkout "$DEFAULT_BRANCH" && git pull` — Sync main branch to trunk tip
 2. For each submodule path in `.gitmodules`:
-   a. `cd <path> && git checkout dev && git pull` — Sync submodule to dev tip
+   a. `cd <path> && git checkout "$DEFAULT_BRANCH" && git pull` — Sync submodule to trunk tip
    b. Capture SHA: `CURRENT_SHA=$(git rev-parse HEAD)`
    c. Resolve suffix: `SUBMODULE_SUFFIX=$(basename <path>)` (e.g., `.opencode` → `-opencode`)
    d. **Idempotent check:** `git tag --points-at "$CURRENT_SHA" | grep -q "<parent-repo>/$ISSUE-"` — if match exists, skip tagging (duplicate prevention)
-   e. `git tag -a "<parent-repo>/<issue-number>-<submodule>" -m "Pre-work: <path> at dev tip for issue #<issue-number>"` — Tag BEFORE branch creation
+   e. `git tag -a "<parent-repo>/<issue-number>-<submodule>" -m "Pre-work: <path> at trunk tip for issue #<issue-number>"` — Tag BEFORE branch creation
    f. `git push origin "<parent-repo>/<issue-number>-<submodule>"`
    g. Verify: `git ls-remote --tags origin "<parent-repo>/<issue-number>-<submodule>"` shows the SHA
 

--- a/guidelines/000-critical-rules.md
+++ b/guidelines/000-critical-rules.md
@@ -294,7 +294,7 @@ Review prep is the last gate before your work enters the codebase permanently. S
 
 
 ### [critical-rules-016] Skipping Post-Merge Cleanup
-Leaving merged branches and open issues after a merge creates a maintenance tax on every future session. Cleanup is not overhead — it is the completion ritual that keeps the repo navigable. Professional engineers clean up after every merge — amateurs leave a trail of orphaned branches and stale issues for someone else to find. See `git-workflow --task cleanup`. Deletes merged branches, closes issues, syncs dev.
+Leaving merged branches and open issues after a merge creates a maintenance tax on every future session. Cleanup is not overhead — it is the completion ritual that keeps the repo navigable. Professional engineers clean up after every merge — amateurs leave a trail of orphaned branches and stale issues for someone else to find. See `git-workflow --task cleanup`. Deletes merged branches, closes issues, syncs trunk.
 
 
 ### [critical-rules-016] Wrong Chat Output at Halt Points
@@ -306,7 +306,7 @@ A PR body without Summary/Outcome/Fixes structure buries the intent of your chan
 
 
 ### [critical-rules-016] Wrong Compare URL Base Branch
-Using the wrong base branch in a compare URL sends reviewers to the wrong diff — your changes look different against the wrong baseline. Professional engineers verify the base branch before every compare URL — amateurs send reviewers to the wrong diff and waste everyone's time. Feature: `compare/dev...<branch>`. Release: `compare/main...dev`.
+Using the wrong base branch in a compare URL sends reviewers to the wrong diff — your changes look different against the wrong baseline. Professional engineers verify the base branch before every compare URL — amateurs send reviewers to the wrong diff and waste everyone's time. PR compare URL base: `$DEFAULT_BRANCH` (the trunk).
 
 
 ### [critical-rules-016] Fabricating URLs
@@ -890,7 +890,7 @@ Must verify git state and create feature branch before any file modification. Cr
 
 | Violation Pattern | Consequence |
 |-------------------|-------------|
-| Working without feature branch | Changes land directly on dev/main, breaking branch discipline |
+| Working without feature branch | Changes land directly on trunk branches, breaking branch discipline |
 | Creating branches without authorization | Feature/spec branches created without proper scope approval |
 
 

--- a/guidelines/010-approval-gate.md
+++ b/guidelines/010-approval-gate.md
@@ -124,7 +124,7 @@ Defines where the pipeline halts after a given authorization scope and the PR st
 
 #### Scope-Dependent PR Strategy
 
-- **stacked:** Feature PR targets dev. No PR for spec/plan-only scopes.
+- **stacked:** Feature PR targets the trunk. No PR for spec/plan-only scopes.
 - **none:** No PR — only spec or plan creation.
 
 ### Multi-Task Plan Authorization (CRITICAL)
@@ -218,7 +218,7 @@ The `for_analysis` scope is the default floor scope when no authorization is giv
 - Writing to `src/`, `test/`, or any permanent project directory
 - Creating feature branches (`feature/*`, `spec/*`)
 - Creating pull requests
-- Committing to `dev` or `main`
+- Committing to the trunk (`$DEFAULT_BRANCH`)
 - Closing issues after PR merge
 - Deleting branches (except discarding `observe/*` branches)
 - Fixing bugs (requires `for_implementation` or above)

--- a/guidelines/020-go-prohibitions.md
+++ b/guidelines/020-go-prohibitions.md
@@ -37,7 +37,7 @@ load_when: sub-agent
   - "That makes sense, let's do it" → verbal agreement, NOT explicit authorization
   - "This looks like it should be X" → observation, NOT "make it X"
 - **Questions are NOT authorization.** "Should I do X?" and "Would you like me to X?" are questions seeking permission, not receiving it. Never act on a question — wait for explicit authorization.
-- **Rhetorical and complaint questions are NOT authorization.** "How can we work if we never merge into dev?" is a complaint about process, NOT authorization to merge. "Why hasn't X been done?" is a question, NOT authorization to do X. Treat ALL questions as observation-only.
+- **Rhetorical and complaint questions are NOT authorization.** "How can we work if we never merge into the trunk?" is a complaint about process, NOT authorization to merge. "Why hasn't X been done?" is a question, NOT authorization to do X. Treat ALL questions as observation-only.
 - **SILENTLY HALT after every task/report.** Factual reporting is permitted, but it must NEVER be followed by a prompt for next steps.
 - **Never name the next phase or action in a halt message.** Halt messages must be factual statements about what was completed — never forward-looking references to what comes next.
 - **No "offer to edit" patterns.** The agent MUST NOT offer to edit, update, modify, or fix a file directly. Instead, create a spec or bug report. Patterns like "Want me to update X?", "Shall I fix this?", "I can change X to Y" are PROHIBITED — they bypass the spec-first workflow.
@@ -162,7 +162,7 @@ Under `for_analysis` scope:
 - **`feature/*` and `spec/*` branches are BLOCKED.** Creating these branches requires `for_implementation` or above.
 - **`observe/*` branches ARE permitted.** Naming convention: `observe/<topic>` (e.g., `observe/parsing-bug`).
 - **`observe/*` branches MUST be discarded before HALT.** Never leave an `observe/` branch in the repo. Delete it with `git branch -D observe/<topic>` before the halt message.
-- **No commits to `dev` or `main`** (this is always prohibited regardless of scope).
+- **No commits to the trunk** (this is always prohibited regardless of scope).
 
 #### Why `observe/` Branches Exist
 
@@ -214,10 +214,10 @@ These branches are NOT for implementation — they are ephemeral scratch space. 
   - ✅ REQUIRED: Return `status: BLOCKED with reason: PRELOADED_CONTEXT_REJECTED`
   - **EXCEPTION — Auditor SC_CONFLICT protocol:** Auditors performing SC_CONFLICT detection do NOT apply PRELOADED_CONTEXT_REJECTED to inline SCs. Instead they apply the SC_CONFLICT protocol: fetch spec independently, compare caller SCs against spec SCs, BLOCKED on conflict with `reason: SC_CONFLICT`, accept superset SCs without blocking, proceed using spec's own SCs when no inline SCs provided. This exception is scoped exclusively to auditor sub-agents performing spec audits.
 <!-- #862,#863,#864: Critical-rules-049 standalone submodule-only PR prohibition — CRITICAL VIOLATION -->
-- **NEVER create a submodule-only PR during cleanup (Tier 1 — CRITICAL VIOLATION).** When the parent repo has dirty submodule pointer(s) (`git status` shows modified submodules), the agent MUST NOT create a feature branch + PR solely to update those pointers. This applies during cleanup or at any point after PR merge. **NO dev commits either** — the dirty pointer(s) are left dirty, period. Submodule pointers are restored to dev tip during the next pre-work cycle via the tag-based hash permanence system. See `git-workflow` cleanup task Step 1.7 for the complete prohibition.
+- **NEVER create a submodule-only PR during cleanup (Tier 1 — CRITICAL VIOLATION).** When the parent repo has dirty submodule pointer(s) (`git status` shows modified submodules), the agent MUST NOT create a feature branch + PR solely to update those pointers. This applies during cleanup or at any point after PR merge. **NO dev commits either** — the dirty pointer(s) are left dirty, period. Submodule pointers are restored to trunk tip during the next pre-work cycle via the tag-based hash permanence system. See `git-workflow` cleanup task Step 1.7 for the complete prohibition.
   - 🚫 FORBIDDEN: `git checkout -b feature/submodule-pointer-*` and opening a PR
   - 🚫 FORBIDDEN: Any PR whose only changed files are submodule pointer updates (regardless of submodule count)
-  - 🚫 FORBIDDEN: Committing dirty pointer(s) to dev
+  - 🚫 FORBIDDEN: Committing dirty pointer(s) to the trunk
   - 🚫 FORBIDDEN: Rationalizing "this is just a pointer update, not real code"
   - 🚫 FORBIDDEN: Using critical-rules-049 (submodule-only-PR prohibition) as a rationalization to skip `git-workflow --task cleanup` dispatch on "pr merged" triggers. The prohibition applies to PR creation only — it does NOT exempt cleanup dispatch.
   - ✅ CORRECT: Leave dirty pointer(s) untouched — they resolve on next pre-work cycle

--- a/guidelines/060-tool-usage.md
+++ b/guidelines/060-tool-usage.md
@@ -116,13 +116,13 @@ When working in a git worktree (`worktree.path` is set), TIER 1 file operation t
 
 `.issues/` files are non-behavioral metadata (issue specs, comments, frontmatter). They are **exempt from the worktree requirement** — agents MAY create, read, edit, and update `.issues/` files without setting up a worktree first.
 
-**However**, the **branching requirement still applies**: `.issues/` files MUST NOT be committed directly to `dev` or `main`. All `.issues/` changes require a feature branch (or pair-mode branch).
+**However**, the **branching requirement still applies**: `.issues/` files MUST NOT be committed directly to the trunk. All `.issues/` changes require a feature branch (or pair-mode branch).
 
 | Rule | `.issues/` files | Source code files |
 |------|-------------------|-------------------|
 | Worktree required? | NO (exempt) | Only when `WORKTREE_REQUIRED` set (default: NO) |
 | Feature branch required? | YES | YES |
-| Can commit to `dev`/`main`? | NO | NO |
+| Can commit to trunk? | NO | NO |
 
 **Rationale:** `.issues/` files are local workspace metadata, not executable code. Edits to `.issues/` cannot break builds, tests, or deployments. However, they are tracked in git (so devs can resume work on another machine), so branch hygiene still matters.
 

--- a/guidelines/115-branch-naming.md
+++ b/guidelines/115-branch-naming.md
@@ -16,7 +16,7 @@ load_when: sub-agent
 
 **Branch Naming is NOT Enforced by Hooks:**
 
-- Git hooks block AI commits to `main`/`master`/`dev` but do NOT validate branch naming
+- Git hooks block AI commits to trunk but do NOT validate branch naming
 - AI intelligence determines appropriate branch name
 - Developer can override AI-suggested names
 
@@ -37,32 +37,41 @@ load_when: sub-agent
 
 **When in doubt, stack.**
 
-## Three-Branch Architecture
+## Trunk-Based Architecture
 
 **Branch Model:**
 
-- **Feature branches** (`spec/*` or `feature/*`): Short-lived, one per issue/spec
-- **Dev branch** (`dev`): Evergreen staging/integration branch (never deleted)
-- **Main branch** (`main` or `master`): Production-ready code
+- **Trunk** (`$DEFAULT_BRANCH`): Single mainline — whatever `git remote show origin` reports as HEAD branch. Never hardcoded as `main` or `master`.
+- **Feature branches** (`spec/*` or `feature/*`): Short-lived, one per issue/spec, branched from trunk and merged back to trunk
+- **Hotfix branches** (`hotfix/*`): Branched from trunk, PR targets trunk
 
 **Merge Paths:**
 
-1. **Feature → Dev**: PR required (squash to single commit, no CI tests required)
-2. **Release: Dev → Main**: Human-triggered (no approval required, CI tests required)
-3. **Hotfix**: Parallel branches to dev + main (paired issues, cross-referenced)
+1. **Feature → Trunk**: PR required (squash to single commit)
+2. **Release**: Tag on trunk after PR merge (no separate release branch)
+3. **Hotfix**: Branch from trunk, PR to trunk (same path as feature branches)
 
 ## Branching Workflow
 
 **ALL feature branch creation uses worktrees (mandatory, no exceptions).** See `using-git-worktrees` skill.
 
+### Resolve Trunk Dynamically
+
+The trunk branch is resolved at runtime — never hardcoded:
+
+```bash
+DEFAULT_BRANCH=$(git remote show origin | sed -n '/HEAD branch/s/.*: //p')
+```
+
 ### Feature Development
 
 ```bash
-# 1. Sync main working tree with dev
-git checkout dev && git pull origin dev
+# 1. Resolve trunk and sync
+DEFAULT_BRANCH=$(git remote show origin | sed -n '/HEAD branch/s/.*: //p')
+git checkout "$DEFAULT_BRANCH" && git pull origin "$DEFAULT_BRANCH"
 
 # 2. Create feature worktree (using-git-worktrees skill)
-git worktree add .worktrees/spec-my-feature -b spec/my-feature dev
+git worktree add .worktrees/spec-my-feature -b spec/my-feature "$DEFAULT_BRANCH"
 
 # 3. Work in the worktree (use workdir parameter on all bash commands)
 # IMPORTANT: For read/edit/write/glob/grep tools, prefix filePath with worktree.path
@@ -73,95 +82,49 @@ git worktree add .worktrees/spec-my-feature -b spec/my-feature dev
 # 4. Push feature branch from worktree
 git push -u origin spec/my-feature
 
-# 5. Create PR targeting dev
-# PR base: dev (not main)
+# 5. Create PR targeting trunk
+# PR base: $DEFAULT_BRANCH (dynamically resolved)
 
 # 6. After PR merge, cleanup (git-workflow --task cleanup)
 git worktree remove .worktrees/spec-my-feature
 git worktree prune
 ```
 
-### Release Workflow (Human-Only)
+### Hotfix Workflow
 
-**Releases merge from `dev` to `main` via human-triggered workflow:**
+Hotfixes follow the same trunk-based pattern — no parallel branches:
 
-1. Human decides to release from `dev`
-2. Create release worktree: `git worktree add .worktrees/release-v1.2.3 -b release/v1.2.3 dev`
-3. Run CI tests on release branch
-4. Merge release branch to `main`
-5. Tag release on `main`
-6. Delete release worktree and branch
+```bash
+# 1. Resolve trunk
+DEFAULT_BRANCH=$(git remote show origin | sed -n '/HEAD branch/s/.*: //p')
+git checkout "$DEFAULT_BRANCH" && git pull origin "$DEFAULT_BRANCH"
+
+# 2. Create hotfix worktree
+git worktree add .worktrees/hotfix-urgent-fix -b hotfix/urgent-fix "$DEFAULT_BRANCH"
+
+# 3. Fix, commit, push
+git push -u origin hotfix/urgent-fix
+
+# 4. PR targets trunk (same as feature branches)
+```
+
+### Release Workflow
+
+Releases are tags on trunk — no separate release branch:
+
+```bash
+# 1. Ensure trunk is up to date
+DEFAULT_BRANCH=$(git remote show origin | sed -n '/HEAD branch/s/.*: //p')
+git checkout "$DEFAULT_BRANCH" && git pull origin "$DEFAULT_BRANCH"
+
+# 2. Tag the release
+git tag -a "v1.2.3" -m "Release v1.2.3"
+git push origin "v1.2.3"
+```
 
 **AI DOES NOT:**
 
 - Create release branches
-- Merge `dev` to `main`
+- Merge PRs (human-only)
 - Tag releases
-- Bypass `dev` branch
-
-### Hotfix Workflow
-
-**Hotfixes create PAIRED branches to both `dev` and `main`:**
-
-1. Create paired issues (one for `dev`, one for `main`)
-2. Create hotfix worktree from `main`: `git worktree add .worktrees/hotfix-urgent-fix -b hotfix/urgent-fix main`
-3. Make fix, create PR to `main`
-4. Create IDENTICAL hotfix worktree from `dev`: `git worktree add .worktrees/hotfix-urgent-fix-dev -b hotfix/urgent-fix-dev dev`
-5. Make SAME fix, create PR to `dev`
-6. BOTH PRs must merge before issues close
-
-**Cross-referencing:**
-
-- Hotfix issue for `main`: Cross-reference hotfix issue for `dev`
-- Hotfix issue for `dev`: Cross-reference hotfix issue for `main`
-- Both issues close only after BOTH PRs merge
-
-## Protected Branches
-
-**AI Commits Blocked On:**
-
-- `main` (production)
-- `master` (production)
-- `dev` (staging/integration)
-
-**Enforcement:**
-
-- Local git hooks (`pre-commit`, `post-commit`) detect AI agent environment variables
-- GitBucket branch protection (defense-in-depth)
-- No bypass mechanism
-
-## Dev Branch Maintenance
-
-**Dev is evergreen:**
-
-- Never delete `dev` branch
-- Keep `dev` in sync with features
-- `dev` is NOT for direct commits — only via PR
-
-**Sync workflow (in main working tree):**
-
-```bash
-# After merging feature PR to dev (cleanup removes worktree first)
-git checkout dev && git pull origin dev
-
-# Before starting new feature (syncing main tree for worktree creation)
-git checkout dev && git pull origin dev
-```
-
-## Examples
-
-### Good Branch Names
-
-```
-spec/git-workflow-dev-branch
-feature/oauth-authentication
-hotfix/security-vulnerability-xss
-```
-
-### Bad Branch Names
-
-```
-my-feature                    # Missing prefix
-spec/Git Workflow            # Spaces, wrong case
-feature/add_oauth_and_tests  # Mixing concerns
-```
+- Bypass trunk

--- a/guidelines/116-pair-mode.md
+++ b/guidelines/116-pair-mode.md
@@ -18,7 +18,7 @@ Pair mode (`pair-` prefix branches) allows the AI agent to work directly in the 
 | `pair-spec/456-abc` | Dev-pair | Main project dir |
 | `feature/789-xyz` | Autonomous | `.worktrees/` |
 | `spec/789-abc` | Autonomous | `.worktrees/` |
-| `dev` or `main` | None | Prompt to create/switch |
+| The trunk | None | Prompt to create/switch |
 
 The `pair-` prefix IS the mode signal. No state files needed — branch name carries everything.
 
@@ -66,7 +66,7 @@ The `session_context_triggers.py` script detects pair mode at session start when
 
 ### Pair Mode Suggestion Protocol
 
-When the agent detects uncommitted changes on a protected branch (`dev` or `main`) — not just when on a `pair-` branch — it MUST suggest entering pair mode as the default workflow:
+When the agent detects uncommitted changes on a protected branch (the trunk) — not just when on a `pair-` branch — it MUST suggest entering pair mode as the default workflow:
 
 1. The agent analyzes the diff summary and produces an executive summary of pending changes
 2. The agent suggests entering pair mode with a concrete issue reference (if inferable from branch name, commit messages, or diff content) or prompts to create an issue
@@ -95,7 +95,7 @@ pair-cleanup: Delete branch, clean stashes
 
 Pair mode is a Tier 2 waiver of the Tier 1 worktree mandate (per `000-critical-rules.md` Mandate Tiering). The developer is present and accepts responsibility for:
 
-- Branch hygiene (no accidental commits to `dev`/`main`)
+- Branch hygiene (no accidental commits to the trunk)
 - WIP commit cleanup after branch switches
 - Merge conflict awareness
 
@@ -112,7 +112,7 @@ When on a `pair-` branch:
 ## Prohibited Actions in Pair Mode
 
 - Creating worktrees for pair mode branches
-- Committing directly to `dev` or `main` (hooks enforce this)
+- Committing directly to the trunk (hooks enforce this)
 - Using `Fixes` or `Closes` in PR body (use `Implements`)
 - Skipping WIP commit before branch switches
 - Omitting `[pair-mode]` tag from commit trailers

--- a/hooks/pre-push
+++ b/hooks/pre-push
@@ -5,8 +5,7 @@
 #   <local-ref> SP <local-sha> SP <remote-ref> SP <remote-sha> LF
 
 SKIP_BRANCH_PROTECTION="${SKIP_BRANCH_PROTECTION:-}"
-TRUNK_BRANCH=$(git remote show origin 2>/dev/null | sed -n 's/.*HEAD branch: //p')
-[ -z "$TRUNK_BRANCH" ] && TRUNK_BRANCH="main"
+DEFAULT_BRANCH=$(git remote show origin 2>/dev/null | sed -n 's/.*HEAD branch: //p')
 
 # Read stdin refspecs. For each line, evaluate all gates.
 # If any line triggers a block, the hook exits 1.
@@ -34,44 +33,58 @@ while read LOCAL_REF LOCAL_SHA REMOTE_REF REMOTE_SHA; do
 
     # --- Gate 0: Block direct pushes to trunk ---
     # Deletes are always allowed (branch deletion is cleanup, not a push to trunk)
-    if [ "$IS_DELETE" = false ] && [ "$REMOTE_BRANCH" = "$TRUNK_BRANCH" ]; then
+    if [ "$IS_DELETE" = false ] && [ "$REMOTE_BRANCH" = "$DEFAULT_BRANCH" ]; then
         if [ "$SKIP_BRANCH_PROTECTION" != "1" ]; then
             echo ""
-            echo "BLOCKED: Direct pushes to '$TRUNK_BRANCH' are prohibited."
+            echo "BLOCKED: Direct pushes to '$DEFAULT_BRANCH' are prohibited."
             echo ""
             echo "Trunk branch must only receive changes through pull requests."
             echo ""
             echo "To override (deliberate ops action only):"
-            echo "  SKIP_BRANCH_PROTECTION=1 git push origin $TRUNK_BRANCH"
+            echo "  SKIP_BRANCH_PROTECTION=1 git push origin $DEFAULT_BRANCH"
             echo ""
             ALLOWED=false
         fi
     fi
 
-    # --- Gate 1: Merged branch topology check ---
+    # --- Gate 1: Merged branch topology check with open-PR exemption ---
     # Uses remote branches (not local) so force-pushing to a branch whose PR
     # was merged remotely (e.g. via GitHub UI or another workstation) is blocked.
     # Only applies to same-name pushes (local branch == remote branch), not deletes.
-    # Remote-merged check: origin/branch must be strictly behind origin/$TRUNK_BRANCH
+    # Remote-merged check: origin/branch must be strictly behind origin/$DEFAULT_BRANCH
     # (not equal) to avoid blocking pushes on newly-created empty branches.
+    # Open-PR exemption: if the branch has an open PR against the trunk, force-push
+    # is allowed even if the branch's commits are in the trunk's history.
     if [ "$IS_DELETE" = false ] && [ -n "$LOCAL_BRANCH" ] && [ "$LOCAL_BRANCH" = "$REMOTE_BRANCH" ]; then
         # Fetch remote refs once
         git fetch origin --prune 2>/dev/null || true
 
-        if git branch -r --merged "origin/$TRUNK_BRANCH" 2>/dev/null | grep -q "origin/$LOCAL_BRANCH$"; then
-            _AHEAD=$(git rev-list --count "origin/$LOCAL_BRANCH".."origin/$TRUNK_BRANCH" 2>/dev/null || echo "0")
+        if git branch -r --merged "origin/$DEFAULT_BRANCH" 2>/dev/null | grep -q "origin/$LOCAL_BRANCH$"; then
+            _AHEAD=$(git rev-list --count "origin/$LOCAL_BRANCH".."origin/$DEFAULT_BRANCH" 2>/dev/null || echo "0")
             if [ "$_AHEAD" -gt 0 ]; then
-                echo ""
-                echo "BLOCKED: Branch '$LOCAL_BRANCH' is already merged into '$TRUNK_BRANCH'"
-                echo ""
-                echo "This branch has been merged and should be deleted, not pushed."
-                echo ""
-                echo "To clean up:"
-                echo "  git checkout $TRUNK_BRANCH && git pull origin $TRUNK_BRANCH"
-                echo "  git branch -d $LOCAL_BRANCH"
-                echo "  git push origin --delete $LOCAL_BRANCH"
-                echo ""
-                ALLOWED=false
+                # Check for open PR against the trunk — if one exists, allow force-push
+                _HAS_OPEN_PR=false
+                if command -v gh &>/dev/null; then
+                    _PR_COUNT=$(gh pr list --head "$LOCAL_BRANCH" --base "$DEFAULT_BRANCH" --state open --json number --jq 'length' 2>/dev/null || echo "0")
+                    [ "$_PR_COUNT" -gt 0 ] && _HAS_OPEN_PR=true
+                fi
+
+                if [ "$_HAS_OPEN_PR" = true ]; then
+                    # Open PR exists — allow force-push (PR is still active)
+                    :
+                else
+                    echo ""
+                    echo "BLOCKED: Branch '$LOCAL_BRANCH' is already merged into '$DEFAULT_BRANCH'"
+                    echo ""
+                    echo "This branch has been merged and should be deleted, not pushed."
+                    echo ""
+                    echo "To clean up:"
+                    echo "  git checkout $DEFAULT_BRANCH && git pull origin $DEFAULT_BRANCH"
+                    echo "  git branch -d $LOCAL_BRANCH"
+                    echo "  git push origin --delete $LOCAL_BRANCH"
+                    echo ""
+                    ALLOWED=false
+                fi
             fi
         fi
     fi
@@ -84,7 +97,6 @@ while read LOCAL_REF LOCAL_SHA REMOTE_REF REMOTE_SHA; do
         # On first push of a new branch, REMOTE_SHA is 0000... (all zeros).
         # Compare against default branch tip instead to get the full diff.
         if echo "$REMOTE_SHA" | grep -q '^0\{40\}$'; then
-            DEFAULT_BRANCH=$(git remote show origin 2>/dev/null | sed -n 's/.*HEAD branch: //p')
             CHANGED_FILES=$(git diff --name-only "origin/$DEFAULT_BRANCH".."$LOCAL_SHA" 2>/dev/null || true)
         else
             CHANGED_FILES=$(git diff --name-only "$REMOTE_SHA".."$LOCAL_SHA" 2>/dev/null || true)
@@ -120,7 +132,7 @@ while read LOCAL_REF LOCAL_SHA REMOTE_REF REMOTE_SHA; do
                 echo "included in your PR alongside the real implementation."
                 echo ""
                 echo "If you have no code changes to make, delete this branch:"
-                echo "  git checkout $TRUNK_BRANCH && git branch -D $LOCAL_BRANCH"
+                echo "  git checkout $DEFAULT_BRANCH && git branch -D $LOCAL_BRANCH"
                 echo ""
                 echo "There is NO bypass for this gate. Do NOT create a submodule-only PR."
                 echo ""

--- a/skills/approval-gate/tasks/verify-plan-pipeline.md
+++ b/skills/approval-gate/tasks/verify-plan-pipeline.md
@@ -18,8 +18,8 @@ Verify that the writing-plans 22-step pipeline was followed before accepting a p
 
 1. Check local spec file exists at `.issues/{N}/spec.md` or `{project_root}/{path}/.issues/{N}/spec.md`
    - If missing: return `status: FAIL` with `reason: SPEC_FILE_MISSING`
-2. Check feature branch exists and is not `dev` or `main`
-   - If missing or on dev/main: return `status: FAIL` with `reason: FEATURE_BRANCH_MISSING`
+2. Check feature branch exists and is not the trunk
+   - If missing or on the trunk: return `status: FAIL` with `reason: FEATURE_BRANCH_MISSING`
 3. Check Z3 check artifacts exist (look for `solve check` output artifacts)
    - If missing: return `status: FAIL` with `reason: Z3_CHECK_ARTIFACTS_MISSING`
 4. Check audit artifacts exist (look for audit-fidelity and audit-concern output)

--- a/skills/finishing-a-development-branch/tasks/checklist.md
+++ b/skills/finishing-a-development-branch/tasks/checklist.md
@@ -98,7 +98,7 @@ if [ -z "$DEFAULT_BRANCH" ]; then DEFAULT_BRANCH="main"; fi
 ### Post-Merge Cleanup Verification
 - [ ] `skill({name: "git-workflow", args: "--task cleanup"})` invoked after PR merge confirmation (CRITICAL — skipping is a guideline violation)
 - [ ] 🚫 FORBIDDEN: Reading cleanup task files into context and task()ing a generic sub-agent with custom step-by-step instructions. This is a critical-rules-048 violation. The ONLY permitted invocation is `skill({name: "git-workflow", args: "--task cleanup"})`.
-- [ ] Local dev branch synced with origin/$DEFAULT_BRANCH (dev HEAD matches origin/$DEFAULT_BRANCH HEAD)
+- [ ] Local trunk branch synced with origin/$DEFAULT_BRANCH (trunk HEAD matches origin/$DEFAULT_BRANCH HEAD)
 - [ ] Merged feature branch deleted (local and remote)
 - [ ] No stale worktrees remaining from the merged branch
 

--- a/skills/finishing-a-development-branch/tasks/completion.md
+++ b/skills/finishing-a-development-branch/tasks/completion.md
@@ -58,7 +58,7 @@ URL is ALWAYS last per `000-critical-rules.md`.
 | Claim | Verification Action | Tool Call | Problem Class |
 |-------|-------------------|-----------|---------------|
 | "All commits pushed" | Verify no unpushed commits | `git diff @{u} HEAD` → check empty | VERIFICATION-GAP |
-| "Compare URL correct" | Verify URL uses correct base (dev) and session values | Verify URL string format | STRUCTURE-VIOLATION |
+| "Compare URL correct" | Verify URL uses correct base (trunk) and session values | Verify URL string format | STRUCTURE-VIOLATION |
 | "Lifecycle event appended" | Verify lifecycle event exists | `grep -c "event:" {project_root}/tmp/{issue-N}/lifecycle.yaml` | MISSING-ELEMENT |
 
 **Evidence artifact:** Git command output and/or GitHub MCP response confirming each claim.

--- a/skills/finishing-a-development-branch/tasks/prepare.md
+++ b/skills/finishing-a-development-branch/tasks/prepare.md
@@ -35,31 +35,31 @@ If `worktree.path` is not set or empty: **FATAL ERROR → FLAG DEV → HALT.** D
 - [ ] 4. `git rev-parse --show-toplevel` MUST return the worktree path
 - [ ] 5. NEVER operate in the main working directory when in worktree mode
 
-## Step 0: Sync Dev Branch (Fast-Forward Only)
+## Step 0: Sync Trunk Branch (Fast-Forward Only)
 
-**Before running quality checks, ensure local dev is current.** If dev has been updated by other merges since this branch was created, running checks on a stale base produces incorrect results.
+**Before running quality checks, ensure local trunk is current.** If trunk has been updated by other merges since this branch was created, running checks on a stale base produces incorrect results.
 
 ```bash
 git fetch origin "$DEFAULT_BRANCH"
 git pull origin "$DEFAULT_BRANCH" --ff-only
 ```
 
-**The `--ff-only` flag is MANDATORY.** A plain `git pull origin "$DEFAULT_BRANCH"` can silently succeed with a merge commit, hiding divergence. The `--ff-only` flag ensures dev fast-forwards cleanly.
+**The `--ff-only` flag is MANDATORY.** A plain `git pull origin "$DEFAULT_BRANCH"` can silently succeed with a merge commit, hiding divergence. The `--ff-only` flag ensures trunk fast-forwards cleanly.
 
 **If `--ff-only` pull fails (diverged history):**
 
 ```bash
 # HALT and report. Suggest manual resolution:
-echo "ERROR: local dev has diverged from origin/$DEFAULT_BRANCH"
+echo "ERROR: local trunk has diverged from origin/$DEFAULT_BRANCH"
 echo "Suggest: git pull --rebase origin $DEFAULT_BRANCH"
 echo "Or manual resolution required"
 # HALT — do NOT proceed with stale codebase
-# Do NOT create merge commits on dev
+# Do NOT create merge commits on trunk
 ```
 
-**If dev is already up to date:** The ff-only pull is a no-op and proceeds instantly.
+**If trunk is already up to date:** The ff-only pull is a no-op and proceeds instantly.
 
-**Worktree context:** If running from a worktree (`WORKTREE_REQUIRED` is set), `git pull` must target the main working tree's dev, not the worktree. Use `git -C /path/to/main/repo pull origin "$DEFAULT_BRANCH" --ff-only` to ensure operations target the main tree. In direct-branch mode, `git pull origin "$DEFAULT_BRANCH" --ff-only` works directly.
+**Worktree context:** If running from a worktree (`WORKTREE_REQUIRED` is set), `git pull` must target the main working tree's trunk, not the worktree. Use `git -C /path/to/main/repo pull origin "$DEFAULT_BRANCH" --ff-only` to ensure operations target the main tree. In direct-branch mode, `git pull origin "$DEFAULT_BRANCH" --ff-only` works directly.
 
 ## Prepare Branch Workflow
 

--- a/skills/git-workflow/tasks/check-pr.md
+++ b/skills/git-workflow/tasks/check-pr.md
@@ -24,8 +24,8 @@ if [ -z "$DEFAULT_BRANCH" ]; then DEFAULT_BRANCH="main"; fi
 
 - All merged PRs identified and verified
 - Linked issues closed depth-first (sub-repos first, then parent)
-- Submodule branches cleaned up (dev switch, branch delete, tag delete, prune)
-- Parent branches cleaned up (dev switch, branch delete, checkpoint-tag delete, prune)
+- Submodule branches cleaned up (trunk switch, branch delete, tag delete, prune)
+- Parent branches cleaned up (trunk switch, branch delete, checkpoint-tag delete, prune)
 - All repos iterated depth-first with branch-aware parking
 - Working tree clean, repo parked on appropriate branch
 
@@ -95,7 +95,7 @@ For each merged PR, perform a full mergeability diagnosis using the 6-field chec
   - Computation triggered: yes|no (if updated_at == created_at)
   - Action required: <none|rebase needed|conflict resolution|wait for computation>
   ```
-- [ ] Verify the merge commit exists in local dev history: `git log --oneline "$DEFAULT_BRANCH" | grep <merge_sha>`
+- [ ] Verify the merge commit exists in local trunk history: `git log --oneline "$DEFAULT_BRANCH" | grep <merge_sha>`
 - [ ] Report PASS/FAIL per PR with evidence artifact
 
 ## Phase 3: Close Linked Issues
@@ -109,13 +109,13 @@ For each merged PR, perform a full mergeability diagnosis using the 6-field chec
 
 - [ ] Detect submodules via filesystem glob scan: `ls -d .git/ */.git/ */.git/`
 - [ ] For each submodule with a feature branch, clean up the merged branch
-- [ ] Restore submodules to dev tip via sub-agent task()
+- [ ] Restore submodules to trunk tip via sub-agent task()
 - [ ] Do NOT create dependency-sync PRs — leave submodule pointers dirty
 
 ## Phase 5: Parent Branch Cleanup
 
-- [ ] Switch to dev and sync: `git checkout "$DEFAULT_BRANCH" && git pull origin "$DEFAULT_BRANCH" --ff-only`
-- [ ] For each merged branch, verify content exists on dev via `git diff --stat origin/"$DEFAULT_BRANCH"...<branch>` — produce content comparison table
+- [ ] Switch to trunk and sync: `git checkout "$DEFAULT_BRANCH" && git pull origin "$DEFAULT_BRANCH" --ff-only`
+- [ ] For each merged branch, verify content exists on trunk via `git diff --stat origin/"$DEFAULT_BRANCH"...<branch>` — produce content comparison table
 - [ ] Delete local merged branch: `git branch -d <branch>`
 - [ ] Delete remote branch: `git push origin --delete <branch>`
 - [ ] Preserve hash-permanence tags — do NOT delete
@@ -126,9 +126,9 @@ For each merged PR, perform a full mergeability diagnosis using the 6-field chec
 
 - [ ] Iterate ALL discovered repos depth-first: submodule tips, then parent tip
 - [ ] Branch-aware parking per current branch type:
-  - On `feature/*`, `fix/*`, `spec/*` → switch to dev tip
+  - On `feature/*`, `fix/*`, `spec/*` → switch to trunk tip
   - Already on $DEFAULT_BRANCH → pull latest, stay on $DEFAULT_BRANCH
-  - Already on main → pull latest, stay on main
+  - Already on trunk → pull latest, stay on trunk
   - On non-standard branch → pull latest on current branch, do NOT switch
 - [ ] Submodule pointers in the parent repo are dirty by design. They are restored during the next pre-work cycle. Do NOT commit, reset, or otherwise correct them.
 - [ ] Verify clean working tree: `git status --porcelain` must be empty

--- a/skills/git-workflow/tasks/cleanup.md
+++ b/skills/git-workflow/tasks/cleanup.md
@@ -246,7 +246,7 @@ After EVERY merged PR, cleanup is MANDATORY — no exceptions.
 
 **⚠️ CRITICAL: Sub-issues are closed by the cleanup task via API, NOT by platform autoclose.**
 
-GitHub autoclose is inert for this repo (PRs merge to `dev`, not `main`). The cleanup task is the SOLE closure mechanism.
+GitHub autoclose is inert for this repo (PRs merge to the trunk). The cleanup task is the SOLE closure mechanism.
 
 ## Issue Closure Timing
 

--- a/skills/git-workflow/tasks/cleanup/branch-cleanup.md
+++ b/skills/git-workflow/tasks/cleanup/branch-cleanup.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-Delete merged branches, clean stale references, remove worktrees, sync dev, and verify clean repository state after PR merge.
+Delete merged branches, clean stale references, remove worktrees, sync trunk, and verify clean repository state after PR merge.
 
 ## Entry Criteria
 
@@ -289,7 +289,7 @@ blocked_reason: <if BLOCKED, explanation of divergence>
 **After all submodules processed — acknowledge dirty pointer(s):**
 ```bash
 echo "Submodule branch cleanup complete."
-echo "Submodule pointer(s) are dirty — expected state after dev sync."
+echo "Submodule pointer(s) are dirty — expected state after trunk sync."
 echo "No corrective action taken on submodule pointer(s)."
 echo "The parent repo 'git status' will show modified submodule entry/entries — this is correct."
 ```
@@ -297,17 +297,17 @@ echo "The parent repo 'git status' will show modified submodule entry/entries �
 **🚫 FORBIDDEN:**
 - `git add <submodule_path>` or any commit modifying any submodule pointer during cleanup
 - `git submodule update --recursive` or any `--recursive` submodule command
-- Switching the parent repo away from `dev`
+- Switching the parent repo away from `$DEFAULT_BRANCH`
 - Treating a dirty submodule pointer as an error condition
 - Creating a PR whose sole purpose is to update submodule pointer(s) (submodule-only PR, any number of submodules)
 
 **✅ REQUIRED:**
-- Verify each submodule is on `dev` before branch operations
+- Verify each submodule is on `$DEFAULT_BRANCH` before branch operations
 - Content verification gate before each submodule branch deletion
 - Tag-if-untagged for submodule SHAs
 - Acknowledge dirty pointer after all submodules processed
 
-**Evidence artifact (MANDATORY):** Tool-call output showing each submodule's `git branch --show-current` returns `dev`, the list of deleted branches per submodule, and the tag-if-untagged result per submodule. If no submodules exist, evidence that the step was evaluated and skipped is sufficient.
+**Evidence artifact (MANDATORY):** Tool-call output showing each submodule's `git branch --show-current` returns `$DEFAULT_BRANCH`, the list of deleted branches per submodule, and the tag-if-untagged result per submodule. If no submodules exist, evidence that the step was evaluated and skipped is sufficient.
 
 ### Step 2: Remove Feature Worktree
 
@@ -338,17 +338,17 @@ In parallel sub-agent mode, other agents may still be working in their worktrees
 
 **⚠️ CRITICAL: Declaring a branch deletable without content verification is a CRITICAL GUIDELINE VIOLATION (see `000-critical-rules.md` §Content Verification Before Branch Deletion).**
 
-Before deleting ANY merged branch, verify that all branch content is present on the target branch (dev):
+Before deleting ANY merged branch, verify that all branch content is present on the target branch (trunk):
 
-1. **List changed files:** `git diff --stat origin/dev...HEAD` — identify all files changed on the branch vs dev
+1. **List changed files:** `git diff --stat origin/"$DEFAULT_BRANCH"...HEAD` — identify all files changed on the branch vs trunk
 2. **For each file in the diff:**
-   a. If file exists on dev AND content matches: status = `IDENTICAL` — safe to delete
-   b. If file exists on dev BUT has newer/different content: `git diff origin/dev...HEAD -- <file>` to compare; if dev version supersedes branch version, status = `SUPERSEDED` — safe to delete with note
-   c. If file does NOT exist on dev: status = `UNIQUE` — MUST NOT delete branch, flag for developer review
+   a. If file exists on trunk AND content matches: status = `IDENTICAL` — safe to delete
+   b. If file exists on trunk BUT has newer/different content: `git diff origin/"$DEFAULT_BRANCH"...HEAD -- <file>` to compare; if trunk version supersedes branch version, status = `SUPERSEDED` — safe to delete with note
+   c. If file does NOT exist on trunk: status = `UNIQUE` — MUST NOT delete branch, flag for developer review
 3. **For tool/script files:** check version indicators (interface signatures, flag patterns, function presence) to determine supersession
 4. **Produce content comparison table (MANDATORY evidence artifact):**
 
-| File | Branch Version | Dev Version | Status |
+| File | Branch Version | Trunk Version | Status |
 |------|---------------|-------------|--------|
 | path/to/file | v4 (old interface) | v5 (new interface) | SUPERSEDED |
 | path/to/unique | present | absent | UNIQUE — needs review |
@@ -426,10 +426,10 @@ When the merged branch was a work branch (created by the implementation-pipeline
 ### Step 4: Clean Other Merged Branches
 
 ```bash
-git branch --merged dev
+git branch --merged "$DEFAULT_BRANCH"
 ```
 
-For each merged branch (except main/master/dev): `git branch -d <branch>`
+For each merged branch (except the trunk): `git branch -d <branch>`
 
 ### Step 5: Verify Clean State
 
@@ -438,7 +438,7 @@ git status --porcelain  # Must be empty
 git branch -vv          # Should show minimal branches
 ```
 
-**`.issues/<N>/` Persistence:** The `.issues/<issue_number>/` directory MUST NOT be deleted. It persists permanently in the working tree on `dev` as immutable history. After merge, the feature branch's `.issues/<N>/` content lands in `dev` via the merge. Do NOT add cleanup steps that remove or archive these directories.
+**`.issues/<N>/` Persistence:** The `.issues/<issue_number>/` directory MUST NOT be deleted. It persists permanently in the working tree on the trunk as immutable history. After merge, the feature branch's `.issues/<N>/` content lands on the trunk via the merge. Do NOT add cleanup steps that remove or archive these directories.
 
 ### Step 6: Succinct Confirmation
 

--- a/skills/git-workflow/tasks/commit-prep.md
+++ b/skills/git-workflow/tasks/commit-prep.md
@@ -172,7 +172,7 @@ Commits occur during the PR creation workflow, not as a separate step:
 | -- | -- | -- | -- |
 | Staged diff matches intent | `git diff --staged` | Shows exactly what should be committed | CONFLICTING → re-stage |
 | No unintended unstaged changes | `git diff` | Empty or only expected changes | VERIFICATION-GAP → review and stage |
-| On correct branch | `git branch --show-current` | Feature branch (not `main`/`$DEFAULT_BRANCH`) | STRUCTURE-VIOLATION → HALT |
+| On correct branch | `git branch --show-current` | Feature branch (not the trunk) | STRUCTURE-VIOLATION → HALT |
 | Worktree location | `git rev-parse --show-toplevel` | Worktree path | STRUCTURE-VIOLATION → HALT |
 | Status shows expected files | `git status --porcelain` | Only intended files shown | VERIFICATION-GAP → review |
 

--- a/skills/git-workflow/tasks/implementation.md
+++ b/skills/git-workflow/tasks/implementation.md
@@ -121,7 +121,7 @@ When `worktree.path` is set, ALL file operation tool calls (`read`, `edit`, `wri
 
 | Check | Tool Call | Expected Result | On Failure |
 | -- | -- | -- | -- |
-| On correct branch | `git branch --show-current` | Feature branch (not `main`/`$DEFAULT_BRANCH`) | STRUCTURE-VIOLATION → HALT |
+| On correct branch | `git branch --show-current` | Feature branch (not the trunk) | STRUCTURE-VIOLATION → HALT |
 | Worktree location | `git rev-parse --show-toplevel` | Worktree path | STRUCTURE-VIOLATION → HALT |
 | Changes to commit | `git status --porcelain` | Expected modified files listed | MISSING-ELEMENT → no changes found |
 | Staged state matches intent | `git diff --staged` | Intended changes visible | VERIFICATION-GAP → re-stage |

--- a/skills/git-workflow/tasks/operating-protocol.md
+++ b/skills/git-workflow/tasks/operating-protocol.md
@@ -8,14 +8,14 @@
 ## Procedure
 
 - [ ] 1. **Worktree first:** set `worktree.path` before file ops (direct-branch mode when `WORKTREE_REQUIRED` not set).
-- [ ] 2. **Protected branches:** never commit to `main`.
+- [ ] 2. **Protected branches:** never commit to the trunk.
 - [ ] 3. **Squash discipline:** squash ONLY at PR creation, not during feature dev.
 - [ ] 4. **Clean-room content diff:** before branch deletion, verify content exists on target branch.
-- [ ] 5. **Compare URL base:** feature → `compare/<target>...<branch>`. Release → `compare/main...<target>`.
+- [ ] 5. **Compare URL base:** feature → `compare/<target>...<branch>`. Release → `compare/$DEFAULT_BRANCH...<target>`.
 - [ ] 6. **Submodule repos:** git ops from inside submodule dir. No `--recursive`.
 - [ ] 7. **Pair mode:** `pair-*` branches use WIP-commit switching, not worktrees.
 - [ ] 8. **Adversarial-audit call:** after issue closure, before branch cleanup, call `audit --task closure-verification --pr <N>` with `audit_phase: post_merge`.
-- [ ] 9. **Release branches:** use `release/v{semver}` naming convention. Release PRs use `compare/main...<target>` compare URL.
+- [ ] 9. **Release branches:** use `release/v{semver}` naming convention. Release PRs use `compare/$DEFAULT_BRANCH...<target>` compare URL.
 - [ ] 10. **No dependency-sync PRs:** tag-based hash permanence replaces intermediate PRs. Submodule SHAs are preserved via parent-repo-prefixed tags. See AGENTS.md §Tag Layers.
 - [ ] 11. **Correctness over speed.** Every code path with runtime behavior requires live-wire testing against real systems. A slow correct answer is strictly better than a fast incorrect one. Static analysis alone is NOT acceptable verification — behavioral compliance requires actual execution with cross-validated PASS verdict.
 

--- a/skills/git-workflow/tasks/pair-cleanup.md
+++ b/skills/git-workflow/tasks/pair-cleanup.md
@@ -18,7 +18,7 @@ if [ -z "$DEFAULT_BRANCH" ]; then DEFAULT_BRANCH="main"; fi
    ```
    Check that `merged_at` is not None.
 
-- [ ] 2. **Switch to dev:**
+- [ ] 2. **Switch to trunk:**
    ```bash
    git checkout "$DEFAULT_BRANCH"
    git pull origin "$DEFAULT_BRANCH"

--- a/skills/git-workflow/tasks/pair-pr-creation.md
+++ b/skills/git-workflow/tasks/pair-pr-creation.md
@@ -13,7 +13,7 @@ Squash and create PR targeting `$DEFAULT_BRANCH` with `[pair-mode]` trailers.
 
 Pair mode uses the same squash workflow as autonomous mode:
 
-- [ ] 1. **Soft-reset to dev:**
+- [ ] 1. **Soft-reset to trunk:**
    ```bash
    git reset --soft origin/"$DEFAULT_BRANCH"
    ```

--- a/skills/git-workflow/tasks/pr-creation.md
+++ b/skills/git-workflow/tasks/pr-creation.md
@@ -57,7 +57,7 @@ Before squash and push, verify dirty submodule pointers are included in staged c
 
 **Route to:** `pr-creation/squash-push`
 
-Generates changelog (or skips with `[skip changelog]`), squashes commits, rebases on current dev, and pushes to remote with verification.
+Generates changelog (or skips with `[skip changelog]`), squashes commits, rebases on current trunk, and pushes to remote with verification.
 
 ### Step 5-7: Collect Sub-Issues, Create PR, Extract URL
 

--- a/skills/git-workflow/tasks/pr-creation/create-pr.md
+++ b/skills/git-workflow/tasks/pr-creation/create-pr.md
@@ -10,7 +10,7 @@ Create the pull request after squash/push, collect sub-issues, generate PR body,
 
 When invoked with `--release` flag, this task performs post-merge steps after PR merge:
 
-- **Semver tagging:** Auto-increment patch version (or developer-specified), create annotated tag on `main`
+- **Semver tagging:** Auto-increment patch version (or developer-specified), create annotated tag on the trunk
 - **Platform release creation:** Create GitHub/GitBucket release with synthesized release notes
 - **Release notes synthesis:** Summarize changes since last release by category (features, fixes, maintenance)
 
@@ -130,7 +130,7 @@ autoclose_issues = [<parent>] + [sub["number"] for sub in sub_issues]
 | `stacked` | Single PR for all issues in work set |
 | `none` | No PR creation — halt_at boundary |
 
-**⚠️ CRITICAL: Sub-issues are closed by the cleanup task via API, NOT by autoclose.** GitHub autoclose is inert for `dev`-branch merges.
+**⚠️ CRITICAL: Sub-issues are closed by the cleanup task via API, NOT by autoclose.** GitHub autoclose is inert for trunk merges.
 
 ### Step 6: Create PR (Platform-Agnostic)
 
@@ -140,7 +140,7 @@ autoclose_issues = [<parent>] + [sub["number"] for sub in sub_issues]
 github_create_pull_request(
     owner=<github.owner>,
     repo=<github.repo>,
-    title="[SPEC] <description>",  # When is_release: true, use "Release v<version>: promote <target> → main"
+    title="[SPEC] <description>",  # When is_release: true, use "Release v<version>: promote <target> → trunk"
     body="""**Summary:**
 
 <1-2 sentences describing impact and stakeholder value, sourced from issue body via issue-operations --task read-issue>
@@ -265,7 +265,7 @@ When `is_release: true` and the PR has been merged by a human:
 
 #### Step 7.1.1: Determine Version
 
-1. Fetch latest tag matching `<parent>/v*` from `main`
+1. Fetch latest tag matching `<parent>/v*` from the trunk
 2. Auto-increment patch version (e.g., `v0.1.1` → `v0.1.2`)
 3. If developer specified a version, use that instead
 

--- a/skills/git-workflow/tasks/pr-creation/enforcement-gate.md
+++ b/skills/git-workflow/tasks/pr-creation/enforcement-gate.md
@@ -29,7 +29,7 @@ if [ -z "$DEFAULT_BRANCH" ]; then DEFAULT_BRANCH="main"; fi
 
 **If submodules detected:**
 
-The orchestrator dispatches a sub-agent via `task(subagent_type="general")`. The sub-agent performs a report-only liveness verification — it compares committed SHAs against remote `dev` HEAD SHAs and returns PASS/FAIL per submodule. **NO auto-remediation. NO SHA bumps. NO commits.**
+The orchestrator dispatches a sub-agent via `task(subagent_type="general")`. The sub-agent performs a report-only liveness verification — it compares committed SHAs against remote trunk HEAD SHAs and returns PASS/FAIL per submodule. **NO auto-remediation. NO SHA bumps. NO commits.**
 
 #### Task Context
 
@@ -115,7 +115,7 @@ if [ "$CHANGED" = "1" ] && [ "$SUBMODULE_ONLY" = "1" ]; then
 **This gate enforces the commit-per-issue invariant.** Creating a PR with an incorrect commit count is a CRITICAL GUIDELINE VIOLATION per `000-critical-rules.md` §Un-Squashed PR.
 
 ```bash
-# Count commits ahead of dev
+# Count commits ahead of trunk
 git log origin/"$DEFAULT_BRANCH"..HEAD --oneline
 
 # Detect branch type via work state file
@@ -172,7 +172,7 @@ gh pr list --head <branch_name> --state open --json number,html_url
 - The developer must explicitly say "use the closed PR" for it to be considered.
 
 **If a MERGED PR exists on this branch:**
-- Rebase branch on dev, check for remaining changes
+- Rebase branch on trunk, check for remaining changes
 - If branch already merged (no remaining changes):
   ```
   ✅ BRANCH ALREADY MERGED

--- a/skills/git-workflow/tasks/pre-work.md
+++ b/skills/git-workflow/tasks/pre-work.md
@@ -306,7 +306,7 @@ After committing the submodule pointer, if the branch has NO additional commits 
 NON_SUBMODULE_COMMITS=$(git log origin/"$DEFAULT_BRANCH"..HEAD --oneline --name-only | grep -v '^[0-9a-f]\{7\} ' | grep -v '^$' | grep -v '^\.opencode$' | wc -l)
 if [ "$NON_SUBMODULE_COMMITS" -eq 0 ]; then
   echo "HARD BLOCK: Branch has only submodule pointer changes."
-  echo "Delete this branch: git checkout main && git branch -D <branch>"
+  echo "Delete this branch: git checkout \"$DEFAULT_BRANCH\" && git branch -D <branch>"
   echo "Do NOT create a PR. Submodule-only PRs are against policy."
   exit 1
 fi
@@ -556,7 +556,7 @@ If found, report collision and HALT — do not reuse another branch's worktree.
 | Check | Tool Call | Expected Result | On Failure |
 | -- | -- | -- | -- |
 | Default branch synced (when remote exists) | `git ls-remote origin "$DEFAULT_BRANCH"` | Non-empty output | MISSING-ELEMENT → fetch and sync |
-| Current branch | `git branch --show-current` | Feature branch name (not `main`, `$DEFAULT_BRANCH`) | STRUCTURE-VIOLATION → HALT |
+| Current branch | `git branch --show-current` | Feature branch name (not the trunk) | STRUCTURE-VIOLATION → HALT |
 | Working tree clean | `git status --porcelain` | Empty output | VERIFICATION-GAP → stash or commit first |
 | Worktree location (worktree mode only) | `git rev-parse --show-toplevel` | Worktree path (not main repo path) | STRUCTURE-VIOLATION → HALT |
 | worktree.path set (worktree mode only) | `echo $WORKTREE_PATH` | Non-empty, matches worktree dir | STRUCTURE-VIOLATION → HALT (fatal) |

--- a/skills/git-workflow/tasks/rebase-pending.md
+++ b/skills/git-workflow/tasks/rebase-pending.md
@@ -14,16 +14,16 @@ if [ -z "$DEFAULT_BRANCH" ]; then DEFAULT_BRANCH="main"; fi
 ## Operating Protocol
 
 - [ ] 1. **After merge verification:** Run immediately after Step 2 (verify PR merge) in cleanup
-- [ ] 2. **Before dev sync:** Must complete before Step 3 (switch to dev and sync)
+- [ ] 2. **Before trunk sync:** Must complete before Step 3 (switch to trunk and sync)
 - [ ] 3. **Sequential processing:** Rebase one PR at a time to avoid collisions
 - [ ] 4. **Force-push after rebase:** Rebased branches must be force-pushed to update remote PRs
-- [ ] 5. **Submodule re-sync after rebase:** Every rebase against `dev` MUST be followed by submodule sync — this is always-on hygiene
+- [ ] 5. **Submodule re-sync after rebase:** Every rebase against `$DEFAULT_BRANCH` MUST be followed by submodule sync — this is always-on hygiene
 
 ## Entry Criteria
 
 - PR merge verified via GitHub API (Step 2 of cleanup complete)
 - `merged_at` timestamp confirmed on the just-merged PR
-- Local dev branch is up to date (`git pull origin "$DEFAULT_BRANCH"`)
+- Local trunk branch is up to date (`git pull origin "$DEFAULT_BRANCH"`)
 
 ## Exit Criteria
 
@@ -79,7 +79,7 @@ For each pending PR:
 ```
 a. Fetch latest remote: git fetch origin
 b. Checkout the PR branch: git checkout <branch-name>
-c. Rebase onto updated dev: git rebase origin/"$DEFAULT_BRANCH"
+c. Rebase onto updated trunk: git rebase origin/"$DEFAULT_BRANCH"
 d. Submodule re-sync (MANDATORY): git submodule foreach "git checkout \"$DEFAULT_BRANCH\" && git pull"
    - Do NOT skip this step — rebase may change submodule references
 e. Handle outcome:
@@ -94,7 +94,7 @@ a. Fetch latest remote: git fetch origin
 b. Create temporary worktree for the PR branch:
    git worktree add .worktrees/rebase-<branch-name> -b <branch-name> origin/<branch-name>
    (If branch already has a worktree, use existing)
-c. In worktree, rebase onto updated dev:
+c. In worktree, rebase onto updated trunk:
    git rebase origin/"$DEFAULT_BRANCH"
 d. Submodule re-sync (MANDATORY): git submodule foreach "git checkout \"$DEFAULT_BRANCH\" && git pull"
 e. Handle outcome:
@@ -115,7 +115,7 @@ git worktree remove "$WORKTREE_PATH"
 
 **Important:** Always clean up temporary worktrees between PRs. Never leave rebase worktrees dangling.
 
-**Submodule re-sync is MANDATORY after every rebase:** After `git rebase origin/"$DEFAULT_BRANCH"`, run `git submodule foreach "git checkout \"$DEFAULT_BRANCH\" && git pull"` to realign submodules with the updated dev state. Skipping this causes drift that breaks builds and tests.
+**Submodule re-sync is MANDATORY after every rebase:** After `git rebase origin/"$DEFAULT_BRANCH"`, run `git submodule foreach "git checkout \"$DEFAULT_BRANCH\" && git pull"` to realign submodules with the updated trunk state. Skipping this causes drift that breaks builds and tests.
 
 ### Step 3: Conflict Classification
 
@@ -266,7 +266,7 @@ Continuing with cleanup for the merged PR...
 
 | Check | Tool Call | Expected Result | On Failure |
 | -- | -- | -- | -- |
-| On correct branch | `git branch --show-current` | PR branch name (not `main`/`$DEFAULT_BRANCH`) | STRUCTURE-VIOLATION → HALT |
+| On correct branch | `git branch --show-current` | PR branch name (not the trunk) | STRUCTURE-VIOLATION → HALT |
 | Worktree location (worktree mode only) | `git rev-parse --show-toplevel` | Worktree path (not main repo) | STRUCTURE-VIOLATION → HALT |
 | Working tree clean | `git status --porcelain` | Empty output | VERIFICATION-GAP → stash or commit first |
 | Dev is up to date | `git fetch origin && git log --oneline origin/"$DEFAULT_BRANCH" -1` | Recent SHA, post-merge | MISSING-ELEMENT → re-fetch |

--- a/skills/git-workflow/tasks/review-prep.md
+++ b/skills/git-workflow/tasks/review-prep.md
@@ -54,14 +54,14 @@ fi
 
 **Route to:** `review-prep/push-and-cleanup`
 
-Tasks sub-agent for submodule changes (if a submodule `.git` file or directory is discovered), then handles temp file cleanup, rebase on current dev, worktree handoff, and branch push verification.
+Tasks sub-agent for submodule changes (if a submodule `.git` file or directory is discovered), then handles temp file cleanup, rebase on current trunk, worktree handoff, and branch push verification.
 
 ### Step 2.5: Squash Verification (MANDATORY GATE)
 
 **Before generating the compare URL, verify the commit-per-issue invariant.** This gate catches unsquashed branches before the compare URL is exposed to the developer.
 
 ```bash
-# Count commits ahead of dev
+# Count commits ahead of trunk
 git log origin/"$DEFAULT_BRANCH"..HEAD --oneline
 
 # Detect branch type

--- a/skills/git-workflow/tasks/review-prep/push-and-cleanup.md
+++ b/skills/git-workflow/tasks/review-prep/push-and-cleanup.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-Clean temp files, handle submodule push automation, rebase on current dev, and verify branch is pushed to remote — all prerequisite steps before generating the compare URL.
+Clean temp files, handle submodule push automation, rebase on current trunk, and verify branch is pushed to remote — all prerequisite steps before generating the compare URL.
 
 ## Default Branch Resolution
 
@@ -20,7 +20,7 @@ if [ -z "$DEFAULT_BRANCH" ]; then DEFAULT_BRANCH="main"; fi
 
 - Temp files cleaned
 - Submodule changes pushed (if applicable)
-- Branch rebased on current dev
+- Branch rebased on current trunk
 - Branch pushed to remote with tracking
 
 ## Procedure
@@ -84,7 +84,7 @@ rm -rf {project_root}/tmp/{issue-N}/temp_*.py {project_root}/tmp/{issue-N}/test_
 rm -rf {project_root}/tmp/{issue-N}/.cache 2>/dev/null
 ```
 
-### Step 1.5: Rebase on Current Dev (MANDATORY)
+### Step 1.5: Rebase on Current Trunk (MANDATORY)
 
 ```bash
 git fetch origin

--- a/skills/pr-creation-workflow/tasks/sub-issue-collection.md
+++ b/skills/pr-creation-workflow/tasks/sub-issue-collection.md
@@ -20,7 +20,7 @@ ls {project_root}/tmp/{issue-N}/work.md 2>/dev/null
 
 **PR strategy check (from scope fields):** Read `pr_strategy` from the work state file. When `pr_strategy == stacked`, use work PR format regardless. When `pr_strategy == none`, HALT — PR creation not authorized.
 
-**Note:** GitHub autoclose (`Fixes #N`/`Closes #N`) does NOT trigger for PRs merging into `dev`. The cleanup task (`git-workflow --task cleanup`) is the sole closure mechanism. PR body keywords are informational labels for human readers.
+**Note:** GitHub autoclose (`Fixes #N`/`Closes #N`) does NOT trigger for PRs merging into the trunk. The cleanup task (`git-workflow --task cleanup`) is the sole closure mechanism. PR body keywords are informational labels for human readers.
 
 ### Multi-Task Spec with Sub-Issues
 

--- a/skills/release-promoter/tasks/tag.md
+++ b/skills/release-promoter/tasks/tag.md
@@ -15,7 +15,7 @@ Create an annotated git tag with v prefix on the merge commit and push it to the
 
 Verify the release PR has actually merged:
 - Check `git log --oneline -1` to confirm we're on the merge commit
-- If on a feature branch, checkout the target branch (main/dev) and pull latest
+- If on a feature branch, checkout the target branch (the trunk) and pull latest
 
 ### Step 2: Create Annotated Tag
 

--- a/skills/using-git-worktrees/tasks/create-worktree.md
+++ b/skills/using-git-worktrees/tasks/create-worktree.md
@@ -16,7 +16,7 @@ State clearly: "Using the using-git-worktrees skill to set up an isolated worksp
 
 ### 2. Sync with Base Branch
 
-Create worktrees from an up-to-date base branch. The default base is the remote HEAD branch (typically `main`), but for work execution workflows where a work branch already exists, the base can be the work branch or another feature branch:
+Create worktrees from an up-to-date base branch. The default base is the remote HEAD branch (the trunk), but for work execution workflows where a work branch already exists, the base can be the work branch or another feature branch:
 
 ```bash
 git checkout $BASE_BRANCH

--- a/skills/using-git-worktrees/tasks/reference.md
+++ b/skills/using-git-worktrees/tasks/reference.md
@@ -31,7 +31,7 @@ If NOT ignored:
 | Mistake | Problem | Fix |
 |---------|---------|-----|
 | Skipping ignore verification | Worktree contents tracked, pollute git status | Always use `git check-ignore` before creating |
-| Creating worktree from `main` | Based on wrong branch | Always `git checkout $DEFAULT_BRANCH && git pull origin $DEFAULT_BRANCH` first |
+| Creating worktree from the wrong branch | Based on wrong branch | Always `git checkout $DEFAULT_BRANCH && git pull origin $DEFAULT_BRANCH` first |
 | Proceeding with failing tests | Can't distinguish new bugs from pre-existing. See critical-rules-069 — "pre-existing failure" rationalization is a CRITICAL VIOLATION | Report failures, get explicit permission, remediate before proceeding |
 | Not announcing worktree creation | Other agents unaware of parallel workspace | Always announce at start |
 
@@ -81,7 +81,7 @@ This cleanup happens as part of the standard `git-workflow --task cleanup` seque
 
 **Never:**
 - Create worktree without verifying it's ignored (project-local)
-- Create worktree from `main` (always branch from the default branch)
+- Create worktree from the wrong branch (always branch from the default branch)
 - Skip baseline test verification
 - Proceed with failing tests without asking
 - Assume directory location when ambiguous
@@ -92,6 +92,6 @@ This cleanup happens as part of the standard `git-workflow --task cleanup` seque
 - Verify directory is ignored for project-local
 - Auto-detect and run `uv sync` for project setup
 - Announce worktree creation at start
-- Create branch from the default branch (not `main`)
+- Create branch from the default branch (the trunk)
 - Verify clean test baseline
 - HALT immediately if `worktree.fatal=1` appears in session init

--- a/skills/writing-plans/tasks/pre-plan-readiness.md
+++ b/skills/writing-plans/tasks/pre-plan-readiness.md
@@ -7,7 +7,7 @@ Verify that the local spec file and feature branch exist before allowing plan cr
 ## Entry Criteria
 
 - Spec file exists at `.issues/{N}/spec.md` or `{project_root}/{path}/.issues/{N}/spec.md`
-- Feature branch exists (not `dev` or `main`)
+- Feature branch exists (not the trunk)
 - `local-issues sync` has been run
 
 ## Exit Criteria
@@ -21,8 +21,8 @@ Verify that the local spec file and feature branch exist before allowing plan cr
 
 1. Check spec file exists at `.issues/{N}/spec.md` or `{project_root}/{path}/.issues/{N}/spec.md`
    - If missing: return `status: BLOCKED` with `reason: SPEC_FILE_MISSING`
-2. Check feature branch exists and is not `dev` or `main`
-   - If missing or on dev/main: return `status: BLOCKED` with `reason: FEATURE_BRANCH_MISSING`
+2. Check feature branch exists and is not the trunk
+   - If missing or on the trunk: return `status: BLOCKED` with `reason: FEATURE_BRANCH_MISSING`
 3. Check `local-issues sync` has been run (verify `.issues/{N}/` directory is synced)
    - If not synced: return `status: BLOCKED` with `reason: LOCAL_ISSUES_NOT_SYNCED`
 4. Return `status: PASS` with `finding_summary: "All prerequisites met"`


### PR DESCRIPTION
## Summary

Completes the trunk-based development branch name remediation for #1817. Subsumes #1632.

## Outcome

Zero hardcoded `dev` or `main` branch names remain in any agent-facing text across 35 files. All git commands use `$DEFAULT_BRANCH` (dynamically resolved via `git remote show origin`). Prose uses "trunk" as the conceptual term.

## Fixes

- **Closes #1817** — Holistic trunk-based development branch name remediation
- **Subsumes #1632** — Pre-push Gate 1 redesign (now Phase 1 of this PR)

## Changes

| Phase | Scope | Files |
|-------|-------|-------|
| 1 | Pre-push Gate 1: `origin/dev` → `origin/$DEFAULT_BRANCH`, remove release exemption, add open-PR detection | `hooks/pre-push` |
| 2 | Rewrite `115-branch-naming.md`: three-branch model → trunk-based dev | `guidelines/115-branch-naming.md` |
| 3 | Root files: AGENTS.md, README.md, branch-first-protocol.md, submodule-tag-prework.md | 4 files |
| 4 | Guidelines: 000, 010, 020, 060, 116 — `dev`/`main` → trunk | 5 files |
| 5 | Prose/command mismatches: prose said "dev" but commands used `$DEFAULT_BRANCH` | 9 skill task files |
| 6 | Hardcoded `main` → `$DEFAULT_BRANCH`/trunk in skill task files | 6 files |

## Verification

- `grep` sweep confirms zero `dev` branch references in all agent-facing files
- `grep` sweep confirms zero hardcoded `main` in git commands
- Pre-push Gate 1 verified: `origin/dev` removed, release exemption removed, open-PR detection added

---

🤖 Co-authored with AI: OpenCode (deepseek-v4-flash)