### PR TITLE
[SPEC-FIX] Plan writer generates behavioral exit criteria with evidence type metadata

### DIFF
--- a/skills/writing-plans/tasks/create.md
+++ b/skills/writing-plans/tasks/create.md
@@ -76,6 +76,7 @@ Each item is tagged with dispatch scope and chain dependency.
 - [ ] 10. (**sub-agent**) Write — `task(..., prompt: "execute write task from writing-plans")`. **Post-dispatch file verification:** After the sub-agent returns DONE with a file path, run `ls` or `file-exists` to confirm the file exists on disk. If the file does not exist, re-task clean-room (do not accept the empty result).
   - Chain: `step_9`
   - Expected: plan file path in write output
+  - **Behavioral SC requirement:** The write sub-agent MUST generate phase exit criteria for behavioral SCs that include both `behavior_run` artifact generation AND `behavioral-test-evaluation` clean-room dispatch steps. Each SC in the exit criteria MUST carry an `evidence_type` metadata annotation (e.g., `evidence_type: behavioral`). The VbC section for behavioral SCs MUST include a mandatory gate: after artifact generation, dispatch `behavioral-test-evaluation` before allowing PASS verdict.
 
 - [ ] 11. (**sub-agent**) Clean-room plan generation — **MANDATORY GATE — MUST NOT be skipped.** `task(..., prompt: "execute write task from writing-plans")` with spec body only, no existing plan context. The orchestrator MUST NOT proceed past Step 10 without dispatching Step 11. If Step 11 is skipped, the pipeline MUST halt.
   - Chain: `step_10`
@@ -134,6 +135,9 @@ Each item is tagged with dispatch scope and chain dependency.
 - Approval cascade applied (auto-approval for pipeline scope)
 - All implementation-pipeline gate steps enumerated in exit criteria or phase structure
 - Step numbering is globally sequential across all phases
+- Phase exit criteria for behavioral SCs include both `behavior_run` artifact generation AND `behavioral-test-evaluation` clean-room dispatch steps
+- Each SC in the exit criteria carries an `evidence_type` metadata annotation (e.g., `evidence_type: behavioral`)
+- The VbC section for behavioral SCs includes a mandatory gate: after artifact generation, dispatch `behavioral-test-evaluation` before allowing PASS verdict
 - Output contract loaded from `contracts/create-output-template.yaml` and validated before returning
 
 ## Plan Format

--- a/skills/writing-plans/tasks/validate.md
+++ b/skills/writing-plans/tasks/validate.md
@@ -96,6 +96,16 @@ Check an existing plan for placeholders and completeness.
   - SC: SC-5
   - Expected: all dispatch indicators match step content; FAIL on mismatch
 
+- [ ] 19. (**inline**) Behavioral SC exit criteria validation — Reject structural-only exit criteria for behavioral SCs
+  - Command: For each SC in the plan's exit criteria section, check if the SC has `evidence_type: behavioral` annotation. If yes, verify the exit criteria include both `behavior_run` artifact generation AND `behavioral-test-evaluation` clean-room dispatch steps. Exit criteria that use only structural evidence (file exists, annotations present, exit 0) for behavioral SCs MUST be rejected.
+  - SC: SC-2
+  - Expected: all behavioral SCs have model-execution-and-evaluation steps in their exit criteria; FAIL on structural-only exit criteria for behavioral SCs
+
+- [ ] 20. (**inline**) Evidence type metadata presence — Verify each SC in the plan's exit criteria section carries an `evidence_type` annotation
+  - Command: `grep(pattern="evidence_type:")` on each phase file's exit criteria section
+  - SC: SC-4
+  - Expected: every SC in every phase file has an `evidence_type` annotation; FAIL on missing annotations
+
 ## Result Contract Schema
 
 Before returning, load the output contract from `contracts/validate-output-template.yaml` and validate the result against it. The contract defines the expected output structure:


### PR DESCRIPTION
## Summary

Fixes #1791. The plan writer (writing-plans skill) was generating structural-only exit criteria for behavioral SCs — checking file existence and exit codes instead of requiring model-execution-and-evaluation steps. This fix adds behavioral SC requirements to both the create and validate tasks.

## Changes

### `skills/writing-plans/tasks/create.md`
- **Step 10 (Write):** Added behavioral SC requirement block — write sub-agent MUST generate phase exit criteria for behavioral SCs that include both `behavior_run` artifact generation AND `behavioral-test-evaluation` clean-room dispatch steps. Each SC MUST carry `evidence_type` metadata annotation. VbC section for behavioral SCs MUST include a mandatory `behavioral-test-evaluation` gate before PASS verdict.
- **Exit Criteria:** Added 3 new exit criteria covering behavioral SC exit criteria, evidence type metadata, and VbC gate.

### `skills/writing-plans/tasks/validate.md`
- **Check 19:** New validation — rejects structural-only exit criteria for behavioral SCs. Checks each SC's `evidence_type: behavioral` annotation and verifies the exit criteria include model-execution-and-evaluation steps.
- **Check 20:** New validation — verifies every SC in every phase file carries an `evidence_type` annotation.

## Success Criteria

| ID | Criterion | Status |
|----|-----------|--------|
| SC-1 | create.md generates behavioral exit criteria with behavior_run + behavioral-test-evaluation | ✅ |
| SC-2 | validate.md rejects structural-only exit criteria for behavioral SCs | ✅ |
| SC-3 | VbC section includes mandatory behavioral-test-evaluation gate | ✅ |
| SC-4 | Each SC carries evidence_type metadata annotation | ✅ |

---

🤖 Co-authored with AI: OpenCode (ollama-cloud/deepseek-v4-flash)