### PR TITLE
[SPEC-FIX] implementation-pipeline Step-Level Dispatch Mandate — eliminate phase-level batching modes

### DIFF
--- a/skills/implementation-pipeline/SKILL.md
+++ b/skills/implementation-pipeline/SKILL.md
@@ -16,13 +16,18 @@ compatibility: opencode
 
 Orchestrator-facing dispatch router for the implementation pipeline. The orchestrator holds only routing metadata — each step dispatches to an existing skill's task file via `task()`. The orchestrator is a pure router — never reads task file content, never performs inline analysis. Sub-agents do the work.
 
-The orchestrator reads the plan's `Dispatch` column (split plans) or `**Dispatch:**` field (non-split plans) to determine how to route each phase. Three dispatch modes are supported: `inline` (orchestrator interleaves inline and sub-agent steps), `sub-agent-with-context` (entire phase to one sub-agent with context), and `sub-agent-clean-room` (entire phase to one sub-agent with routing metadata only). The orchestrator MUST read the Dispatch declaration before dispatching any phase — defaulting to `sub-agent-with-context` when no Dispatch declaration is present.
+**Step-level dispatch is the ONLY valid dispatch mode.** The orchestrator processes the plan INLINE, step by step. For each step, the orchestrator reads the step's dispatch indicator:
+- `(**inline**)` — orchestrator executes directly
+- `(**sub-agent**)` — orchestrator dispatches to a sub-agent with context via `task()`
+- `(**clean-room**)` — orchestrator dispatches to a sub-agent with routing metadata only via `task()`
+
+The orchestrator MUST NOT dispatch entire phases or batches to a single sub-agent. Every step with a `(**sub-agent**)` or `(**clean-room**)` indicator receives its own clean-room sub-agent. No phase-level batching. No batched dispatch. Each step's sub-agent is independent, receives only the step's SCs, and produces its own result contract.
 
 ## Persona
 
 Pipeline router. Routes each pipeline stage to a clean-room sub-agent via `task()`. The orchestrator holds routing metadata only — never reads task file content, never performs inline analysis. An orchestrator that performs inline work has stopped being a router and started being a contaminant — every inline analysis artifact carries the orchestrator's preloaded bias through every downstream sub-agent, and the pipeline is poisoned from the first byte. Professional pipeline routers dispatch to sub-agents. Inlining means the pipeline was never clean.
 
-The orchestrator reads the plan's Dispatch declaration per-phase and routes accordingly: `inline` phases require the orchestrator to interleave inline execution and sub-agent dispatch; `sub-agent-with-context` phases are dispatched whole to a sub-agent with orchestrator-provided context; `sub-agent-clean-room` phases are dispatched whole to a sub-agent with routing metadata only. The orchestrator MUST NOT dispatch an `inline` phase to a single sub-agent — doing so would cause the sub-agent to execute steps marked for the orchestrator.
+**Step-level dispatch only.** The orchestrator reads the plan's steps sequentially and checks each step's dispatch indicator. Steps marked `(**inline**)` are executed directly by the orchestrator. Steps marked `(**sub-agent**)` or `(**clean-room**)` are dispatched individually to clean-room sub-agents. The orchestrator MUST NOT dispatch entire phases or batches to a single sub-agent. There is no default dispatch mode — every step declares its indicator explicitly.
 
 **MUST dispatch here after plan approval, before any file modification.** This is the mandatory entry point for all implementation work.
 
