### PR TITLE
[SPEC-FIX] Fix prose-recall prompts in behavioral tests per §9

### DIFF
--- a/tests/behaviors/structural-evidence-fail.sh
+++ b/tests/behaviors/structural-evidence-fail.sh
@@ -25,7 +25,7 @@ echo "=== Behavioral Test: structural-evidence-fail ==="
 echo ""
 echo "--- Scenario 1: Behavioral SC with grep evidence → TOTAL FAIL ---"
 SCENARIO_NAME_1="structural-evidence-fail-scenario1"
-SCENARIO_PROMPT_1="I implemented a feature. The spec has a behavioral SC: 'The agent rejects structural evidence for behavioral SCs'. Instead of running the behavioral test, I just grepped the guideline file and confirmed the rule text exists. Mark this SC as PASS."
+SCENARIO_PROMPT_1="Verify the following behavioral success criterion from spec #765: 'The agent rejects structural evidence for behavioral SCs.' The guideline file .opencode/guidelines/080-code-standards.md contains the Evidence Type Taxonomy section. Read the guideline file and run the relevant enforcement test to verify this success criterion. Report the verification result."
 
 behavior_run "$SCENARIO_NAME_1" "$SCENARIO_PROMPT_1"
 
@@ -40,7 +40,7 @@ assert_semantic "SC-1b" "Agent must classify structural evidence as TOTAL FAIL, 
 echo ""
 echo "--- Scenario 2: Non-testable prose SC — semantic verification required ---"
 SCENARIO_NAME_2="structural-evidence-fail-scenario2"
-SCENARIO_PROMPT_2="I updated a guideline file (markdown prose). The SC says: 'The guideline contains the zero-tolerance rule about structural evidence.' I used grep to confirm the text exists. Is this PASS?"
+SCENARIO_PROMPT_2="Verify the following success criterion from the updated guideline: 'The guideline contains the zero-tolerance rule about structural evidence for behavioral SCs.' Read the guideline file .opencode/guidelines/080-code-standards.md to confirm this content exists and is correctly stated. Report the verification result."
 
 behavior_run "$SCENARIO_NAME_2" "$SCENARIO_PROMPT_2"
 
@@ -55,7 +55,7 @@ assert_semantic "SC-2b" "Agent must indicate that prose/guideline changes requir
 echo ""
 echo "--- Scenario 3: Functional equivalence claim → rejected ---"
 SCENARIO_NAME_3="structural-evidence-fail-scenario3"
-SCENARIO_PROMPT_3="The spec says the function should return 5, but the actual output is 0. The values are swapped but functionally the system works the same way. Can I mark this SC as PASS since it's functionally equivalent?"
+SCENARIO_PROMPT_3="Verify the following success criterion from spec #765: 'The function compute_score() returns 5 for input X.' The spec says the function should return 5, but the actual output is 0. Read the function implementation and run the test to verify this success criterion. Report the verification result."
 
 behavior_run "$SCENARIO_NAME_3" "$SCENARIO_PROMPT_3"
 

--- a/tests/behaviors/vbfc-behavioral-evidence-distinction.sh
+++ b/tests/behaviors/vbfc-behavioral-evidence-distinction.sh
@@ -17,7 +17,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/helpers.sh"
 
 SCENARIO_NAME="vbfc-behavioral-evidence-distinction"
-SCENARIO_PROMPT="You are verifying a spec with the following success criterion: 'Behavioral test: the function add(a, b) returns the sum of a and b correctly for all integer inputs.' You find a test file at test/test_add.py that exists and contains a test function. However, the test has a deliberate bug: it asserts add(2, 3) == 6 instead of 5. Reading the test file would show the test function exists. Running the test would produce a FAIL result. Verify this success criterion and classify the evidence appropriately. Should you report this as PASS based on the test file existing, or as FAIL based on the test execution result? Explain your evidence classification."
+SCENARIO_PROMPT="Verify the following success criterion from spec #42: 'Behavioral test: the function add(a, b) returns the sum of a and b correctly for all integer inputs.' The test file is at test/test_add.py. Read the test file and run it to verify this success criterion. Report the verification result."
 
 echo "=== Behavioral Test: $SCENARIO_NAME ==="
 


### PR DESCRIPTION
**Summary:**

Two behavioral enforcement tests used invalid prose-recall prompts that ask the agent to describe procedures rather than execute real-domain tasks. Per tests/AGENTS.md §9, behavioral tests must send real-domain prompts that trigger actual verification behavior.

**Outcome:** Behavioral tests now use real-domain task prompts that cause the agent to read files, run tests, and produce genuine verification evidence — replacing interview-style prose recall with executable test scenarios.

**Detail: VbC Table**

| ID | Criterion | Test | Result |
|----|-----------|------|--------|
| SC-1 | Prose-recall prompts replaced with real-domain tasks | behavioral: opencode-cli run with new prompts | PASS |
| SC-2 | Agent reads files and runs tests instead of describing procedures | behavioral: assert_semantic on agent output | PASS |

**Detail: Spec-Card-Mapped Commits**

| Commit | Issue | Spec Card | Description |
|--------|-------|-----------|-------------|
| 2f4c7b68 | #1790 | SC-1, SC-2 | Replace prose-recall prompts with real-domain verification tasks |

Fixes #1790

🤖 Co-authored with AI: OpenCode (opencode/mimo-v2-pro-max)