### PR TITLE
Phase 10: add version-discovery and release-tagging behavioral tests

### DIFF
--- a/tests/behaviors/release-tagging.sh
+++ b/tests/behaviors/release-tagging.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# Behavioral test: release-tagging
+# See .opencode/tests/AGENTS.md for the test harness specification and paradigm.
+# This script is an artifact-only generator — it does NOT evaluate model output.
+# SC-24: release-promoter creates annotated tag with v prefix
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/helpers.sh"
+
+SCENARIO_NAME="release-tagging"
+SCENARIO_PROMPT="tag and create a release for v1.2.3"
+
+behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT"
+exit 0

--- a/tests/behaviors/version-discovery.sh
+++ b/tests/behaviors/version-discovery.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# Behavioral test: version-discovery
+# See .opencode/tests/AGENTS.md for the test harness specification and paradigm.
+# This script is an artifact-only generator — it does NOT evaluate model output.
+# SC-23: version-manager discovers versions in multiple file formats
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/helpers.sh"
+
+SCENARIO_NAME="version-discovery"
+SCENARIO_PROMPT="discover version strings in the project"
+
+behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT"
+exit 0


### PR DESCRIPTION
## Summary

Completes #1709 Phase 10 gap: adds 2 missing behavioral test scripts for version-manager and release-promoter skills.

## Changes

- `.opencode/tests/behaviors/version-discovery.sh` — new artifact-only generator (SC-23)
- `.opencode/tests/behaviors/release-tagging.sh` — new artifact-only generator (SC-24)

Both follow the `tests/behaviors/AGENTS.md` artifact-only generator paradigm: `behavior_run` + `exit 0`, no inline evaluation.

## Verification

- [x] Both scripts use the cross-reference header and artifact-only generator pattern
- [x] Both scripts source `helpers.sh` and call `behavior_run` with `exit 0`

## Fixes

Closes #1897 (together with michael-conrad/opencode-config#286)