### PR TITLE
[SPEC-FIX] Add analytical artifact gate to writing-plans; conditionalize mandatory_remediation

Closes #1885, Closes #1886

### DIFF
--- a/guidelines/000-critical-rules.md
+++ b/guidelines/000-critical-rules.md
@@ -411,6 +411,10 @@ Professional engineers implement exactly what the spec defines — nothing more,
 Professional engineers inspect the codebase before writing a spec — live verification prevents assumptions. Amateurs spec from memory and training data — then wonder why the implementation doesn't fit the actual code.
 
 
+### [critical-rules-010] Plan Creation Without Analytical Artifacts — bypassing the artifact gate
+Professional engineers verify all 7 analytical artifacts exist before plan creation (blast-radius, concern-map, code-path-inventory, cross-cutting-matrix, interface-compatibility, state-analysis, testability-assessment). Amateurs skip artifact verification and produce plans disconnected from codebase reality — then wonder why every phase encounters a dependency or constraint the artifacts would have caught. The artifact gate is enforced at the writing-plans TDT entry, Entry Criteria, pre-plan-readiness task, and spec-to-plan handoff manifest. Skipping any of these gates means the plan was never structurally validated against the spec.
+
+
 ### [critical-rules-010] Implementing Stale or Superseded Specs
 Professional engineers check for superseding open issues before implementing — stale specs produce wasted work. Amateurs implement whatever spec they find first — then wonder why their output is obsolete before the PR is opened.
 

--- a/skills/audit/tasks/cross-validate.md
+++ b/skills/audit/tasks/cross-validate.md
@@ -352,7 +352,7 @@ self_corrections:
     corrected_verdict: FAIL
 dark_pattern_violations: []
 warnings: []
-mandatory_remediation: "Remit for mandatory remediation. Non-clean PASS requires full remediation before re-audit. Default assumption is FAIL unless 100% clean PASS with no caveats, concerns, or notes."
+mandatory_remediation: "Remit for mandatory remediation. Non-clean PASS requires full remediation before re-audit. Default assumption is FAIL unless 100% clean PASS with no caveats, concerns, or notes."  # Only present when overall_verdict == FAIL; null when PASS
 ```
 
 Create `{project_root}/tmp/{issue-N}/artifacts/` if needed (write tool creates implicitly). Use the `write` tool to persist the full YAML document.
@@ -374,8 +374,8 @@ overall_verdict: PASS|FAIL
 next_step: "proceed|remediate then re-audit"
 artifact_path: "{project_root}/tmp/{issue-N}/artifacts/pipeline-cross-validate-{STATUS}-{timestamp}.yaml"
 summary: "N SCs: X agreed, Y disagreed, Z evidence_type_mismatch"
-all_criteria_pass: false
-mandatory_remediation: "Remit for mandatory remediation. Non-clean PASS requires full remediation before re-audit. Default assumption is FAIL unless 100% clean PASS with no caveats, concerns, or notes."
+all_criteria_pass: false | true
+mandatory_remediation: "Remit for mandatory remediation..."  # Only present when overall_verdict == FAIL; null when PASS
 ```
 
 When self-corrections are present, `overall_verdict` MUST be FAIL. Any single self-correction in any criterion cascades to overall FAIL.
@@ -383,6 +383,10 @@ When self-corrections are present, `overall_verdict` MUST be FAIL. Any single se
 The `next_step` field:
 - `overall_verdict == PASS` → `next_step: "proceed"` (next pipeline continuation)
 - `overall_verdict == FAIL` → `next_step: "remediate then re-audit"` (orchestrator routes to recovery)
+
+The `mandatory_remediation` field:
+- `overall_verdict == FAIL` → `mandatory_remediation: "Remit for mandatory remediation..."` (signals orchestrator to enforce remediation before re-audit)
+- `overall_verdict == PASS` → `mandatory_remediation: null` (no remediation needed; orchestrator proceeds normally)
 
 ## Context Required
 

