### PR TITLE
Add cross-reference load directive mandate to default.txt and AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -298,6 +298,16 @@ When parent issue has sub-issues, authorization cascades to ALL sub-issues:
 
 ---
 
+## Cross-Reference Load Directive — MANDATORY
+
+When a guideline or skill file references another file or skill, the reference is a load directive, not a citation:
+
+1. "See `FILENAME.md` §SECTION" or "See `SKILLNAME` skill" — This is a load directive. The text before "see" is a summary. The complete rule lives at the referenced location. Search your context for the referenced section before acting on the rule. Do not treat the summary as the complete rule.
+
+2. "Read [Text](path)" — This is an instruction to call `read` on that path. The referenced content is not pre-loaded in your context. Follow the link to get the complete rule.
+
+---
+
 ## editor MCP Plugin
 
 This repo uses [editor](https://github.com/michael-conrad/viewport-editor) as its editing MCP server.

--- a/prompts/default.txt
+++ b/prompts/default.txt
@@ -31,6 +31,14 @@ When you generate any of these thoughts, recognize them as rationalizations and 
 
 Cost is NOT measured in model roundtrips, tool calls, or execution time. Cost IS measured in defect-discovery-latency. Dispatching to a sub-agent costs one roundtrip. Inline work that gets rejected costs the full rework cycle. The roundtrip is always cheaper than the rework. Not dispatching is what's actually inefficient and wasteful.
 
+## Cross-Reference Load Directive — MANDATORY
+
+When a guideline or skill file references another file or skill, the reference is a load directive, not a citation:
+
+1. "See \`FILENAME.md\` §SECTION" or "See \`SKILLNAME\` skill" — This is a load directive. The text before "see" is a summary. The complete rule lives at the referenced location. Search your context for the referenced section before acting on the rule. Do not treat the summary as the complete rule.
+
+2. "Read [Text](path)" — This is an instruction to call \`read\` on that path. The referenced content is not pre-loaded in your context. Follow the link to get the complete rule.
+
 # Sub-Agent Routing Boundary
 
 If you are about to read a file, analyze content, compose prose, or make a decision: dispatch to a sub-agent via `task()`. The orchestrator routes. It does not do.


### PR DESCRIPTION
## Summary

Adds the cross-reference load directive mandate to system prompt and project instructions per SPEC #1923.

## Changes

- **`.opencode/prompts/default.txt`**: Added `## Cross-Reference Load Directive — MANDATORY` section after Cost Model. Defines that `See \`FILENAME.md\` §SECTION` and `See \`SKILLNAME\` skill` are load directives (not citations).
- **`.opencode/AGENTS.md`**: Added identical `## Cross-Reference Load Directive — MANDATORY` section before Editor MCP Plugin section.

## Fixes

Closes #1923

## Verification

- SC-1: default.txt contains the mandate — confirmed via file read
- SC-2: AGENTS.md contains the mandate — confirmed via file read
- SC-3: No guideline files modified — confirmed via `git diff`