### PR TITLE
fix(#1863): resolve committed merge conflict markers in writing-plans

### DIFF
--- a/skills/writing-plans/SKILL.md
+++ b/skills/writing-plans/SKILL.md
@@ -1,10 +1,6 @@
 ---
 name: writing-plans
-<<<<<<< Updated upstream
-description: "Implementation plan creator that breaks approved specs into phases, tasks, and work breakdowns. Dispatch when creating an implementation plan from an approved spec, breaking down work into phases, planning implementation steps, or creating task breakdowns. Also dispatch when retroactively creating a plan for an existing spec, or backfilling plan documentation. Plans are REQUIRED. — distinct from plan (AI planning with PDDL/Z3) and plan-creation-pipeline (task()-dispatch pipeline). User phrases: create plan, write plan, draft plan, implementation plan, plan implementation, break down work, create tasks, define phases, plan phases, retroactive plan, backfill plan, task breakdown, create a plan, write a plan, draft a plan, make a plan, make plan, create an implementation plan, write an implementation plan, implementation steps, task list, break down the work, create the tasks, define the phases."
-=======
-description: "Use when creating an implementation plan from an approved spec, breaking down work into phases, planning implementation steps, or creating task breakdowns. Also use when retroactively creating a plan for an existing spec, or backfilling plan documentation. Also use when running holistic self-checks on plans before completion, or verifying plan quality against the 11-dimension holistic gate. Invoke for: plan creation, implementation planning, task breakdown, phase definition, work decomposition, retroactive planning, plan backfill, holistic check, self-check, pre-completion check, plan quality verification. Plans are REQUIRED. — distinct from plan (AI planning with PDDL/Z3) and plan-creation-pipeline (task()-dispatch pipeline). Trigger phrases: create plan, write plan, draft plan, implementation plan, plan implementation, break down work, create tasks, define phases, plan phases, retroactive plan, backfill plan, task breakdown, create a plan, write a plan, draft a plan, make a plan, make plan, create an implementation plan, write an implementation plan, implementation steps, task list, break down the work, create the tasks, define the phases."
->>>>>>> Stashed changes
+description: "Implementation plan creator that breaks approved specs into phases, tasks, and work breakdowns. Dispatch when creating an implementation plan from an approved spec, breaking down work into phases, planning implementation steps, or creating task breakdowns. Also dispatch when retroactively creating a plan for an existing spec, or backfilling plan documentation. Also dispatch when running holistic self-checks on plans before completion, or verifying plan quality against the 11-dimension holistic gate. Plans are REQUIRED. — distinct from plan (AI planning with PDDL/Z3) and plan-creation-pipeline (task()-dispatch pipeline). User phrases: create plan, write plan, draft plan, implementation plan, plan implementation, break down work, create tasks, define phases, plan phases, retroactive plan, backfill plan, task breakdown, holistic check, self-check, pre-completion check, plan quality verification, create a plan, write a plan, draft a plan, make a plan, make plan, create an implementation plan, write an implementation plan, implementation steps, task list, break down the work, create the tasks, define the phases."
 license: MIT
 compatibility: opencode
 ---
@@ -46,7 +42,6 @@ This skill operates in the main repo directory (direct-branch mode). When `WORKT
 | "update plan" / "plan update" / "auto-update plan" / "revise plan" | `update` | `sub-task` | {spec_issue_number, plan_issue_number} |
 | "spec-to-plan" / "handoff to plan" | `handoffs/spec-to-plan` | `sub-task` | {spec_issue_number} |
 | "pre-plan-readiness" / "readiness check" / "verify prerequisites" | `pre-plan-readiness` | `sub-task` | {spec_issue_number} |
-<<<<<<< Updated upstream
 | "analytical artifacts ready for plan" | `create` | `sub-task` | {spec_issue_number, spec_body, analytical_artifact_dir} |
 | "blast-radius artifact missing for plan" | HALT | — | — |
 | "concern-map artifact missing for plan" | HALT | — | — |
@@ -54,9 +49,7 @@ This skill operates in the main repo directory (direct-branch mode). When `WORKT
 | "interface-compatibility artifact missing for plan" | HALT | — | — |
 | "state-analysis artifact missing for plan" | HALT | — | — |
 | "testability-assessment artifact missing for plan" | HALT | — | — |
-=======
 | "holistic check" / "self-check" / "pre-completion check" | `holistic-self-check` | `sub-task` | {plan_context} |
->>>>>>> Stashed changes
 | completion / workflow end | `completion` | `sub-task` | {workflow_state} |
 
 ## Persona

--- a/skills/writing-plans/tasks/create.md
+++ b/skills/writing-plans/tasks/create.md
@@ -7,7 +7,6 @@
 
 Create an implementation plan from an approved spec. The orchestrator dispatches the 21-step pipeline to a sub-agent, which reads this task file and executes the steps, dispatching sub-agents for sub-task steps and running z3-check steps inline.
 
-<<<<<<< Updated upstream
 ## Step 0: Holistic Spec Evaluation (Pre-Flight Gate)
 
 **MANDATORY GATE — MUST NOT be skipped.** Before any plan creation steps, dispatch a clean-room sub-agent to evaluate the spec against the 11 holistic dimensions defined in `.opencode/reference/holistic-dimensions.yaml`.
@@ -18,7 +17,7 @@ Create an implementation plan from an approved spec. The orchestrator dispatches
   - Expected: PASS for all 11 dimensions
   - On FAIL: hard-fail immediately, escalate to user with failing dimension details and resolution guidance
   - On PASS: proceed to Prerequisites
-=======
+
 ## Plan Template Sections
 
 The write sub-agent MUST include the following sections in every plan produced. These sections feed the 11 holistic dimensions and are mandatory — not optional.
@@ -103,7 +102,6 @@ Any step that performs a destructive operation (data mutation, file deletion, ir
 ### Plan-Spec Alignment
 
 The plan MUST actually implement the spec it claims to implement. The plan's goal MUST match the spec's goal. The plan MUST NOT add phases the spec didn't ask for or omit phases the spec requires.
->>>>>>> Stashed changes
 
 ## Prerequisites
 


### PR DESCRIPTION
## Summary

Resolve 3 unresolved merge conflict blocks committed in merge `22a2a853` (PR #1859) that left `<<<<<<<` markers in the committed tree.

## Outcome

| File | Conflict | Resolution |
|------|----------|------------|
| `skills/writing-plans/SKILL.md` | Description field (lines 3-7) | Keep #1855 noun-phrase format, add #1853 holistic self-check references |
| `skills/writing-plans/SKILL.md` | Dispatch table (lines 49-59) | Keep both #1835 artifact HALT rows and #1853 holistic-self-check row |
| `skills/writing-plans/tasks/create.md` | Step 0 vs template sections (lines 10-106) | Keep both #1850 Step 0 pre-flight gate and #1853 template sections, Step 0 first |

## Fixes

- #1863

## Verification

- Zero `<<<<<<<`, `=======`, `>>>>>>>` markers in both files
- YAML frontmatter valid
- Description uses #1855 format with #1853 additions
- Dispatch table has both artifact HALT rows and holistic-self-check row
- create.md has both Step 0 gate and template sections

🤖 Co-authored with AI: OpenCode (ollama-cloud/deepseek-v4-flash)