### PR TITLE
Change default test model from gpt-oss:20b-cloud to qwen3.6:35b-256k

### DIFF
--- a/tests-v2/default-model.sh
+++ b/tests-v2/default-model.sh
@@ -1,4 +1,4 @@
 # Default model for all opencode test runs.
 # Override: DEFAULT_TEST_MODEL=custom-model
 # Single source of truth — do not embed model strings elsewhere.
-DEFAULT_TEST_MODEL="${DEFAULT_TEST_MODEL:-ollama/gpt-oss:20b-cloud}"
+DEFAULT_TEST_MODEL="${DEFAULT_TEST_MODEL:-ollama/qwen3.6:35b-256k}"


### PR DESCRIPTION
## Summary

Change `DEFAULT_TEST_MODEL` in `tests-v2/default-model.sh` from `ollama/gpt-oss:20b-cloud` (cloud) to `ollama/qwen3.6:35b-256k` (local).

## Problem

`gpt-oss:20b-cloud` is a cloud model that hits rate limits during behavioral test runs, causing tests to fail with `Too Many Requests` errors. The default model should be a local model that is always available.

## Testing

Both `qwen3.6:35b-256k` and `ornith:35b-256k` were tested with the same Read-link experiment:
- **qwen3.6:35b-256k**: More thorough — dispatched `approval-gate-scope` skill, produced detailed analysis. ~4 min runtime.
- **ornith:35b-256k**: Faster — used direct tool calls. ~3 min runtime.

qwen3.6:35b-256k is the better default for behavioral test runs due to more thorough agent behavior.

## Change

Single line in `tests-v2/default-model.sh`:
```
-DEFAULT_TEST_MODEL="${DEFAULT_TEST_MODEL:-ollama/gpt-oss:20b-cloud}"
+DEFAULT_TEST_MODEL="${DEFAULT_TEST_MODEL:-ollama/qwen3.6:35b-256k}"
```

Closes #1956

🤖 Co-authored with AI: OpenCode (deepseek-v4-flash)