--- a/skills/writing-plans/SKILL.md
+++ b/skills/writing-plans/SKILL.md
@@ -38,6 +38,7 @@ This skill operates in the main repo directory (direct-branch mode). When `WORKT
 | User says / Context | Task | Dispatch | Context passed |
 |---------------------|------|----------|----------------|
 | "create plan" / "implementation plan" / "write plan" / "plan" / "draft plan" / "auto-create plan" / "gap-fill plan" | `create` | `sub-task` | {spec_issue_number, spec_body} |
+| | **Pre-check:** If `create` entry invoked, verify all 7 analytical artifacts exist in `.issues/{N}/` before dispatch. Missing artifact → route to corresponding HALT entry above. | | |
 | "retroactive" / "retroactive plan" / "backfill plan" | `retroactive` | `sub-task` | {spec_issue_number} |
 | "update plan" / "plan update" / "auto-update plan" / "revise plan" | `update` | `sub-task` | {spec_issue_number, plan_issue_number} |
 | "spec-to-plan" / "handoff to plan" | `handoffs/spec-to-plan` | `sub-task` | {spec_issue_number} |
@@ -98,6 +99,7 @@ This skill produces plans by dispatching pipeline steps to sub-agents. The orche
 
 - Spec is approved (check `approved-for-*` label)
 - Authorization scope is `for_plan` or above
+- All 7 analytical artifacts exist in `.issues/{N}/` (blast-radius, concern-map, code-path-inventory, cross-cutting-matrix, interface-compatibility, state-analysis, testability-assessment). Missing artifacts produce BLOCKED with `MISSING_SPEC_ARTIFACT`.
 
 ### Execution Model
 

--- a/skills/writing-plans/tasks/handoffs/spec-to-plan.md
+++ b/skills/writing-plans/tasks/handoffs/spec-to-plan.md
@@ -10,6 +10,7 @@ Verify spec structural completeness before plan creation begins. Runs as an entr
 - `.issues/{issue-N}/spec.md` or `{project_root}/{path}/.issues/{issue-N}/spec.md` exists
 - `.issues/{issue-N}/` or `{project_root}/{path}/.issues/{issue-N}/` directory exists
 - `.issues/{issue-N}/sc-summary.yaml` or `{project_root}/{path}/.issues/{issue-N}/sc-summary.yaml` exists and is valid YAML
+- All 7 analytical artifacts exist in `.issues/{issue-N}/`
 
 ## Exit Criteria
 
@@ -40,19 +41,32 @@ Verify spec structural completeness before plan creation begins. Runs as an entr
 3. Verify every SC-ID in `sc_coverage.phases[].sc_ids` is unique (no duplicates)
 4. Report parse errors or structural issues
 
-### Step 4: Validate Risk Traceability Cross-References
+### Step 4: Validate Analytical Artifacts
+
+1. Verify all 7 analytical artifacts exist in `.issues/{issue-N}/`:
+   - `blast-radius.md`
+   - `concern-map.md`
+   - `code-path-inventory.md`
+   - `cross-cutting-matrix.md`
+   - `interface-compatibility.md`
+   - `state-analysis.md`
+   - `testability-assessment.md`
+2. If any artifact missing: write preliminary BLOCKED manifest with `MISSING_SPEC_ARTIFACT`
+3. If all present: continue to Step 5
+
+### Step 5: Validate Risk Traceability Cross-References
 
 1. Read the spec's Risk Traceability table
 2. For each RISK-ID with a Verifying SC, verify the SC-ID exists in `sc-summary.yaml`
 3. Flag orphan RISK references (Verifying SC not in sc-summary)
 
-### Step 5: Validate Decision Ledger Contradictions
+### Step 6: Validate Decision Ledger Contradictions
 
 1. Read the spec's Decision Ledger
 2. Check for detected contradictions (from spec-auditor findings)
 3. If contradictions detected: write BLOCKED manifest with `DECISION_CONTRADICTION`
 
-### Step 6: Validate Decomposition Consistency
+### Step 7: Validate Decomposition Consistency
 
 1. Read the spec's decomposition classification (single-task or multi-phase)
 2. Read `sc-summary.yaml` phase bindings
@@ -60,7 +74,7 @@ Verify spec structural completeness before plan creation begins. Runs as an entr
 4. For multi-phase: verify SCs are distributed across phases with no orphan SCs
 5. Flag inconsistency between decomposition classification and SC-to-phase bindings
 
-### Step 7: Write Handoff Manifest
+### Step 8: Write Handoff Manifest
 
 Generate timestamp via `.opencode/tools/schema-version`. Store result in `$TIMESTAMP`.
 
@@ -79,6 +93,9 @@ checks:
     result: PASS | FAIL
     detail: "..."
   - check_id: YAML_VALIDATION
+    result: PASS | FAIL
+    detail: "..."
+  - check_id: ANALYTICAL_ARTIFACTS
     result: PASS | FAIL
     detail: "..."
   - check_id: RISK_CROSS_REFS

--- a/skills/writing-plans/tasks/pre-plan-readiness.md
+++ b/skills/writing-plans/tasks/pre-plan-readiness.md
@@ -9,12 +9,14 @@ Verify that the local spec file and feature branch exist before allowing plan cr
 - Spec file exists at `.issues/{N}/spec.md` or `{project_root}/{path}/.issues/{N}/spec.md`
 - Feature branch exists (not the trunk)
 - `local-issues sync` has been run
+- All 7 analytical artifacts exist in `.issues/{N}/`
 
 ## Exit Criteria
 
 - BLOCKED if spec file is missing
 - BLOCKED if feature branch is missing
 - BLOCKED if `local-issues sync` has not been run
+- BLOCKED if any analytical artifact is missing (returns `MISSING_SPEC_ARTIFACT`)
 - PASS if all prerequisites are met
 
 ## Procedure
@@ -25,4 +27,13 @@ Verify that the local spec file and feature branch exist before allowing plan cr
    - If missing or on the trunk: return `status: BLOCKED` with `reason: FEATURE_BRANCH_MISSING`
 3. Check `local-issues sync` has been run (verify `.issues/{N}/` directory is synced)
    - If not synced: return `status: BLOCKED` with `reason: LOCAL_ISSUES_NOT_SYNCED`
-4. Return `status: PASS` with `finding_summary: "All prerequisites met"`
+4. Verify all 7 analytical artifacts exist in `.issues/{N}/`:
+   - `blast-radius.md`
+   - `concern-map.md`
+   - `code-path-inventory.md`
+   - `cross-cutting-matrix.md`
+   - `interface-compatibility.md`
+   - `state-analysis.md`
+   - `testability-assessment.md`
+   - If any missing: return `status: BLOCKED` with `reason: MISSING_SPEC_ARTIFACT` and list the missing artifacts
+5. Return `status: PASS` with `finding_summary: "All prerequisites met"`


### PR DESCRIPTION
## Summary

Two SPEC-FIX changes on a stacked branch (2 commits, 1 PR):

**`.opencode#1885` — Artifact gate bypass escape hatch:** Plan creation now requires all 7 analytical artifacts to exist before proceeding. Enforced at 4 gates:
1. **SKILL.md TDT** — Pre-check note on "create plan" entry routes missing artifacts to HALT
2. **Entry Criteria** — Artifact presence is a prerequisite
3. **pre-plan-readiness.md** — Step 4 verifies all 7 artifacts; returns BLOCKED with `MISSING_SPEC_ARTIFACT`
4. **spec-to-plan.md** — New Step 4 validates artifacts; `ANALYTICAL_ARTIFACTS` check in manifest; Entry Criteria requires artifacts

**`.opencode#1886` — Conditional mandatory_remediation:** The `mandatory_remediation` field in cross-validate.md return contract is now `null` when `overall_verdict == PASS` and only populated when `overall_verdict == FAIL`. Sample template annotated with conditionality comment.

## Outcome

- Tool: `created`
- Branch: `feature/1885-1886-artifact-gate-close`
- Commits: 2 (one per issue)

Fixes https://github.com/michael-conrad/.opencode/issues/1885
Fixes https://github.com/michael-conrad/.opencode/issues/1886