@@ -69,9 +74,7 @@ This skill operates in the main repo directory (direct-branch mode). When `WORKT
 | "create-pr" / "create pull request" | `create-pr` | `pr-creation-workflow --task create` | `sub-task` | {issue_number, authorization_scope, halt_at} |
 | "exec-summary" / "completion" | `exec-summary` | `completion-core --task completion` | `sub-task` | {issue_number} |
 | "multiple red phases" / "batch red" / "red/red/red" / "batched RED/GREEN" | `tdd-chaining-gate` | `implementation-pipeline --task tdd-chaining-gate` | `sub-task` | {issue_number} |
-| "inline dispatch" / "inline phase" | `inline-dispatch` | Orchestrator reads phase file, executes `(**inline**)` steps directly, dispatches `(**sub-agent**)` / `(**clean-room**)` steps via `task()` | `orchestrator` | {issue_number, plan_path, phase_number} |
-| "sub-agent-with-context dispatch" / "sub-agent phase with context" | `sub-agent-with-context-dispatch` | Orchestrator dispatches entire phase to one sub-agent with orchestrator-provided context | `sub-task` | {issue_number, plan_path, phase_number, orchestrator_context} |
-| "sub-agent-clean-room dispatch" / "clean-room phase" | `sub-agent-clean-room-dispatch` | Orchestrator dispatches entire phase to one sub-agent with routing metadata only | `sub-task` | {issue_number, plan_path, phase_number} |
+| "execute step" / "dispatch step" / "step dispatch" | `step-dispatch` | Orchestrator reads step's dispatch indicator: `(**inline**)` executes directly, `(**sub-agent**)` dispatches with context, `(**clean-room**)` dispatches with routing metadata only | `orchestrator` | {issue_number, plan_path, step_number} |
 
 **Note:** The `audit` step dispatches the appropriate audit task (e.g., `verification-audit` for post-implementation, `spec-audit` for pre-implementation, `plan-fidelity` for plan validation) via `task(subagent_type="general")`:
 - [ ] 1. Dispatch the audit task from audit skill with {spec_local_dir, artifact_evidence_dir}
@@ -84,7 +87,7 @@ See `implementation-pipeline/tasks/pre-flight.md` for pre-flight verification an
 
 ## Step Labels (for #932 naming convention)
 
-`assemble-work`, `sc-coherence-gate`, `pre-red-baseline`, `red-phase`, `z3-check-red`, `red-doublecheck`, `z3-check-red-doublecheck`, `post-red-enforcement`, `z3-check-post-red`, `green-phase`, `z3-check-green`, `post-green-enforcement`, `z3-check-post-green`, `checkpoint-tag-create`, `checkpoint-commit`, `structural-checks`, `green-doublecheck`, `green-vbc`, `sc-count-gate`, `pre-pr-gate`, `audit`, `cross-validate`, `regression-check`, `behavioral-test-remediation`, `review-prep`, `create-pr`, `exec-summary`
+`assemble-work`, `sc-coherence-gate`, `pre-red-baseline`, `red-phase`, `z3-check-red`, `red-doublecheck`, `z3-check-red-doublecheck`, `post-red-enforcement`, `z3-check-post-red`, `green-phase`, `z3-check-green`, `post-green-enforcement`, `z3-check-post-green`, `checkpoint-tag-create`, `checkpoint-commit`, `structural-checks`, `green-doublecheck`, `green-vbc`, `sc-count-gate`, `pre-pr-gate`, `audit`, `cross-validate`, `regression-check`, `behavioral-test-remediation`, `review-prep`, `create-pr`, `exec-summary`, `step-dispatch`
 
 ## Invocation
 
@@ -130,7 +133,7 @@ Steps that route to owning skills use the owning skill's canonical dispatch stri
 
 ## Sub-Agent Routing
 
-**Orchestrator entry point:** The orchestrator reads the plan, creates branches, and dispatches sub-agents per the Trigger Dispatch Table. The Trigger Dispatch Table IS the single source of truth — the orchestrator dispatches each step using the canonical dispatch string from the table. No task files are read by the orchestrator.
+**Orchestrator entry point:** The orchestrator reads the plan and dispatches each step per the Trigger Dispatch Table using step-level dispatch. The orchestrator reads each step's dispatch indicator: `(**inline**)` for direct execution, `(**sub-agent**)` or `(**clean-room**)` for individual `task()` dispatch. No phase-level batching. The Trigger Dispatch Table IS the single source of truth — the orchestrator dispatches each step using the canonical dispatch string from the table. No task files are read by the orchestrator.
 
 All substantive work runs via `task(subagent_type="general")`. The orchestrator is a pure router — no creative work, no file edits, no inline analysis. Auditor tasks also use `subagent_type="general"` — the task file provides all role-specific behavior. Dispatch contracts carry exactly 2 fields: `spec_local_dir` and `artifact_evidence_dir`. No `audit_phase` field. See audit SKILL.md §DISPATCH_GATE. `pre-analysis` receives only `{ issue_number, task_description, github.owner, github.repo }`.
 

--- a/skills/implementation-pipeline/enforcement/dispatch-mode-verification.md
+++ b/skills/implementation-pipeline/enforcement/dispatch-mode-verification.md
@@ -1,0 +1,74 @@
+---
+name: dispatch-mode-verification
+description: "Pre-execution gate that verifies no plan step uses per-phase or batched dispatch modes. Blocks execution if any step lacks an explicit dispatch indicator or uses eliminated modes."
+license: MIT
+provenance: AI-generated
+---
+
+# Dispatch Mode Verification Gate
+
+Pre-execution verification gate that runs after `assemble-work` creates the dispatch plan but before `pipeline-executor` begins execution. Rejects any plan containing `per-phase` or `batched` dispatch modes, or steps without explicit dispatch indicators.
+
+## Entry Criteria
+
+- [ ] 1. Work state file exists at `{project_root}/tmp/{issue-N}/work.md`
+- [ ] 2. Plan is available at `{plan_path}`
+- [ ] 3. All plan steps are identified with step numbers
+
+## Procedure
+
+### 1. Scan for Prohibited Modes
+
+Check the entire plan for any occurrence of:
+- `per-phase` — forbidden
+- `batched` — forbidden
+- `batch` — forbidden
+- `Dispatch: sub-agent-with-context` — forbidden
+- `Dispatch: sub-agent-clean-room` — forbidden
+- Phase-level dispatch without per-step indicators — forbidden
+
+**If any prohibited mode found:**
+1. Record the exact location (file, line, step)
+2. Return `status: BLOCKED` with `reason: PROHIBITED_DISPATCH_MODE`
+3. Include `artifact_path` pointing to the scan output
+
+### 2. Verify Every Step Has an Explicit Indicator
+
+Check every step in the plan for an explicit dispatch indicator:
+- `(**inline**)` — valid
+- `(**sub-agent**)` — valid
+- `(**clean-room**)` — valid
+
+**If any step lacks an indicator:**
+1. Record the step number and name
+2. Return `status: BLOCKED` with `reason: MISSING_DISPATCH_INDICATOR`
+3. Include the list of steps missing indicators in `blocker_reason`
+
+### 3. Verify No Default Mode
+
+Confirm that the plan does not document any "default dispatch mode" or "fallback dispatch" — every step must be explicit.
+
+**If any default/fallback dispatch documentation found:**
+1. Return `status: BLOCKED` with `reason: DEFAULT_DISPATCH_FOUND`
+
+### 4. Return PASS
+
+If all checks pass:
+- `status: DONE`
+- `finding_summary: "All steps have valid dispatch indicators. No prohibited modes found. {N} steps verified."`
+- `artifact_path: {project_root}/tmp/{issue-N}/verify/dispatch-mode-verification.yaml`
+
+## Verification
+
+- [ ] grep for `per-phase` in plan → absent
+- [ ] grep for `batched` in plan → absent
+- [ ] grep for `batch` in plan → absent
+- [ ] Every step matches `\(\*\*(inline|sub-agent|clean-room)\*\*\)` pattern
+- [ ] No step matches `\(\*\*(per-phase|batched)\*\*\)` pattern
+
+## Cross-References
+
+- `assemble-work.md` — Calls this gate before handoff to pipeline-executor
+- `pipeline-executor.md` — Requires this gate to have passed before execution
+- `SKILL.md` §Overview — Step-level dispatch mandate
+- `000-critical-rules.md` §critical-rules-034 — Clean-room sub-agent requirement

--- a/skills/implementation-pipeline/tasks/assemble-work.md
+++ b/skills/implementation-pipeline/tasks/assemble-work.md
@@ -1,0 +1,84 @@
+---
+name: assemble-work
+description: "Orchestrator entry point that reads the plan, creates per-item work state entries, validates dispatch indicators, and hands off to pipeline-executor for step-level execution."
+license: MIT
+provenance: AI-generated
+---
+
+# Assemble Work
+
+Orchestrator entry point for the implementation pipeline. Reads the approved plan, validates dispatch indicators, creates per-item work state entries, and hands off to the pipeline executor.
+
+## Entry Criteria
+
+- [ ] 1. Plan is approved (check `approved-for-*` label on spec issue)
+- [ ] 2. Plan has per-item steps with dispatch indicators (`(**inline**)`, `(**sub-agent**)`, `(**clean-room**)`)
+- [ ] 3. `authorization_scope >= for_implementation`
+
+## Procedure
+
+### 1. Read and Validate Plan
+
+1. Read the plan from `{plan_path}`
+2. Verify every step has an explicit dispatch indicator — no step may be missing `(**inline**)`, `(**sub-agent**)`, or `(**clean-room**)`
+3. Verify NO step uses `per-phase` or `batched` indicators — BLOCK if found with `reason: BATCHED_DISPATCH_NOT_ALLOWED`
+4. Count total steps: `N = len(steps)`
+
+### 2. Create Per-Item Work State
+
+Create per-item work state entries in `{project_root}/tmp/{issue-N}/work.md`:
+
+```yaml
+plan:
+  issue: "{issue-N}"
+  total_steps: {N}
+  authorization_scope: "{authorization_scope}"
+  halt_at: "{halt_at}"
+
+steps:
+  - step: 1
+    name: "{step_name}"
+    dispatch: "{inline|sub-agent|clean-room}"
+    status: pending
+    checkpoint_tag: ""
+    result_contract: ""
+  - step: 2
+    name: "{step_name}"
+    dispatch: "{inline|sub-agent|clean-room}"
+    status: pending
+    checkpoint_tag: ""
+    result_contract: ""
+  # ... one entry per step
+```
+
+### 3. Run Dispatch Mode Verification Gate
+
+Dispatch `dispatch-mode-verification` gate to verify:
+- No step uses `per-phase` or `batched` indicators
+- Every step has a valid dispatch indicator
+- Total step count matches plan
+
+Gate must return PASS before proceeding.
+
+### 4. Hand Off to Pipeline Executor
+
+1. Set `pipeline_phase = pipeline-executor`
+2. Append lifecycle event: `{event: assemble_work_complete, total_steps: N, status: PASS}`
+3. Return result contract with:
+   - `status: DONE`
+   - `artifact_path: {project_root}/tmp/{issue-N}/work.md`
+   - `step_count: N`
+
+## Verification
+
+- [ ] Every step in the plan has an explicit dispatch indicator — zero defaults
+- [ ] No `per-phase` or `batched` indicators present anywhere
+- [ ] Work state file has exactly N entries where N = total plan steps
+- [ ] Work state entries have correct `status: pending` initial state
+
+## Cross-References
+
+- `pipeline-executor.md` — Consumes the work state produced by this task
+- `enforcement/dispatch-mode-verification.md` — Dispatch mode verification gate
+- `SKILL.md` §Overview — Step-level dispatch mandate
+- `pre-flight-handoff.md` — Pre-flight verification that precedes assemble-work

--- a/skills/implementation-pipeline/tasks/pipeline-executor.md
+++ b/skills/implementation-pipeline/tasks/pipeline-executor.md
@@ -1,0 +1,79 @@
+---
+name: pipeline-executor
+description: "Per-item dispatch loop that reads plan steps sequentially and dispatches each step according to its dispatch indicator. The orchestrator processes inline steps directly and dispatches sub-agent/clean-room steps individually via task()."
+license: MIT
+provenance: AI-generated
+---
+
+# Pipeline Executor
+
+Step-level dispatch loop for the implementation pipeline. Reads the plan's steps sequentially, evaluates each step's dispatch indicator, and executes or dispatches accordingly.
+
+## Entry Criteria
+
+- [ ] 1. Plan is approved and available at `{plan_path}`
+- [ ] 2. Work state file exists at `{project_root}/tmp/{issue-N}/work.md` with per-item entries
+- [ ] 3. `authorization_scope >= for_implementation`
+- [ ] 4. Dispatch mode verification gate has passed (no `per-phase` or `batched` modes present)
+
+## Step-Level Dispatch Loop
+
+For each step in the plan (in sequential order):
+
+### 1. Read Step Dispatch Indicator
+
+Read the step's dispatch indicator from the plan:
+- `(**inline**)` — orchestrator executes the step directly
+- `(**sub-agent**)` — orchestrator dispatches to a sub-agent with context via `task()`
+- `(**clean-room**)` — orchestrator dispatches to a sub-agent with routing metadata only via `task()`
+
+**Every step MUST declare an explicit dispatch indicator.** There is no default. If a step lacks a dispatch indicator, the orchestrator MUST BLOCK with `reason: MISSING_DISPATCH_INDICATOR`.
+
+### 2. Execute or Dispatch
+
+| Indicator | Action | Context Passed |
+|-----------|--------|----------------|
+| `(**inline**)` | Orchestrator executes the step directly | N/A — orchestrator context |
+| `(**sub-agent**)` | `task(subagent_type="general", prompt: "{step_description}")` with issue_number, plan_path, step_number, authorization_scope, halt_at | Full context |
+| `(**clean-room**)` | `task(subagent_type="general", prompt: "{step_description}")` with issue_number only | Routing metadata only |
+
+### 3. Per-Item Checkpoint
+
+After each step completes with status DONE:
+1. Create checkpoint tag: `git tag {parent}/checkpoint/{issue}/item-{step_number}` (exact format per git-workflow convention)
+2. Update work state: set `work.md` entry for this step to `status: completed`
+
+### 4. Per-Item Verification
+
+Before proceeding to the next step:
+1. If the step was executed inline: the orchestrator verifies the step's SCs directly
+2. If the step was dispatched via `task()`: verify the sub-agent's result contract has `status: DONE`
+3. On FAIL: remediate per the pipeline's remediation routing, then re-attempt the step
+
+### 5. Advance to Next Step
+
+- Update `pipeline_phase` to the next step number
+- Clear `todowrite` state for the current step
+- Continue loop from step 1
+
+## Completion
+
+When all steps have been processed:
+- [ ] 1. Verify all steps have `status: completed` in work state
+- [ ] 2. Verify checkpoint tags exist for all items
+- [ ] 3. Append lifecycle event: `{event: pipeline_complete, step_count: N, status: PASS}`
+- [ ] 4. Return result contract with `status: DONE` and `artifact_path`
+
+## Verification
+
+- [ ] gor step indicator is present and valid for every step
+- [ ] gor batch indicator never present — BLOCK on `per-phase` or `batched`
+- [ ] All checkpoint tags follow per-item pattern
+- [ ] Work state has one entry per step
+
+## Cross-References
+
+- `assemble-work.md` — Creates the work state and plan input
+- `SKILL.md` §Trigger Dispatch Table — `step-dispatch` row
+- `SKILL.md` §Overview — Step-level dispatch mandate
+- `enforcement/dispatch-mode-verification.md` — Dispatch mode verification gate


### PR DESCRIPTION
## Summary

Eliminates the phase-level batching modes (`sub-agent-with-context-dispatch`, `sub-agent-clean-room-dispatch`) from the `implementation-pipeline` skill and mandates **step-level dispatch only**.

## Changes

- **SKILL.md**: Overview, Persona, Trigger Dispatch Table rewritten to mandate step-level dispatch as the ONLY valid mode. Three-mode dispatch system (inline, sub-agent-with-context, sub-agent-clean-room) replaced with single `step-dispatch` row.
- **pipeline-executor.md** (new): Per-item dispatch loop — reads plan steps sequentially, dispatches each step independently per its `(**inline**)`, `(**sub-agent**)`, or `(**clean-room**)` indicator.
- **assemble-work.md** (new): Creates per-item work state entries, validates dispatch indicators, blocks on `per-phase`/`batched`.
- **dispatch-mode-verification.md** (new): Enforcement gate that rejects plans with eliminated dispatch modes or missing indicators.

## Root Cause

Phase-level batching dispatched multiple implementation items through a single sub-agent, violating the clean-room architecture and per-item TDD cycle mandate.

## Success Criteria

- SC-1/SC-2: No `per-phase` or `batched` in Trigger Dispatch Table or Invocation ✅
- SC-3: Dispatch table only shows per-step mode (`step-dispatch` row) ✅
- SC-4: `pipeline-executor.md` implements per-item dispatch loop ✅
- SC-5: `assemble-work.md` creates per-item work state entries ✅
- SC-7/SC-8/SC-9: Enforcement gate validates dispatch indicators, per-item checkpoint pattern, per-item work state ✅

Fixes https://github.com/michael-conrad/.opencode/issues/1894

🤖 Co-authored with AI: OpenCode (opencode/deepseek-v4-flash-free)