### PR TITLE
[SPEC-FIX] Adopt Agent-Intent as single canonical skill description format

### DIFF
--- a/skills/skill-creator/reference/routing-only-template.md
+++ b/skills/skill-creator/reference/routing-only-template.md
@@ -15,16 +15,18 @@ This template defines the canonical structure for a routing-only SKILL.md file. 
 ```markdown
 ---
 name: skill-name
-description: "<Noun phrase describing what the skill is>. Dispatch when <agent-facing trigger conditions>. Also dispatch when <additional trigger conditions>. <Enforcement statement>. User phrases: <preserved user-facing trigger phrases>."
+description: "<Noun phrase describing what the skill is>. Dispatch when <agent-facing trigger conditions>. Also dispatch when <additional trigger conditions>. Invoke for: <comma-separated task names (OPTIONAL)>. <Enforcement statement>. — distinct from <exclusion clauses>."
 
 **Description format (agent-intent pattern):**
 - `<Noun phrase>` — what the skill IS (not when to use it)
-- `Dispatch when` — agent-facing trigger conditions (what the agent is doing)
+- `Dispatch when` — primary agent-facing trigger conditions (what the agent is doing)
 - `Also dispatch when` — additional agent-facing trigger conditions
+- `Invoke for:` — optional structural reference to task names from dispatch table
 - Enforcement statement — e.g., "Spec creation is REQUIRED before implementation."
-- `User phrases:` — preserved user-facing trigger phrases (same content as old "Trigger phrases:")
+- `— distinct from` — exclusion clauses for skills that could false-match
 - Max 1024 characters (opencode limit)
-- Exclusion clauses (`— distinct from <exclusion>`) for skills that could false-match
+- **Rejected elements:** `Use when`, `Also use when`, `Trigger phrases:` — deprecated Farmage format, MUST NOT appear
+- **Optional elements:** `User phrases:` — example user-facing trigger patterns for semantic dispatch matching (not required, not rejected); `Invoke for:` — structural reference to task names from dispatch table
 license: MIT
 provenance: AI-generated
 ---

--- a/skills/skill-creator/scripts/validate_skill_cards.py
+++ b/skills/skill-creator/scripts/validate_skill_cards.py
@@ -140,13 +140,13 @@ def validate_req1(
         )
     else:
         desc = fields["description"]
-        if "Invoke for:" in desc:
+        if "Use when" in desc or "Also use when" in desc:
             violations.append(
                 Violation(
                     "REQ-1",
                     name,
                     "description",
-                    "Description contains 'Invoke for:' (old pattern — must use 'Dispatch when')",
+                    "Description contains 'Use when' or 'Also use when' (deprecated Farmage format — must use 'Dispatch when' / 'Also dispatch when')",
                     desc[:60],
                     file_path=file_path,
                 )
@@ -157,22 +157,13 @@ def validate_req1(
                     "REQ-1",
                     name,
                     "description",
-                    "Description contains 'Trigger phrases:' (old pattern — must use 'User phrases:')",
+                    "Description contains 'Trigger phrases:' (deprecated Farmage format — rejected)",
                     desc[:60],
                     file_path=file_path,
                 )
             )
-        if "Also use when" in desc:
-            violations.append(
-                Violation(
-                    "REQ-1",
-                    name,
-                    "description",
-                    "Description contains 'Also use when' (old pattern — must use 'Also dispatch when')",
-                    desc[:60],
-                    file_path=file_path,
-                )
-            )
+        # User phrases: is optional — provides example user-facing trigger patterns
+        # for semantic dispatch matching. Not required, not rejected.
         if "Dispatch when" not in desc:
             violations.append(
                 Violation(
@@ -180,17 +171,6 @@ def validate_req1(
                     name,
                     "description",
                     "Description missing 'Dispatch when' (required in agent-intent pattern)",
-                    desc[:60],
-                    file_path=file_path,
-                )
-            )
-        if "User phrases:" not in desc:
-            violations.append(
-                Violation(
-                    "REQ-1",
-                    name,
-                    "description",
-                    "Description missing 'User phrases:' (required in agent-intent pattern)",
                     desc[:60],
                     file_path=file_path,
                 )
@@ -236,20 +216,11 @@ def validate_sc_lint_001(name: str, fields: dict[str, str], file_path: str) -> l
                 severity="ERROR", pass_fail="FAIL",
             )
         )
-    if "User phrases:" not in desc:
+    if "Use when" in desc or "Also use when" in desc:
         violations.append(
             Violation(
                 "SC-LINT", name, "SC-LINT-001",
-                "Description missing 'User phrases:' (required in agent-intent pattern)",
-                desc[:60], file_path=file_path,
-                severity="ERROR", pass_fail="FAIL",
-            )
-        )
-    if "Invoke for:" in desc:
-        violations.append(
-            Violation(
-                "SC-LINT", name, "SC-LINT-001",
-                "Description contains 'Invoke for:' (old pattern)",
+                "Description contains 'Use when' or 'Also use when' (deprecated Farmage format)",
                 desc[:60], file_path=file_path,
                 severity="ERROR", pass_fail="FAIL",
             )
@@ -258,20 +229,13 @@ def validate_sc_lint_001(name: str, fields: dict[str, str], file_path: str) -> l
         violations.append(
             Violation(
                 "SC-LINT", name, "SC-LINT-001",
-                "Description contains 'Trigger phrases:' (old pattern)",
+                "Description contains 'Trigger phrases:' (deprecated Farmage format)",
                 desc[:60], file_path=file_path,
                 severity="ERROR", pass_fail="FAIL",
             )
         )
-    if "Also use when" in desc:
-        violations.append(
-            Violation(
-                "SC-LINT", name, "SC-LINT-001",
-                "Description contains 'Also use when' (old pattern)",
-                desc[:60], file_path=file_path,
-                severity="ERROR", pass_fail="FAIL",
-            )
-        )
+    # User phrases: is optional — provides example user-facing trigger patterns
+    # for semantic dispatch matching. Not required, not rejected.
     return violations
 
 MANDATORY_KEYWORDS = re.compile(

--- a/skills/skill-creator/tasks/validate.md
+++ b/skills/skill-creator/tasks/validate.md
@@ -20,26 +20,29 @@ When using `--json` for programmatic consumption, the JSON array contains object
 
 For each skill that failed mechanical validation, the agent reads the full SKILL.md content and understands the skill's purpose, operations, and triggering conditions before writing any corrections. This is not a search-and-replace exercise — each fix must reflect what the skill actually does.
 
-CSO descriptions are the most common mechanical failure. The fix is not to prepend "Use when" to an existing noun phrase like "Skill-creator" or "Git-workflow". Instead, the agent reformulates the description as a proper sentence that captures the skill's triggering conditions: "Use when creating a new skill or updating an existing skill that extends AI capabilities with specialized knowledge, workflows, or tool integrations." The triggering conditions come from reading the skill, not from pattern-matching the old description.
+CSO descriptions are the most common mechanical failure. The fix is not to prepend "Dispatch when" to an existing noun phrase like "Skill-creator" or "Git-workflow". Instead, the agent reformulates the description as a proper sentence that captures the skill's triggering conditions: "Dispatch when creating a new skill or updating an existing skill that extends AI capabilities with specialized knowledge, workflows, or tool integrations." The triggering conditions come from reading the skill, not from pattern-matching the old description.
 
-### Farmage Description Pattern (MANDATORY)
+### Agent-Intent Description Pattern (CANONICAL)
 
-All skill card `description` fields MUST follow the farmage/opencode-skills pattern:
+All skill card `description` fields MUST follow the Agent-Intent format:
 
 ```
