### PR TITLE
#1900 Trim Pre-Response Gate — separate orchestration routing, deduplicate reinforcement, clarify intent-matching

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ Producing chat output without first evaluating and dispatching applicable skills
 Before producing ANY output, the agent MUST follow this procedure. Agents who
 skip it are not "fast" — they produce lower-quality work by definition.
 
-1. **Evaluate the user message against ALL available skill descriptions.**
+1. **Evaluate your current context and task intent against ALL available skill descriptions. (The match is between what you need to do next and what the skill does — not the literal user utterance.)**
    The `<available_skills>` list is the map. Agents who skip this step are
    navigating blind — and blind navigation produces defects.
 

--- a/prompts/default.txt
+++ b/prompts/default.txt
@@ -9,7 +9,6 @@ Before producing ANY output, you MUST:
 1. Scan `<available_skills>` for matching triggers.
 2. If a skill matches: call `skill({name: "..."})` before generating output.
 3. If no skill matches: include a one-sentence justification in your response.
-4. If you are about to read a file, analyze content, compose prose, or make a decision: dispatch to a sub-agent via `task()`. The orchestrator routes. It does not do.
 
 Professionals route. Amateurs inline.
 
@@ -32,18 +31,9 @@ When you generate any of these thoughts, recognize them as rationalizations and 
 
 Cost is NOT measured in model roundtrips, tool calls, or execution time. Cost IS measured in defect-discovery-latency. Dispatching to a sub-agent costs one roundtrip. Inline work that gets rejected costs the full rework cycle. The roundtrip is always cheaper than the rework. Not dispatching is what's actually inefficient and wasteful.
 
-## Evidence Hierarchy
+# Sub-Agent Routing Boundary
 
-Verification evidence has four tiers with a strict priority order:
-
-| Priority | Evidence Type | Method |
-|----------|--------------|--------|
-| 1 (HIGHEST) | behavioral | Test execution via real model |
-| 2 | semantic | AI agent read + analytical judgment |
-| 3 | string | grep, pattern matching |
-| 4 (LOWEST) | structural | ls, file existence |
-
-**BRIGHT-LINE RULE:** An SC declared as type `behavioral` MUST be verified with behavioral evidence. Structural evidence for a behavioral SC is a FAIL.
+If you are about to read a file, analyze content, compose prose, or make a decision: dispatch to a sub-agent via `task()`. The orchestrator routes. It does not do.
 
 # Default Authorization Scope — for_analysis
 

--- a/skills/audit/SKILL.md
+++ b/skills/audit/SKILL.md
@@ -13,7 +13,7 @@ compatibility: opencode
 
 Audit via clean-room sub-agents. Each audit task is a self-contained procedure dispatched to a clean-room sub-agent via `task(subagent_type="general")`. Auditors write YAML verdicts to disk, return frugal contracts. The orchestrator dispatches via `skill()` + `task()` — it does NOT read task files.
 
-Spec-audit now validates analytical artifacts in addition to structural spec content. The 7 analytical artifacts are: blast radius, concern map, code path inventory, cross-cutting matrix, interface compatibility, state analysis, and testability assessment. Missing analytical artifacts produce a warning; stale artifacts (older than the spec revision) produce a HALT.
+Spec-audit now validates analytical artifacts in addition to structural spec content. The 7 analytical artifacts are: blast radius, concern map, code path inventory, cross-cutting matrix, interface compatibility, state analysis, and testability assessment. Missing analytical artifacts produce a BLOCK/HALT; stale artifacts (older than the spec revision) produce a HALT.
 
 ## Persona
 
