### PR TITLE
fix: migrate three-tier classification to binary PASS/FAIL across all skills (#1793)

### DIFF
--- a/guidelines/000-critical-rules.md
+++ b/guidelines/000-critical-rules.md
@@ -419,7 +419,7 @@ Every step in pipeline chain is enforceable, not advisory. Professional engineer
 
 
 ### [critical-rules-016] Auditor Skills Enforcement
-Professional engineers subject every deliverable to independent audit — amateurs ship unverified work. See `spec-auditor` skill. Auto-fix/conditional/flag-for-review classification.
+Professional engineers subject every deliverable to independent audit — amateurs ship unverified work. See `spec-auditor` skill. Binary PASS/FAIL classification (auto-fix as remediation action only).
 
 
 ### [critical-rules-011] Bug Reports Without Fix Spec

--- a/skills/approval-gate/enforcement/adversarial-verification.md
+++ b/skills/approval-gate/enforcement/adversarial-verification.md
@@ -11,7 +11,7 @@ Check: [what was verified]
 Tool: [tool call and parameters]
 Result: [actual state found]
 Classification: [STRUCTURE-VIOLATION|MISSING-ELEMENT|CONFLICTING|VERIFICATION-GAP|MISSING-TRACEABILITY]
-Action: [auto-fix|conditional|flag-for-review]
+Action: [auto-fix|escalate]
 ```
 
 ### Evidence Rules
@@ -23,16 +23,14 @@ Action: [auto-fix|conditional|flag-for-review]
 
 ## Finding Classification
 
-Findings from verification follow the three-tier model:
+Findings from verification follow a binary model: PASS or FAIL. No classification tier may imply "defects are acceptable."
 
 | Classification | When | Action |
 |----------------|------|--------|
-| auto-fix | Safe, mechanical correction (stale reference, wrong issue number) | Apply fix, note in evidence |
-| conditional | Requires scope/safety check (authorization from wrong person, wrong issue) | Verify scope, then proceed if safe |
-| flag-for-review | Requires domain judgment (conflicting authorization, ambiguous approval) | Report in findings, HALT for human review |
+| PASS | Finding matches expected state | No action needed |
+| FAIL | Finding deviates from expected state | Remediate or escalate |
 
-### Tier Actions
+### Remediation Actions
 
-- **auto-fix**: Apply the fix directly, include in evidence table
-- **conditional**: Verify scope and safety before applying; if safe, apply; if not, HALT
-- **flag-for-review**: Report in findings, do NOT apply, HALT for developer review
+- **auto-fix**: Apply automated correction for non-substantive mechanical FAILs (formatting, typos, stale references). This is a remediation action, not a classification tier — the finding is still FAIL until corrected.
+- **escalate**: Report FAIL findings that require domain judgment in findings, do NOT apply, HALT for developer review.

--- a/skills/approval-gate/tasks/column-validation.md
+++ b/skills/approval-gate/tasks/column-validation.md
@@ -27,7 +27,7 @@ When running the pre-approval gate for standard/complex specs, validate the foll
 | Re-Entry Step | MUST specify re-entry point on verification failure | BLOCK |
 | Verification Gate | MUST be one of: red-green, pre-commit, ci | BLOCK |
 | Artifact Path | MUST use `{project_root}/tmp/{issue-N}/` convention | BLOCK |
-| Phase Binding | MUST annotate phase for multi-phase specs | FLAG (conditional) |
+| Phase Binding | MUST annotate phase for multi-phase specs | FLAG |
 
 For `for_spec` scope, only minimal-tier requirements enforced (Pipeline Step Binding, Re-Entry Step).
 

--- a/skills/approval-gate/tasks/completion.md
+++ b/skills/approval-gate/tasks/completion.md
@@ -150,9 +150,9 @@ This format is verified by behavioral enforcement tests in `.opencode/tests/beha
 
 ### Verification Checklist
 
-- **Label state matches authorization:** Check labels via `issue-operations -> read-labels`. If `needs-approval` present AND authorization granted → STRUCTURE-VIOLATION (auto-fix: remove label). If `needs-approval` absent AND no authorization found → VERIFICATION-GAP (flag-for-review). <!-- Routes through issue-operations per SPEC #683 -->
-- **Local state file matches authorization:** Read `.issues/{N}/issue.yaml` and verify authorization scope marker matches the current session authorization. If mismatch → VERIFICATION-GAP (flag-for-review).
-- **Status report matches workflow outcome:** If completion claims "approved" but no local state file authorization found → CONFLICTING (flag-for-review). If claims "blocked" but blocker issue is closed → VERIFICATION-GAP (flag-for-review).
+- **Label state matches authorization:** Check labels via `issue-operations -> read-labels`. If `needs-approval` present AND authorization granted → STRUCTURE-VIOLATION (auto-fix: remove label). If `needs-approval` absent AND no authorization found → VERIFICATION-GAP (FAIL). <!-- Routes through issue-operations per SPEC #683 -->
+- **Local state file matches authorization:** Read `.issues/{N}/issue.yaml` and verify authorization scope marker matches the current session authorization. If mismatch → VERIFICATION-GAP (FAIL).
+- **Status report matches workflow outcome:** If completion claims "approved" but no local state file authorization found → CONFLICTING (FAIL). If claims "blocked" but blocker issue is closed → VERIFICATION-GAP (FAIL).
 
 ### Completion Task Scope Clarification
 

--- a/skills/approval-gate/tasks/post-implementation.md
+++ b/skills/approval-gate/tasks/post-implementation.md
@@ -129,7 +129,7 @@ PR URL: <html_url from github_create_pull_request API response>
 | No branch pushed (no-changes path) | ❌ No | Omit URL element entirely; byline follows outcome directly |
 | PR already created | ✅ Yes | Use PR URL label with `pull/<N>` format instead of "Compare URL" |
 
-**Finding Classification:** See `enforcement/adversarial-verification.md` for the three-tier classification model (auto-fix, conditional, flag-for-review) and evidence artifact format.
+**Finding Classification:** See `enforcement/adversarial-verification.md` for the binary PASS/FAIL classification model (auto-fix as remediation action only) and evidence artifact format.
 
 **Auto-fix on failure:** If any element is missing or misordered, fix the output before sending. Missing elements are auto-fixed before output is sent — NOT reported after the fact.
 
@@ -150,7 +150,7 @@ PR URL: <html_url from github_create_pull_request API response>
 
 ### Verification Checklist
 
-- **All changes committed:** Run `git status --porcelain`. If not empty → VERIFICATION-GAP (conditional: commit remaining changes). Run `git diff --staged` to confirm clean state.
+- **All changes committed:** Run `git status --porcelain`. If not empty → VERIFICATION-GAP (FAIL: commit remaining changes). Run `git diff --staged` to confirm clean state.
 - **Branch actually pushed:** Verify tracking branch exists via `git branch -vv`. Verify no unpushed commits via `git diff @{u} HEAD`. Verify commits ahead of dev via `git log origin/"$DEFAULT_BRANCH"..HEAD`.
 - **Compare URL correctness:** Verify URL uses correct base branch ($DEFAULT_BRANCH, not main). Verify URL uses session init values (not hardcoded).
 - **Chat output format:** Verify each required element is present: executive summary, outcome, URL (if applicable), byline. See Step 4.5 for the full checklist.

--- a/skills/approval-gate/tasks/pre-impl/build-dependency-graph.md
+++ b/skills/approval-gate/tasks/pre-impl/build-dependency-graph.md
@@ -232,7 +232,7 @@ For each file path or symbol from screening `file_references`/`symbol_references
 
 ### Finding Classification
 
-See `enforcement/adversarial-verification.md` for the three-tier classification model (auto-fix, conditional, flag-for-review) and evidence artifact format.
+See `enforcement/adversarial-verification.md` for the binary PASS/FAIL classification model (auto-fix as remediation action only) and evidence artifact format.
 
 ## Enforcement References
 

--- a/skills/approval-gate/tasks/screen/screen-issue-gate2.md
+++ b/skills/approval-gate/tasks/screen/screen-issue-gate2.md
@@ -54,9 +54,9 @@ A merged PR proves code was merged. It does NOT prove that success criteria are 
 
 | Failure Condition | Classification | Action |
 |-----------------|----------------|--------|
-| No success criteria extracted | VERIFICATION-GAP | Re-read issue body; if criteria cannot be found, flag for review |
+| No success criteria extracted | VERIFICATION-GAP | Re-read issue body; if criteria cannot be found, FAIL |
 | Criterion fails verification | DOWNGRADE | "partially-implemented" — criterion not met despite closure |
-| Criterion unverified (no tool call) | VERIFICATION-GAP | Re-run verification; if unverifiable, flag for review |
+| Criterion unverified (no tool call) | VERIFICATION-GAP | Re-run verification; if unverifiable, FAIL |
 | Success criteria not in issue body | MISSING-ELEMENT | Search comments; if absent, flag for developer to confirm |
 | Agent claims "all criteria met" without evidence | CRITICAL VIOLATION | Re-run gate with evidence collection |
 
@@ -76,7 +76,7 @@ For each candidate "already-implemented" issue:
       ref_issue = issue-operations -> read-issue (github_issue_read(method="get", issue_number=ref_num) <!-- Routes through issue-operations per SPEC #683 -->
       
       if ref_issue["state"] == "open" and candidate is classified as "already-implemented":
-        DOWNGRADE to "partially-implemented" or flag-for-review
+        DOWNGRADE to "partially-implemented" or FAIL
       
       if ref_issue["state"] == "closed":
         # Verify referenced issue was legitimately closed (merged PR exists)
@@ -87,9 +87,9 @@ For each candidate "already-implemented" issue:
 
 | Failure Condition | Classification | Action |
 |-----------------|----------------|--------|
-| Referenced issue is open | CONFLICTING | DOWNGRADE or flag-for-review — state mismatch |
-| Referenced issue closed without merged PR | VERIFICATION-GAP | Flag for review — may be premature closure |
-| Cross-reference 404 | MISSING-TRACEABILITY | Flag for developer — referenced issue doesn't exist |
+| Referenced issue is open | CONFLICTING | DOWNGRADE or FAIL — state mismatch |
+| Referenced issue closed without merged PR | VERIFICATION-GAP | FAIL — may be premature closure |
+| Cross-reference 404 | MISSING-TRACEABILITY | FAIL — referenced issue doesn't exist |
 
 **Key principle:** Even if Gate 1 and Gate 2 pass, cross-reference inconsistencies invalidate the "already-implemented" classification. The full issue graph must be consistent.
 

--- a/skills/approval-gate/tasks/verify-already-implemented.md
+++ b/skills/approval-gate/tasks/verify-already-implemented.md
@@ -195,7 +195,7 @@ For each sub-issue:
     if state_reason == "not_planned":
       # Sub-issue was intentionally not implemented
       # Parent CANNOT be autoclosed — some work was deliberately skipped
-      VERIFICATION-GAP — flag-for-review
+      VERIFICATION-GAP — FAIL
       HALT autoclose
 
     elif state_reason == "completed":
@@ -210,12 +210,12 @@ For each sub-issue:
 
       if not merged_pr_found:
         # Closed as "completed" but no merged PR — may be premature closure
-        VERIFICATION-GAP — flag-for-review
+        VERIFICATION-GAP — FAIL
         HALT autoclose
 
     else:
       # Closed without clear reason
-      VERIFICATION-GAP — flag-for-review
+      VERIFICATION-GAP — FAIL
       HALT autoclose
 
   elif child.state == "open":
@@ -239,7 +239,7 @@ For each sub-issue verified as legitimately closed:
 
 ### Pre-Autoclose Verification Finding Classification
 
-See `enforcement/adversarial-verification.md` for the three-tier classification model (auto-fix, conditional, flag-for-review) and evidence artifact format.
+See `enforcement/adversarial-verification.md` for the binary PASS/FAIL classification model (auto-fix as remediation action only) and evidence artifact format.
 
 ## What This Is NOT
 

--- a/skills/approval-gate/tasks/verify-authorization/auto-dispatch.md
+++ b/skills/approval-gate/tasks/verify-authorization/auto-dispatch.md
@@ -38,7 +38,7 @@ authorization_source: "User approved #N on YYYY-MM-DD"
 | **Plan approval** | Local plan file exists at `.issues/{N}/plan.md` or `{project_root}/{path}/.issues/{N}/plan.md` | `executing-plans --task start` |
 | **Already implemented** | Step 5d.4 (`verify-already-implemented`) returns positive | No dispatch — auto-close instead (execution path: Step 0 of auto-route procedure) |
 | **Reconciled during verification** | reconcile-issue-graph returned auto-closed or reopened tickets | Include reconciled tickets in chat output; proceed with dispatch |
-| **Closed but NOT verified** | Step 5.4 closed-issue verification finds closure without merged PR evidence | flag-for-review — do NOT autoclose |
+| **Closed but NOT verified** | Step 5.4 closed-issue verification finds closure without merged PR evidence | FAIL — do NOT autoclose |
 
 ## Scope-Aware Route Targets
 
@@ -64,7 +64,7 @@ When `authorization_scope == "for_analysis"`:
    - If verify-already-implemented returned positive → auto-close issue, check parent plan, HALT
    - If verify-codebase found staleness → HALT, report staleness
    - If verify-blockers found blockers → HALT, report blockers
-   - If verify-closed-issue-main found VERIFICATION_GAP → flag-for-review, HALT
+   - If verify-closed-issue-main found VERIFICATION_GAP → FAIL, HALT
    - Otherwise → proceed to spec/plan routing
 
 1. Determine approval context (spec vs plan) by checking:

--- a/skills/approval-gate/tasks/verify-authorization/sub-issue-verification.md
+++ b/skills/approval-gate/tasks/verify-authorization/sub-issue-verification.md
@@ -51,7 +51,7 @@ for sub_issue in sub_issues:
 
 For multi-task plans, verify that the number of sub-issues matches the number of phases in the plan body. A mismatch indicates incomplete sub-issue linkage. See `enforcement/sub-issue-graph-traversal.md` for the phase-count cross-reference algorithm.
 
-**Finding Classification:** See `enforcement/adversarial-verification.md` for the three-tier classification model (auto-fix, conditional, flag-for-review) and evidence artifact format.
+**Finding Classification:** See `enforcement/adversarial-verification.md` for the binary PASS/FAIL classification model (auto-fix as remediation action only) and evidence artifact format.
 
 ### 5.3 Adversarial Verification of Sub-Issue State
 
@@ -72,7 +72,7 @@ For each sub-issue:
 
 Before skipping a closed issue in any workflow gate, verify it was closed for the right reason. See `enforcement/closed-issue-verification.md` for the complete closed-issue verification procedure.
 
-**Finding Classification for Closed-Issue Verification:** See `enforcement/adversarial-verification.md` for the three-tier classification model and evidence artifact format.
+**Finding Classification for Closed-Issue Verification:** See `enforcement/adversarial-verification.md` for the binary PASS/FAIL classification model and evidence artifact format.
 
 ### 5.5 Transitive Issue Graph Verification (MANDATORY on Authorization and Re-Approval)
 
@@ -93,7 +93,7 @@ After traversal completes, dispatch `reconcile-issue-graph` to act on findings. 
 
 ### Finding Classification for Sub-Issue Verification
 
-See `enforcement/adversarial-verification.md` for the three-tier classification model (auto-fix, conditional, flag-for-review) and evidence artifact format.
+See `enforcement/adversarial-verification.md` for the binary PASS/FAIL classification model (auto-fix as remediation action only) and evidence artifact format.
 
 ## Work State I/O
 

--- a/skills/approval-gate/tasks/verify-blockers.md
+++ b/skills/approval-gate/tasks/verify-blockers.md
@@ -59,7 +59,7 @@ For each dependency listed in spec:
 
 ## Adversarial Verification: Blocker State
 
-Adversarial verification model (evidence format, classification tiers, tier actions): see `enforcement/adversarial-verification.md`
+Adversarial verification model (evidence format, binary PASS/FAIL classification): see `enforcement/adversarial-verification.md`
 
 ### Verify Blocker Issues Exist and Are Actually Blocking
 
@@ -69,7 +69,7 @@ For each identified blocker issue:
   
   - Verify issue exists (404 → MISSING-TRACEABILITY: blocker reference is stale)
   - Verify issue state matches claimed state:
-    - If claimed "open" but actually "closed" → VERIFICATION-GAP (blocker resolved)
+    - If claimed "open" but actually "closed" → VERIFICATION-GAP (FAIL: blocker resolved)
     - If claimed "closed" but actually "open" → CONFLICTING (blocker still active)
   - Verify issue is genuinely blocking:
     - If blocker has a merged PR that resolves it → blocker is resolved
@@ -127,7 +127,7 @@ Labels are advisory visibility markers only — they do NOT gate execution. If t
 
 ### Task-Specific Findings
 
-See `enforcement/adversarial-verification.md` for the three-tier classification model (auto-fix, conditional, flag-for-review) and evidence artifact format.
+See `enforcement/adversarial-verification.md` for the binary PASS/FAIL classification model (auto-fix as remediation action only) and evidence artifact format.
 
 ## Context Required
 

--- a/skills/approval-gate/tasks/verify-closed-issue.md
+++ b/skills/approval-gate/tasks/verify-closed-issue.md
@@ -333,7 +333,7 @@ for adj_issue in adjacent:
 
 #### 8.3 Graph Verification Findings
 
-Classification tiers and actions (auto-fix, conditional, flag-for-review): see `enforcement/adversarial-verification.md`
+Binary PASS/FAIL classification (auto-fix as remediation action only): see `enforcement/adversarial-verification.md`
 
 #### 8.4 Report
 
@@ -370,7 +370,7 @@ Overall: CONSISTENT / HAS_FLAGS
 
 ## Finding Classification
 
-Classification tiers (auto-fix, conditional, flag-for-review) and evidence format: see `enforcement/adversarial-verification.md`
+Binary PASS/FAIL classification (auto-fix as remediation action only) and evidence format: see `enforcement/adversarial-verification.md`
 
 ## Integration Points
 

--- a/skills/approval-gate/tasks/verify-codebase.md
+++ b/skills/approval-gate/tasks/verify-codebase.md
@@ -64,10 +64,10 @@ If staleness detected:
 
 ### Verification Checklist
 
-- **File existence:** Use `glob` or `read` to verify each file mentioned in the spec exists at its specified path. If missing → VERIFICATION-GAP (flag-for-review).
-- **Code references:** Use `srclight_get_signature` or `srclight_search_symbols` to verify each symbol mentioned in the spec exists and signatures match. If mismatch → CONFLICTING (flag-for-review).
+- **File existence:** Use `glob` or `read` to verify each file mentioned in the spec exists at its specified path. If missing → VERIFICATION-GAP (FAIL).
+- **Code references:** Use `srclight_get_signature` or `srclight_search_symbols` to verify each symbol mentioned in the spec exists and signatures match. If mismatch → CONFLICTING (FAIL).
 - **Superseding issues:** Use `issue-operations -> read-issue (github_issue_read` to verify each candidate superseding issue is still open and covers the current spec's scope. Closed as `not_planned` → NOT superseding. <!-- Routes through issue-operations per SPEC #683 -->
-- **Staleness:** Use `srclight_recent_changes` or `git log --since=<spec-date>` to verify referenced files are unchanged since spec creation. If changed → VERIFICATION-GAP (conditional: re-verify).
+- **Staleness:** Use `srclight_recent_changes` or `git log --since=<spec-date>` to verify referenced files are unchanged since spec creation. If changed → VERIFICATION-GAP (FAIL: re-verify).
 
 ## Enforcement References
 

--- a/skills/approval-gate/tasks/verify-fix-spec.md
+++ b/skills/approval-gate/tasks/verify-fix-spec.md
@@ -83,9 +83,9 @@ Examine sub-issues for:
 
 ### Verification Checklist
 
-- **Fix spec existence:** Verify each sub-issue exists via `issue-operations -> read-issue (github_issue_read(method=get)` — not just claimed to exist. 404 → MISSING-TRACEABILITY (flag-for-review). <!-- Routes through issue-operations per SPEC #683 -->
-- **Label and STATUS maturity:** Verify labels and STATUS markers match content maturity. Stale labels → STRUCTURE-VIOLATION (auto-fix). Overstated STATUS → CONFLICTING (flag-for-review).
-- **Premature closure:** Verify closed sub-issues have merged PR evidence. No merged PR → VERIFICATION-GAP (flag-for-review).
+- **Fix spec existence:** Verify each sub-issue exists via `issue-operations -> read-issue (github_issue_read(method=get)` — not just claimed to exist. 404 → MISSING-TRACEABILITY (FAIL). <!-- Routes through issue-operations per SPEC #683 -->
+- **Label and STATUS maturity:** Verify labels and STATUS markers match content maturity. Stale labels → STRUCTURE-VIOLATION (auto-fix). Overstated STATUS → CONFLICTING (FAIL).
+- **Premature closure:** Verify closed sub-issues have merged PR evidence. No merged PR → VERIFICATION-GAP (FAIL).
 
 ## Enforcement References
 

--- a/skills/approval-gate/tasks/verify-open-questions.md
+++ b/skills/approval-gate/tasks/verify-open-questions.md
@@ -80,14 +80,14 @@ comments = issue-operations -> read-comments (github_issue_read(method="get_comm
 
 - Check ALL comments for questions not listed in the spec's "Open Questions" section
 - Developer may have raised new questions in comments
-- If new questions found → MISSING-ELEMENT (conditional: add to open questions)
+- If new questions found → MISSING-ELEMENT (FAIL: add to open questions)
 ```
 
 **Evidence artifact:** Comment scan results showing any unlisted questions.
 
 ### Task-Specific Findings
 
-See `enforcement/adversarial-verification.md` for the three-tier classification model (auto-fix, conditional, flag-for-review) and evidence artifact format.
+See `enforcement/adversarial-verification.md` for the binary PASS/FAIL classification model (auto-fix as remediation action only) and evidence artifact format.
 
 ## Context Required
 

--- a/skills/approval-gate/tasks/verify-qa-mode.md
+++ b/skills/approval-gate/tasks/verify-qa-mode.md
@@ -363,7 +363,7 @@ git_status = git status
 
 ### Task-Specific Findings
 
-See `enforcement/adversarial-verification.md` for the three-tier classification model (auto-fix, conditional, flag-for-review) and evidence artifact format.
+See `enforcement/adversarial-verification.md` for the binary PASS/FAIL classification model (auto-fix as remediation action only) and evidence artifact format.
 
 ## Edge Cases
 

--- a/skills/approval-gate/tasks/verify-sub-issues.md
+++ b/skills/approval-gate/tasks/verify-sub-issues.md
@@ -214,7 +214,7 @@ For each sub-issue:
   - If work.md phase tracking is mismatched to actual sub-issue progress → STRUCTURE-VIOLATION
     (auto-fix: update work.md per ground-truth progress)
   - If work.md says completed but sub-issue is open → CONFLICTING
-    (flag-for-review: may indicate tracking mismatch)
+    (FAIL: may indicate tracking mismatch)
 ```
 
 **Evidence artifact:** Label list and work.md state for each sub-issue.
@@ -234,7 +234,7 @@ parent_check = issue-operations -> read-sub-issues (github_issue_read(method="ge
 
 ### Task-Specific Findings
 
-See `enforcement/adversarial-verification.md` for the three-tier classification model (auto-fix, conditional, flag-for-review) and evidence artifact format.
+See `enforcement/adversarial-verification.md` for the binary PASS/FAIL classification model (auto-fix as remediation action only) and evidence artifact format.
 
 ## Context Required
 

--- a/skills/audit/tasks/concern-separation.md
+++ b/skills/audit/tasks/concern-separation.md
@@ -241,7 +241,7 @@ self_consistency:
 findings:
   - type: "BOILERPLATE_TITLE"
     phase: "<phase>"
-    verdict: "FAIL"
+verdict: "FAIL"
     recommendation: "<recommendation>"
 exec_summary: "Concern separation: X/Y criteria. N phases need review."
 all_criteria_pass: false
@@ -320,7 +320,7 @@ rules:
         - "per_criterion[].result == 'FAIL' AND per_criterion[].next_step != 'remediate'"
         - "per_criterion[].result == 'PASS' AND per_criterion[].next_step != 'proceed'"
     actions: [HALT, REQUIRE_CORRECT_NEXT_STEP]
-    source: "concern-separation.md §Step 7 — conditional next_step enforcement"
+    source: "concern-separation.md §Step 7 — FAIL next_step enforcement"
 
   - id: concern-separation-005
     title: "all_criteria_pass MUST be true when every criterion result is 'PASS', false otherwise"

--- a/skills/audit/tasks/plan-fidelity.md
+++ b/skills/audit/tasks/plan-fidelity.md
@@ -230,9 +230,9 @@ After verdict collection, classify each discrepancy:
 | MISSING_STEP | auto-fix | Add step from clean-room |
 | EXTRA_STEP | FAIL | May be intentional — must be justified |
 | APPROACH_DIFFERENCE | auto-fix | Clarify difference |
-| MISSING_EDGE_CASE | conditional | Verify clean-room correctness |
+| MISSING_EDGE_CASE | FAIL | Verify clean-room correctness |
 | DEPENDENCY_REVERSAL | auto-fix | Reorder phases |
-| MISSING_TDD_CHECKPOINT | conditional | Add RED checkpoint |
+| MISSING_TDD_CHECKPOINT | FAIL | Add RED checkpoint |
 
 ### Step 6: Generate Bidirectional Findings
 
@@ -372,7 +372,7 @@ rules:
         - "per_criterion[].result == 'FAIL' AND per_criterion[].next_step != 'remediate'"
         - "per_criterion[].result == 'PASS' AND per_criterion[].next_step != 'proceed'"
     actions: [HALT, REQUIRE_CORRECT_NEXT_STEP]
-    source: "plan-fidelity.md §Step 7 — conditional next_step enforcement"
+    source: "plan-fidelity.md §Step 7 — FAIL next_step enforcement"
 
   - id: plan-fidelity-007
     title: "all_criteria_pass MUST be true when every criterion result is 'PASS', false otherwise"

--- a/skills/brainstorming/tasks/enforcement.md
+++ b/skills/brainstorming/tasks/enforcement.md
@@ -19,7 +19,7 @@ Enforcement rules and messages for the brainstorming skill. Ensures brainstormin
    | Exploration invoked, batch-dump detected | Agent produced findings without developer interaction | HALT — require developer confirmation of each item |
    | Exploration invoked, partial protocol | Agent asked one question then ignored the answer | HALT — require per-item developer confirmation before proceeding |
     | Exploration invoked, protocol followed | Interactive Q&A with developer confirmation for key items | PROCEED to spec creation |
-    | Terminal routing to spec-creation occurred (not just issue-operations)? | Verify spec-creation was invoked after exploration | Chat + tool call evidence | SOFT-PASS |
+    | Terminal routing to spec-creation occurred (not just issue-operations)? | Verify spec-creation was invoked after exploration | Chat + tool call evidence | FAIL |
 
 - [ ] 3. **What does NOT bypass exploration:**
 
@@ -146,20 +146,20 @@ Check: [what was verified]
 Tool: [tool call and parameters]
 Result: [actual state found]
 Classification: [STRUCTURE-VIOLATION|MISSING-ELEMENT|CONFLICTING|VERIFICATION-GAP|MISSING-TRACEABILITY]
-Action: [auto-fix|conditional|flag-for-review]
+Action: [auto-fix|FAIL]
 ```
 
 ### Classification on Failure
 
 | Failure | Problem Class | Classification | Action |
 | -- | -- | -- | -- |
-| Checklist items claimed without tool-call evidence | VERIFICATION-GAP | conditional | Complete the tool calls before proceeding |
+| Checklist items claimed without tool-call evidence | VERIFICATION-GAP | FAIL | Complete the tool calls before proceeding |
 | Problem statement missing from issue | STRUCTURE-VIOLATION | auto-fix | Add problem statement to issue body |
-| No alternatives documented for significant decision | MISSING-ELEMENT | conditional | Document alternatives before proceeding |
-| Approval from non-developer (bot/agent) | CONFLICTING | flag-for-review | HALT — requires real developer authorization |
+| No alternatives documented for significant decision | MISSING-ELEMENT | FAIL | Document alternatives before proceeding |
+| Approval from non-developer (bot/agent) | CONFLICTING | FAIL | HALT — requires real developer authorization |
 | STATUS marker claims maturity but content is incomplete | STRUCTURE-VIOLATION | auto-fix | Update STATUS to reflect actual maturity |
-| Consecutive agent messages without developer response | CONFLICTING | flag-for-review | HALT — batch-dump detected, re-engage developer interactively |
-| Significant findings lack developer confirmation | VERIFICATION-GAP | conditional | Re-present each finding for developer confirmation before proceeding |
-| Fewer than 2 Q&A exchanges before proceeding | VERIFICATION-GAP | conditional | Continue Q&A until minimum turns met |
+| Consecutive agent messages without developer response | CONFLICTING | FAIL | HALT — batch-dump detected, re-engage developer interactively |
+| Significant findings lack developer confirmation | VERIFICATION-GAP | FAIL | Re-present each finding for developer confirmation before proceeding |
+| Fewer than 2 Q&A exchanges before proceeding | VERIFICATION-GAP | FAIL | Continue Q&A until minimum turns met |
 
 **These verifications are MANDATORY before transitioning out of brainstorming. Skipping them is a CRITICAL GUIDELINE VIOLATION.**

--- a/skills/brainstorming/tasks/explore/pre-spec-inspection.md
+++ b/skills/brainstorming/tasks/explore/pre-spec-inspection.md
@@ -36,19 +36,19 @@ Check: [what was verified]
 Tool: [tool call and parameters]
 Result: [actual state found]
 Classification: [STRUCTURE-VIOLATION|MISSING-ELEMENT|CONFLICTING|VERIFICATION-GAP|MISSING-TRACEABILITY]
-Action: [auto-fix|conditional|flag-for-review]
+Action: [auto-fix|FAIL]
 ```
 
 ## Classification on Failure
 
 | Failure | Problem Class | Classification | Action |
 | -- | -- | -- | -- |
-| Call path assumption wrong | CONFLICTING | conditional | Re-map actual call path |
-| Import path assumed but not found | VERIFICATION-GAP | conditional | Search alternates |
+| Call path assumption wrong | CONFLICTING | FAIL | Re-map actual call path |
+| Import path assumed but not found | VERIFICATION-GAP | FAIL | Search alternates |
 | Dead code claimed as alive | MISSING-ELEMENT | auto-fix | Remove from affected-files |
-| Data format assumption wrong | CONFLICTING | flag-for-review | HALT — redesign may be needed |
-| Architectural layer violation | STRUCTURE-VIOLATION | flag-for-review | HALT — redesign may be needed |
-| Alternative solution exists | MISSING-ELEMENT | conditional | Evaluate existing solution |
+| Data format assumption wrong | CONFLICTING | FAIL | HALT — redesign may be needed |
+| Architectural layer violation | STRUCTURE-VIOLATION | FAIL | HALT — redesign may be needed |
+| Alternative solution exists | MISSING-ELEMENT | FAIL | Evaluate existing solution |
 
 ## Step 0.5: Cross-Spec Scope Search (MANDATORY)
 

--- a/skills/engineering-approach/tasks/verify-understanding.md
+++ b/skills/engineering-approach/tasks/verify-understanding.md
@@ -137,7 +137,7 @@ Report understanding verification to chat (NOT as GitHub Issue comment). The und
 
 | Finding | Problem Class | Classification | Action |
 |--------|---------------|----------------|--------|
-| Code not actually read | VERIFICATION-GAP | conditional | Read relevant code now |
-| Dependency unverified | VERIFICATION-GAP | conditional | Verify dependency chain |
-| Problem statement contradicted by code | CONFLICTING | flag-for-review | HALT — revise understanding |
-| Success criteria not testable | STRUCTURE-VIOLATION | flag-for-review | Request measurable criteria |
+| Code not actually read | VERIFICATION-GAP | FAIL | Read relevant code now |
+| Dependency unverified | VERIFICATION-GAP | FAIL | Verify dependency chain |
+| Problem statement contradicted by code | CONFLICTING | FAIL | HALT — revise understanding |
+| Success criteria not testable | STRUCTURE-VIOLATION | FAIL | Request measurable criteria |

--- a/skills/finishing-a-development-branch/tasks/checklist.md
+++ b/skills/finishing-a-development-branch/tasks/checklist.md
@@ -149,8 +149,8 @@ if [ -z "$DEFAULT_BRANCH" ]; then DEFAULT_BRANCH="main"; fi
 
 | Finding | Problem Class | Classification | Action |
 | -- | -- | -- | -- |
-| Uncommitted changes found | VERIFICATION-GAP | conditional | Commit before proceeding |
+| Uncommitted changes found | VERIFICATION-GAP | FAIL | Commit before proceeding |
 | Branch not pushed | MISSING-ELEMENT | auto-fix | Push immediately |
-| Lint/test failures | VERIFICATION-GAP | flag-for-review | HALT — fix issues before PR |
+| Lint/test failures | VERIFICATION-GAP | FAIL | HALT — fix issues before PR |
 | Debug prints or TODOs found | STRUCTURE-VIOLATION | auto-fix | Remove before proceeding |
-| Unrelated files in diff | CONFLICTING | flag-for-review | Report — scope may have deviated |
+| Unrelated files in diff | CONFLICTING | FAIL | Report — scope may have deviated |

--- a/skills/finishing-a-development-branch/tasks/prepare.md
+++ b/skills/finishing-a-development-branch/tasks/prepare.md
@@ -152,7 +152,7 @@ git branch -vv
 
 | Finding | Problem Class | Classification | Action |
 |--------|---------------|----------------|--------|
-| Uncommitted changes exist | VERIFICATION-GAP | conditional | Commit first |
-| Lint failures | VERIFICATION-GAP | flag-for-review | HALT — fix before PR |
-| Test failures | VERIFICATION-GAP | flag-for-review | HALT — fix before PR |
-| Unrelated changes in diff | CONFLICTING | flag-for-review | Report — scope deviation |
+| Uncommitted changes exist | VERIFICATION-GAP | FAIL | Commit first |
+| Lint failures | VERIFICATION-GAP | FAIL | HALT — fix before PR |
+| Test failures | VERIFICATION-GAP | FAIL | HALT — fix before PR |
+| Unrelated changes in diff | CONFLICTING | FAIL | Report — scope deviation |

--- a/skills/git-workflow/tasks/cleanup/issue-closure.md
+++ b/skills/git-workflow/tasks/cleanup/issue-closure.md
@@ -211,10 +211,10 @@ For issues with `[Task: #N]` or `Phase N:` patterns that reference a parent plan
 | Finding | Problem Class | Action |
 | -- | -- | -- |
 | Closed + merged PR | VERIFIED | auto-proceed |
-| Closed "completed" + no merged PR | VERIFICATION-GAP | flag-for-review |
+| Closed "completed" + no merged PR | VERIFICATION-GAP | FAIL |
 | Closed "not_planned" | VERIFIED | auto-proceed |
-| Closed "duplicate" | VERIFICATION-GAP | conditional |
-| Open sub-issue | MISSING-ELEMENT | conditional |
+| Closed "duplicate" | VERIFICATION-GAP | FAIL |
+| Open sub-issue | MISSING-ELEMENT | FAIL |
 
 **Only proceed to parent closure after ALL sub-issues are verified.**
 

--- a/skills/git-workflow/tasks/cleanup/verify-merge.md
+++ b/skills/git-workflow/tasks/cleanup/verify-merge.md
@@ -141,11 +141,11 @@ Verify ALL phases/sub-issues have merged PRs before allowing closure of a multi-
 
 | Failure | Problem Class | Classification | Action |
 | -- | -- | -- | -- |
-| `merged_at` is None | CONFLICTING | flag-for-review | HALT — PR not merged, cannot close issues |
-| `merged_by` is None but `merged_at` set | VERIFICATION-GAP | conditional | Investigate — may be bot merge |
-| Branch not in `--merged "$DEFAULT_BRANCH"` list | VERIFICATION-GAP | conditional | Sync dev, recheck |
-| Sub-issue closed without merged PR | VERIFICATION-GAP | flag-for-review | Investigate closure reason |
-| Sub-issue still open after merge | VERIFICATION-GAP | conditional | Close manually via API |
+| `merged_at` is None | CONFLICTING | FAIL | HALT — PR not merged, cannot close issues |
+| `merged_by` is None but `merged_at` set | VERIFICATION-GAP | FAIL | Investigate — may be bot merge |
+| Branch not in `--merged "$DEFAULT_BRANCH"` list | VERIFICATION-GAP | FAIL | Sync dev, recheck |
+| Sub-issue closed without merged PR | VERIFICATION-GAP | FAIL | Investigate closure reason |
+| Sub-issue still open after merge | VERIFICATION-GAP | FAIL | Close manually via API |
 
 ## Context Required
 

--- a/skills/git-workflow/tasks/commit-prep.md
+++ b/skills/git-workflow/tasks/commit-prep.md
@@ -194,11 +194,11 @@ Commits occur during the PR creation workflow, not as a separate step:
 
 | Failure | Problem Class | Classification | Action |
 | -- | -- | -- | -- |
-| Staged files not matching intent | CONFLICTING | flag-for-review | Selective `git add` to correct staging |
-| Unstaged changes present | VERIFICATION-GAP | conditional | Review — may need `git add` or `.gitignore` |
+| Staged files not matching intent | CONFLICTING | FAIL | Selective `git add` to correct staging |
+| Unstaged changes present | VERIFICATION-GAP | FAIL | Review — may need `git add` or `.gitignore` |
 | On `main` or `$DEFAULT_BRANCH` | STRUCTURE-VIOLATION | auto-fix | HALT — must be on feature branch in worktree |
 | Wrong toplevel path | STRUCTURE-VIOLATION | auto-fix | HALT — not in worktree context |
-| Locked/deleted files in status | VERIFICATION-GAP | flag-for-review | Investigate — may need `git rm` or recovery |
+| Locked/deleted files in status | VERIFICATION-GAP | FAIL | Investigate — may need `git rm` or recovery |
 
 **These verifications are MANDATORY before committing. Skipping them is a CRITICAL GUIDELINE VIOLATION.**
 

--- a/skills/git-workflow/tasks/implementation.md
+++ b/skills/git-workflow/tasks/implementation.md
@@ -148,10 +148,10 @@ When `worktree.path` is set, ALL file operation tool calls (`read`, `edit`, `wri
 
 | Failure | Problem Class | Classification | Action |
 | -- | -- | -- | -- |
-| On `main` or `$DEFAULT_BRANCH` | CONFLICTING | flag-for-review | HALT — must be in worktree on feature branch |
+| On `main` or `$DEFAULT_BRANCH` | CONFLICTING | FAIL | HALT — must be in worktree on feature branch |
 | Wrong toplevel path | STRUCTURE-VIOLATION | auto-fix | HALT — not in worktree, re-invoke pre-work |
-| No changes to commit | MISSING-ELEMENT | conditional | Verify changes were saved — may need `git add` |
-| Staged changes don't match intent | VERIFICATION-GAP | conditional | Review diff, adjust staging |
+| No changes to commit | MISSING-ELEMENT | FAIL | Verify changes were saved — may need `git add` |
+| Staged changes don't match intent | VERIFICATION-GAP | FAIL | Review diff, adjust staging |
 
 **These verifications are MANDATORY before each commit. Skipping them is a CRITICAL GUIDELINE VIOLATION.**
 

--- a/skills/git-workflow/tasks/pre-work.md
+++ b/skills/git-workflow/tasks/pre-work.md
@@ -578,11 +578,11 @@ If found, report collision and HALT — do not reuse another branch's worktree.
 | Failure | Problem Class | Classification | Action |
 | -- | -- | -- | -- |
 | Default branch not synced | MISSING-ELEMENT | auto-fix | Run `git fetch origin "$DEFAULT_BRANCH"` |
-| On `main` or `$DEFAULT_BRANCH` branch | CONFLICTING | flag-for-review | HALT — must create feature branch first |
-| Dirty working tree | VERIFICATION-GAP | conditional | Stash or commit before implementation |
+| On `main` or `$DEFAULT_BRANCH` branch | CONFLICTING | FAIL | HALT — must create feature branch first |
+| Dirty working tree | VERIFICATION-GAP | FAIL | Stash or commit before implementation |
 | `rev-parse` returns main repo path (worktree mode) | STRUCTURE-VIOLATION | auto-fix | Not in worktree — re-invoke using-git-worktrees |
 | worktree.path empty (worktree mode) | STRUCTURE-VIOLATION | auto-fix | FATAL — cannot safely do file operations |
-| base hash stale | MISSING-ELEMENT | conditional | Re-run `git pull origin "$DEFAULT_BRANCH"` |
+| base hash stale | MISSING-ELEMENT | FAIL | Re-run `git pull origin "$DEFAULT_BRANCH"` |
 
 **These verifications are MANDATORY. Skipping them is a CRITICAL GUIDELINE VIOLATION.**
 

--- a/skills/git-workflow/tasks/rebase-pending.md
+++ b/skills/git-workflow/tasks/rebase-pending.md
@@ -287,12 +287,12 @@ Continuing with cleanup for the merged PR...
 
 | Failure | Problem Class | Classification | Action |
 | -- | -- | -- | -- |
-| On wrong branch | CONFLICTING | flag-for-review | Switch to correct branch before rebase |
+| On wrong branch | CONFLICTING | FAIL | Switch to correct branch before rebase |
 | Not in worktree (worktree mode only) | STRUCTURE-VIOLATION | auto-fix | Create worktree or use existing one |
-| Dirty working tree | VERIFICATION-GAP | conditional | Stash changes before rebase (`git stash`) |
+| Dirty working tree | VERIFICATION-GAP | FAIL | Stash changes before rebase (`git stash`) |
 | Dev SHA is stale | MISSING-ELEMENT | auto-fix | `git fetch origin` to update |
 | Rebase conflicts (Tier 1-2) | VERIFICATION-GAP | auto-fix | Auto-resolve, note in chat |
-| Rebase conflicts (Tier 3) | CONFLICTING | flag-for-review | HALT for developer review |
+| Rebase conflicts (Tier 3) | CONFLICTING | FAIL | HALT for developer review |
 
 **These verifications are MANDATORY before each rebase. Skipping them is a CRITICAL GUIDELINE VIOLATION.**
 

--- a/skills/git-workflow/tasks/review-prep.md
+++ b/skills/git-workflow/tasks/review-prep.md
@@ -111,7 +111,7 @@ Guideline and documentation changes are NOT exempt from PR workflow.
 
 | Sub-Task | Purpose | Handler | Words |
 | -- | -- | -- | -- |
-| `review-prep/push-and-cleanup` | Submodule push via sub-agent, temp cleanup, rebase, branch push, worktree handoff | sub-agent (Step 0, conditional) | ≈700 |
+| `review-prep/push-and-cleanup` | Submodule push via sub-agent, temp cleanup, rebase, branch push, worktree handoff | sub-agent (Step 0) | ≈700 |
 | `review-prep/report-url` | URL generation, chat format, HALT protocol | — | ≈600 |
 
 ## Enforcement Checklist

--- a/skills/issue-operations/tasks/body-edit.md
+++ b/skills/issue-operations/tasks/body-edit.md
@@ -230,12 +230,12 @@ Before dispatching any sub-agent, verify ALL:
 
 | Finding | Problem Class | Classification | Action |
 |--------|---------------|----------------|--------|
-| remote.md not found | MISSING-ELEMENT | flag-for-review | HALT — run sync pull first |
-| Edit script pattern not found | STRUCTURE-DAMAGE | flag-for-review | HALT — report to caller |
-| Frontmatter corrupted | STRUCTURE-DAMAGE | conditional | HALT — verify agent rejected edit |
-| Null bytes detected | CORRUPTION | conditional | HALT — investigate source |
-| Sync push failed | VERIFICATION-GAP | flag-for-review | Report failure, local commit preserved |
-| Remote body mismatch | VERIFICATION-GAP | conditional | Retry sync push once, then report |
+| remote.md not found | MISSING-ELEMENT | FAIL | HALT — run sync pull first |
+| Edit script pattern not found | STRUCTURE-DAMAGE | FAIL | HALT — report to caller |
+| Frontmatter corrupted | STRUCTURE-DAMAGE | FAIL | HALT — verify agent rejected edit |
+| Null bytes detected | CORRUPTION | FAIL | HALT — investigate source |
+| Sync push failed | VERIFICATION-GAP | FAIL | Report failure, local commit preserved |
+| Remote body mismatch | VERIFICATION-GAP | FAIL | Retry sync push once, then report |
 
 ## Context Required
 

--- a/skills/issue-operations/tasks/capabilities.md
+++ b/skills/issue-operations/tasks/capabilities.md
@@ -101,6 +101,6 @@ When the GitBucket MCP plugin implements missing endpoints, the capability lands
 
 | Finding | Problem Class | Classification | Action |
 |--------|---------------|----------------|--------|
-| Platform not detected | MISSING-ELEMENT | flag-for-review | HALT — default to github-mcp |
+| Platform not detected | MISSING-ELEMENT | FAIL | HALT — default to github-mcp |
 | Capability claim wrong | CONFLICTING | auto-fix | Update capability set from live probe |
 | MCP not present | VERIFICATION-GAP | auto-fix | Fall back to static manifest |

--- a/skills/issue-operations/tasks/close.md
+++ b/skills/issue-operations/tasks/close.md
@@ -116,7 +116,7 @@ All tasks complete from this specification.
 
 | Finding | Problem Class | Classification | Action |
 |--------|---------------|----------------|--------|
-| PR not merged | VERIFICATION-GAP | flag-for-review | HALT — do not close issue |
-| Sub-issues still open | VERIFICATION-GAP | flag-for-review | Do not close parent |
-| No PR references issue | MISSING-ELEMENT | flag-for-review | HALT — cannot verify implementation |
+| PR not merged | VERIFICATION-GAP | FAIL | HALT — do not close issue |
+| Sub-issues still open | VERIFICATION-GAP | FAIL | Do not close parent |
+| No PR references issue | MISSING-ELEMENT | FAIL | HALT — cannot verify implementation |
 | Platform lacks PATCH | CONFLICTING | auto-fix | Use closure comment fallback |

--- a/skills/issue-operations/tasks/completion.md
+++ b/skills/issue-operations/tasks/completion.md
@@ -85,10 +85,10 @@ URL is ALWAYS last per `000-critical-rules.md`.
 
 | Finding | Problem Class | Classification | Action |
 |--------|---------------|----------------|--------|
-| Issue not found | MISSING-ELEMENT | flag-for-review | HALT — creation may have failed |
+| Issue not found | MISSING-ELEMENT | FAIL | HALT — creation may have failed |
 | Label missing | MISSING-ELEMENT | auto-fix | Add label immediately |
-| Sub-issues missing (multi-task) | MISSING-ELEMENT | conditional | Create sub-issues if multi-task spec |
-| Auditor not invoked | VERIFICATION-GAP | conditional | Invoke spec-auditor |
+| Sub-issues missing (multi-task) | MISSING-ELEMENT | FAIL | Create sub-issues if multi-task spec |
+| Auditor not invoked | VERIFICATION-GAP | FAIL | Invoke spec-auditor |
 
 ## Context Required
 

--- a/skills/issue-operations/tasks/creation.md
+++ b/skills/issue-operations/tasks/creation.md
@@ -373,9 +373,9 @@ Before proceeding, verify ALL:
 | ---------------------------------------- | ------------------- | --------------- | ------------------------------------------------------------------------------------------------ |
 | Step 0.5 dedup evidence missing          | MISSING-ELEMENT     | HALT            | HALT — "Cannot create issue: Step 0.5 dedup gate evidence missing. Run pre-creation task first." |
 | Step 0.75 runtime search found duplicate | CONFLICTING         | HALT            | HALT — report duplicate, do not create                                                           |
-| Pre-creation not run                     | MISSING-ELEMENT     | flag-for-review | HALT — run pre-creation first                                                                    |
-| Conflicting spec found                   | CONFLICTING         | flag-for-review | HALT — report conflict                                                                           |
+| Pre-creation not run                     | MISSING-ELEMENT     | FAIL | HALT — run pre-creation first                                                                    |
+| Conflicting spec found                   | CONFLICTING         | FAIL | HALT — report conflict                                                                           |
 | Wrong title format                       | STRUCTURE-VIOLATION | auto-fix        | Correct title before creation                                                                    |
-| Creation API failed                      | MISSING-ELEMENT     | flag-for-review | HALT — retry or report error                                                                     |
+| Creation API failed                      | MISSING-ELEMENT     | FAIL | HALT — retry or report error                                                                     |
 | Label missing post-creation              | MISSING-ELEMENT     | auto-fix        | Add label immediately                                                                            |
 | Byline missing                           | STRUCTURE-VIOLATION | auto-fix        | Add byline to body                                                                               |

--- a/skills/issue-operations/tasks/link-sub-issue.md
+++ b/skills/issue-operations/tasks/link-sub-issue.md
@@ -162,7 +162,7 @@ Title format: `[Task: #<plan-number>] <descriptive-title>`
 | Finding | Problem Class | Classification | Action |
 |--------|---------------|----------------|--------|
 | Plan is single-task | VERIFICATION-GAP | auto-fix | Skip sub-issue creation per exemption |
-| Sub-issue creation failed | MISSING-ELEMENT | flag-for-review | HALT — retry |
+| Sub-issue creation failed | MISSING-ELEMENT | FAIL | HALT — retry |
 | Sub-issue under wrong parent | STRUCTURE-VIOLATION | auto-fix | Re-link under plan |
 | Used issue number instead of DB ID | STRUCTURE-VIOLATION | auto-fix | Re-link with correct DB ID |
 | Platform lacks sub-issue API | CONFLICTING | auto-fix | Use comment-based fallback |

--- a/skills/issue-operations/tasks/post-creation.md
+++ b/skills/issue-operations/tasks/post-creation.md
@@ -80,6 +80,6 @@ Before proceeding, verify ALL:
 
 | Finding | Problem Class | Classification | Action |
 |--------|---------------|----------------|--------|
-| Issue not found | MISSING-ELEMENT | flag-for-review | HALT — creation may have failed |
+| Issue not found | MISSING-ELEMENT | FAIL | HALT — creation may have failed |
 | Auditor not invoked | MISSING-ELEMENT | auto-fix | Invoke spec-auditor immediately |
-| Approval exists before audit | CONFLICTING | flag-for-review | HALT — auditors must run first |
+| Approval exists before audit | CONFLICTING | FAIL | HALT — auditors must run first |

--- a/skills/issue-operations/tasks/pre-creation.md
+++ b/skills/issue-operations/tasks/pre-creation.md
@@ -248,17 +248,17 @@ Check: [what was verified]
 Tool: [tool call and parameters]
 Result: [actual state found]
 Classification: [STRUCTURE-VIOLATION|MISSING-ELEMENT|CONFLICTING|VERIFICATION-GAP|MISSING-TRACEABILITY]
-Action: [auto-fix|conditional|flag-for-review]
+Action: [auto-fix|FAIL]
 ```
 
 **Classification on failure:**
 
 | Failure | Problem Class | Classification | Action |
 | -- | -- | -- | -- |
-| Spec claimed implemented but code not found | VERIFICATION-GAP | conditional | Verify with broader search before marking stale |
+| Spec claimed implemented but code not found | VERIFICATION-GAP | FAIL | Verify with broader search before marking stale |
 | Code location changed | CONFLICTING | auto-fix | Update spec reference to new location |
 | Problem already resolved | VERIFICATION-GAP | auto-fix | Mark spec as resolved, suggest closure |
-| Superseding issue not actually related | CONFLICTING | flag-for-review | HALT — do not block creation incorrectly |
+| Superseding issue not actually related | CONFLICTING | FAIL | HALT — do not block creation incorrectly |
 
 ## Context Required
 

--- a/skills/issue-operations/tasks/single-task-check.md
+++ b/skills/issue-operations/tasks/single-task-check.md
@@ -192,6 +192,6 @@ Before proceeding, verify ALL:
 | Finding | Problem Class | Classification | Action |
 |--------|---------------|----------------|--------|
 | Phase count wrong | VERIFICATION-GAP | auto-fix | Re-parse spec body |
-| Mixed concerns in single phase | CONFLICTING | flag-for-review | Classify as multi-task |
-| Decomposition needed | VERIFICATION-GAP | flag-for-review | Classify as multi-task |
-| Parse error | STRUCTURE-VIOLATION | conditional | Re-parse or flag ambiguous |
+| Mixed concerns in single phase | CONFLICTING | FAIL | Classify as multi-task |
+| Decomposition needed | VERIFICATION-GAP | FAIL | Classify as multi-task |
+| Parse error | STRUCTURE-VIOLATION | FAIL | Re-parse or flag ambiguous |

--- a/skills/issue-operations/tasks/verify-merge.md
+++ b/skills/issue-operations/tasks/verify-merge.md
@@ -107,7 +107,7 @@ gb pr list -R <github.owner>/<github.repo> --state closed
 
 | Finding | Problem Class | Classification | Action |
 |--------|---------------|----------------|--------|
-| PR not merged | VERIFICATION-GAP | flag-for-review | HALT — do not close issue |
-| PR closed without merge | VERIFICATION-GAP | flag-for-review | HALT — PR was rejected |
-| PR doesn't reference issue | MISSING-ELEMENT | flag-for-review | Verify association manually |
-| Platform returns unreliable data | CONFLICTING | conditional | Use search fallback to verify |
+| PR not merged | VERIFICATION-GAP | FAIL | HALT — do not close issue |
+| PR closed without merge | VERIFICATION-GAP | FAIL | HALT — PR was rejected |
+| PR doesn't reference issue | MISSING-ELEMENT | FAIL | Verify association manually |
+| Platform returns unreliable data | CONFLICTING | FAIL | Use search fallback to verify |

--- a/skills/issue-review/tasks/audit.md
+++ b/skills/issue-review/tasks/audit.md
@@ -103,7 +103,7 @@ Format per `000-critical-rules.md`:
 
 | Finding | Problem Class | Classification | Action |
 |--------|---------------|----------------|--------|
-| Audit never performed | VERIFICATION-GAP | conditional | Invoke audit now |
-| New comments since audit | VERIFICATION-GAP | conditional | Re-audit with new context |
-| Triage classification wrong | CONFLICTING | flag-for-review | Report mismatch, re-evaluate path |
-| Fix spec missing for bug | MISSING-ELEMENT | conditional | Proceed to `analyze-and-spec` |
+| Audit never performed | VERIFICATION-GAP | FAIL | Invoke audit now |
+| New comments since audit | VERIFICATION-GAP | FAIL | Re-audit with new context |
+| Triage classification wrong | CONFLICTING | FAIL | Report mismatch, re-evaluate path |
+| Fix spec missing for bug | MISSING-ELEMENT | FAIL | Proceed to `analyze-and-spec` |

--- a/skills/issue-review/tasks/gather.md
+++ b/skills/issue-review/tasks/gather.md
@@ -137,7 +137,7 @@ Prose summary of all gathered data, organized by the five categories above. Incl
 | Finding | Problem Class | Classification | Action |
 |--------|---------------|----------------|--------|
 | Comment count mismatched | VERIFICATION-GAP | auto-fix | Re-count and report correct number |
-| Authorization from bot/agent | CONFLICTING | flag-for-review | Reject as valid authorization |
-| Sub-issue 404 | MISSING-TRACEABILITY | flag-for-review | Developer must resolve missing issue |
+| Authorization from bot/agent | CONFLICTING | FAIL | Reject as valid authorization |
+| Sub-issue 404 | MISSING-TRACEABILITY | FAIL | Developer must resolve missing issue |
 | Label state contradicted claim | STRUCTURE-VIOLATION | auto-fix | Report actual label state |
-| Fix spec missing for bug | MISSING-ELEMENT | conditional | Proceed to `analyze-and-spec` to create one |
+| Fix spec missing for bug | MISSING-ELEMENT | FAIL | Proceed to `analyze-and-spec` to create one |

--- a/skills/issue-review/tasks/qa.md
+++ b/skills/issue-review/tasks/qa.md
@@ -117,5 +117,5 @@ HALT after posting the summary. Wait for the developer to act on the outcomes.
 | Finding | Problem Class | Classification | Action |
 |--------|---------------|----------------|--------|
 | Bug language found in Q/A path | CONFLICTING | auto-fix | Re-triage to `analyze-and-spec` |
-| Existing spec found for topic | MISSING-ELEMENT | conditional | Offer to link to existing spec |
-| New comments since Q/A | VERIFICATION-GAP | conditional | Re-read and consider new context |
+| Existing spec found for topic | MISSING-ELEMENT | FAIL | Offer to link to existing spec |
+| New comments since Q/A | VERIFICATION-GAP | FAIL | Re-read and consider new context |

--- a/skills/issue-review/tasks/triage.md
+++ b/skills/issue-review/tasks/triage.md
@@ -112,7 +112,7 @@ Each sub-issue gets its own independent triage decision. A parent may be `audit`
 If any verification fails, do NOT classify as `already-handled`. Instead:
 - Route to `analyze-and-spec` (if bug report with open fix spec)
 - Route to `audit` (if spec with open sub-issues)
-- Report as `flag-for-review` with specific verification failures
+- Report as `FAIL` with specific verification failures
 
 ## Confidence Levels
 
@@ -154,6 +154,6 @@ If any verification fails, do NOT classify as `already-handled`. Instead:
 | Finding | Problem Class | Classification | Action |
 |--------|---------------|----------------|--------|
 | `[SPEC]` prefix on bug report | STRUCTURE-VIOLATION | auto-fix | Re-triage to `analyze-and-spec` |
-| `already-handled` but no merged PR | VERIFICATION-GAP | flag-for-review | Re-classify as `audit` or `just-review` |
-| Authorization from bot/agent | CONFLICTING | flag-for-review | Require human authorization |
-| Sub-issue closed without merged PR | VERIFICATION-GAP | flag-for-review | Investigate closure reason |
+| `already-handled` but no merged PR | VERIFICATION-GAP | FAIL | Re-classify as `audit` or `just-review` |
+| Authorization from bot/agent | CONFLICTING | FAIL | Require human authorization |
+| Sub-issue closed without merged PR | VERIFICATION-GAP | FAIL | Investigate closure reason |

--- a/skills/spec-creation/tasks/change-control.md
+++ b/skills/spec-creation/tasks/change-control.md
@@ -68,7 +68,7 @@ Check: [what was verified]
 Tool: [tool call and parameters]
 Result: [actual state found]
 Classification: [STRUCTURE-VIOLATION|MISSING-ELEMENT|CONFLICTING|VERIFICATION-GAP|MISSING-TRACEABILITY]
-Action: [auto-fix|conditional|flag-for-review]
+Action: [auto-fix|FAIL]
 ```
 
 ### Classification on Failure
@@ -76,9 +76,9 @@ Action: [auto-fix|conditional|flag-for-review]
 | Failure | Problem Class | Classification | Action |
 | -- | -- | -- | -- |
 | Claims "initial creation" but `STATUS: 1.0` exists | CONFLICTING | auto-fix | Increment version, apply change control |
-| Claims "non-substantive" but content changed | CONFLICTING | flag-for-review | HALT — requires domain review |
+| Claims "non-substantive" but content changed | CONFLICTING | FAIL | HALT — requires domain review |
 | Claims "STATUS update" but content also changed | STRUCTURE-VIOLATION | auto-fix | Apply full change control to content change |
-| Claims "bug report" but adds spec requirements | VERIFICATION-GAP | conditional | Verify scope; if requirements changed, apply change control |
+| Claims "bug report" but adds spec requirements | VERIFICATION-GAP | FAIL | Verify scope; if requirements changed, apply change control |
 
 **These verifications are MANDATORY for any STATUS exemption claim. Skipping them is a CRITICAL GUIDELINE VIOLATION.**
 

--- a/skills/spec-creation/tasks/create.md
+++ b/skills/spec-creation/tasks/create.md
@@ -496,7 +496,7 @@ Assemble the final spec with acceptance criteria, ambiguity elimination, and del
 
     1. **SC evidence type re-check**: For each SC in the spec body, evaluate the substrate question: "Does this change affect runtime behavior?"
     2. **Uplift misclassified SCs**: If runtime-behavioral YES but evidence type is NOT behavioral → auto-uplift to `behavioral`. Log the uplift action as a finding.
-    3. **Downgrade flag (conditional)**: If runtime-behavioral NO but evidence type IS behavioral → flag for review. The writer may have intended a behavioral test for structural reasons, but this mismatch warrants human review.
+    3. **Downgrade flag (FAIL)**: If runtime-behavioral NO but evidence type IS behavioral → flag for review. The writer may have intended a behavioral test for structural reasons, but this mismatch warrants human review.
     4. **Remediation guidance**: For each uplifted SC, provide guidance on what changes the verification method needs:
        - `structural` → `behavioral`: Must add a real test execution command (e.g., `opencode-cli run`, `pytest`, `bash test.sh`)
        - `string` → `behavioral`: Must replace grep assertion with test execution + semantic inspection
@@ -519,7 +519,7 @@ Assemble the final spec with acceptance criteria, ambiguity elimination, and del
     Tool: [tool call and parameters]
     Result: [actual state found]
     Classification: [STRUCTURE-VIOLATION|MISSING-ELEMENT|CONFLICTING|VERIFICATION-GAP|MISSING-TRACEABILITY]
-    Action: [auto-fix|conditional|flag-for-review]
+    Action: [auto-fix|FAIL]
     ```
 
     **Classification on failure:**
@@ -527,8 +527,8 @@ Assemble the final spec with acceptance criteria, ambiguity elimination, and del
     | Failure | Problem Class | Classification | Action |
     | ------------------------------------------ | ------------------- | --------------- | ------------------------------------------- |
     | Placeholders found in spec body | STRUCTURE-VIOLATION | auto-fix | Replace with concrete content |
-    | Contradictory requirements across sections | CONFLICTING | flag-for-review | Report, do not auto-resolve |
-    | Scope too large for single plan | VERIFICATION-GAP | conditional | Flag decomposition, then apply if confirmed |
+    | Contradictory requirements across sections | CONFLICTING | FAIL | Report, do not auto-resolve |
+    | Scope too large for single plan | VERIFICATION-GAP | FAIL | Flag decomposition, then apply if confirmed |
     | Vague/ambiguous terms present | STRUCTURE-VIOLATION | auto-fix | Replace with measurable terms |
 
     **These verifications are MANDATORY after self-review. Skipping them is a CRITICAL GUIDELINE VIOLATION.**

--- a/skills/spec-creation/tasks/traceability.md
+++ b/skills/spec-creation/tasks/traceability.md
@@ -85,7 +85,7 @@ Check: [what was verified]
 Tool: [tool call and parameters]
 Result: [actual state found]
 Classification: [STRUCTURE-VIOLATION|MISSING-ELEMENT|CONFLICTING|VERIFICATION-GAP|MISSING-TRACEABILITY]
-Action: [auto-fix|conditional|flag-for-review]
+Action: [auto-fix|FAIL]
 ```
 
 ### Classification on Failure
@@ -93,11 +93,11 @@ Action: [auto-fix|conditional|flag-for-review]
 | Failure | Problem Class | Classification | Action |
 | -- | -- | -- | -- |
 | Referenced issue does not exist | MISSING-TRACEABILITY | auto-fix | Remove or replace the broken reference |
-| Referenced spec lacks [SPEC] prefix | MISSING-TRACEABILITY | conditional | Verify it IS a spec; add prefix or fix reference |
-| Referenced code symbol not found | VERIFICATION-GAP | conditional | May be renamed/removed; verify alternate names |
-| Referenced file path not found | VERIFICATION-GAP | conditional | May be reorganized; search for file |
+| Referenced spec lacks [SPEC] prefix | MISSING-TRACEABILITY | FAIL | Verify it IS a spec; add prefix or fix reference |
+| Referenced code symbol not found | VERIFICATION-GAP | FAIL | May be renamed/removed; verify alternate names |
+| Referenced file path not found | VERIFICATION-GAP | FAIL | May be reorganized; search for file |
 | Requirement with no section mapping | MISSING-TRACEABILITY | auto-fix | Add section mapping |
-| Section with no requirement mapping | STRUCTURE-VIOLATION | flag-for-review | Possible scope creep; report for domain review |
+| Section with no requirement mapping | STRUCTURE-VIOLATION | FAIL | Possible scope creep; report for domain review |
 
 **These verifications are MANDATORY. Skipping them is a CRITICAL GUIDELINE VIOLATION.**
 

--- a/skills/systematic-debugging/tasks/diagnose.md
+++ b/skills/systematic-debugging/tasks/diagnose.md
@@ -102,6 +102,6 @@ If the agent catches itself about to edit code without an approved spec:
 
 | Finding | Problem Class | Classification | Action |
 |--------|---------------|----------------|--------|
-| Hypothesis not verified against code | VERIFICATION-GAP | conditional | Verify before reporting |
-| Root cause location wrong | CONFLICTING | flag-for-review | Re-trace call path |
+| Hypothesis not verified against code | VERIFICATION-GAP | FAIL | Verify before reporting |
+| Root cause location wrong | CONFLICTING | FAIL | Re-trace call path |
 | Unintended code changes during diagnosis | STRUCTURE-VIOLATION | auto-fix | `git checkout` to revert |

--- a/skills/systematic-debugging/tasks/fix.md
+++ b/skills/systematic-debugging/tasks/fix.md
@@ -102,7 +102,7 @@ result = some_function(timeout=60, retries=3)
 
 | Finding | Problem Class | Classification | Action |
 |--------|---------------|----------------|--------|
-| Fix doesn't target root cause | VERIFICATION-GAP | flag-for-review | HALT — re-diagnose before fixing |
-| Tests still failing | VERIFICATION-GAP | flag-for-review | Fix tests before claiming complete |
-| Unrelated changes in diff | CONFLICTING | flag-for-review | Report scope deviation |
-| Refactoring disguised as fix | CONFLICTING | flag-for-review | Revert and create spec |
+| Fix doesn't target root cause | VERIFICATION-GAP | FAIL | HALT — re-diagnose before fixing |
+| Tests still failing | VERIFICATION-GAP | FAIL | Fix tests before claiming complete |
+| Unrelated changes in diff | CONFLICTING | FAIL | Report scope deviation |
+| Refactoring disguised as fix | CONFLICTING | FAIL | Revert and create spec |

--- a/skills/verification-before-completion/tasks/collect.md
+++ b/skills/verification-before-completion/tasks/collect.md
@@ -175,6 +175,6 @@ These files are **exempt from mandatory cleanup** per `060-tool-usage.md` and MU
 
 | Finding | Problem Class | Classification | Action |
 |--------|---------------|----------------|--------|
-| Evidence missing for criterion | MISSING-ELEMENT | conditional | Re-run tool call for missing evidence |
-| Verification report not created | MISSING-ELEMENT | auto-fix | Create report now |
-| Placeholder evidence detected | VERIFICATION-GAP | conditional | Replace with actual tool-call output |
+| Evidence missing for criterion | MISSING-ELEMENT | FAIL | Re-run tool call for missing evidence |
+| Verification report not created | MISSING-ELEMENT | FAIL | Create report now |
+| Placeholder evidence detected | VERIFICATION-GAP | FAIL | Replace with actual tool-call output |

--- a/skills/verification-before-completion/tasks/completion.md
+++ b/skills/verification-before-completion/tasks/completion.md
@@ -73,8 +73,8 @@ This checkpoint catches direct API calls that bypassed the `issue-operations` sk
 
 | Finding | Problem Class | Classification | Action |
 |--------|---------------|----------------|--------|
-| No verification report found | VERIFICATION-GAP | conditional | Re-run verification |
-| Criterion lacks evidence | MISSING-ELEMENT | conditional | Collect evidence for missing criterion |
+| No verification report found | VERIFICATION-GAP | FAIL | Re-run verification |
+| Criterion lacks evidence | MISSING-ELEMENT | FAIL | Collect evidence for missing criterion |
 
 ## Pipeline Signal
 

--- a/skills/verification-before-completion/tasks/verify.md
+++ b/skills/verification-before-completion/tasks/verify.md
@@ -509,8 +509,8 @@ Please replace placeholder with actual evidence.
 
 | Finding | Problem Class | Classification | Action |
 | -- | -- | -- | -- |
-| Criterion claimed met without evidence | VERIFICATION-GAP | conditional | Re-verify with actual tool call |
-| Test not actually passing | CONFLICTING | flag-for-review | HALT — fix test before claiming completion |
-| Files differ from spec | CONFLICTING | flag-for-review | Report — scope may have deviated |
-| Uncommitted changes exist | VERIFICATION-GAP | conditional | Commit before proceeding |
-| Branch not pushed | MISSING-ELEMENT | auto-fix | Push immediately |
+| Criterion claimed met without evidence | VERIFICATION-GAP | FAIL | Re-verify with actual tool call |
+| Test not actually passing | CONFLICTING | FAIL | HALT — fix test before claiming completion |
+| Files differ from spec | CONFLICTING | FAIL | Report — scope may have deviated |
+| Uncommitted changes exist | VERIFICATION-GAP | FAIL | Commit before proceeding |
+| Branch not pushed | MISSING-ELEMENT | FAIL | Push immediately |

--- a/skills/writing-plans/contracts/validate-output-template.yaml
+++ b/skills/writing-plans/contracts/validate-output-template.yaml
@@ -4,7 +4,7 @@ per_check_results:
     check_name: string  # e.g., "Placeholder detection"
     status: string  # PASS | FAIL
     evidence_type: string  # structural | string | semantic | behavioral
-    finding_classification: string  # auto-fix | conditional | flag-for-review
+    finding_classification: string  # auto-fix | FAIL
     action: string  # description of action taken or required
 artifact_path: string  # path to full evidence on disk
 summary: string  # 1-3 sentence summary

--- a/skills/writing-plans/tasks/clean-room.md
+++ b/skills/writing-plans/tasks/clean-room.md
@@ -151,10 +151,10 @@ affected_files_count: K
 
 | Finding | Problem Class | Classification | Action |
 |--------|---------------|----------------|--------|
-| Input file missing | MISSING-ELEMENT | flag-for-review | HALT — cannot generate without input |
-| Referenced file not found | VERIFICATION-GAP | flag-for-review | Mark `⚠️ UNVERIFIED` — fidelity comparison will flag |
-| Function signature mismatch | VERIFICATION-GAP | conditional | Correct or mark `⚠️ UNVERIFIED` |
-| Pattern doesn't exist | CONFLICTING | flag-for-review | Remove claim from clean-room plan |
+| Input file missing | MISSING-ELEMENT | FAIL | HALT — cannot generate without input |
+| Referenced file not found | VERIFICATION-GAP | FAIL | Mark `⚠️ UNVERIFIED` — fidelity comparison will flag |
+| Function signature mismatch | VERIFICATION-GAP | FAIL | Correct or mark `⚠️ UNVERIFIED` |
+| Pattern doesn't exist | CONFLICTING | FAIL | Remove claim from clean-room plan |
 
 ## Cross-References
 

--- a/skills/writing-plans/tasks/validate.md
+++ b/skills/writing-plans/tasks/validate.md
@@ -175,8 +175,8 @@ Does NOT enforce a specific section order. A plan without "Risks" is valid if ri
 
 | Finding | Problem Class | Classification | Action |
 | -- | -- | -- | -- |
-| Placeholders found | VERIFICATION-GAP | conditional | Remove placeholders or mark plan invalid |
+| Placeholders found | VERIFICATION-GAP | FAIL | Remove placeholders or mark plan invalid |
 | Missing spec reference | MISSING-ELEMENT | auto-fix | Add spec reference to plan body |
 | Sub-issues under wrong parent | STRUCTURE-VIOLATION | auto-fix | Re-link under plan |
 | Missing `plan` label | MISSING-ELEMENT | auto-fix | Add label immediately |
-| Abstract goals found | VERIFICATION-GAP | flag-for-review | Flag for plan author to rewrite |
+| Abstract goals found | VERIFICATION-GAP | FAIL | Flag for plan author to rewrite |

--- a/tests/behaviors/1793-sc4-no-flag-for-review.sh
+++ b/tests/behaviors/1793-sc4-no-flag-for-review.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+# Behavioral test: 1793-sc4-no-flag-for-review
+# SC-4: Audit sub-agent does not produce flag-for-review findings — all findings are binary PASS/FAIL
+# See .opencode/tests/AGENTS.md for the test harness specification and paradigm.
+# This script is an artifact-only generator — it does NOT evaluate model output.
+#
+# Evidence type: behavioral — verified by clean-room semantic inspection.
+# Per 080-code-standards.md §Rule 5, grep/string assertions on agent output
+# are EVIDENCE_TYPE_MISMATCH for behavioral SCs. Only assert_semantic
+# (clean-room sub-agent evaluation) is acceptable for verifying agent
+# ACTIONS and DECISIONS.
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/helpers.sh"
+
+SCENARIO_NAME="1793-sc4-no-flag-for-review"
+# BEHAVIORAL PROMPT: real-domain task — evaluate a concern-separation audit finding
+# where the finding is not clean PASS. The agent must return FAIL, not flag-for-review.
+SCENARIO_PROMPT="Evaluate this concern-separation audit finding. The auditor identified a BOILERPLATE_TITLE finding: the phase name 'Phase 1' is generic and not descriptive. Per the concern-separation task file, all finding types must be binary PASS/FAIL — no flag-for-review classification exists. Determine the correct verdict for this finding."
+
+echo "=== Behavioral Test: $SCENARIO_NAME ==="
+echo "SC-4: Audit sub-agent must return FAIL (not flag-for-review) for any finding that is not clean PASS"
+
+behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT"
+
+OVERALL_RESULT=0
+
+# SC-4: Behavioral evidence — clean-room semantic inspector verifies
+# the agent returned FAIL (not flag-for-review) for a finding that is
+# not clean PASS. The concern-separation task file has been migrated
+# to binary PASS/FAIL — flag-for-review no longer exists as a classification.
+#
+# The inspector sees full agent output including reasoning, classification
+# decisions, and verdicts. It judges MEANING, not strings.
+assert_semantic "SC-4" "Agent must classify the concern-separation finding as FAIL, not flag-for-review. The agent must NOT accept 'flag-for-review' as a valid classification. The agent must explicitly state that the correct verdict is FAIL because the three-tier classification model has been replaced with binary PASS/FAIL. The agent must NOT produce a PASS verdict for a finding with any concern, issue, or caveat." "required" || OVERALL_RESULT=1
+
+echo ""
+if [ "$OVERALL_RESULT" -eq 0 ]; then
+    echo "PASS: $SCENARIO_NAME"
+else
+    echo "FAIL: $SCENARIO_NAME"
+fi
+
+exit $OVERALL_RESULT

--- a/tests/behaviors/1793-sc5-no-conditional.sh
+++ b/tests/behaviors/1793-sc5-no-conditional.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+# Behavioral test: 1793-sc5-no-conditional
+# SC-5: VbC sub-agent does not produce conditional findings — all findings are binary PASS/FAIL
+# See .opencode/tests/AGENTS.md for the test harness specification and paradigm.
+# This script is an artifact-only generator — it does NOT evaluate model output.
+#
+# Evidence type: behavioral — verified by clean-room semantic inspection.
+# Per 080-code-standards.md §Rule 5, grep/string assertions on agent output
+# are EVIDENCE_TYPE_MISMATCH for behavioral SCs. Only assert_semantic
+# (clean-room sub-agent evaluation) is acceptable for verifying agent
+# ACTIONS and DECISIONS.
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/helpers.sh"
+
+SCENARIO_NAME="1793-sc5-no-conditional"
+# BEHAVIORAL PROMPT: real-domain task — evaluate a VbC verification finding
+# where the finding is not clean PASS. The agent must return FAIL, not conditional.
+# The verification-before-completion task files have been migrated to binary PASS/FAIL.
+SCENARIO_PROMPT="Evaluate this VbC verification finding. The verifier identified a MISSING-ELEMENT finding: the checklist item 'Run linting' was not completed. Per the verification-before-completion task files, all finding types must be binary PASS/FAIL — no conditional classification exists. Determine the correct verdict for this finding."
+
+echo "=== Behavioral Test: $SCENARIO_NAME ==="
+echo "SC-5: VbC sub-agent must return FAIL (not conditional) for any finding that is not clean PASS"
+
+behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT"
+
+OVERALL_RESULT=0
+
+# SC-5: Behavioral evidence — clean-room semantic inspector verifies
+# the agent returned FAIL (not conditional) for a finding that is
+# not clean PASS. The verification-before-completion task files have
+# been migrated to binary PASS/FAIL — conditional no longer exists
+# as a classification.
+#
+# The inspector sees full agent output including reasoning, classification
+# decisions, and verdicts. It judges MEANING, not strings.
+assert_semantic "SC-5" "Agent must classify the VbC verification finding as FAIL, not conditional. The agent must NOT accept 'conditional' as a valid classification. The agent must explicitly state that the correct verdict is FAIL because the three-tier classification model has been replaced with binary PASS/FAIL. The agent must NOT produce a PASS verdict for a finding with any concern, issue, or caveat." "required" || OVERALL_RESULT=1
+
+echo ""
+if [ "$OVERALL_RESULT" -eq 0 ]; then
+    echo "PASS: $SCENARIO_NAME"
+else
+    echo "FAIL: $SCENARIO_NAME"
+fi
+
+exit $OVERALL_RESULT


### PR DESCRIPTION
## Summary

Redesign the three-tier finding classification model (`auto-fix`/`conditional`/`flag-for-review`) to binary PASS/FAIL across all skills. This is the systemic fix following the surgical audit-only fix in #1792.

## Changes

- **adversarial-verification.md redesigned** (SC-1): Removed `conditional` and `flag-for-review` tiers. Preserved `auto-fix` as remediation action only. Added `escalate` as remediation action for FAILs requiring domain judgment (SC-6).
- **56 task files migrated** (SC-2): All `conditional` and `flag-for-review` classification references replaced with `FAIL` across all skills.
- **Guideline reference updated** (SC-3): `000-critical-rules.md:422` updated.
- **Behavioral tests added** (SC-4, SC-5): `1793-sc4-no-flag-for-review.sh` and `1793-sc5-no-conditional.sh`.
- **#1792 test files recovered**: `1792-sc6-hedging-fail.sh` and `1792-sc7-flag-for-review-fail.sh` restored after rebase.

## Fixes

Closes #1793

🤖 Co-authored with AI: OpenCode (ollama-cloud/deepseek-v4-flash)