-description: "Use when <primary use case>. Also use when <secondary use cases>. Invoke for: <comma-separated task list>. <Mandatory enforcement statement>. Trigger phrases: <comma-separated trigger phrase list>."
+description: "Dispatch when <primary agent-facing trigger>. Also dispatch when <secondary triggers>. Invoke for: <comma-separated task list>. <Mandatory enforcement statement>. — distinct from <exclusion clauses>."
 ```
 
 **Validation checks:**
-1. `Use when` — present and describes primary use case
-2. `Also use when` — present (omit only if no secondary use cases exist)
-3. `Invoke for:` — present with comma-separated task list
+1. `Dispatch when` — present and describes primary agent-facing trigger
+2. `Also dispatch when` — present (omit only if no secondary triggers exist)
+3. `Invoke for:` — present with comma-separated task list (optional structural reference)
 4. Enforcement statement — present (e.g., "Validation is REQUIRED.")
-5. `Trigger phrases:` — present with comma-separated trigger phrase list
+5. `— distinct from` — present with exclusion clauses for skills that could false-match
 6. Max 1024 characters
-7. Exclusion clauses (`— distinct from <exclusion>`) for skills that could false-match
 
-Skills that fail any of these checks are flagged as farmage-pattern violations and must be corrected.
+**Rejected elements:** `Use when`, `Also use when`, and `Trigger phrases:` are NOT valid in the Agent-Intent format. Skills containing these elements are flagged as deprecated-format violations and MUST be corrected to Agent-Intent format.
+
+**Optional elements:** `User phrases:` is optional — provides example user-facing trigger patterns for semantic dispatch matching. Not required, not rejected. `Invoke for:` is optional — structural reference to task names from dispatch table.
+
+Skills that fail any of these checks are flagged as Agent-Intent pattern violations and must be corrected.
 
 Worktree mode sections fail REQ-3 when they are missing or generic. The agent writes a section that reflects the skill's specific operations in a worktree context. For example, `git-workflow` discusses branch operations and how branch targets change when working in a worktree, while `mcp-tool-usage` discusses tool path resolution and why file operations must target the worktree path. A generic boilerplate section like "This skill operates in worktrees by using worktree.path" signals that the agent did not read the skill.
 


### PR DESCRIPTION
## Summary

Resolves #1883. Adopts Agent-Intent as the single canonical format for skill card `description` fields, deprecating the Farmage/CSO pattern.

## Changes

### Files Modified

| File | Change |
|------|--------|
| `skills/skill-creator/tasks/validate.md` | REQ-2 rewritten to specify Agent-Intent as canonical; Farmage validation removed |
| `skills/skill-creator/scripts/validate_skill_cards.py` | Validate Agent-Intent format; REJECT `Use when`, `Also use when`, `Trigger phrases:`; accept `User phrases:` and `Invoke for:` as optional |
| `skills/skill-creator/reference/routing-only-template.md` | Template updated to show Agent-Intent as canonical with optional elements |

### Key Design Decisions

1. **Agent-Intent is canonical** — Farmage is deprecated and rejected
2. **Semantic dispatch** — AI agent dispatches based on understanding intent, not matching magic phrases
3. **`User phrases:` is optional** — provides example user-facing trigger patterns as training signals for semantic dispatch matching
4. **`Invoke for:` is optional** — structural reference to task names from dispatch table
5. **No transition period** — validation rejects Farmage format immediately

## Verification

- `validate_skill_cards.py` passes all 37 existing skills (REQ-1 description check)
- `spec-creation` correctly fails for containing `Use when` (deprecated Farmage)
- REQ-6 failures are pre-existing (missing DISPATCH_GATE subsections) — unrelated

Fixes #1883