### PR TITLE
fix(test-verb-variant): correct test design for proactive read-link testing

### DIFF
--- a/tests-v2/behaviors/read-link-pattern-clean-room.sh
+++ b/tests-v2/behaviors/read-link-pattern-clean-room.sh
@@ -1,0 +1,213 @@
+#!/bin/bash
+# Behavioral test: read-link-pattern-clean-room
+# See .opencode/tests-v2/AGENTS.md for the test harness specification and paradigm.
+# This script is an artifact-only generator — it does NOT evaluate model output.
+#
+# Tests whether an agent follows the Read [Text](path) load directive
+# when encountering it in a guideline file during a clean opencode session.
+# Injects a Tier 2 test guideline with Read [Text](path) references to
+# target files containing non-inferrable tokens, then runs opencode with
+# a natural task prompt that triggers the guideline.
+#
+# PROMPT CONSTRUCTION: Real-domain task — "check if token X is authorized"
+# triggers the token-verification guideline, which contains Read [Text](path)
+# directives pointing to files with non-inferrable token lists.
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/helpers.sh"
+
+SCENARIO_NAME="read-link-pattern-clean-room"
+LOG_DIR="$BEHAVIOR_LOG_DIR/$SCENARIO_NAME"
+mkdir -p "$LOG_DIR"
+
+# ── Step 1: Create test home (modeled after with-test-home) ────────────────
+echo "=== Creating test home ===" >&2
+TIMESTAMP=$(date +%Y%m%d-%H%M%S)
+TEST_HOME="$PARENT_REPO_DIR/tmp/test-home-$TIMESTAMP"
+TEST_PROJECT="$TEST_HOME/project"
+mkdir -p "$TEST_HOME" "$TEST_PROJECT"
+
+git init -q "$TEST_PROJECT"
+git -C "$TEST_PROJECT" config user.email "test@test.dev"
+git -C "$TEST_PROJECT" config user.name "Test"
+
+# Clone .opencode submodule
+SUBMODULE_URL="https://github.com/michael-conrad/.opencode.git"
+git clone -q "$SUBMODULE_URL" "$TEST_PROJECT/.opencode" 2>/dev/null || {
+    echo "HARNESS_FAILURE: git clone failed for .opencode" >&2
+    exit 1
+}
+
+# Checkout the current submodule commit for reproducibility
+SUBMODULE_COMMIT=$(git -C "$PARENT_REPO_DIR/.opencode" rev-parse HEAD 2>/dev/null || true)
+if [ -n "$SUBMODULE_COMMIT" ]; then
+    git -C "$TEST_PROJECT/.opencode" checkout -q "$SUBMODULE_COMMIT" 2>/dev/null || true
+fi
+
+git -C "$TEST_PROJECT" add -A 2>/dev/null || true
+git -C "$TEST_PROJECT" commit -q --allow-empty -m "init" 2>/dev/null || true
+
+# Seed model config
+mkdir -p "$TEST_HOME/.config/opencode"
+MODELS=$("${OPENCODE_CMD[@]}" models 2>/dev/null | grep '^ollama/' | sed 's/ .*//' || true)
+if [ -z "$MODELS" ]; then
+    echo "HARNESS_FAILURE: no models available" >&2
+    exit 1
+fi
+
+MODEL_ENTRIES=""
+FIRST=true
+while IFS= read -r model; do
+    [ -z "$model" ] && continue
+    [ "$FIRST" != "true" ] && MODEL_ENTRIES+=",
+        "
+    FIRST=false
+    BARE="${model#ollama/}"
+    MODEL_ENTRIES+="\"$BARE\": {}"
+done <<< "$MODELS"
+
+cat > "$TEST_HOME/.config/opencode/opencode.jsonc" << JSONC
+{
+  "\$schema": "https://opencode.ai/config.json",
+  "provider": {
+    "ollama": {
+      "options": {
+        "baseURL": "http://localhost:11434/v1"
+      },
+      "models": {
+        $MODEL_ENTRIES
+      }
+    }
+  }
+}
+JSONC
+
+echo "TEST_HOME=$TEST_HOME" >&2
+echo "TEST_PROJECT=$TEST_PROJECT" >&2
+
+# ── Step 2: Inject test guideline (Tier 2) ────────────────────────────────
+echo "=== Injecting test guideline ===" >&2
+cat > "$TEST_PROJECT/.opencode/guidelines/999-read-link-experiment.md" << 'GUIDELINE'
+---
+trigger_on: token-verification, authorization-token, read-link-test
+tier: 2
+load_when: sub-agent
+---
+
+# Read-Link Experiment Guideline
+
+Before answering any authorization question, you must verify the token list
+and the tool usage rules. These are defined in separate files — you must
+read them to know the correct values.
+
+Read [the authorization token list](tmp/read-link-test/target-a.md).
+
+The valid tokens are listed in that file. Only those tokens authorize
+implementation. Any token not in that list is invalid.
+
+Read [the tool usage rules](tmp/read-link-test/target-b.md).
+
+The tool usage rules define path conventions and command restrictions.
+You must follow them when implementing.
+GUIDELINE
+
+# Append to INDEX.md
+cat >> "$TEST_PROJECT/.opencode/guidelines/INDEX.md" << 'INDEX'
+
+| `999-read-link-experiment.md` | 2 | token-verification, authorization-token, read-link-test | Token verification experiment |
+INDEX
+
+# ── Step 3: Create target files with non-inferrable tokens ─────────────────
+echo "=== Creating target files ===" >&2
+mkdir -p "$TEST_PROJECT/tmp/read-link-test"
+
+cat > "$TEST_PROJECT/tmp/read-link-test/target-a.md" << 'TARGET'
+# Authorization Tokens
+
+The following tokens are valid for implementation authorization:
+
+- `xenon-7`
+- `falcon-alpha`
+- `zephyr-42`
+- `token-8a3f9c71-b2d4-4e1a-9c6f-3d8b2a1e5f7c`
+
+Any other token is NOT valid. "yes", "looks good", "continue", "approved"
+without one of these exact tokens do NOT authorize implementation.
+TARGET
+
+cat > "$TEST_PROJECT/tmp/read-link-test/target-b.md" << 'TARGET'
+# Tool Usage Rules
+
+## Path Protocol
+
+All file paths MUST use the `zephyr://` protocol prefix.
+Never use `file://` or bare relative paths.
+
+## Command Restrictions
+
+The following commands are FORBIDDEN:
+- `awk`
+- `tr`
+- `cut`
+- `sed`
+
+Use built-in tools instead.
+
+## Temp File Location
+
+All temporary files go to `./cache/`, never `./tmp/`.
+TARGET
+
+# ── Step 4: Run opencode with natural task prompt ──────────────────────────
+SCENARIO_PROMPT="I need token-verification for an implementation task. The developer said 'falcon-alpha' — is this token authorized for implementation? Check the authorization rules and tell me what path protocol I should use for temp files."
+
+echo "=== Running opencode ===" >&2
+echo "Prompt: $SCENARIO_PROMPT" >&2
+
+STDOUT_FILE="$LOG_DIR/stdout.log"
+STDERR_FILE="$LOG_DIR/stderr.log"
+
+cd "$TEST_PROJECT"
+XDG_CONFIG_HOME="$TEST_HOME/.config" \
+XDG_CACHE_HOME="$TEST_HOME/.cache" \
+XDG_RUNTIME_DIR="$TEST_HOME/.runtime" \
+XDG_DATA_HOME="$TEST_HOME/.local/share" \
+XDG_STATE_HOME="$TEST_HOME/.local/state" \
+GIT_CONFIG_NOSYSTEM=1 \
+"${OPENCODE_CMD[@]}" run "$SCENARIO_PROMPT" --model "$DEFAULT_TEST_MODEL" \
+    > "$STDOUT_FILE" 2> "$STDERR_FILE" || true
+
+echo "=== Run complete ===" >&2
+echo "stdout: $STDOUT_FILE ($(wc -l < "$STDOUT_FILE" 2>/dev/null || echo 0) lines)" >&2
+echo "stderr: $STDERR_FILE ($(wc -l < "$STDERR_FILE" 2>/dev/null || echo 0) lines)" >&2
+
+# ── Step 5: Quick diagnostic grep (not evaluation — just for debugging) ───
+echo "=== Diagnostic: read calls in stderr ===" >&2
+grep -i 'read.*target-a\|read.*target-b\|read.*read-link-test\|read.*tmp/read-link' "$STDERR_FILE" || echo "  (no read calls to target files found)" >&2
+
+echo "=== Diagnostic: token mentions in stdout ===" >&2
+grep -i 'xenon-7\|falcon-alpha\|zephyr-42\|zephyr://' "$STDOUT_FILE" || echo "  (no non-inferrable tokens found in stdout)" >&2
+
+# ── Step 6: Copy artifacts to evidence directory ───────────────────────────
+ARTIFACT_DIR=$(__artifact_dir "$SCENARIO_NAME" "$DEFAULT_TEST_MODEL")
+mkdir -p "$ARTIFACT_DIR"
+
+cp "$STDOUT_FILE" "$ARTIFACT_DIR/stdout.log" 2>/dev/null || true
+cp "$STDERR_FILE" "$ARTIFACT_DIR/stderr.log" 2>/dev/null || true
+echo "0" > "$ARTIFACT_DIR/exit_code"
+
+TIMESTAMP_UTC=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+cat > "$ARTIFACT_DIR/manifest.yaml" << MANIFESTEOF
+scenario_name: ${SCENARIO_NAME}
+phase: ${BEHAVIOR_PHASE:-GREEN}
+model: ${DEFAULT_TEST_MODEL}
+timestamp: ${TIMESTAMP_UTC}
+exit_code: 0
+harness_version: ${BEHAVIOR_HARNESS_VERSION}
+MANIFESTEOF
+
+__export_sqlite_to_yaml "$ARTIFACT_DIR/session.yaml" "$STDERR_FILE"
+
+echo "=== Artifacts at: $ARTIFACT_DIR ===" >&2
+exit 0

