### PR TITLE
fix(local-issues): fix legacy format warning and duplicate root repo entries

### DIFF
--- a/tools/local-issues
+++ b/tools/local-issues
@@ -1958,6 +1958,8 @@ def _check_legacy_formats(issues_dir: Path) -> None:
     if legacy_found:
         print(
             "Warning: Legacy issue directory format detected in .issues/. "
+            "Correct format is .issues/{N}/ (flat numbered directories) "
+            "or .opencode/.issues/{N}/ for submodule repos. "
             "AI agent must inspect and remediate manually.",
             file=sys.stderr,
         )

--- a/tools/local-issues
+++ b/tools/local-issues
@@ -1045,7 +1045,7 @@ def _resolve_qualified(qualified_str: str) -> list[tuple[Path, str, str]]:
         sys.exit(1)
 
     results: list[tuple[Path, str, str]] = [(current, current_name, number_str)]
-    seen: set[str] = set()
+    seen: set[str] = {current_name}
     for child in _discover_all_repos():
         if child.name not in seen:
             seen.add(child.name)
@@ -1358,14 +1358,11 @@ def _format_search_results(results: list[tuple[str, str, str, str, str]]) -> Non
 
 def cmd_search(args: argparse.Namespace) -> None:
     query = args.query.lower()
-    current_repo_name = _resolve_repo_name()
     current_cwd = Path(os.getcwd()).resolve()
 
     child_repos = _discover_all_repos()
 
-    repo_infos: list[tuple[Path, str]] = [(current_cwd, current_repo_name)]
-    for child in child_repos:
-        repo_infos.append((child, child.name))
+    repo_infos: list[tuple[Path, str]] = [(child, child.name) for child in child_repos]
 
     found: list[tuple[str, str, str, str, str]] = []
     for repo_path, repo_name in repo_infos:
@@ -1380,13 +1377,10 @@ def _resolve_repo_name() -> str:
 
 def _print_available_repos() -> None:
     """Print current repo and all discovered child repos with qualifiers and paths."""
-    current = Path(os.getcwd()).resolve()
-    current_name = _resolve_repo_name()
     repos = _discover_all_repos()
-    names = [current_name] + [r.name for r in repos]
+    names = [r.name for r in repos]
     max_name_len = max(len(n) for n in names) if names else 0
     print("Available qualifiers (use name#N format):", file=sys.stderr)
-    print(f"  {current_name:<{max_name_len}}     {current}", file=sys.stderr)
     for child in repos:
         print(f"  {child.name:<{max_name_len}}     {child}", file=sys.stderr)
 
@@ -1423,16 +1417,12 @@ def _format_list_output(
 
 
 def cmd_list(args: argparse.Namespace) -> None:
-    current_repo_name = _resolve_repo_name()
     current_cwd = Path(os.getcwd()).resolve()
     child_repos = _discover_all_repos()
     all_entries: list[tuple[int, str, str, str, str, str, int]] = []
-    all_entries.extend(
-        _list_issues_in_repo(current_cwd, current_repo_name, 0, current_cwd)
-    )
     for idx, child in enumerate(child_repos):
         all_entries.extend(
-            _list_issues_in_repo(child, child.name, idx + 1, current_cwd)
+            _list_issues_in_repo(child, child.name, idx, current_cwd)
         )
     _format_list_output(all_entries)
 


### PR DESCRIPTION
## Summary

Two SPEC-FIX fixes for `local-issues` tool:

1. **#1842** — Legacy format warning now states the correct format (`.issues/{N}/` for root, `.opencode/.issues/{N}/` for submodules)
2. **#1841** — Removes duplicate root repo entries from `list`, `search`, `repos`, and bare `N` resolution commands

## Changes

### Commit 1: `fix(local-issues): update legacy format warning to state correct format`
- Updated `_check_legacy_formats()` warning message to include the correct format

### Commit 2: `fix(local-issues): remove duplicate root repo entries from list/search/repos commands`
- `cmd_list`: Removed explicit `_list_issues_in_repo` for root (already in `_discover_all_repos()`)
- `cmd_search`: Removed explicit `(current_cwd, current_repo_name)` prepend
- `_print_available_repos`: Removed explicit `current_name` print
- `_resolve_qualified`: Pre-seeded `current_name` in `seen` set

## Verification

- [x] Warning message contains `.issues/{N}/` format string
- [x] Warning message mentions submodule variant
- [x] Sentinel file mechanism (`.legacy-warned`) preserved
- [x] Detection logic unchanged
- [x] `_discover_all_repos()` unchanged (function is correct)
- [x] `local-issues list` runs without errors

Fixes #1842
Fixes #1841

🤖 Co-authored with AI: OpenCode (ollama-cloud/deepseek-v4-flash)