### PR TITLE
feat(change-control): mandate re-audit after fixing audit findings (#1845)

### DIFF
--- a/skills/spec-creation/tasks/change-control.md
+++ b/skills/spec-creation/tasks/change-control.md
@@ -15,6 +15,7 @@ Version the spec, document rationale and impact analysis for changes. Enforce ch
 - Rationale documented for each change
 - Impact analysis completed
 - STATUS updated to `REVISED - NEEDS APPROVAL`
+- **When revision was triggered by spec-audit FAILs:** All prior audit FAILs resolved to PASS
 
 ## Procedure
 
@@ -39,6 +40,17 @@ For each change, document:
 - Which success criteria need updating
 - Which traceability mappings changed
 - Whether the change requires re-audit
+
+### Step 3.5: Mandatory Re-Audit (Audit-Triggered Revisions Only)
+
+**When the revision was triggered by spec-audit FAILs**, the change-control task MUST dispatch a re-audit to confirm the fixes resolved the original findings:
+
+- [ ] 1. Dispatch `audit --task spec-audit` on the revised spec
+- [ ] 2. Confirm all prior audit FAILs are now PASS
+- [ ] 3. If re-audit produces new FAILs: HALT — the fixes did not resolve the original findings
+- [ ] 4. If re-audit produces different FAILs than the original: HALT — the fixes introduced new issues
+
+**When the revision was NOT triggered by spec-audit FAILs** (user feedback, scope adjustments, etc.), skip this step — re-audit is not required.
 
 ### Step 4: HALT
 

--- a/tests/behaviors/1845-sc4-anti-lobotomization.sh
+++ b/tests/behaviors/1845-sc4-anti-lobotomization.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# Behavioral test: 1845-sc4-anti-lobotomization
+# Verifies no SC lobotomization occurred during implementation of #1845.
+# See .opencode/tests/AGENTS.md for the test harness specification and paradigm.
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/helpers.sh"
+
+SCENARIO_NAME="1845-sc4-anti-lobotomization"
+SCENARIO_PROMPT="Implement SPEC-FIX #1845: change-control task must mandate re-audit after fixing audit findings. Read the spec at .opencode/.issues/1845/spec.md and implement all SCs without lobotomizing, weakening, deferring, or reclassifying any SC to a lower evidence type."
+
+behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT"
+exit 0


### PR DESCRIPTION
## Summary

Adds mandatory re-audit step to the change-control task when revision was triggered by spec-audit FAILs.

## Outcome

- **Exit criteria** updated: "All prior audit FAILs resolved to PASS" when revision was audit-triggered
- **Step 3.5** inserted: Mandatory Re-Audit between Impact Analysis and HALT
- Re-audit is conditional — only required when revision was triggered by spec-audit FAILs
- Non-audit-triggered revisions preserve existing behavior
- Behavioral anti-lobotomization test added

## Fixes

- Fixes #1845

## Verification

| SC | Evidence Type | Result |
|----|--------------|--------|
| SC-1 | string | ✅ PASS |
| SC-2 | string | ✅ PASS |
| SC-3 | string | ✅ PASS |
| SC-4 | behavioral | ✅ PASS |

🤖 Co-authored with AI: OpenCode (ollama-cloud/deepseek-v4-pro)