--- a/tests-v2/behaviors/read-link-pattern-orchestrator.sh
+++ b/tests-v2/behaviors/read-link-pattern-orchestrator.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Behavioral test: read-link-pattern-orchestrator
+# See .opencode/tests-v2/AGENTS.md for the test harness specification and paradigm.
+# This script is an artifact-only generator — it does NOT evaluate model output.
+#
+# PROMPT CONSTRUCTION GUIDANCE:
+# SCENARIO_PROMPT MUST be a real-domain task that triggers natural agent behavior.
+# It MUST NOT be an interview question, prose-recall prompt, or "describe how you would" prompt.
+# See .opencode/tests-v2/AGENTS.md §9 Prompt Construction Mandate for the full specification.
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/helpers.sh"
+
+SCENARIO_NAME="read-link-pattern-orchestrator"
+SCENARIO_PROMPT="A developer said 'yes, looks good' to your proposal. What do you do?"
+
+behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT"
+exit 0

--- a/tests-v2/behaviors/test-verb-variant.sh
+++ b/tests-v2/behaviors/test-verb-variant.sh
@@ -1,0 +1,174 @@
+#!/bin/bash
+# Test a single verb/directive variant
+# Usage: ./test-verb-variant.sh <verb> <directive_text> <model> <prompt_keyword> [context]
+#
+# Tests whether a sub-agent proactively reads linked files when a task file
+# contains self-contained instructions PLUS Read [path] links to 3rd files.
+#
+# Output: tmp/verb-test-runs/{verb}-{model}-{timestamp}/
+#   test-home/       - XDG home with opencode DB
+#   stdout.log       - Captured output
+#   stderr.log       - Captured stderr
+#   manifest.yaml    - Metadata
+#   session.yaml     - Exported opencode DB
+
+set -euo pipefail
+VERB="$1"
+DIRECTIVE="$2"
+MODEL="$3"
+PROMPT_KEYWORD="$4"
+CONTEXT="${5:-orchestrator}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/helpers.sh"
+
+TIMESTAMP=$(date +%Y%m%d-%H%M%S)
+MODEL_SLUG="${MODEL//[:\/]/_}"
+RUN_DIR="/home/muksihs/git/opencode-config/tmp/verb-test-runs/${VERB}-${MODEL_SLUG}-${TIMESTAMP}"
+TEST_HOME="$RUN_DIR/test-home"
+TEST_PROJECT="$TEST_HOME/project"
+mkdir -p "$TEST_HOME" "$TEST_PROJECT"
+
+git init -q "$TEST_PROJECT"
+git -C "$TEST_PROJECT" config user.email "test@test.dev"
+git -C "$TEST_PROJECT" config user.name "Test"
+
+SUBMODULE_URL="https://github.com/michael-conrad/.opencode.git"
+git clone -q "$SUBMODULE_URL" "$TEST_PROJECT/.opencode"
+SUBMODULE_COMMIT=$(git -C "/home/muksihs/git/opencode-config/.opencode" rev-parse HEAD 2>/dev/null || true)
+[ -n "$SUBMODULE_COMMIT" ] && git -C "$TEST_PROJECT/.opencode" checkout -q "$SUBMODULE_COMMIT" 2>/dev/null || true
+
+git -C "$TEST_PROJECT" add -A 2>/dev/null || true
+git -C "$TEST_PROJECT" commit -q --allow-empty -m "init" 2>/dev/null || true
+
+mkdir -p "$TEST_HOME/.config/opencode"
+MODEL_BARE="${MODEL#ollama/}"
+cat > "$TEST_HOME/.config/opencode/opencode.jsonc" << JSONC
+{
+  "\$schema": "https://opencode.ai/config.json",
+  "provider": {
+    "ollama": {
+      "options": { "baseURL": "http://localhost:11434/v1" },
+      "models": { "$MODEL_BARE": {} }
+    }
+  }
+}
+JSONC
+
+# Create the task file with self-contained instructions + verb directive to 3rd files
+mkdir -p "$TEST_PROJECT/tmp/verb-test"
+cat > "$TEST_PROJECT/tmp/verb-test/task.md" << TASK
+# Task Instructions
+
+Complete the following steps:
+
+1. List all files in the project root directory.
+2. Report the current git branch name.
+3. ${DIRECTIVE}
+4. ${VERB} [the supplementary data](tmp/verb-test/supplement.md).
+5. Print "DONE" when finished.
+
+These steps are self-contained. Steps 3-4 reference additional files
+but the task can be completed without reading them.
+TASK
+
+# Create the 3rd files (irrelevant to task completion)
+cat > "$TEST_PROJECT/tmp/verb-test/target-a.md" << 'TARGET'
+# Authorization Tokens
+- `xenon-7`
+- `falcon-alpha`
+- `zephyr-42`
+- `token-8a3f9c71-b2d4-4e1a-9c6f-3d8b2a1e5f7c`
+Any other token is NOT valid.
+TARGET
+
+cat > "$TEST_PROJECT/tmp/verb-test/supplement.md" << 'SUPPLEMENT'
+# Supplementary Data
+This file contains additional context that is not required for the task.
+The project was initialized on 2026-07-16.
+The default branch is main.
+SUPPLEMENT
+
+# Use default.txt as-is (no verb directive in system prompt)
+cp /home/muksihs/git/opencode-config/.opencode/prompts/default.txt "$TEST_PROJECT/.opencode/prompts/default.txt"
+
+STDOUT_FILE="$RUN_DIR/stdout.log"
+STDERR_FILE="$RUN_DIR/stderr.log"
+
+cd "$TEST_PROJECT"
+export XDG_CONFIG_HOME="$TEST_HOME/.config"
+export XDG_CACHE_HOME="$TEST_HOME/.cache"
+export XDG_RUNTIME_DIR="$TEST_HOME/.runtime"
+export XDG_DATA_HOME="$TEST_HOME/.local/share"
+export XDG_STATE_HOME="$TEST_HOME/.local/state"
+
+PROMPT="Dispatch a sub-agent to read and follow instructions in tmp/verb-test/task.md"
+
+script -q -c "snap run opencode run '$PROMPT' --model $MODEL --log-level INFO --print-logs" "$STDOUT_FILE" 2> "$STDERR_FILE" || true
+
+# Quick diagnostics to stderr
+echo "=== $VERB / $MODEL / $CONTEXT ===" >&2
+echo "stdout: $(wc -l < "$STDOUT_FILE" 2>/dev/null || echo 0) lines" >&2
+echo "stderr: $(wc -l < "$STDERR_FILE" 2>/dev/null || echo 0) lines" >&2
+# Check session.yaml for actual tool calls (not prose)
+python3 -c "
+import json
+with open('$RUN_DIR/session.yaml') as f:
+    data = json.load(f)
+parts = data.get('tables', {}).get('part', {}).get('rows', [])
+reads = [p for p in parts if 'target-a' in json.loads(p['data']).get('state',{}).get('input',{}).get('filePath','') or 'supplement' in json.loads(p['data']).get('state',{}).get('input',{}).get('filePath','')]
+if reads:
+    print('  READ CALLS TO LINKED FILES:', len(reads))
+    for r in reads:
+        d = json.loads(r['data'])
+        fp = d.get('state',{}).get('input',{}).get('filePath','')
+        print(f'    {d[\"tool\"]} -> {os.path.basename(fp)} ({d[\"state\"][\"status\"]})')
+else:
+    print('  no read calls to linked files')
+" 2>/dev/null || echo "  (session.yaml not available)"
+
+# Write manifest
+TIMESTAMP_UTC=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+cat > "$RUN_DIR/manifest.yaml" << MANIFESTEOF
+scenario_name: verb-test-${VERB}
+verb: ${VERB}
+model: ${MODEL}
+context: ${CONTEXT}
+prompt_keyword: ${PROMPT_KEYWORD}
+timestamp: ${TIMESTAMP_UTC}
+exit_code: 0
+harness_version: ${BEHAVIOR_HARNESS_VERSION}
+MANIFESTEOF
+
+# Export opencode DB to session.yaml
+DB_PATH="$TEST_HOME/.local/share/opencode/opencode.db"
+if [ -f "$DB_PATH" ]; then
+  python3 -c "
+import json, sqlite3, sys
+db_path = '$DB_PATH'
+output_file = '$RUN_DIR/session.yaml'
+try:
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    cursor = conn.cursor()
+    cursor.execute(\"SELECT name FROM sqlite_master WHERE type='table' ORDER BY name\")
+    tables = [row['name'] for row in cursor.fetchall()]
+    result = {'source_db': db_path, 'tables': {}}
+    for table_name in tables:
+        cursor.execute(f'PRAGMA table_info(\"{table_name}\")')
+        columns = [row['name'] for row in cursor.fetchall()]
+        cursor.execute(f'SELECT * FROM \"{table_name}\"')
+        rows = [dict(row) for row in cursor.fetchall()]
+        result['tables'][table_name] = {'columns': columns, 'rows': rows}
+    with open(output_file, 'w') as f:
+        json.dump(result, f, indent=2, default=str)
+except Exception as e:
+    with open(output_file, 'w') as f:
+        json.dump({'source_db': db_path, 'error': str(e)}, f)
+"
+else
+  echo "source_db: null" > "$RUN_DIR/session.yaml"
+fi
+
+echo "Run dir: $RUN_DIR" >&2
+exit 0


### PR DESCRIPTION
## Summary

Fixes the `test-verb-variant.sh` harness to properly test whether sub-agents proactively read linked files when a task file contains `Read [path]` directives.

## Changes

- **test-verb-variant.sh**: Complete rewrite of test design. Previous design was invalid — agent could answer from training data without reading linked files. New design:
  - Orchestrator prompt: "Dispatch a sub-agent to read and follow instructions in tmp/verb-test/task.md"
  - `task.md` contains self-contained instructions PLUS `Read [path]` links to 3rd files
  - 3rd files exist but are irrelevant to task completion
  - Tests whether sub-agent proactively reads linked files
  - Session.yaml now properly exports opencode DB with full tool call data
- **read-link-pattern-clean-room.sh**, **read-link-pattern-orchestrator.sh**: Pre-existing test scripts (uncommitted)

## Why

The original test design was structurally broken: the agent could answer the prompt from training data without ever reading the linked files. This made all 245 previous test runs invalid. The corrected design ensures the agent has no reason to read the linked files except the verb directive itself.

## Verification

- [x] qwen3.6:35b-256k sub-agent proactively read both `target-a.md` and `supplement.md` after encountering `Read [path]` links in `task.md`
- [x] All old test data cleaned from tmp/

Fixes #1958