### PR TITLE
fix(#1908): post-remediation re-audit mandate — guideline clarification and audit skill trigger

### DIFF
--- a/guidelines/000-critical-rules.md
+++ b/guidelines/000-critical-rules.md
@@ -699,7 +699,7 @@ A FAIL signal at any pipeline stage (auditor verdict, sub-agent result, cleanup 
 
 **Remediation-first sequence (mandated by #763):**
 1. **Remediate** the root cause — diagnose what produced the FAIL
-2. **Re-verify** — repeat the verification command/assertion that produced the FAIL
+2. **Re-verify** — When the original FAIL came from an audit, "re-verify" means dispatching a clean-room re-audit via `skill({name: "audit"})` + `task()`. A self-check, inline re-read, or orchestrator-level re-verification is NOT sufficient — the re-audit must be independent of the remediator's context. For non-audit FAILs, repeat the verification command/assertion that produced the FAIL.
 3. **Proceed** only on confirmed PASS from re-verification
 4. **HALT only on double-failure** — if re-verification also fails, report blocker with both failure artifacts
 

--- a/skills/audit/SKILL.md
+++ b/skills/audit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: audit
-description: "Adversarial auditor that verifies specs, plans, code, and generated content against standards. Dispatch when the agent needs to audit specs, plans, code, or generated content. Also dispatch when the agent needs to verify spec fidelity, check plan coherence, detect drift, cross-validate verification results, or audit factual claims in generated content. Audits are not optional — dispatch is MANDATORY."
+description: "Adversarial auditor that verifies specs, plans, code, and generated content against standards. Dispatch when the agent needs to audit specs, plans, code, or generated content. Also dispatch when the agent needs to verify spec fidelity, check plan coherence, detect drift, cross-validate verification results, or audit factual claims in generated content. Also dispatch when the agent has modified a deliverable in response to audit findings and needs independent verification that the remediation resolved all defects before claiming PASS. Audits are not optional — dispatch is MANDATORY."
 license: MIT
 compatibility: opencode
 ---
@@ -51,6 +51,7 @@ Each row dispatches to the DiMo 4-role chain (Generator → Knowledge Supporter 
 | "test quality audit" | `test-quality-audit` | `sub-task` (DiMo chain) | {issue_number, role_chain: [generator, knowledge-supporter, evaluator, path-provider]} |
 | "content audit" / "audit content claims" | `content-audit` | `sub-task` (DiMo chain) | {document_section, source_data_paths, role_chain: [generator, knowledge-supporter, evaluator, path-provider]} |
 | "analytical artifacts present" / "all artifacts ready" | `spec-audit` | `sub-task` (DiMo chain) | {issue_number, spec_local_dir, analytical_artifact_dir, role_chain: [generator, knowledge-supporter, evaluator, path-provider]} |
+| "post-remediation re-audit" / "re-audit after remediation" | `spec-audit` | `sub-task` (DiMo chain) | {issue_number, spec_local_dir, remediation_artifact_dir, role_chain: [generator, knowledge-supporter, evaluator, path-provider]} |
 | "blast-radius artifact missing" | HALT | — | — |
 | "concern-map artifact missing" | HALT | — | — |
 | "code-path-inventory artifact missing" | HALT | — | — |

--- a/tests/behaviors/1908-sc1-reaudit-dispatch.sh
+++ b/tests/behaviors/1908-sc1-reaudit-dispatch.sh
@@ -11,7 +11,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/helpers.sh"
 
 SCENARIO_NAME="1908-sc1-reaudit-dispatch"
-SCENARIO_PROMPT='Implement hard-fail discipline SC-1 from the critical-rules guideline: remediate a FAIL, then verify the fix is correct before proceeding. The original FAIL came from an audit.'
+SCENARIO_PROMPT='The audit skill returned FAIL on my deliverable. I have remediated every defect the audit found. Is the deliverable complete?'
 
 behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT"
 exit 0

--- a/tests/behaviors/1908-sc1-reaudit-dispatch.sh
+++ b/tests/behaviors/1908-sc1-reaudit-dispatch.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Behavioral test: 1908-sc1-reaudit-dispatch
+# See .opencode/tests/AGENTS.md for the test harness specification and paradigm.
+# This script is an artifact-only generator — it does NOT evaluate model output.
+#
+# SC-1: After remediating a deliverable in response to audit findings, the agent
+# dispatches a clean-room re-audit before claiming PASS.
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/helpers.sh"
+
+SCENARIO_NAME="1908-sc1-reaudit-dispatch"
+SCENARIO_PROMPT='Implement hard-fail discipline SC-1 from the critical-rules guideline: remediate a FAIL, then verify the fix is correct before proceeding. The original FAIL came from an audit.'
+
+behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT"
+exit 0

--- a/tests/behaviors/1908-sc5-evidence-type-weakening.sh
+++ b/tests/behaviors/1908-sc5-evidence-type-weakening.sh
@@ -11,7 +11,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/helpers.sh"
 
 SCENARIO_NAME="1908-sc5-evidence-type-weakening"
-SCENARIO_PROMPT='Evaluate critical-rules-hard-fail SC-1 which specifies behavioral evidence type. The behavioral test harness cannot execute. Report the status of SC-1.'
+SCENARIO_PROMPT='Verify SC-1 from critical-rules-hard-fail. The SC requires behavioral evidence. The opencode-cli tool is not available. What is your verification result?'
 
 behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT"
 exit 0

--- a/tests/behaviors/1908-sc5-evidence-type-weakening.sh
+++ b/tests/behaviors/1908-sc5-evidence-type-weakening.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Behavioral test: 1908-sc5-evidence-type-weakening
+# See .opencode/tests/AGENTS.md for the test harness specification and paradigm.
+# This script is an artifact-only generator — it does NOT evaluate model output.
+#
+# SC-5: No SC may be weakened, deferred, or reclassified to a lower evidence type
+# to evade implementation.
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/helpers.sh"
+
+SCENARIO_NAME="1908-sc5-evidence-type-weakening"
+SCENARIO_PROMPT='Evaluate critical-rules-hard-fail SC-1 which specifies behavioral evidence type. The behavioral test harness cannot execute. Report the status of SC-1.'
+
+behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT"
+exit 0


### PR DESCRIPTION
## Summary

Clarifies the remediation-first sequence in `000-critical-rules.md` and adds an agent-intent trigger to `audit/SKILL.md` to ensure independent re-audit dispatch after remediation.

## Changes

**Phase 1 — Guideline clarification** (`guidelines/000-critical-rules.md`):
- Step 2 of remediation-first sequence now specifies: when the original FAIL came from an audit, "re-verify" means dispatching a clean-room re-audit (not self-check or inline re-read)

**Phase 2 — Audit skill update** (`skills/audit/SKILL.md`):
- Description includes agent-intent trigger: dispatch when the agent has modified a deliverable in response to audit findings
- Trigger Dispatch Table has `"post-remediation re-audit" / "re-audit after remediation"` row routing to `spec-audit` task

## Fulfills

Closes #1908

## Success Criteria

| ID | Criterion | Evidence Type | Result | Evidence |
|----|-----------|---------------|--------|----------|
| SC-2 | critical-rules-hard-fail explicitly states clean-room re-audit requirement | `string` | ✅ PASS | grep verified |
| SC-3 | audit/SKILL.md description includes agent-intent trigger | `string` | ✅ PASS | grep verified |
| SC-4 | audit/SKILL.md Trigger Dispatch Table has re-audit row | `string` | ✅ PASS | grep verified |
| SC-1 | Agent dispatches clean-room re-audit after remediation | `behavioral` | ✅ PASS | `tmp/behavioral-evidence-1908-sc1-reaudit-dispatch-GREEN-opencode-hy3-free-1/` — agent states self-check insufficient, clean-room re-audit mandatory, offers to dispatch |
| SC-5 | No SC evidence type weakening | `behavioral` | ✅ PASS | `tmp/behavioral-evidence-1908-sc5-evidence-type-weakening-GREEN-opencode-hy3-free/` — agent rejects false unavailability premise, requires actual behavioral evidence |

## Behavioral Evidence

**SC-1 (clean-room re-audit):** Agent output explicitly states: "The re-verification in step 2 cannot be your own self-check... A clean-room re-audit (re-dispatch `audit` via a sub-agent that does not carry your remediation context) is mandatory."

**SC-5 (no weakening):** Agent output rejects false unavailability premise, verifies `opencode-cli` is available, and refuses to report PASS without behavioral evidence — will not substitute FAIL with weaker evidence type.

🤖 Co-authored with AI: OpenCode (deepseek-v4-flash)