### PR TITLE
Remove dead BEHAVIOR_TIMEOUT variable from helpers.sh error messages

### DIFF
--- a/tests-v2/behaviors/helpers.sh
+++ b/tests-v2/behaviors/helpers.sh
@@ -338,14 +338,13 @@ behavior_run() {
             exit_code=1
         else
             echo "HARNESS_FAILURE: behavior_run produced empty output after all retries"
-            echo "  BEHAVIOR_TIMEOUT=$BEHAVIOR_TIMEOUT, BEHAVIOR_MODEL=$model"
-            echo "  stdout: empty, stderr word count: $(wc -w < "$err_file" 2>/dev/null || echo 0)"
+            echo "  model=$model, stderr word count: $(wc -w < "$err_file" 2>/dev/null || echo 0)"
             echo "HARNESS_FAILURE: empty output" >> "$output_file"
             exit_code=1
         fi
     elif [ "${word_count:-0}" -le 3 ]; then
-        echo "  NOTE: behavior_run produced short output (${word_count} words). Consider increasing BEHAVIOR_TIMEOUT if this is unexpected."
-        echo "  BEHAVIOR_TIMEOUT=$BEHAVIOR_TIMEOUT, BEHAVIOR_MODEL=$model"
+        echo "  NOTE: behavior_run produced short output (${word_count} words). Consider increasing the bash tool timeout if this is unexpected."
+        echo "  model=$model"
     fi
 
     sleep 1


### PR DESCRIPTION
## Summary

Remove the dead `BEHAVIOR_TIMEOUT` variable from two error messages in `tests-v2/behaviors/helpers.sh`.

## Problem

`BEHAVIOR_TIMEOUT` was referenced on lines 341 and 348 but never defined, never assigned, and never passed to `opencode run`. It controlled nothing and only surfaced as a crash when `set -u` hit it during error reporting, obscuring the real error (empty model output).

## Fix

- Line 341: Removed `BEHAVIOR_TIMEOUT=$BEHAVIOR_TIMEOUT,` from the empty-output error message. Kept model name and stderr word count for diagnosis.
- Line 348: Removed the entire `BEHAVIOR_TIMEOUT` line. Replaced the advisory message to reference "bash tool timeout" instead of the dead variable.

## Verification

```
grep -rn "BEHAVIOR_TIMEOUT" .opencode/tests-v2/
# zero matches
```

Closes #1954

🤖 Co-authored with AI: OpenCode (deepseek-v4-flash)