### PR TITLE
fix(audit): add self-consistency gates, remove non-binary classifications (#1792)

### DIFF
--- a/skills/audit/tasks/closure-verification.md
+++ b/skills/audit/tasks/closure-verification.md
@@ -217,7 +217,36 @@ if follow_up_issues:
 | OPEN_BLOCKERS | HIGH | Blocking issues remain |
 | FOLLOW_UP_NOT_OPEN | MEDIUM | Follow-up issue closed |
 
-### Step 12: Write Verdict Artifact to Disk (Legacy — kept for backward compatibility)
+### Step 12: Self-Consistency Gate — Downgrade PASS with Hedging to FAIL
+
+Before writing the verdict artifact, run a self-consistency check on every `per_criterion` entry:
+
+- [ ] 1. For each criterion where `result: "PASS"`, scan `explanation` for hedging/critique language
+- [ ] 2. If any of the following phrases appear in `explanation`, downgrade `result` to `"FAIL"`:
+  - `"should be"`, `"needs"`, `"missing"`, `"could improve"`, `"minor"`, `"some issues"`, `"mostly"`, `"generally"`
+- [ ] 3. Append a `self_consistency` field to the criterion entry documenting the downgrade:
+
+```yaml
+self_consistency:
+  original_result: "PASS"
+  downgraded_to: "FAIL"
+  trigger_phrase: "<phrase that triggered downgrade>"
+  context: "<snippet of explanation containing the phrase>"
+```
+
+- [ ] 4. If no hedging is found, set:
+
+```yaml
+self_consistency:
+  original_result: "PASS"
+  downgraded_to: null
+  trigger_phrase: null
+  context: null
+```
+
+- [ ] 5. After all criteria are processed, recompute `all_criteria_pass` and `exec_summary` — if any criterion was downgraded, `all_criteria_pass` MUST be `false`.
+
+### Step 13: Write Verdict Artifact to Disk (Legacy — kept for backward compatibility)
 
 Write the full YAML verdict artifact to `{project_root}/tmp/{issue-N}/artifacts/pipeline-audit-closure-verification-{STATUS}-{timestamp}.yaml`:
 
@@ -244,12 +273,17 @@ per_criterion:
     explanation: "<reasoning>"
     remediation: ""
     next_step: "proceed"  # Conditional: "remediate" when result is "FAIL", "proceed" when result is "PASS"
+    self_consistency:
+      original_result: "PASS"
+      downgraded_to: null
+      trigger_phrase: null
+      context: null
 exec_summary: "Closure verification: X/Y criteria. Consensus: PASS|FAIL."
 all_criteria_pass: false
 remediation_required: true  # When status is FAIL: full mandatory re-audit required
 ```
 
-### Step 13: Return Frugal Result Contract
+### Step 14: Return Frugal Result Contract
 
 ## Remediation
 
@@ -285,7 +319,9 @@ Every step in this task is a mandatory dependency. Skipping any step produces an
 - Step 9 (Check for Open Blockers) → INVALID if skipped
 - Step 10 (Check Follow-up Issues) → INVALID if skipped
 - Step 11 (Classify Verification Gaps) → INVALID if skipped
-- Step 12 (Build Result Contract) → INVALID if skipped
+- Step 12 (Self-Consistency Gate) → INVALID if skipped
+- Step 13 (Write Verdict Artifact) → INVALID if skipped
+- Step 14 (Return Frugal Result Contract) → INVALID if skipped
 
 ## Cross-References
 
@@ -296,7 +332,7 @@ Every step in this task is a mandatory dependency. Skipping any step produces an
 
 ```yaml+symbolic
 schema_version: "2.0"
-last_updated: "2026-05-08T00:00:00Z"
+last_updated: "2026-07-09T00:00:00Z"
 rules:
   - id: closure-verification-001
     title: "Spec issue must be closed after PR merge"
@@ -335,5 +371,15 @@ rules:
         - "all(criterion.result == 'PASS' for criterion in per_criterion) AND all_criteria_pass != true"
         - "any(criterion.result == 'FAIL' for criterion in per_criterion) AND all_criteria_pass != false"
     actions: [HALT, REQUIRE_CORRECT_ALL_CRITERIA_PASS]
-    source: "closure-verification.md §Step 12 — all_criteria_pass enforcement"
+    source: "closure-verification.md §Step 13 — all_criteria_pass enforcement"
+
+  - id: closure-verification-006
+    title: "Self-consistency gate — PASS with hedging language downgraded to FAIL"
+    conditions:
+      all:
+        - "per_criterion[].result == 'PASS'"
+        - "per_criterion[].explanation matches hedging_pattern"
+    hedging_pattern: "(should be|needs|missing|could improve|minor|some issues|mostly|generally)"
+    actions: [DOWNGRADE_TO_FAIL, SET_SELF_CONSISTENCY_FIELDS]
+    source: "closure-verification.md §Step 12 — self-consistency gate"
 ```

--- a/skills/audit/tasks/coherence-maintenance.md
+++ b/skills/audit/tasks/coherence-maintenance.md
@@ -147,6 +147,31 @@ for skill_behavior in current_state["skills"]["behaviors"]:
 
 Write verdict to `./tmp/{issue-N}/artifacts/coherence-maintenance/verdict.yaml`
 
+#### Self-Consistency Gate (applied after verdict.yaml is written)
+
+Before accepting the verdict, run a self-consistency check on every criterion entry:
+
+```python
+hedging_patterns = [
+    "should be", "needs", "missing", "could improve",
+    "minor", "some issues", "mostly", "generally"
+]
+
+for criterion in verdict["criteria"]:
+    if criterion["result"] == "PASS":
+        explanation_lower = criterion.get("explanation", "").lower()
+        for pattern in hedging_patterns:
+            if pattern in explanation_lower:
+                criterion["result"] = "FAIL"
+                criterion["self_consistency_note"] = (
+                    f"Downgraded from PASS to FAIL: explanation contains "
+                    f"critique/hedging language ('{pattern}') inconsistent with PASS verdict"
+                )
+                break
+```
+
+If any criterion is downgraded, the `overall_verdict` MUST also be set to `FAIL`.
+
 ### Step 8: Build Result Contract
 
 ```yaml

--- a/skills/audit/tasks/concern-separation.md
+++ b/skills/audit/tasks/concern-separation.md
@@ -168,13 +168,13 @@ scope_creep:
 
 ### Step 5: Classify Findings
 
-| Finding Type | Problem Class | Classification |
-|-------------|---------------|----------------|
-| BOILERPLATE_TITLE | Phase name generic | flag-for-review |
-| CONCERN_MIXING | Steps from different concerns | flag-for-review |
-| DEPENDENCY_REVERSAL | Wrong order | auto-fix |
-| HIGH_RISK_GROUPING | Risk mixing | conditional |
-| MISSING_INDEPENDENCE | Cannot deploy phase alone | flag-for-review |
+| Finding Type | Problem Class | Verdict |
+|-------------|---------------|---------|
+| BOILERPLATE_TITLE | Phase name generic | FAIL |
+| CONCERN_MIXING | Steps from different concerns | FAIL |
+| DEPENDENCY_REVERSAL | Wrong order | FAIL |
+| HIGH_RISK_GROUPING | Risk mixing | FAIL |
+| MISSING_INDEPENDENCE | Cannot deploy phase alone | FAIL |
 
 ### Step 6: Verify Boundary Claims
 
@@ -194,6 +194,24 @@ Each boundary claim must be verified:
 ### Step 7: Write verdict.yaml
 
 Write verdict to `./tmp/{issue-N}/artifacts/concern-separation/verdict.yaml`
+
+### Step 7a: Self-Consistency Gate
+
+Before writing the final artifact, verify verdict self-consistency:
+
+- [ ] 1. For each `per_criterion` entry, check: if `result: "PASS"` and `explanation` contains critique, hedging, or caveat language (e.g., "but", "however", "minor", "mostly", "functionally equivalent", "close enough", "with concerns"), the verdict is downgraded to FAIL
+- [ ] 2. If any criterion was downgraded, append a `self_consistency` section to the verdict:
+
+```yaml
+self_consistency:
+  downgraded_criteria:
+    - criterion_id: "CS-N"
+      original_result: "PASS"
+      downgraded_to: "FAIL"
+      reason: "explanation contained hedging language: '<matched phrase>'"
+```
+
+- [ ] 3. Update `all_criteria_pass` to `false` and `remediation_required` to `true` if any downgrade occurred
 
 ### Step 8: Write Verdict Artifact to Disk (Legacy — kept for backward compatibility)
 
@@ -218,10 +236,12 @@ per_criterion:
     explanation: "<reasoning>"
     remediation: ""
     next_step: "proceed"  # Conditional: "remediate" when result is "FAIL", "proceed" when result is "PASS"
+self_consistency:
+  downgraded_criteria: []
 findings:
   - type: "BOILERPLATE_TITLE"
     phase: "<phase>"
-    classification: "flag-for-review"
+    verdict: "FAIL"
     recommendation: "<recommendation>"
 exec_summary: "Concern separation: X/Y criteria. N phases need review."
 all_criteria_pass: false

--- a/skills/audit/tasks/content-audit.md
+++ b/skills/audit/tasks/content-audit.md
@@ -150,6 +150,37 @@ all_claims_verified: false
 remediation_required: true  # When status is FAIL: full mandatory re-audit required
 ```
 
+### Step 5c: Self-Consistency Gate
+
+Before returning, verify that every `result: "PASS"` entry has an `explanation` free of critique/hedging language. If a PASS entry's explanation contains any of the following patterns, downgrade the verdict to FAIL:
+
+| Hedging Pattern | Examples |
+|-----------------|----------|
+| "should be" | "should be 12", "should be present" |
+| "needs" | "needs improvement", "needs correction" |
+| "missing" | "missing context", "missing evidence" |
+| "could improve" | "could improve clarity", "could improve accuracy" |
+| "minor" | "minor discrepancy", "minor issue" |
+| "some issues" | "some issues found", "some issues remain" |
+| "mostly" | "mostly correct", "mostly matches" |
+| "generally" | "generally accurate", "generally supported" |
+
+```yaml
+# Self-consistency check: PASS + hedging = FAIL
+- claim_id: "C-1"
+  claim_text: "12 models were tested"
+  result: "PASS"  # ← downgraded to FAIL
+  explanation: "Source data shows 12 models. Minor formatting differences exist."
+  # ↑ "minor" detected → verdict downgraded to FAIL
+  self_consistency: FAIL
+  self_consistency_reason: "explanation contains hedging language: 'minor'"
+```
+
+- [ ] 1. For each `result: "PASS"` entry, scan `explanation` for hedging patterns
+- [ ] 2. If any hedging pattern is found: change `result` to `FAIL`, add `self_consistency: FAIL` and `self_consistency_reason: "<pattern detected>"`
+- [ ] 3. If no hedging patterns found: add `self_consistency: PASS` to the entry
+- [ ] 4. Recompute summary counts (pass/fail/fabricated) after any downgrades
+
 ### Step 6: Return Frugal Result Contract
 
 ```yaml
@@ -177,6 +208,7 @@ Every step in this task is a mandatory dependency. Skipping any step produces an
 - [ ] 3. Verify each claim → INVALID if skipped
 - [ ] 4. Generate findings → INVALID if skipped
 - [ ] 5. Write verdict artifact → INVALID if skipped
+- [ ] 5c. Self-Consistency Gate → INVALID if skipped
 - [ ] 6. Return result contract → INVALID if skipped
 
 ## Next Pipeline Step (MANDATORY CONTINUATION)

--- a/skills/audit/tasks/cross-validate.md
+++ b/skills/audit/tasks/cross-validate.md
@@ -270,7 +270,7 @@ The cross-validate result contract MUST use the following finding type classific
 
 `overall_verdict = PASS` iff `consensus == PASS` for ALL criteria. Any single `FAIL` in the table cascades to `overall_verdict = FAIL`.
 
-**Severity-based exception for SC-SEM criteria:** SC-SEM criteria carry a `severity` field (`ERROR` or `WARNING`). A FAIL on a WARNING-severity criterion does NOT cascade to `overall_verdict = FAIL` — it is recorded as a warning in the findings but does not block the pipeline. A FAIL on an ERROR-severity criterion DOES cascade to `overall_verdict = FAIL` and blocks the pipeline. Non-SC-SEM criteria (without a `severity` field) are treated as ERROR-severity by default — any FAIL blocks the pipeline.
+**No severity-based exceptions:** All FAILs cascade to `overall_verdict = FAIL` regardless of severity. WARNING is a FAIL condition — there is no distinction between WARNING and ERROR. The `severity` field in findings is informational only and does not affect the verdict cascade.
 
 ### Step 6.5: Verdict Self-Consistency Gate
 

--- a/skills/audit/tasks/drift-detection.md
+++ b/skills/audit/tasks/drift-detection.md
@@ -206,6 +206,30 @@ Present options for developer decision.
 
 Write verdict to `./tmp/{issue-N}/artifacts/drift-detection/verdict.yaml`
 
+#### Self-Consistency Gate (Post-Write Validation)
+
+After writing `verdict.yaml`, run a self-consistency check on every verdict entry:
+
+```yaml
+for each entry in verdict.yaml:
+  if entry.result == "PASS":
+    hedging_patterns = [
+      "should be", "needs", "missing", "could improve",
+      "minor", "some issues", "mostly", "generally"
+    ]
+    for pattern in hedging_patterns:
+      if pattern in entry.explanation.lower():
+        entry.result = "FAIL"
+        entry.self_consistency_note = (
+          f"Downgraded from PASS to FAIL: explanation contains hedging "
+          f"language ('{pattern}') that contradicts a PASS verdict. "
+          f"A PASS verdict must be unequivocal — no critique, no hedging."
+        )
+        break
+```
+
+**Rationale:** A PASS verdict with critique/hedging in the explanation is internally inconsistent. The explanation must match the verdict: PASS means no issues found; FAIL means issues found. Hedging language in a PASS explanation indicates the evaluator is soft-passing — reporting PASS while documenting concerns. This gate catches that contradiction and enforces binary honesty.
+
 ### Step 10: Build Result Contract
 
 ```yaml
@@ -279,7 +303,7 @@ Every step in this task is a mandatory dependency. Skipping any step produces an
 
 ```yaml+symbolic
 schema_version: "2.0"
-last_updated: "2026-05-08T00:00:00Z"
+last_updated: "2026-07-09T00:00:00Z"
 rules:
   - id: drift-detection-001
     title: "Spec drift must be reported before merge"
@@ -301,4 +325,11 @@ rules:
       all: ["drift_found == true", "revision_options == null"]
     actions: [APPEND_DEFAULT_OPTIONS]
     source: "drift-detection.md §Step 8"
+
+  - id: drift-detection-004
+    title: "Self-consistency gate — PASS with hedging language is downgraded to FAIL"
+    conditions:
+      all: ["verdict_written == true", "any_entry_has_pass_with_hedging == true"]
+    actions: [DOWNGRADE_TO_FAIL, APPEND_SELF_CONSISTENCY_NOTE]
+    source: "drift-detection.md §Step 9 — Self-Consistency Gate"
 ```

--- a/skills/audit/tasks/guideline-audit.md
+++ b/skills/audit/tasks/guideline-audit.md
@@ -208,6 +208,41 @@ Fix: <fix_action>
 
 Write verdict to `./tmp/{issue-N}/artifacts/guideline-audit/verdict.yaml`
 
+### Step 7a: Self-Consistency Gate — Verdict vs. Explanation
+
+Before writing the final verdict artifact, run a self-consistency check on every `per_criterion` entry:
+
+For each criterion where `result: "PASS"`, scan `explanation` for hedging or critique language. If any of the following phrases appear in the explanation, the verdict is **downgraded to FAIL**:
+
+| Phrase | Example |
+|--------|---------|
+| "should be" | "The rule should be more specific" |
+| "needs" | "The rule needs clearer wording" |
+| "missing" | "Missing explicit examples" |
+| "could improve" | "Could improve by adding examples" |
+| "minor" | "Minor issues with wording" |
+| "some issues" | "Some issues with clarity" |
+| "mostly" | "Mostly clear but..." |
+| "generally" | "Generally acceptable but..." |
+
+```yaml
+# Before self-consistency gate (INCONSISTENT — PASS with critique):
+per_criterion:
+  - criterion_id: "GA-1"
+    result: "PASS"
+    explanation: "Mostly clear but should be more specific about conditions"
+    # ↑ SELF-CONSISTENCY FAIL: "mostly" + "should be" → downgrade to FAIL
+
+# After self-consistency gate (CORRECTED):
+per_criterion:
+  - criterion_id: "GA-1"
+    result: "FAIL"
+    explanation: "Mostly clear but should be more specific about conditions"
+    remediation: "Self-consistency gate: explanation contains hedging language ('mostly', 'should be') inconsistent with PASS verdict"
+```
+
+**This gate fires AFTER Step 7 verdict.yaml is written and BEFORE Step 8 artifact is produced.** If any criterion is downgraded, update `verdict.yaml` in place, set `all_criteria_pass: false`, and note the downgrade in the report.
+
 ### Step 8: Write Verdict Artifact to Disk (Legacy — kept for backward compatibility)
 
 Write the full YAML verdict artifact to `{project_root}/tmp/{issue-N}/artifacts/pipeline-audit-guideline-audit-{STATUS}-{timestamp}.yaml`:
@@ -297,6 +332,13 @@ rules:
     source: "guideline-audit.md §Step 5"
 
   - id: guideline-audit-003
+    title: "Self-consistency gate — PASS with hedging language is downgraded to FAIL"
+    conditions:
+      all: ["per_criterion.result == PASS", "per_criterion.explanation contains hedging_or_critique_phrase"]
+    actions: [DOWNGRADE_TO_FAIL, UPDATE_VERDICT_YAML, SET_ALL_CRITERIA_PASS_FALSE]
+    source: "guideline-audit.md §Step 7a"
+
+  - id: guideline-audit-004
     title: "Audit report must be timestamped"
     conditions:
       all: ["report_written == true", "timestamp_in_report == false"]

--- a/skills/audit/tasks/plan-fidelity.md
+++ b/skills/audit/tasks/plan-fidelity.md
@@ -226,9 +226,9 @@ After verdict collection, classify each discrepancy:
 | Finding Type | Classification | Action |
 |-------------|----------------|--------|
 | MISSING_PHASE | auto-fix | Add phase from clean-room |
-| EXTRA_PHASE | flag-for-review | May be intentional |
+| EXTRA_PHASE | FAIL | May be intentional — must be justified |
 | MISSING_STEP | auto-fix | Add step from clean-room |
-| EXTRA_STEP | flag-for-review | May be intentional |
+| EXTRA_STEP | FAIL | May be intentional — must be justified |
 | APPROACH_DIFFERENCE | auto-fix | Clarify difference |
 | MISSING_EDGE_CASE | conditional | Verify clean-room correctness |
 | DEPENDENCY_REVERSAL | auto-fix | Reorder phases |
@@ -246,11 +246,21 @@ For FAIL/DISAGREE criteria:
 
 Present revision options.
 
-### Step 7: Write verdict.yaml
+### Step 7: Self-Consistency Gate — Verdict Integrity Check
+
+Before writing verdict.yaml, run the self-consistency gate on every criterion:
+
+- [ ] 1. For each criterion where `result: "PASS"`, inspect `explanation` for critique/hedging language:
+  - Hedging patterns: "mostly", "largely", "generally", "for the most part", "minor issues", "some concerns", "slight", "mostly correct", "functionally equivalent", "close enough", "with caveats", "with notes"
+  - If ANY hedging pattern is found, downgrade `result` to `FAIL` and set `remediation` to `"Self-consistency gate: PASS verdict contradicted by hedging in explanation"`
+- [ ] 2. If `result: "FAIL"` and `explanation` contains no hedging or critique, the verdict stands — no upgrade to PASS
+- [ ] 3. Log the self-consistency check result in the verdict YAML under `self_consistency_gate: { triggered: true|false, downgraded_criteria: ["<criterion IDs>"] }`
+
+### Step 8: Write verdict.yaml
 
 Write verdict to `./tmp/{issue-N}/artifacts/plan-fidelity/verdict.yaml`
 
-### Step 8: Write Verdict Artifact to Disk (Legacy — kept for backward compatibility)
+### Step 9: Write Verdict Artifact to Disk (Legacy — kept for backward compatibility)
 
 Write the full YAML verdict artifact to `{project_root}/tmp/{issue-N}/artifacts/pipeline-audit-plan-fidelity-{STATUS}-{timestamp}.yaml`:
 
@@ -274,7 +284,6 @@ per_criterion:
 all_criteria_pass: false
 remediation_required: true  # When status is FAIL: full mandatory re-audit required
 auto_fixes_applied: []
-flagged_for_review: []
 exec_summary: "Plan fidelity: X/Y criteria. N discrepancies found."
 ```
 

--- a/skills/audit/tasks/resolve-models.md
+++ b/skills/audit/tasks/resolve-models.md
@@ -33,7 +33,8 @@ The Path Provider role is the fourth and final role in the DiMo role chain. It r
 1. Read `evidence.yaml` (Generator output) — raw evidence and initial findings
 2. Read `reasoning.yaml` (Knowledge Supporter output) — validated evidence with source references
 3. Read `verdict.yaml` (Evaluator output) — per-criterion PASS/FAIL verdicts
-4. Write `judgment.yaml` — final judgment with cross-reference summary and `next_step`
+4. **Self-consistency gate**: For each finding where `result: "PASS"`, inspect the `explanation` field. If it contains any critique/hedging language ("should be", "needs", "missing", "could improve", "minor", "some issues", "mostly", "generally"), downgrade that finding's `result` to `FAIL` and set `self_consistency_downgrade: true` in the finding. A PASS verdict with hedging language is internally inconsistent — the explanation contradicts the result.
+5. Write `judgment.yaml` — final judgment with cross-reference summary and `next_step`
 
 ### Artifact Output
 
@@ -48,6 +49,7 @@ findings:
     result: PASS|FAIL
     evidence: "<tool-call reference>"
     explanation: "<reasoning>"
+    self_consistency_downgrade: false  # true if PASS was downgraded to FAIL by self-consistency gate
 ```
 
 ## Cross-References

--- a/skills/audit/tasks/spec-audit.md
+++ b/skills/audit/tasks/spec-audit.md
@@ -140,12 +140,12 @@ Define audit criteria based on spec-auditor task structure:
 | SC-PIPELINE-GATES | Pipeline gates use canonical checklist format, not gate tables | Spec requires numbered `- [ ] N.` checklist steps with dispatch mode indicators (`(**clean-room**)` or `(**inline**)`). Gate tables (per-unit or shared cross-reference) → VIOLATION. Expect dispatch indicators in every step title. |
 | SC-CANONICAL-PLAN-FORM | Plan output format uses canonical checklist format | If the spec defines plan output format requirements, validate they use the canonical checklist format: numbered `- [ ] N.` with sub-bullet metadata, dispatch mode indicators, no dispatch tables, no shared cross-references. |
 | SC-ADMONISHMENT | Mandatory Task Discipline admonishment present in SKILL.md | For skill card audits, verify the SKILL.md contains the 5-item Mandatory Task Discipline admonishment after Overview and before Trigger Dispatch Table. For task card audits, verify the 4-item (non-inline) or 3-item (inline) Task Discipline admonishment after Purpose and before Operating Protocol. |
-| SC-SEM-001 | Unambiguous dispatch condition | Does the description unambiguously tell an agent when to invoke this skill? Sub-agent reads the description and the Trigger Dispatch Table, judges whether the description provides clear dispatch conditions. **Severity: ERROR.** Failure: description is ambiguous about when to invoke (e.g., "Use when working with data" is too vague). |
-| SC-SEM-002 | Mandatory invocation signal | Does the description signal that invocation is mandatory (not optional)? Sub-agent reads the description and judges whether an agent would understand that this skill MUST be invoked when conditions match. **Severity: WARNING.** Failure: description reads as optional or discretionary (e.g., "Use when you want to..." implies choice). |
-| SC-SEM-003 | Dispatch table alignment | Does the description match the Trigger Dispatch Table's intent? Sub-agent compares the description against the table's trigger conditions and judges alignment. **Severity: ERROR.** Failure: description describes use cases the table does not cover, or table has triggers the description omits. |
-| SC-SEM-004 | Full coverage of dispatch conditions | Would an agent reading only the description know to invoke this skill in all conditions listed in the dispatch table? Sub-agent reads the description, then reads the table, and judges whether every table trigger is represented in the description. **Severity: WARNING.** Failure: one or more table triggers are not reflected in the description. |
-| SC-SEM-005 | No optional/discretionary language | Does the description contain any language that could be interpreted as making dispatch optional or discretionary? Sub-agent reads the description and identifies phrases that imply choice ("you can", "you may", "optionally", "if desired", "consider using"). **Severity: WARNING.** Failure: description contains optional/discretionary language. |
-| SC-SEM-006 | Dispatch table sub-item type correctness | Do dispatch table sub-items use the correct semantic type — sub-bullets for parameter metadata, sub-checkboxes for actionable sub-steps? Sub-agent reads the Trigger Dispatch Table and classifies each sub-item as parameter metadata (context fields, task file paths, dispatch type) or actionable sub-step (must be performed). Verifies sub-bullets used for metadata, sub-checkboxes used for actions. **Severity: WARNING.** Failure: sub-bullet used for an actionable sub-step, or sub-checkbox used for parameter metadata. |
+| SC-SEM-001 | Unambiguous dispatch condition | Does the description unambiguously tell an agent when to invoke this skill? Sub-agent reads the description and the Trigger Dispatch Table, judges whether the description provides clear dispatch conditions. Failure: description is ambiguous about when to invoke (e.g., "Use when working with data" is too vague). |
+| SC-SEM-002 | Mandatory invocation signal | Does the description signal that invocation is mandatory (not optional)? Sub-agent reads the description and judges whether an agent would understand that this skill MUST be invoked when conditions match. Failure: description reads as optional or discretionary (e.g., "Use when you want to..." implies choice). |
+| SC-SEM-003 | Dispatch table alignment | Does the description match the Trigger Dispatch Table's intent? Sub-agent compares the description against the table's trigger conditions and judges alignment. Failure: description describes use cases the table does not cover, or table has triggers the description omits. |
+| SC-SEM-004 | Full coverage of dispatch conditions | Would an agent reading only the description know to invoke this skill in all conditions listed in the dispatch table? Sub-agent reads the description, then reads the table, and judges whether every table trigger is represented in the description. Failure: one or more table triggers are not reflected in the description. |
+| SC-SEM-005 | No optional/discretionary language | Does the description contain any language that could be interpreted as making dispatch optional or discretionary? Sub-agent reads the description and identifies phrases that imply choice ("you can", "you may", "optionally", "if desired", "consider using"). Failure: description contains optional/discretionary language. |
+| SC-SEM-006 | Dispatch table sub-item type correctness | Do dispatch table sub-items use the correct semantic type — sub-bullets for parameter metadata, sub-checkboxes for actionable sub-steps? Sub-agent reads the Trigger Dispatch Table and classifies each sub-item as parameter metadata (context fields, task file paths, dispatch type) or actionable sub-step (must be performed). Verifies sub-bullets used for metadata, sub-checkboxes used for actions. Failure: sub-bullet used for an actionable sub-step, or sub-checkbox used for parameter metadata. |
 
 <!-- Fragment ID: sc-enforcement-gate -->
 
@@ -438,12 +438,11 @@ When the spec being audited is a skill card (SKILL.md file), evaluate the SC-SEM
 - PASS: all sub-items use the correct semantic type
 - FAIL: sub-bullet used for an actionable sub-step, or sub-checkbox used for parameter metadata
 
-Record each SC-SEM criterion result in the per_criterion array with the same format as other criteria, adding a `severity` field:
+Record each SC-SEM criterion result in the per_criterion array with the same format as other criteria:
 
 ```yaml
   - criterion_id: "SC-SEM-001"
     declared_evidence_type: "semantic"
-    severity: "ERROR"
     result: "PASS|FAIL"
     evidence: "<tool-call reference>"
     explanation: "<reasoning>"
@@ -461,6 +460,8 @@ For each criterion:
 - Both auditors PASS → criterion consensus PASS
 - Either auditor FAIL → criterion consensus FAIL
 - Auditors disagree → mark as DISAGREE, present bidirectional finding
+
+**Self-consistency gate:** After computing consensus, apply a self-consistency check to every PASS verdict. If `result: "PASS"` and the `explanation` contains critique/hedging language ("should be", "needs", "missing", "could improve", "minor", "some issues", "mostly", "generally"), the verdict is downgraded to FAIL. A PASS verdict must be strictly confirmatory with no critique or hedging.
 
 ### Step 4.5: Evaluate SC Determinism (SC-DET)
 
@@ -497,7 +498,7 @@ For each success criterion in the spec, evaluate determinism:
 
 ### Step 5: Generate Bidirectional Findings
 
-For FAIL/DISAGREE criteria:
+Generate findings ONLY for FAIL/DISAGREE criteria. PASS criteria MUST NOT appear in the findings table — a PASS verdict with findings is contradictory and will be caught by the self-consistency gate in Step 4.
 
 | Finding Type | Direction | Description |
 |-------------|-----------|-------------|
@@ -528,7 +529,6 @@ summary:
 per_criterion:
   - criterion_id: "SC-1"
     declared_evidence_type: "string"
-    severity: "ERROR"  # ERROR or WARNING; only present for SC-SEM criteria
     result: "PASS"
     evidence: "<tool-call reference>"
     explanation: "<reasoning>"

--- a/skills/audit/tasks/spec-summary.md
+++ b/skills/audit/tasks/spec-summary.md
@@ -161,15 +161,17 @@ else:
 
 ### Step 9: Classify Mismatches
 
-| Mismatch Type | Severity | Classification |
-|--------------|----------|----------------|
-| TITLE_MISMATCH | LOW | May be cosmetic |
-| CRITERIA_MISSING | HIGH | Success criteria must be documented |
-| FILES_MISSMATCH | MEDIUM | Extra/missing files need explanation |
-| SCOPE_EXPANSION | HIGH | PR exceeds spec scope |
-| SCOPE_INCOMPLETE | HIGH | PR doesn't address full spec |
-| LINK_MISSING | MEDIUM | Should reference spec issue |
-| CLOSING_MISSING | MEDIUM | PR won't auto-close spec issue |
+All findings are binary — PASS or FAIL. No severity tiers.
+
+| Mismatch Type | Classification |
+|--------------|----------------|
+| TITLE_MISMATCH | PR title does not match spec title |
+| CRITERIA_MISSING | Success criteria must be documented |
+| FILES_MISSMATCH | Extra/missing files need explanation |
+| SCOPE_EXPANSION | PR exceeds spec scope |
+| SCOPE_INCOMPLETE | PR doesn't address full spec |
+| LINK_MISSING | Should reference spec issue |
+| CLOSING_MISSING | PR won't auto-close spec issue |
 
 ### Step 10: Write verdict.yaml
 

--- a/skills/audit/tasks/test-quality-audit.md
+++ b/skills/audit/tasks/test-quality-audit.md
@@ -47,7 +47,7 @@ Structural test quality audit — reader-only checks on test files. Evaluates te
 
 ## Exit Criteria
 
-- All five checklist criteria evaluated with PASS/FAIL (no FAIL (inconclusive) verdicts)
+- All five checklist criteria evaluated with PASS/FAIL (no inconclusive verdicts)
 - Verdict produced in standard YAML block format per criterion
 - Remediation recommended as FIX_TEST, FIX_CODE, or SPEC_GAP
 
@@ -113,7 +113,7 @@ Do expected values reference the spec SC's specified values? Are expected values
 
 - PASS: All assertions reference specific expected values from the spec SCs
 - FAIL: Any assertion is tautological or references values unrelated to SCs
-- FAIL (inconclusive): Insufficient evidence to determine
+- FAIL: Insufficient evidence to determine
 
 #### 2. Cross-Boundary Coverage
 
@@ -121,7 +121,7 @@ Is there at least one test that references symbols from outside the immediate co
 
 - PASS: At least one test calls a function or uses a class from a different module than the one under test
 - FAIL: All tests are strictly intra-module
-- FAIL (inconclusive): Single-module change where cross-boundary testing is not applicable
+- FAIL: Single-module change where cross-boundary testing is not applicable
 
 #### 3. Edge-Case Completeness
 
@@ -129,7 +129,7 @@ Is there more than one test per function? Missing boundary/error/empty/null case
 
 - PASS: At least one test per function, plus separate tests for boundary values, error conditions, empty/null inputs
 - FAIL: Single test per function, missing edge cases
-- FAIL (inconclusive): Cannot determine function boundaries from file structure
+- FAIL: Cannot determine function boundaries from file structure
 
 #### 4. Assertion Weakening Detection (Retroactive)
 
@@ -137,7 +137,7 @@ Does git diff show expected values changing between commits while the function i
 
 - PASS: No evidence of assertion weakening — expected values consistent across commits
 - FAIL: Expected values changed in test while implementation remained unchanged
-- FAIL (inconclusive): Single commit or no git history available
+- FAIL: Single commit or no git history available
 
 #### 5. RED Evidence
 
@@ -145,7 +145,7 @@ Is there evidence that the test was confirmed FAIL before implementation (in git
 
 - PASS: Git history or VbC artifact shows test was run and failed before implementation began
 - FAIL: No evidence of RED state — test was created alongside or after implementation
-- FAIL (inconclusive): Cannot determine order from available evidence
+- FAIL: Cannot determine order from available evidence
 
 #### 6. Sequential TDD (TQ-11)
 
@@ -153,37 +153,37 @@ Across multiple test items, is there evidence of RED-before-GREEN ordering (each
 
 - PASS: Multiple items show individual RED/GREEN cycles — each test confirmed FAIL before its implementation was written
 - FAIL: Tests for multiple items were all written before any implementation (RED-ALL → GREEN-ALL pattern)
-- FAIL (inconclusive): Single item only, or insufficient git history to determine ordering
+- FAIL: Single item only, or insufficient git history to determine ordering
 
 ### Step 3: Produce Verdict
 
 ```yaml
 criterion: assertion_plausibility
-result: PASS|FAIL|FAIL (inconclusive)
+result: PASS|FAIL
 evidence: "<tool-call reference or file path>"
 remediation: FIX_TEST|FIX_CODE|SPEC_GAP
 recommendation: "<prose description of what to fix>"
 ---
 criterion: cross_boundary_coverage
-result: PASS|FAIL|FAIL (inconclusive)
+result: PASS|FAIL
 evidence: "<tool-call reference>"
 remediation: FIX_CODE
 recommendation: "<prose>"
 ---
 criterion: edge_case_completeness
-result: PASS|FAIL|FAIL (inconclusive)
+result: PASS|FAIL
 evidence: "<tool-call reference>"
 remediation: FIX_TEST|SPEC_GAP
 recommendation: "<prose>"
 ---
 criterion: assertion_weakening
-result: PASS|FAIL|FAIL (inconclusive)
+result: PASS|FAIL
 evidence: "<git diff reference>"
 remediation: FIX_TEST
 recommendation: "<prose>"
 ---
 criterion: red_evidence
-result: PASS|FAIL|FAIL (inconclusive)
+result: PASS|FAIL
 evidence: "<VbC artifact reference or git log>"
 remediation: FIX_TEST|SPEC_GAP
 recommendation: "<prose>"
@@ -205,7 +205,7 @@ orchestrator_model: "<model>"
 overall: PASS|FAIL|PARTIAL
 criteria:
   - criterion: "assertion_plausibility"
-    result: "PASS|FAIL|FAIL (inconclusive)"
+    result: "PASS|FAIL"
     evidence: "<tool-call reference>"
     remediation: "FIX_TEST|FIX_CODE|SPEC_GAP"
     recommendation: "<prose>"
@@ -240,7 +240,7 @@ Every step in this task is a mandatory dependency. Skipping any step produces an
 |-------|--------|
 | Test files do not exist | Return BLOCKED with missing file paths |
 | VbC artifact unavailable | Return BLOCKED — prerequisite unmet |
-| No git history for weakening check | Mark assertion_weakening as FAIL (inconclusive) with note |
+| No git history for weakening check | Mark assertion_weakening as FAIL with note |
 
 ## Cross-References
 

--- a/skills/audit/tasks/verification-audit.md
+++ b/skills/audit/tasks/verification-audit.md
@@ -200,6 +200,23 @@ all_criteria_pass: false
 remediation_required: true  # When status is FAIL: full mandatory re-audit required
 ```
 
+### Self-Consistency Gate
+
+After writing the verdict YAML, run a self-consistency check on every `per_criterion` entry where `result: "PASS"`:
+
+- [ ] 1. Scan `explanation` for critique/hedging language: "should be", "needs", "missing", "could improve", "minor", "some issues", "mostly", "generally"
+- [ ] 2. If ANY hedging language is found, downgrade `result` to `"FAIL"` and set `remediation` to `"Self-consistency gate: explanation contains hedging language despite PASS result."`
+- [ ] 3. Recompute `all_criteria_pass` and `remediation_required` after downgrades
+- [ ] 4. Log the downgrade in the verdict YAML under a `self_consistency_downgrades` field:
+
+```yaml
+self_consistency_downgrades:
+  - criterion_id: "SC-N"
+    original_result: "PASS"
+    downgraded_to: "FAIL"
+    hedging_phrase: "<matched phrase>"
+```
+
 ### Step 11: Return Frugal Result Contract
 
 ## Remediation

--- a/tests/behaviors/1792-sc6-hedging-fail.sh
+++ b/tests/behaviors/1792-sc6-hedging-fail.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+# Behavioral test: 1792-sc6-hedging-fail
+# SC-6: Spec-audit sub-agent returns FAIL (not PASS with caveats) when its own explanation contains hedging language
+# See .opencode/tests/AGENTS.md for the test harness specification and paradigm.
+# This script is an artifact-only generator — it does NOT evaluate model output.
+#
+# PROMPT CONSTRUCTION GUIDANCE:
+# Real-domain task: triggers spec-audit evaluation where the auditor's explanation
+# contains hedging language ("minor concerns", "should be improved", "some issues").
+# The current spec-audit task file has no self-consistency gate, so the agent
+# will likely accept PASS+hedging as valid. This test verifies the agent returns
+# FAIL instead.
+#
+# Evidence type: behavioral — verified by clean-room semantic inspection.
+# Per 080-code-standards.md §Rule 5, grep/string assertions on agent output
+# are EVIDENCE_TYPE_MISMATCH for behavioral SCs. Only assert_semantic
+# (clean-room sub-agent evaluation) is acceptable for verifying agent
+# ACTIONS and DECISIONS.
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/helpers.sh"
+
+SCENARIO_NAME="1792-sc6-hedging-fail"
+# BEHAVIORAL PROMPT: instruct the agent to ACT, not describe.
+# The agent must evaluate a spec-audit verdict where the explanation contains
+# hedging language and return FAIL (not PASS with caveats).
+SCENARIO_PROMPT="Evaluate this spec-audit verdict. The auditor returned result: PASS with explanation: 'The spec is mostly correct, though it should improve the description of error handling. Some minor concerns about the timeout value. Generally the criteria are met but could use more detail.' The spec-audit task file currently has no self-consistency gate. Determine the correct verdict for this audit result."
+
+echo "=== Behavioral Test: $SCENARIO_NAME ==="
+echo "SC-6: Spec-audit sub-agent must return FAIL (not PASS with caveats) when explanation contains hedging language"
+
+behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT"
+
+OVERALL_RESULT=0
+
+# SC-6: Behavioral evidence — clean-room semantic inspector verifies
+# the agent returned FAIL (not PASS with caveats) when the auditor's
+# explanation contains hedging language ("mostly correct", "should improve",
+# "minor concerns", "could use more detail").
+#
+# The current spec-audit task file has no self-consistency gate, so the
+# expected RED behavior is that the agent accepts PASS+hedging as valid.
+# After the self-consistency gate is added (GREEN), the agent must
+# downgrade to FAIL.
+#
+# The inspector sees full agent output including reasoning, classification
+# decisions, and verdicts. It judges MEANING, not strings.
+#
+# NO grep/string assertions on agent output — that would be
+# EVIDENCE_TYPE_MISMATCH per 080-code-standards.md §Rule 5.
+assert_semantic "SC-6" "Agent must classify the spec-audit verdict as FAIL, not PASS with caveats, when the auditor's explanation contains hedging language ('mostly correct', 'should improve', 'minor concerns', 'could use more detail', or similar qualifiers). The agent must NOT accept PASS+critique as a valid PASS. The agent must explicitly state that the correct verdict is FAIL because the explanation contains critique or hedging that contradicts a PASS verdict. The agent must NOT produce a PASS verdict for an audit result whose explanation contains any critique, concern, or hedging language." "required" || OVERALL_RESULT=1
+
+echo ""
+if [ "$OVERALL_RESULT" -eq 0 ]; then
+    echo "PASS: $SCENARIO_NAME"
+else
+    echo "FAIL: $SCENARIO_NAME"
+fi
+
+exit $OVERALL_RESULT

--- a/tests/behaviors/1792-sc7-flag-for-review-fail.sh
+++ b/tests/behaviors/1792-sc7-flag-for-review-fail.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+# Behavioral test: 1792-sc7-flag-for-review-fail
+# SC-7: Concern-separation sub-agent returns FAIL (not flag-for-review) for a finding that is not clean PASS
+# See .opencode/tests/AGENTS.md for the test harness specification and paradigm.
+# This script is an artifact-only generator — it does NOT evaluate model output.
+#
+# PROMPT CONSTRUCTION GUIDANCE:
+# Real-domain task: triggers concern-separation audit on a spec with a phase that has
+# boilerplate naming (e.g., "Phase 1: Implementation") which should be classified as FAIL,
+# not flag-for-review. The current concern-separation task file classifies BOILERPLATE_TITLE
+# as flag-for-review — this test verifies the agent returns FAIL instead.
+#
+# Evidence type: behavioral — verified by clean-room semantic inspection.
+# Per 080-code-standards.md §Rule 5, grep/string assertions on agent output
+# are EVIDENCE_TYPE_MISMATCH for behavioral SCs. Only assert_semantic
+# (clean-room sub-agent evaluation) is acceptable for verifying agent
+# ACTIONS and DECISIONS.
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/helpers.sh"
+
+SCENARIO_NAME="1792-sc7-flag-for-review-fail"
+# BEHAVIORAL PROMPT: instruct the agent to ACT, not describe.
+# The agent must run a concern-separation audit on a spec with a boilerplate phase name
+# and return FAIL (not flag-for-review) for the finding.
+SCENARIO_PROMPT="Run a concern-separation audit on this spec. The spec has a phase called 'Phase 1: Implementation' which is a boilerplate title. The concern-separation task file currently classifies BOILERPLATE_TITLE as flag-for-review. Evaluate this finding and return the correct classification."
+
+echo "=== Behavioral Test: $SCENARIO_NAME ==="
+echo "SC-7: Concern-separation sub-agent must return FAIL (not flag-for-review) for a finding that is not clean PASS"
+
+behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT"
+
+OVERALL_RESULT=0
+
+# SC-7: Behavioral evidence — clean-room semantic inspector verifies
+# the agent returned FAIL (not flag-for-review) for a finding that is
+# not clean PASS. The concern-separation task file currently classifies
+# BOILERPLATE_TITLE as flag-for-review, but the correct behavior per
+# hard-fail discipline is to return FAIL for any finding that is not
+# a clean PASS.
+#
+# The inspector sees full agent output including reasoning, classification
+# decisions, and verdicts. It judges MEANING, not strings.
+#
+# NO grep/string assertions on agent output — that would be
+# EVIDENCE_TYPE_MISMATCH per 080-code-standards.md §Rule 5.
+assert_semantic "SC-7" "Agent must classify the boilerplate title finding as FAIL, not flag-for-review. The agent must NOT accept flag-for-review as a valid classification for a finding that is not clean PASS. The agent must explicitly state that the correct verdict is FAIL, or that flag-for-review is insufficient and the finding must be FAIL. The agent must NOT produce a PASS verdict for a finding with any concern, issue, or caveat." "required" || OVERALL_RESULT=1
+
+echo ""
+if [ "$OVERALL_RESULT" -eq 0 ]; then
+    echo "PASS: $SCENARIO_NAME"
+else
+    echo "FAIL: $SCENARIO_NAME"
+fi
+
+exit $OVERALL_RESULT


### PR DESCRIPTION
## Summary

Add self-consistency gates to 9 audit task files, remove non-binary classifications from 6 files, and remove severity-based exceptions from 2 files.

## Changes

- **Self-consistency gates** (SC-1, SC-2, SC-11-16): Added to spec-audit, verification-audit, closure-verification, content-audit, guideline-audit, coherence-maintenance, drift-detection, resolve-models — PASS verdicts with hedging/critique explanations are downgraded to FAIL
- **flag-for-review removed** (SC-4, SC-5): concern-separation and plan-fidelity now use binary PASS/FAIL only
- **FAIL (inconclusive) removed** (SC-8): test-quality-audit uses binary PASS/FAIL only
- **cosmetic severity removed** (SC-9): spec-summary uses binary PASS/FAIL only
- **Severity exception removed** (SC-10): cross-validate — all FAILs cascade to overall_verdict = FAIL
- **WARNING/ERROR severity removed** (SC-17): spec-audit — all SC-SEM criteria are ERROR
- **Behavioral tests** (SC-6, SC-7): Added for hedging-fail and flag-for-review-fail scenarios

## Fixes

Closes #1792

🤖 Co-authored with AI: OpenCode (ollama-cloud/deepseek-v4-flash)