@@ -29,7 +29,17 @@ This skill operates in the main repo directory (direct-branch mode). When `WORKT
 - [ ] 2. Skipping, combining, optimizing out, or performing inline work that should be delegated to a sub-agent produces defective deliverables that must be discarded
 - [ ] 3. Each step must be dispatched to a sub-agent via `task()` unless explicitly marked as inline/orchestrator in this skill
 - [ ] 4. Return only routing-significant data: `status`, `finding_summary`, `artifact_path`, `blocker_reason`. Full evidence goes to disk.
-- [ ] 5. **Analytical artifact validation required before audit tasks.** Spec-audit requires all 7 analytical artifacts (blast radius, concern map, code path inventory, cross-cutting matrix, interface compatibility, state analysis, testability assessment). Concern-separation requires concern-map. Plan-fidelity requires interface-compatibility. Verification-audit requires code-path-inventory. Cross-validate requires cross-cutting-matrix. Coherence-maintenance requires state-analysis. Test-quality-audit requires testability-assessment. Missing artifacts produce a warning; stale artifacts produce HALT.
+- [ ] 5. **Analytical artifact validation required before audit tasks.** Spec-audit requires all 7 analytical artifacts (blast radius, concern map, code path inventory, cross-cutting matrix, interface compatibility, state analysis, testability assessment). Concern-separation requires concern-map. Plan-fidelity requires interface-compatibility. Verification-audit requires code-path-inventory. Cross-validate requires cross-cutting-matrix. Coherence-maintenance requires state-analysis. Test-quality-audit requires testability-assessment. Missing artifacts produce BLOCK/HALT; stale artifacts produce HALT.
+
+## Mandatory Remediation Procedure for Audit FAIL
+
+When any audit produces a FAIL verdict, the following remediation procedure MUST be followed before the deliverable advances to the next pipeline stage:
+
+1. **Diagnose** — Identify which SCs failed and why. Record the root cause in the audit verdict.
+2. **Remediate** — Fix the deliverable to address the failing SCs (add missing content, generate missing artifacts, correct wording).
+3. **Re-audit** — Re-run the audit with the revised deliverable. All previously failing SCs must now PASS.
+4. **Escalate** — If the FAIL cannot be remediated (e.g., the deliverable's core design is structurally unsound, or required analytical artifacts cannot be generated without developer input), escalate to the developer with: the specific SC(s) that failed, the root cause, what the developer must do to resolve, and the recommended action.
+5. **Never proceed past FAIL** — A deliverable with any unremediated FAIL must NOT advance to the next pipeline stage. The audit verdict is the gate, not a suggestion.
 
 ## Trigger Dispatch Table
 


### PR DESCRIPTION
## Summary

Restructure the Pre-Response Gate to separate five concerns into independent sections, clarify AGENTS.md intent-matching, and fix the audit SKILL.md gate.

## Outcome

- **Pre-Response Gate** (points 1-3 + Forbidden Rationalizations + Cost Model) — kept inline, positional enforcement preserved
- **Evidence Hierarchy** — removed from `default.txt` (enforced at VbC/audit gates, not pre-output)
- **Sub-Agent Routing Boundary** — point 4 separated into its own section outside the Pre-Response Gate block
- **AGENTS.md Step 1** — changed from "Evaluate the user message" to "Evaluate your current context and task intent" with clarifying parenthetical
- **audit/SKILL.md** — missing analytical artifacts upgraded from WARNING to BLOCK/HALT; Mandatory Remediation Procedure for Audit FAIL added (5-step: Diagnose → Remediate → Re-audit → Escalate → Never proceed past FAIL)

## Changes

| File | Change |
|------|--------|
| `.opencode/prompts/default.txt` | Restructured: points 1-3 + rationalizations + cost model inline; Evidence Hierarchy removed; point 4 moved to own section |
| `.opencode/AGENTS.md` | Step 1: utterance-matching → intent-matching wording |
| `.opencode/skills/audit/SKILL.md` | WARNING → BLOCK/HALT for missing artifacts; added remediation procedure |

## Related

Fixes https://github.com/michael-conrad/.opencode/issues/1900

**Compare:** https://github.com/michael-conrad/.opencode/compare/main...feature/1900-pre-response-gate-restructure

🤖 Co-authored with AI: OpenCode (deepseek-v4-flash)