### PR TITLE
feat(plugins): git binary resolution, submodule hooks, per-turn watchdog gate

### DIFF
--- a/plugins/env-loader.ts
+++ b/plugins/env-loader.ts
@@ -22,8 +22,36 @@
 import type { Plugin } from "@opencode-ai/plugin";
 import fs from "fs";
 import path from "path";
+import { execSync } from "child_process";
 
 const ENV_FILE = ".env";
+
+const GIT_FALLBACK_PATHS = [
+  "/usr/bin/git",
+  "/usr/local/bin/git",
+  "/snap/bin/git",
+];
+
+function resolveGitPath(): string | null {
+  // Try `which git` first (works in normal PATH environments)
+  try {
+    const whichResult = execSync("which git", { encoding: "utf8", timeout: 5000, stdio: ["pipe", "pipe", "pipe"] }).trim();
+    if (whichResult) return whichResult;
+  } catch {
+    // `which` failed — fall through to common paths
+  }
+  for (const candidate of GIT_FALLBACK_PATHS) {
+    if (fs.existsSync(candidate)) {
+      try {
+        execSync(`"${candidate}" --version`, { encoding: "utf8", timeout: 5000, stdio: ["pipe", "pipe", "pipe"] });
+        return candidate;
+      } catch {
+        continue;
+      }
+    }
+  }
+  return null;
+}
 
 interface PluginDiagnostic {
   source: string;
@@ -259,11 +287,16 @@ export const EnvLoaderPlugin: Plugin = async ({ project, client, $, directory, w
       }
 
       const GIT_CMD_TIMEOUT_MS = 5000;
+      const gitPath = resolveGitPath();
 
       async function gitCmd(cmd: string): Promise<{ exitCode: number; text: () => string } | null> {
+        if (!gitPath) {
+          console.error("[env-loader] git binary not found — skipping git operations");
+          return null;
+        }
         try {
           const result = await Promise.race([
-            $.nothrow()`${cmd}`,
+            $.nothrow()`${gitPath} ${cmd}`,
             new Promise<null>((_, reject) =>
               setTimeout(() => reject(new Error(`git command timed out: ${cmd}`)), GIT_CMD_TIMEOUT_MS)
             ),
@@ -275,7 +308,7 @@ export const EnvLoaderPlugin: Plugin = async ({ project, client, $, directory, w
       }
 
       try {
-        const branchResult = await gitCmd("git branch --show-current");
+        const branchResult = await gitCmd("branch --show-current");
         if (branchResult && branchResult.exitCode === 0) {
           const branch = branchResult.text().trim();
           if (branch) {
@@ -283,7 +316,7 @@ export const EnvLoaderPlugin: Plugin = async ({ project, client, $, directory, w
           }
         }
 
-        const remoteResult = await gitCmd("git remote get-url origin");
+        const remoteResult = await gitCmd("remote get-url origin");
         if (remoteResult && remoteResult.exitCode === 0) {
           const remoteUrl = remoteResult.text().trim();
 
@@ -314,7 +347,7 @@ export const EnvLoaderPlugin: Plugin = async ({ project, client, $, directory, w
           }
         }
 
-        const nameResult = await gitCmd("git config user.name");
+        const nameResult = await gitCmd("config user.name");
         if (nameResult && nameResult.exitCode === 0) {
           const name = nameResult.text().trim();
           if (name) {
@@ -322,7 +355,7 @@ export const EnvLoaderPlugin: Plugin = async ({ project, client, $, directory, w
           }
         }
 
-        const emailResult = await gitCmd("git config user.email");
+        const emailResult = await gitCmd("config user.email");
         if (emailResult && emailResult.exitCode === 0) {
           const email = emailResult.text().trim();
           if (email) {

--- a/plugins/session-enforcement.ts
+++ b/plugins/session-enforcement.ts
@@ -714,7 +714,7 @@ interface FrontmatterError {
  * Load skill descriptions from YAML frontmatter in SKILL.md files.
  * Adapted from obra/superpowers/plugins/superpowers.js skill discovery pattern.
  *
- * Description format: noun phrase identity with embedded "Dispatch when" clause.
+ * Description format: agent-intent statement with embedded "Load via skill() when" clause.
  * See .opencode/reference/skill-card-schema.md for the canonical schema.
  *
  * Returns { skills, errors } where errors collects frontmatter validation issues.

--- a/plugins/session-enforcement.ts
+++ b/plugins/session-enforcement.ts
@@ -31,6 +31,35 @@ import { execSync } from "child_process";
 
 const CACHE_TTL_MS = 5 * 60 * 1000;
 
+const GIT_FALLBACK_PATHS = [
+  "/usr/bin/git",
+  "/usr/local/bin/git",
+  "/snap/bin/git",
+];
+
+function resolveGitPath(): string | null {
+  // Try `which git` first (works in normal PATH environments)
+  try {
+    const whichResult = execSync("which git", { encoding: "utf8", timeout: 5000, stdio: ["pipe", "pipe", "pipe"] }).trim();
+    if (whichResult) return whichResult;
+  } catch {
+    // `which` failed — fall through to common paths
+  }
+  for (const candidate of GIT_FALLBACK_PATHS) {
+    if (fs.existsSync(candidate)) {
+      try {
+        execSync(`"${candidate}" --version`, { encoding: "utf8", timeout: 5000, stdio: ["pipe", "pipe", "pipe"] });
+        return candidate;
+      } catch {
+        continue;
+      }
+    }
+  }
+  return null;
+}
+
+const gitPath = resolveGitPath();
+
 interface GitConfigBaseline {
   configHash: string;
   localConfigHash: string;
@@ -85,13 +114,15 @@ function captureGitConfigBaseline(projectDir: string): GitConfigBaseline | null 
 
     let localConfigOutput = "";
     try {
-      localConfigOutput = execSync("git config --local --list", {
-        cwd: projectDir,
-        encoding: "utf8",
-        input: "",
-        timeout: 5000,
-        stdio: ["pipe", "pipe", "pipe"],
-      }).trim();
+      if (gitPath) {
+        localConfigOutput = execSync(gitPath + " config --local --list", {
+          cwd: projectDir,
+          encoding: "utf8",
+          input: "",
+          timeout: 5000,
+          stdio: ["pipe", "pipe", "pipe"],
+        }).trim();
+      }
     } catch {
       // No local config or git unavailable
     }
@@ -99,13 +130,15 @@ function captureGitConfigBaseline(projectDir: string): GitConfigBaseline | null 
 
     let remoteOutput = "";
     try {
-      remoteOutput = execSync("git remote -v", {
-        cwd: projectDir,
-        encoding: "utf8",
-        input: "",
-        timeout: 5000,
-        stdio: ["pipe", "pipe", "pipe"],
-      }).trim();
+      if (gitPath) {
+        remoteOutput = execSync(gitPath + " remote -v", {
+          cwd: projectDir,
+          encoding: "utf8",
+          input: "",
+          timeout: 5000,
+          stdio: ["pipe", "pipe", "pipe"],
+        }).trim();
+      }
     } catch {
       // No remotes or git unavailable
     }
@@ -296,8 +329,9 @@ const injectedFirstTurnSessions = new Set<string>();
 const sessionParentCache = new Map<string, string>();
 
 function resolveGitDir(projectDir: string): string | null {
+  if (!gitPath) return null;
   try {
-    const result = execSync("git rev-parse --git-dir", {
+    const result = execSync(gitPath + " rev-parse --git-dir", {
       cwd: projectDir,
       encoding: "utf8",
       input: "",
@@ -306,6 +340,48 @@ function resolveGitDir(projectDir: string): string | null {
     }).trim();
     if (path.isAbsolute(result)) return result;
     return path.resolve(projectDir, result);
+  } catch {
+    return null;
+  }
+}
+
+function getSubmodulePaths(projectDir: string): string[] {
+  if (!gitPath) return [];
+  try {
+    const result = execSync(gitPath + " submodule status", {
+      cwd: projectDir,
+      encoding: "utf8",
+      input: "",
+      timeout: 10000,
+      stdio: ["pipe", "pipe", "pipe"],
+    }).trim();
+    if (!result) return [];
+    return result.split("\n")
+      .filter(line => line.trim().length > 0 && !line.trim().startsWith("-"))
+      .map(line => line.trim().split(/\s+/)[1])
+      .filter(Boolean);
+  } catch {
+    return [];
+  }
+}
+
+function resolveSubmoduleGitDir(submodulePath: string, projectDir: string): string | null {
+  const gitPath = path.join(projectDir, submodulePath, ".git");
+  try {
+    if (!fs.existsSync(gitPath)) return null;
+    const stat = fs.statSync(gitPath);
+    if (stat.isDirectory()) {
+      return gitPath;
+    }
+    if (stat.isFile()) {
+      const content = fs.readFileSync(gitPath, "utf8").trim();
+      const match = content.match(/^gitdir:\s*(.+)$/);
+      if (match) {
+        const resolved = path.resolve(projectDir, submodulePath, match[1]);
+        return resolved;
+      }
+    }
+    return null;
   } catch {
     return null;
   }
@@ -359,6 +435,47 @@ function ensureHooksInstalled(projectDir: string): void {
     if (needsCopy) {
       fs.copyFileSync(sourcePath, targetPath);
       fs.chmodSync(targetPath, 0o755);
+    }
+  }
+
+  const submodulePaths = getSubmodulePaths(projectDir);
+  for (const submodulePath of submodulePaths) {
+    const submoduleGitDir = resolveSubmoduleGitDir(submodulePath, projectDir);
+    if (!submoduleGitDir) {
+      console.warn(`[session-enforcement] Could not resolve .git directory for submodule: ${submodulePath}`);
+      writeDiagnostic(projectDir, {
+        source: "session-enforcement",
+        level: "warning",
+        message: `Could not resolve .git directory for submodule: ${submodulePath}`,
+      });
+      continue;
+    }
+
+    const submoduleHooksTargetDir = path.join(submoduleGitDir, "hooks");
+    fs.mkdirSync(submoduleHooksTargetDir, { recursive: true });
+
+    for (const hookName of sourceEntries) {
+      const sourcePath = path.join(hooksSourceDir, hookName);
+      if (!fs.statSync(sourcePath).isFile()) continue;
+      if (hookName.endsWith(".sample")) continue;
+
+      const targetPath = path.join(submoduleHooksTargetDir, hookName);
+      let needsCopy = false;
+
+      if (!fs.existsSync(targetPath)) {
+        needsCopy = true;
+      } else {
+        const sourceContent = fs.readFileSync(sourcePath, "utf8");
+        const targetContent = fs.readFileSync(targetPath, "utf8");
+        if (sourceContent !== targetContent) {
+          needsCopy = true;
+        }
+      }
+
+      if (needsCopy) {
+        fs.copyFileSync(sourcePath, targetPath);
+        fs.chmodSync(targetPath, 0o755);
+      }
     }
   }
 }
@@ -751,9 +868,9 @@ export default async function sessionEnforcementPlugin(input: PluginInput): Prom
 
   // Capture git config baseline for mutation watchdog
   gitConfigBaseline = captureGitConfigBaseline(projectDir);
-  if (gitConfigBaseline) {
+  if (gitConfigBaseline && gitPath) {
     try {
-      baselineLocalConfig = execSync("git config --local --list", {
+      baselineLocalConfig = execSync(gitPath + " config --local --list", {
         cwd: projectDir,
         encoding: "utf8",
         input: "",
@@ -971,9 +1088,10 @@ export default async function sessionEnforcementPlugin(input: PluginInput): Prom
       }
 
       // --- Per-turn: Git config mutation watchdog ---
-      if (gitConfigBaseline) {
+      // Gated to first-turn-only: baseline captured at startup, comparison runs once.
+      if (isFirstTurn && gitConfigBaseline && gitPath) {
         try {
-          const currentLocalConfig = execSync("git config --local --list", {
+          const currentLocalConfig = execSync(gitPath + " config --local --list", {
             cwd: projectDir,
             encoding: "utf8",
             input: "",

--- a/skills/approval-gate-scope/SKILL.md
+++ b/skills/approval-gate-scope/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: approval-gate-scope
-description: "Dispatch when the agent needs to verify authorization scope, apply approval labels, handle spec revision revocation, or execute bug discovery protocol. Also dispatch when the agent needs to check approval state, enforce pipeline halt boundaries, or manage spec-to-plan cascade. Triggers when: agent determines authorization verification is needed, agent needs to apply or remove approved-for-* labels, agent detects a spec revision that revokes plan approval, agent discovers a bug during implementation."
+description: "Authorization scope verification and label management. Load via skill() when the agent needs to verify authorization scope, apply approval labels, handle spec revision revocation, or execute bug discovery protocol. Also load when checking approval state, enforcing pipeline halt boundaries, or managing spec-to-plan cascade. Authorization verification is REQUIRED before any implementation. User phrases: verify authorization, check approval, apply label, approved, go, authorization"
 license: MIT
 provenance: AI-generated
 ---

--- a/skills/approval-gate/SKILL.md
+++ b/skills/approval-gate/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: approval-gate
-description: "Authorization gatekeeper dispatcher that routes to approval-gate-scope sub-skill. Dispatch when the agent needs to verify authorization scope, apply approval labels, handle spec revision revocation, or execute bug discovery protocol. Also dispatch when the agent needs to check approval state, enforce pipeline halt boundaries, or manage spec-to-plan cascade. Triggers when: agent determines authorization verification is needed, agent needs to apply or remove approved-for-* labels, agent detects a spec revision that revokes plan approval, agent discovers a bug during implementation."
+description: "Authorization gatekeeper dispatcher that routes to approval-gate-scope sub-skill. Load via skill() when the agent needs to verify authorization scope, apply approval labels, handle spec revision revocation, or execute bug discovery protocol. Also load when checking approval state, enforcing pipeline halt boundaries, or managing spec-to-plan cascade. Authorization verification is REQUIRED before any implementation. User phrases: verify authorization, check approval, apply label, approved, go, authorization, spec revision, bug discovery"
 license: MIT
 compatibility: opencode
 provenance: AI-generated

--- a/skills/audit/SKILL.md
+++ b/skills/audit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: audit
-description: "Adversarial auditor that verifies specs, plans, code, and generated content against standards. Dispatch when the agent needs to audit specs, plans, code, or generated content. Also dispatch when the agent needs to verify spec fidelity, check plan coherence, detect drift, cross-validate verification results, or audit factual claims in generated content. Also dispatch when the agent has modified a deliverable in response to audit findings and needs independent verification that the remediation resolved all defects before claiming PASS. Audits are not optional — dispatch is MANDATORY."
+description: "Adversarial auditor that verifies specs, plans, code, and generated content against standards. Load via skill() when the agent needs to audit specs, plans, code, or generated content. Also load when verifying spec fidelity, checking plan coherence, detecting drift, cross-validating verification results, or auditing factual claims. Also load when a deliverable was modified in response to audit findings and needs independent re-verification. Audits are not optional — dispatch is MANDATORY. User phrases: audit spec, audit plan, audit code, verify fidelity, check coherence, detect drift, cross-validate"
 license: MIT
 compatibility: opencode
 ---

--- a/skills/brainstorming/SKILL.md
+++ b/skills/brainstorming/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: brainstorming
-description: "Requirements exploration and problem decomposition skill. Dispatch when creating a spec, planning a feature, or exploring requirements before implementation. Also dispatch when decomposing a problem into success criteria, extracting requirements, or documenting change control. Brainstorming is REQUIRED before spec creation — it is not optional"
+description: "Requirements exploration and problem decomposition. Load via skill() when creating a spec, planning a feature, or exploring requirements before implementation. Also load when decomposing a problem into success criteria, extracting requirements, or documenting change control. Brainstorming is REQUIRED before spec creation — it is not optional. User phrases: brainstorm, explore requirements, decompose problem, extract requirements, create spec"
 license: MIT
 compatibility: opencode
 ---

--- a/skills/changelog-generator/SKILL.md
+++ b/skills/changelog-generator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: changelog-generator
-description: "Release note and changelog generator for version-to-version change documentation. Dispatch when creating release notes, documenting changes between versions, or preparing a changelog. Also dispatch when comparing diffs between releases or generating structured version history. Changelog generation is REQUIRED before every release — not optional"
+description: "Release note and changelog generator for version-to-version change documentation. Load via skill() when creating release notes, documenting changes between versions, or preparing a changelog. Also load when comparing diffs between releases or generating structured version history. Changelog generation is REQUIRED before every release — not optional. User phrases: create changelog, generate release notes, document changes, version history"
 license: MIT
 compatibility: opencode
 ---

--- a/skills/completeness-gate/SKILL.md
+++ b/skills/completeness-gate/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: completeness-gate
-description: "Non-audit completeness gate that verifies deliverable covers all success criteria before routing to auditor. Dispatch when running a completeness check on a deliverable after RED/GREEN sub-agent returns, before routing to auditor. Also dispatch when verifying that a deliverable covers all success criteria from the spec. Completeness check is MANDATORY before routing to audit — not optional"
+description: "Non-audit completeness gate that verifies deliverable covers all success criteria before routing to auditor. Load via skill() when running a completeness check on a deliverable after RED/GREEN sub-agent returns, before routing to auditor. Also load when verifying that a deliverable covers all success criteria from the spec. Completeness check is MANDATORY before routing to audit — not optional. User phrases: check completeness, verify success criteria, pre-audit check"
 license: MIT
 compatibility: opencode
 ---

--- a/skills/completion-core/SKILL.md
+++ b/skills/completion-core/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: completion-core
-description: "Shared completion operations for skill task workflows including push, URL generation, lifecycle event append, and executive summary reporting. Dispatch when completing skill task workflows. Also dispatch when generating structured completion signals or appending lifecycle events to issue bodies. Completion signals MUST be clear and structured — always required"
+description: "Shared completion operations for skill task workflows including push, URL generation, lifecycle event append, and executive summary reporting. Load via skill() when completing skill task workflows. Also load when generating structured completion signals or appending lifecycle events to issue bodies. Completion signals MUST be clear and structured — always required. User phrases: complete task, push changes, generate URL, append lifecycle event, report summary"
 license: MIT
 compatibility: opencode
 ---

--- a/skills/conflict-resolution/SKILL.md
+++ b/skills/conflict-resolution/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: conflict-resolution
-description: "Git conflict resolver that analyzes intent, classifies tiers, and applies resolution strategies. Dispatch when resolving git conflicts during rebase, merge, or cherry-pick operations. Also dispatch when analyzing conflict intent, classifying conflict tiers, or applying resolution strategies. Intent analysis MUST be performed before resolution — always required"
+description: "Git conflict resolver that analyzes intent, classifies tiers, and applies resolution strategies. Load via skill() when resolving git conflicts during rebase, merge, or cherry-pick operations. Also load when analyzing conflict intent, classifying conflict tiers, or applying resolution strategies. Intent analysis MUST be performed before resolution — always required. User phrases: resolve conflict, merge conflict, rebase conflict, cherry-pick conflict, conflict analysis"
 license: MIT
 compatibility: opencode
 ---

--- a/skills/correspondence/SKILL.md
+++ b/skills/correspondence/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: correspondence
-description: "Stakeholder communication drafter for emails, status updates, and external correspondence. Dispatch when drafting stakeholder emails, status updates, or external communications. Also dispatch when analyzing audience context, maintaining audience separation, or generating structured correspondence. Audience separation MUST be maintained — always required. Internal audit findings and raw status updates go to chat only — never to stakeholder channels"
+description: "Stakeholder communication drafter for emails, status updates, and external correspondence. Load via skill() when drafting stakeholder emails, status updates, or external communications. Also load when analyzing audience context, maintaining audience separation, or generating structured correspondence. Audience separation MUST be maintained — always required. Internal audit findings and raw status updates go to chat only — never to stakeholder channels. User phrases: draft email, write status update, compose correspondence, stakeholder communication"
 license: MIT
 compatibility: opencode
 ---

--- a/skills/engineering-approach/SKILL.md
+++ b/skills/engineering-approach/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: engineering-approach
-description: "Engineering discipline enforcer that verifies design decisions, scope boundaries, and constraint compliance. Dispatch when implementing a spec, or when design, verification, and scope discipline are needed. Also dispatch when verifying design decisions against constraints, analyzing scope boundaries, or enforcing engineering discipline. Design, verification, and scope discipline are REQUIRED — not optional"
+description: "Engineering discipline enforcer that verifies design decisions, scope boundaries, and constraint compliance. Load via skill() when implementing a spec, or when design, verification, and scope discipline are needed. Also load when verifying design decisions against constraints, analyzing scope boundaries, or enforcing engineering discipline. Design, verification, and scope discipline are REQUIRED — not optional. User phrases: verify design, check scope, enforce discipline, engineering approach"
 license: MIT
 compatibility: opencode
 ---

--- a/skills/executing-plans/SKILL.md
+++ b/skills/executing-plans/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: executing-plans
-description: "Plan executor that dispatches each step to clean-room sub-agents and progresses through implementation gates. Dispatch when executing an approved plan step-by-step or moving through implementation gates sequentially. Also dispatch when dispatching each plan step to clean-room sub-agents for independent execution. Every step in the plan MUST be executed — skipping, combining, or reordering steps is not optional"
+description: "Plan executor that dispatches each step to clean-room sub-agents and progresses through implementation gates. Load via skill() when executing an approved plan step-by-step or moving through implementation gates sequentially. Also load when dispatching each plan step to clean-room sub-agents for independent execution. Every step in the plan MUST be executed — skipping, combining, or reordering steps is not optional. User phrases: execute plan, run implementation, dispatch steps, progress through gates"
 license: MIT
 compatibility: opencode
 ---

--- a/skills/finishing-a-development-branch/SKILL.md
+++ b/skills/finishing-a-development-branch/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: finishing-a-development-branch
-description: "Branch finishing gate that runs final checks, readiness verification, and pre-PR preparation. Dispatch when implementation is complete and branch needs final checks before PR. Also dispatch when running the finishing checklist, verifying branch readiness, or preparing for PR submission. Dispatch is MANDATORY — the prepare, checklist, and completion tasks are REQUIRED gates, not optional steps"
+description: "Branch finishing gate that runs final checks, readiness verification, and pre-PR preparation. Load via skill() when implementation is complete and branch needs final checks before PR. Also load when running the finishing checklist, verifying branch readiness, or preparing for PR submission. Dispatch is MANDATORY — the prepare, checklist, and completion tasks are REQUIRED gates, not optional steps. User phrases: finish branch, prepare for PR, run checklist, verify readiness, pre-PR checks"
 license: MIT
 compatibility: opencode
 ---

--- a/skills/git-workflow-branch/SKILL.md
+++ b/skills/git-workflow-branch/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: git-workflow-branch
-description: "Dispatch when the agent needs to create or manage feature branches, sync submodules, or verify provenance. Also dispatch when the agent needs to set up pair mode branches or resume pair mode sessions. Triggers when: agent determines a branch operation is needed, agent needs to sync submodules, agent needs to verify provenance, agent needs to set up pair mode."
+description: "Feature branch creation and management, submodule sync, and provenance verification. Load via skill() when the agent needs to create or manage feature branches, sync submodules, or verify provenance. Also load when setting up pair mode branches or resuming pair mode sessions. Branch creation is REQUIRED before any file modification. User phrases: create branch, manage branch, sync submodules, verify provenance, pair mode"
 license: MIT
 provenance: AI-generated
 ---

--- a/skills/git-workflow-cleanup/SKILL.md
+++ b/skills/git-workflow-cleanup/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: git-workflow-cleanup
-description: "Dispatch when the agent needs to clean up after a PR merge, check PR state, or handle pair mode cleanup. Also dispatch when the agent needs to verify merge status or close completed issues. Triggers when: agent determines cleanup is needed, agent needs to check PR state, agent needs to handle post-merge cleanup."
+description: "Post-merge cleanup, PR state verification, and issue closure. Load via skill() when the agent needs to clean up after a PR merge, check PR state, or handle pair mode cleanup. Also load when verifying merge status or closing completed issues. Cleanup is REQUIRED after every merge — not optional. User phrases: cleanup after merge, check PR state, close issues, post-merge cleanup"
 license: MIT
 provenance: AI-generated
 ---

--- a/skills/git-workflow-commit/SKILL.md
+++ b/skills/git-workflow-commit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: git-workflow-commit
-description: "Dispatch when the agent needs to commit changes or prepare commit messages. Also dispatch when the agent needs to implement changes and commit them, or handle pair mode commits. Triggers when: agent determines a commit is needed, agent needs to prepare commit messages, agent needs to implement and commit changes."
+description: "Change implementation and commit preparation. Load via skill() when the agent needs to commit changes or prepare commit messages. Also load when implementing changes and committing them, or handling pair mode commits. Commits MUST be atomic and well-described. User phrases: commit changes, prepare commit, implement and commit, pair mode commit"
 license: MIT
 provenance: AI-generated
 ---

--- a/skills/git-workflow-conflict/SKILL.md
+++ b/skills/git-workflow-conflict/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: git-workflow-conflict
-description: "Dispatch when the agent needs to resolve git conflicts during rebase, merge, or cherry-pick operations. Triggers when: agent determines a conflict resolution is needed, agent encounters a rebase conflict, agent needs to resolve merge conflicts."
+description: "Git conflict resolution during rebase, merge, or cherry-pick operations. Load via skill() when the agent needs to resolve git conflicts during rebase, merge, or cherry-pick operations. Conflict resolution MUST analyze intent before applying changes. User phrases: resolve conflict, rebase conflict, merge conflict, cherry-pick conflict"
 license: MIT
 provenance: AI-generated
 ---

--- a/skills/git-workflow-pr/SKILL.md
+++ b/skills/git-workflow-pr/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: git-workflow-pr
-description: "Dispatch when the agent needs to create pull requests, prepare reviews, or handle PR lifecycle completion. Also dispatch when the agent needs to handle pair mode PR creation or post-implementation tasks. Triggers when: agent determines a PR operation is needed, agent needs to prepare a review, agent needs to complete a PR lifecycle, agent needs to handle post-implementation tasks."
+description: "Pull request creation, review preparation, and PR lifecycle management. Load via skill() when the agent needs to create pull requests, prepare reviews, or handle PR lifecycle completion. Also load when handling pair mode PR creation or post-implementation tasks. Every PR MUST be an authorized, intentional delivery. User phrases: create PR, prepare review, complete PR lifecycle, pair mode PR"
 license: MIT
 provenance: AI-generated
 ---

--- a/skills/git-workflow/SKILL.md
+++ b/skills/git-workflow/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: git-workflow
-description: "Git branch, commit, push, and PR workflow dispatcher that routes to sub-skills. Dispatch when creating a branch, committing, pushing, or creating a PR. Also dispatch when handling rebase/merge conflicts, checking PR state and cleanup, or running provenance tracking. Triggers when: agent determines a branch operation is needed, agent needs to commit changes, agent needs to create a PR, agent needs to clean up after merge, agent encounters a rebase conflict."
+description: "Branch, commit, push, and PR workflow dispatcher that routes to sub-skills. Load via skill() when creating a branch, committing, pushing, or creating a PR. Also load when handling rebase/merge conflicts, checking PR state and cleanup, or running provenance tracking. Branch-and-PR discipline is REQUIRED — always follow the workflow. User phrases: create branch, commit, push, create PR, rebase, merge, check pr, check prs, cleanup, provenance"
 license: MIT
 compatibility: opencode
 provenance: AI-generated

--- a/skills/implementation-pipeline/SKILL.md
+++ b/skills/implementation-pipeline/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: implementation-pipeline
-description: "Implementation pipeline that dispatches stages to clean-room sub-agents, manages state, and handles remediation routing. Dispatch when executing an approved plan through the implementation pipeline. Also dispatch when dispatching pipeline stages to clean-room sub-agents, managing pipeline state, or handling remediation routing. MUST dispatch here after plan approval, before any file modification"
+description: "Implementation pipeline that dispatches stages to clean-room sub-agents, manages state, and handles remediation routing. Load via skill() when executing an approved plan through the implementation pipeline. Also load when dispatching pipeline stages to clean-room sub-agents, managing pipeline state, or handling remediation routing. MUST dispatch here after plan approval, before any file modification. User phrases: execute pipeline, dispatch stages, manage state, handle remediation"
 license: MIT
 compatibility: opencode
 ---

--- a/skills/issue-operations-comments/SKILL.md
+++ b/skills/issue-operations-comments/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: issue-operations-comments
-description: "Issue comment gating and posting skill that enforces the substantive comment gate. Dispatch when posting comments to issues or PRs. Also dispatch when checking whether comment content is substantive enough to post. Comment posting is gated by the substantiveness check — non-substantive progress updates MUST NOT be posted to GitHub Issues"
+description: "Issue comment gating and posting that enforces the substantive comment gate. Load via skill() when posting comments to issues or PRs. Also load when checking whether comment content is substantive enough to post. Comment posting is gated by the substantiveness check — non-substantive progress updates MUST NOT be posted to GitHub Issues. User phrases: post comment, check substantiveness, gate comment"
 license: MIT
 provenance: AI-generated
 ---

--- a/skills/issue-operations-core/SKILL.md
+++ b/skills/issue-operations-core/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: issue-operations-core
-description: "Core issue CRUD operations dispatcher that routes to GitHub MCP or GitBucket API based on github.platform. Dispatch when creating, reading, updating, closing, or listing issues. Also dispatch when editing issue bodies, verifying merge status, checking single-task plans, pushing spec artifacts, or running pre/post-creation validation. Issue tracking is REQUIRED"
+description: "Core issue CRUD operations that routes to GitHub MCP or GitBucket API based on github.platform. Load via skill() when creating, reading, updating, closing, or listing issues. Also load when editing issue bodies, verifying merge status, checking single-task plans, pushing spec artifacts, or running pre/post-creation validation. Issue tracking is REQUIRED. User phrases: create issue, read issue, update issue, close issue, list issues, edit body"
 license: MIT
 provenance: AI-generated
 ---

--- a/skills/issue-operations-sub-issues/SKILL.md
+++ b/skills/issue-operations-sub-issues/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: issue-operations-sub-issues
-description: "Sub-issue management skill for linking and reading sub-issues. Dispatch when creating sub-issues under parent plan issues or reading sub-issue relationships. Also dispatch when verifying authorization cascade or closure order through sub-issue structure. Sub-issue tracking is REQUIRED for multi-task plans"
+description: "Sub-issue management for linking and reading sub-issue relationships. Load via skill() when creating sub-issues under parent plan issues or reading sub-issue relationships. Also load when verifying authorization cascade or closure order through sub-issue structure. Sub-issue tracking is REQUIRED for multi-task plans. User phrases: create sub-issue, link sub-issue, read sub-issues, verify hierarchy"
 license: MIT
 provenance: AI-generated
 ---

--- a/skills/issue-operations-sync/SKILL.md
+++ b/skills/issue-operations-sync/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: issue-operations-sync
-description: "Issue synchronization skill for reconciling remote and local issue tracking. Dispatch when syncing issues from remote to local, mirroring remote issue bodies to local spec files, or retroactively importing pre-existing remote issues into local tracking. Sync is REQUIRED maintenance for multi-platform issue workflows"
+description: "Issue synchronization for reconciling remote and local issue tracking. Load via skill() when syncing issues from remote to local, mirroring remote issue bodies to local spec files, or retroactively importing pre-existing remote issues into local tracking. Sync is REQUIRED maintenance for multi-platform issue workflows. User phrases: sync issues, mirror remote, import issues, reconcile tracking"
 license: MIT
 provenance: AI-generated
 ---

--- a/skills/issue-operations/SKILL.md
+++ b/skills/issue-operations/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: issue-operations
-description: "Issue operations dispatcher that routes to GitHub MCP or GitBucket API based on github.platform. Dispatch when creating, commenting on, or closing GitHub Issues. Comment posting is gated by the substantiveness check in the comment task — non-substantive progress updates (status updates, phase complete, implemented X) MUST NOT be posted to GitHub Issues. Also dispatch when adding labels, managing sub-issues, or routing to platform-specific implementations. Issue tracking is REQUIRED"
+description: "Issue operations dispatcher that routes to GitHub MCP or GitBucket API based on github.platform. Load via skill() when creating, commenting on, or closing GitHub Issues. Comment posting is gated by the substantiveness check — non-substantive progress updates MUST NOT be posted to GitHub Issues. Also load when adding labels, managing sub-issues, or routing to platform-specific implementations. Issue tracking is REQUIRED. User phrases: create issue, comment on issue, close issue, add label, manage sub-issues"
 license: MIT
 compatibility: opencode
 ---

--- a/skills/issue-operations/platforms/gitbucket-api/SKILL.md
+++ b/skills/issue-operations/platforms/gitbucket-api/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gitbucket-api
-description: "GitBucket platform operations via the gb CLI tool for multi-platform issue management. Dispatch when GitBucket platform operations are needed. Also dispatch when routing issue operations to GitBucket via the gb CLI tool, or when GitBucket-specific API capabilities are required. GitBucket operations without platform awareness fail silently. Platform-aware routing is what makes multi-platform workflows reliable"
+description: "GitBucket platform operations via the gb CLI tool for multi-platform issue management. Load via skill() when GitBucket platform operations are needed. Also load when routing issue operations to GitBucket via the gb CLI tool, or when GitBucket-specific API capabilities are required. GitBucket operations without platform awareness fail silently. Platform-aware routing is REQUIRED. User phrases: GitBucket operations, gb CLI, GitBucket API, platform routing"
 license: MIT
 compatibility: opencode
 ---

--- a/skills/issue-operations/platforms/github-mcp/SKILL.md
+++ b/skills/issue-operations/platforms/github-mcp/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: github-mcp
-description: "GitHub MCP platform operations for issue management via GitHub API tools. Dispatch when GitHub MCP platform operations are needed. Also dispatch when routing issue operations to GitHub via MCP tools, or when GitHub-specific API capabilities are required. API calls without owner/repo verification target the wrong repository. Every misrouted call is wasted effort. Platform-aware routing is REQUIRED — always use the dispatcher"
+description: "GitHub MCP platform operations for issue management via GitHub API tools. Load via skill() when GitHub MCP platform operations are needed. Also load when routing issue operations to GitHub via MCP tools, or when GitHub-specific API capabilities are required. API calls without owner/repo verification target the wrong repository. Platform-aware routing is REQUIRED — always use the dispatcher. User phrases: GitHub operations, GitHub MCP, GitHub API, platform routing"
 license: MIT
 compatibility: opencode
 ---

--- a/skills/issue-operations/platforms/local/SKILL.md
+++ b/skills/issue-operations/platforms/local/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: local
-description: "Local .issues/ tracking platform for offline issue management with YAML frontmatter and markdown files. Dispatch when local .issues/ tracking is needed. Also dispatch when github.platform is local or unset, or when routing issue operations to the .issues/ directory with YAML frontmatter and markdown files. Untracked work is work that can be lost. Even local issues MUST have structured tracking"
+description: "Local .issues/ tracking platform for offline issue management with YAML frontmatter and markdown files. Load via skill() when local .issues/ tracking is needed. Also load when github.platform is local or unset, or when routing issue operations to the .issues/ directory with YAML frontmatter and markdown files. Untracked work is work that can be lost. Even local issues MUST have structured tracking. User phrases: local issues, offline tracking, .issues directory, YAML frontmatter"
 license: MIT
 compatibility: opencode
 ---

--- a/skills/issue-review/SKILL.md
+++ b/skills/issue-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: issue-review
-description: "Issue review skill that gathers context from comments, classifies review paths, and delegates to downstream skills. Dispatch when reviewing a GitHub issue for comments, audits, or Q/A. Also dispatch when gathering context from issue comments, classifying review paths, or delegating to downstream skills. All comments MUST be read before acting on any issue"
+description: "Issue review that gathers context from comments, classifies review paths, and delegates to downstream skills. Load via skill() when reviewing a GitHub issue for comments, audits, or Q/A. Also load when gathering context from issue comments, classifying review paths, or delegating to downstream skills. All comments MUST be read before acting on any issue. User phrases: review issue, read comments, classify review, gather context"
 license: MIT
 compatibility: opencode
 ---

--- a/skills/mcp-tool-usage/SKILL.md
+++ b/skills/mcp-tool-usage/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: mcp-tool-usage
-description: "Tool selection guide that enforces the five-tier priority hierarchy for file operations, code search, and MCP tool choice. Dispatch when selecting tools for file operations, code search, or any task that could use multiple tool options. Also dispatch when evaluating the five-tier priority hierarchy or choosing between MCP tools and CLI alternatives. Tool selection MUST follow the five-tier priority hierarchy — always required"
+description: "Tool selection guide that enforces the five-tier priority hierarchy for file operations, code search, and MCP tool choice. Load via skill() when selecting tools for file operations, code search, or any task that could use multiple tool options. Also load when evaluating the five-tier priority hierarchy or choosing between MCP tools and CLI alternatives. Tool selection MUST follow the five-tier priority hierarchy — always required. User phrases: select tool, choose MCP, file operation, code search, tool hierarchy"
 license: MIT
 compatibility: opencode
 ---

--- a/skills/multimodal-dispatch/SKILL.md
+++ b/skills/multimodal-dispatch/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: multimodal-dispatch
-description: "Modality-aware model router that probes Ollama capabilities and dispatches sub-agents to appropriate models. Dispatch when routing AI agent tasks to appropriate models based on content modality, probing Ollama model capabilities, or dispatching sub-agents with modality-aware model selection. Also dispatch when assessing hardware capabilities or resolving modality hints for model selection. Modality-aware dispatch is REQUIRED — always use the correct model for each modality"
+description: "Modality-aware model router that probes Ollama capabilities and dispatches sub-agents to appropriate models. Load via skill() when routing AI agent tasks to appropriate models based on content modality, probing Ollama model capabilities, or dispatching sub-agents with modality-aware model selection. Also load when assessing hardware capabilities or resolving modality hints for model selection. Modality-aware dispatch is REQUIRED — always use the correct model for each modality. User phrases: route to model, probe capabilities, dispatch sub-agent, assess hardware"
 license: MIT
 compatibility: opencode
 ---

--- a/skills/plan-creation-pipeline/SKILL.md
+++ b/skills/plan-creation-pipeline/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: plan-creation-pipeline
-description: "Structured 6-step plan creation pipeline with Z3-verified state transitions. Dispatch when creating a plan from an approved spec through a formal 6-step pipeline with Z3-verified state transitions. Also dispatch when validating phase solvability, grounding action schemas, or verifying dependency ordering. Plan creation MUST use the structured pipeline — always required. — distinct from plan (formal AI planning) and writing-plans (orchestrator-level plan creation)"
+description: "Structured 6-step plan creation pipeline with Z3-verified state transitions. Load via skill() when creating a plan from an approved spec through a formal 6-step pipeline with Z3-verified state transitions. Also load when validating phase solvability, grounding action schemas, or verifying dependency ordering. Plan creation MUST use the structured pipeline — always required. — distinct from plan (formal AI planning) and writing-plans (orchestrator-level plan creation). User phrases: create plan pipeline, Z3 verification, phase solvability, dependency ordering"
 license: MIT
 compatibility: opencode
 ---

--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: plan
-description: "Formal AI planning skill for phase solvability, PDDL conversion, action grounding, and state file management. Dispatch when generating, validating, or managing plans for phase solvability, converting between YAML and PDDL, grounding action schemas, discovering action schemas, or managing state files. Also dispatch when validating workflow constraints, verifying state against contracts, proving theorems, or checking dependency ordering. An approved spec stored as a local `spec.md` file is REQUIRED before any plan operation. Planning is REQUIRED before implementation. — distinct from writing-plans (implementation plans from specs) and plan-creation-pipeline (6-step orchestrator)"
+description: "Formal AI planning for phase solvability, PDDL conversion, action grounding, and state file management. Load via skill() when generating, validating, or managing plans for phase solvability, converting between YAML and PDDL, grounding action schemas, discovering action schemas, or managing state files. Also load when validating workflow constraints, verifying state against contracts, proving theorems, or checking dependency ordering. An approved spec stored as a local spec.md file is REQUIRED before any plan operation. Planning is REQUIRED before implementation. — distinct from writing-plans (implementation plans from specs) and plan-creation-pipeline (6-step orchestrator). User phrases: create plan, validate plan, PDDL conversion, action grounding, state management"
 license: MIT
 compatibility: opencode
 ---

--- a/skills/playwright-cli/SKILL.md
+++ b/skills/playwright-cli/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: playwright-cli
-description: "Browser automation and web interaction skill using Playwright for page navigation, form filling, snapshot capture, and test generation. Dispatch when browsing the web, automating browser interactions, navigating pages, filling forms, capturing snapshots, evaluating JavaScript, mocking network requests, managing storage/cookies/tabs, recording traces or video, running or generating Playwright tests, managing browser sessions, or installing/setting up Playwright. Also dispatch when capturing page content for verification or testing web application behavior. REQUIRED: dispatch via skill() before any browser automation — do not skip this skill"
+description: "Browser automation and web interaction using Playwright for page navigation, form filling, snapshot capture, and test generation. Load via skill() when browsing the web, automating browser interactions, navigating pages, filling forms, capturing snapshots, evaluating JavaScript, mocking network requests, managing storage/cookies/tabs, recording traces or video, running or generating Playwright tests, managing browser sessions, or installing/setting up Playwright. Also load when capturing page content for verification or testing web application behavior. REQUIRED: dispatch via skill() before any browser automation — do not skip this skill. User phrases: browse web, automate browser, fill form, capture snapshot, run Playwright test"
 allowed-tools: Bash(playwright-cli:*) Bash(npx:*) Bash(npm:*)
 license: Apache-2.0
 compatibility: opencode

--- a/skills/pr-creation-workflow/SKILL.md
+++ b/skills/pr-creation-workflow/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pr-creation-workflow
-description: "PR authorization and readiness verifier that determines when and how to create pull requests. Dispatch when asking about when to create a PR or whether PR creation is authorized. Also dispatch when verifying PR authorization scope, preparing PR body, or determining PR strategy. Every PR MUST be an authorized, intentional delivery"
+description: "PR authorization and readiness verifier that determines when and how to create pull requests. Load via skill() when asking about when to create a PR or whether PR creation is authorized. Also load when verifying PR authorization scope, preparing PR body, or determining PR strategy. Every PR MUST be an authorized, intentional delivery. User phrases: create PR, check PR authorization, prepare PR body, determine PR strategy"
 license: MIT
 compatibility: opencode
 ---

--- a/skills/pre-analysis/SKILL.md
+++ b/skills/pre-analysis/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pre-analysis
-description: "Pre-dispatch scope discovery that independently determines affected files and task partitions before execution sub-agents begin work. Dispatch when task()ing any execution sub-agent to independently determine scope, affected files, and task partitions. Also dispatch when discovering scope boundaries before any execution sub-agent begins work. Pre-analysis MUST be performed before dispatch — always required"
+description: "Pre-dispatch scope discovery that independently determines affected files and task partitions before execution sub-agents begin work. Load via skill() when task()ing any execution sub-agent to independently determine scope, affected files, and task partitions. Also load when discovering scope boundaries before any execution sub-agent begins work. Pre-analysis MUST be performed before dispatch — always required. User phrases: analyze scope, discover affected files, determine partitions, pre-dispatch analysis"
 license: MIT
 compatibility: opencode
 ---

--- a/skills/programming-principles/SKILL.md
+++ b/skills/programming-principles/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: programming-principles
-description: "Code design and architecture skill that enforces programming principles, evaluates tradeoffs, and audits code against standards. Dispatch when designing functions, classes, or modules; writing or reviewing implementation code; making architecture decisions; evaluating tradeoffs, or enforcing code size limits. Also dispatch when auditing code against design principles or detecting principle violations. Programming principles MUST be followed"
+description: "Code design and architecture enforcer that enforces programming principles, evaluates tradeoffs, and audits code against standards. Load via skill() when designing functions, classes, or modules; writing or reviewing implementation code; making architecture decisions; evaluating tradeoffs, or enforcing code size limits. Also load when auditing code against design principles or detecting principle violations. Programming principles MUST be followed. User phrases: design code, review architecture, evaluate tradeoffs, enforce principles, audit code"
 license: MIT
 compatibility: opencode
 ---

--- a/skills/receiving-code-review/SKILL.md
+++ b/skills/receiving-code-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: receiving-code-review
-description: "Code review feedback receiver that analyzes comments, generates responses, and implements review-driven changes. Dispatch when receiving code review feedback on a PR, or when addressing review comments. Also dispatch when analyzing review comments, generating responses, or implementing review-driven changes. All review comments MUST be addressed"
+description: "Code review feedback receiver that analyzes comments, generates responses, and implements review-driven changes. Load via skill() when receiving code review feedback on a PR, or when addressing review comments. Also load when analyzing review comments, generating responses, or implementing review-driven changes. All review comments MUST be addressed. User phrases: receive review, address comments, respond to feedback, implement review changes"
 license: MIT
 compatibility: opencode
 ---

--- a/skills/release-promoter/SKILL.md
+++ b/skills/release-promoter/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: release-promoter
-description: "Git tag and release promoter for creating annotated tags and GitHub Releases with changelog bodies. Dispatch when creating git tags for releases or promoting releases to GitHub. Also dispatch when creating annotated tags with v prefix or creating GitHub Releases from tags with changelog body. Release promotion is REQUIRED after every release PR merge — not optional"
+description: "Git tag and release promoter for creating annotated tags and GitHub Releases with changelog bodies. Load via skill() when creating git tags for releases or promoting releases to GitHub. Also load when creating annotated tags with v prefix or creating GitHub Releases from tags with changelog body. Release promotion is REQUIRED after every release PR merge — not optional. User phrases: create tag, promote release, create GitHub Release, annotate tag"
 license: MIT
 compatibility: opencode
 ---

--- a/skills/requesting-code-review/SKILL.md
+++ b/skills/requesting-code-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: requesting-code-review
-description: "PR review request preparer that assesses readiness and generates reviewer context. Dispatch when preparing a PR for code review, or when reviewer context and documentation are needed. Also dispatch when assessing PR readiness or generating reviewer context summaries. Every review request MUST be treated as a quality gate — not a formality"
+description: "PR review request preparer that assesses readiness and generates reviewer context. Load via skill() when preparing a PR for code review, or when reviewer context and documentation are needed. Also load when assessing PR readiness or generating reviewer context summaries. Every review request MUST be treated as a quality gate — not a formality. User phrases: request review, prepare PR review, assess readiness, generate reviewer context"
 license: MIT
 compatibility: opencode
 ---

--- a/skills/research/SKILL.md
+++ b/skills/research/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: research
-description: "Information discovery skill that produces findings with source attribution and explicit gap reporting using appropriate modalities. Dispatch when discovering information using appropriate modalities, producing findings with source attribution and explicit gap reporting. Also dispatch when investigating root causes, performing exhaustive research, producing remediation scope analysis, verifying claims against live sources, or producing structured research artifacts. All findings MUST be verified against live sources"
+description: "Information discovery that produces findings with source attribution and explicit gap reporting using appropriate modalities. Load via skill() when discovering information using appropriate modalities, producing findings with source attribution and explicit gap reporting. Also load when investigating root causes, performing exhaustive research, producing remediation scope analysis, verifying claims against live sources, or producing structured research artifacts. All findings MUST be verified against live sources. User phrases: research, investigate, find information, verify claim, root cause analysis"
 license: MIT
 compatibility: opencode
 ---

--- a/skills/skill-creator/SKILL.md
+++ b/skills/skill-creator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: skill-creator
-description: "Skill lifecycle manager for creating, updating, validating, and auditing skill cards and managing duplicate content blocks. Dispatch when creating a new skill, updating an existing skill, validating skill cards, or managing duplicate content blocks (fragments) across guidelines or skills. Also dispatch when enforcing the farmage description pattern on all skill cards, or auditing skill card structure for compliance. Validation is REQUIRED"
+description: "Skill lifecycle manager for creating, updating, validating, and auditing skill cards and managing duplicate content blocks. Load via skill() when creating a new skill, updating an existing skill, validating skill cards, or managing duplicate content blocks (fragments) across guidelines or skills. Also load when enforcing the farmage description pattern on all skill cards, or auditing skill card structure for compliance. Validation is REQUIRED. User phrases: create skill, update skill, validate skill card, audit skill, manage fragments"
 license: MIT
 compatibility: opencode
 ---

--- a/skills/skill-creator/reference/routing-only-template.md
+++ b/skills/skill-creator/reference/routing-only-template.md
@@ -15,18 +15,17 @@ This template defines the canonical structure for a routing-only SKILL.md file. 
 ```markdown
 ---
 name: skill-name
-description: "<Noun phrase describing what the skill is>. Dispatch when <agent-facing trigger conditions>. Also dispatch when <additional trigger conditions>. Invoke for: <comma-separated task names (OPTIONAL)>. <Enforcement statement>. — distinct from <exclusion clauses>."
+description: "<Agent-intent statement describing what the skill does>. Load via skill() when <agent-decision conditions>. <Enforcement statement>. User phrases: <comma-separated list>. — distinct from <exclusion clauses>."
 
 **Description format (agent-intent pattern):**
-- `<Noun phrase>` — what the skill IS (not when to use it)
-- `Dispatch when` — primary agent-facing trigger conditions (what the agent is doing)
-- `Also dispatch when` — additional agent-facing trigger conditions
-- `Invoke for:` — optional structural reference to task names from dispatch table
+- `<Agent-intent statement>` — what the skill does (the agent's role when it loads this skill)
+- `Load via skill() when` — primary agent-facing load conditions (when the agent should call skill())
 - Enforcement statement — e.g., "Spec creation is REQUIRED before implementation."
+- `User phrases:` — comma-separated list of natural language phrases a user might say
 - `— distinct from` — exclusion clauses for skills that could false-match
 - Max 1024 characters (opencode limit)
 - **Rejected elements:** `Use when`, `Also use when`, `Trigger phrases:` — deprecated Farmage format, MUST NOT appear
-- **Optional elements:** `Triggers when:` — agent-intent dispatch conditions describing when the agent should invoke this skill based on its own determination (not user utterance matching); `Invoke for:` — structural reference to task names from dispatch table
+- **Rejected elements:** `Dispatch when`, `Also dispatch when` — deprecated dispatch pattern, replaced by "Load via skill() when"
 license: MIT
 provenance: AI-generated
 ---

--- a/skills/skill-creator/reference/skill-card-spec.md
+++ b/skills/skill-creator/reference/skill-card-spec.md
@@ -81,7 +81,7 @@ All new skills MUST use the routing-only template. The SKILL.md variant of the M
 The `description` field in YAML frontmatter uses the **agent-intent pattern**:
 
 ```
-<Noun phrase describing what the skill is>. Dispatch when <agent-facing trigger conditions>. Also dispatch when <additional trigger conditions>. <Enforcement statement>. User phrases: <preserved user-facing trigger phrases>.
+<Agent-intent statement describing what the skill does>. Load via skill() when <agent-decision conditions>. <Enforcement statement>. User phrases: <comma-separated list>.
 ```
 
 See `routing-only-template.md` for the canonical template and validation rules.

--- a/skills/skill-creator/scripts/init_skill.py
+++ b/skills/skill-creator/scripts/init_skill.py
@@ -26,7 +26,7 @@ from pathlib import Path
 
 SKILL_TEMPLATE = """---
 name: {skill_name}
-description: "[TODO: <noun phrase describing skill>. Dispatch when ...]"
+description: "[TODO: <agent-intent statement describing skill>. Load via skill() when ...]"
 license: MIT
 provenance: AI-generated
 ---

--- a/skills/skill-creator/scripts/validate_skill_cards.py
+++ b/skills/skill-creator/scripts/validate_skill_cards.py
@@ -162,15 +162,15 @@ def validate_req1(
                     file_path=file_path,
                 )
             )
-        # Agent-intent dispatch pattern: description must start with "Dispatch when"
+        # Agent-intent dispatch pattern: description must contain "Dispatch when" or "Load via skill() when"
         # to describe the agent-side trigger condition, not user utterance patterns.
-        if "Dispatch when" not in desc:
+        if "Dispatch when" not in desc and "Load via skill() when" not in desc:
             violations.append(
                 Violation(
                     "REQ-1",
                     name,
                     "description",
-                    "Description missing 'Dispatch when' (required in agent-intent pattern)",
+                    "Description missing 'Dispatch when' or 'Load via skill() when' (required in agent-intent pattern)",
                     desc[:60],
                     file_path=file_path,
                 )
@@ -207,11 +207,11 @@ def validate_req1(
 def validate_sc_lint_001(name: str, fields: dict[str, str], file_path: str) -> list[Violation]:
     violations: list[Violation] = []
     desc = fields.get("description", "")
-    if "Dispatch when" not in desc:
+    if "Dispatch when" not in desc and "Load via skill() when" not in desc:
         violations.append(
             Violation(
                 "SC-LINT", name, "SC-LINT-001",
-                "Description missing 'Dispatch when' (required in agent-intent pattern)",
+                "Description missing 'Dispatch when' or 'Load via skill() when' (required in agent-intent pattern)",
                 desc[:60], file_path=file_path,
                 severity="ERROR", pass_fail="FAIL",
             )
@@ -234,7 +234,7 @@ def validate_sc_lint_001(name: str, fields: dict[str, str], file_path: str) -> l
                 severity="ERROR", pass_fail="FAIL",
             )
         )
-    # Agent-intent dispatch pattern: description must start with "Dispatch when"
+    # Agent-intent dispatch pattern: description must contain "Dispatch when" or "Load via skill() when"
     # to describe the agent-side trigger condition, not user utterance patterns.
     return violations
 

--- a/skills/solve/SKILL.md
+++ b/skills/solve/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: solve
-description: "Z3 constraint solver for workflow correctness, state verification, and dependency ordering validation. Dispatch when validating workflow constraints, verifying state against contracts, proving theorems, or checking dependency ordering. Also dispatch when invoked by spec-creation or writing-plans pipeline steps for Z3-verified phase solvability, dependency DAG validation, or state transition verification. Contract YAML files (variable declarations + logical constraints) and state YAML files (variable assignments) are REQUIRED. Workflow constraints MUST be validated with Z3"
+description: "Z3 constraint solver for workflow correctness, state verification, and dependency ordering validation. Load via skill() when validating workflow constraints, verifying state against contracts, proving theorems, or checking dependency ordering. Also load when invoked by spec-creation or writing-plans pipeline steps for Z3-verified phase solvability, dependency DAG validation, or state transition verification. Contract YAML files and state YAML files are REQUIRED. Workflow constraints MUST be validated with Z3. User phrases: solve constraints, verify state, validate workflow, check dependencies, Z3 verification"
 license: MIT
 compatibility: opencode
 ---

--- a/skills/spec-creation-change-control/SKILL.md
+++ b/skills/spec-creation-change-control/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: spec-creation-change-control
-description: "Change control documentation for spec revisions. Dispatch when documenting change control for spec revisions or tracking spec revision history. Triggers when: agent needs to document change control for a spec revision, agent needs to track spec revision history."
+description: "Change control documentation for spec revisions. Load via skill() when documenting change control for spec revisions or tracking spec revision history. Change control documentation is REQUIRED for all spec revisions. User phrases: document change control, track revision history, spec revision"
 license: MIT
 provenance: AI-generated
 ---

--- a/skills/spec-creation-decomposition/SKILL.md
+++ b/skills/spec-creation-decomposition/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: spec-creation-decomposition
-description: "Problem decomposition and analytical artifact generation for spec creation. Dispatch when decomposing a problem into success criteria, generating analytical artifacts, or analyzing blast radius, code paths, cross-cutting concerns, interfaces, state, or testability. Triggers when: agent needs to decompose a problem into analytical artifacts, agent needs to analyze blast radius or code paths, agent needs to assess cross-cutting concerns or interface compatibility."
+description: "Problem decomposition and analytical artifact generation for spec creation. Load via skill() when decomposing a problem into success criteria, generating analytical artifacts, or analyzing blast radius, code paths, cross-cutting concerns, interfaces, state, or testability. Analytical artifacts MUST be generated before plan creation. User phrases: decompose problem, generate artifacts, analyze blast radius, analyze code paths"
 license: MIT
 provenance: AI-generated
 ---

--- a/skills/spec-creation-operating-protocol/SKILL.md
+++ b/skills/spec-creation-operating-protocol/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: spec-creation-operating-protocol
-description: "Operating protocol documentation for spec creation workflows. Dispatch when documenting or updating operating protocols for spec creation. Triggers when: agent needs to document operating protocols for spec creation, agent needs to update spec creation workflow procedures."
+description: "Operating protocol documentation for spec creation workflows. Load via skill() when documenting or updating operating protocols for spec creation. Operating protocols MUST be documented for all spec creation workflows. User phrases: document protocol, update operating protocol, spec creation workflow"
 license: MIT
 provenance: AI-generated
 ---

--- a/skills/spec-creation-requirements/SKILL.md
+++ b/skills/spec-creation-requirements/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: spec-creation-requirements
-description: "Requirements extraction and documentation for spec creation. Dispatch when extracting requirements from problem statements or documenting requirements in spec format. Triggers when: agent needs to extract requirements from a problem statement, agent needs to document requirements in spec format."
+description: "Requirements extraction and documentation for spec creation. Load via skill() when extracting requirements from problem statements or documenting requirements in spec format. Requirements MUST be extracted before spec creation. User phrases: extract requirements, document requirements, spec requirements"
 license: MIT
 provenance: AI-generated
 ---

--- a/skills/spec-creation-validation/SKILL.md
+++ b/skills/spec-creation-validation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: spec-creation-validation
-description: "Spec validation, creation, completion, and quality checking. Dispatch when creating a spec, validating spec content, running holistic self-checks, checking pipeline readiness, assessing risk, or verifying traceability. Also dispatch when running holistic self-checks on specs before completion. Triggers when: agent needs to create or validate a spec, agent needs to run a holistic self-check, agent needs to assess risk or verify traceability."
+description: "Spec validation, creation, completion, and quality checking. Load via skill() when creating a spec, validating spec content, running holistic self-checks, checking pipeline readiness, assessing risk, or verifying traceability. Also load when running holistic self-checks on specs before completion. Spec validation is REQUIRED before implementation. User phrases: validate spec, check quality, assess risk, verify traceability, holistic check"
 license: MIT
 provenance: AI-generated
 ---

--- a/skills/spec-creation/SKILL.md
+++ b/skills/spec-creation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: spec-creation
-description: "Specification authoring skill dispatcher that routes to sub-skills. Dispatch when creating a spec, writing a specification, drafting requirements, authoring a spec document, or specifying a feature. Also dispatch when decomposing a problem into success criteria, extracting requirements, or documenting change control. Also use when running holistic self-checks on specs before completion, or verifying spec quality against the 11-dimension holistic gate. Invoke for: holistic check, self-check, pre-completion check, spec quality verification. Spec creation is REQUIRED before implementation"
+description: "Specification authoring dispatcher that routes to sub-skills. Load via skill() when creating a spec, writing a specification, drafting requirements, authoring a spec document, or specifying a feature. Also load when decomposing a problem into success criteria, extracting requirements, or documenting change control. Also load when running holistic self-checks on specs before completion, or verifying spec quality against the 11-dimension holistic gate. Spec creation is REQUIRED before implementation. User phrases: create spec, write specification, draft requirements, author spec, holistic check"
 license: MIT
 compatibility: opencode
 provenance: AI-generated

--- a/skills/sre-runbook/SKILL.md
+++ b/skills/sre-runbook/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sre-runbook
-description: "Operational runbook generator for infrastructure incidents and procedures. Dispatch when generating operational runbooks for infrastructure incidents or procedures. Also dispatch when documenting incident response steps, recovery procedures, or operational playbooks. SRE discipline is REQUIRED"
+description: "Operational runbook generator for infrastructure incidents and procedures. Load via skill() when generating operational runbooks for infrastructure incidents or procedures. Also load when documenting incident response steps, recovery procedures, or operational playbooks. SRE discipline is REQUIRED. User phrases: generate runbook, document incident, create playbook, recovery procedure"
 license: MIT
 compatibility: opencode
 ---

--- a/skills/sync-guidelines/SKILL.md
+++ b/skills/sync-guidelines/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sync-guidelines
-description: "Cross-repo synchronization tool for guidelines, skills, and tools with drift detection. Dispatch when synchronizing guidelines, skills, or tools between repositories. Also dispatch when detecting drift between source and target, or applying content synchronization. Sync is REQUIRED maintenance"
+description: "Cross-repo synchronization for guidelines, skills, and tools with drift detection. Load via skill() when synchronizing guidelines, skills, or tools between repositories. Also load when detecting drift between source and target, or applying content synchronization. Sync is REQUIRED maintenance. User phrases: sync guidelines, sync skills, detect drift, synchronize tools"
 license: MIT
 compatibility: opencode
 ---

--- a/skills/systematic-debugging/SKILL.md
+++ b/skills/systematic-debugging/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: systematic-debugging
-description: "Systematic debugger that performs root cause analysis, hypothesis testing, and failure mode investigation. Dispatch when encountering a bug, error, or unexpected behavior, or before making code changes to fix an issue. Also dispatch when performing root cause analysis, hypothesis testing, or failure mode investigation. Systematic debugging is REQUIRED"
+description: "Systematic debugger that performs root cause analysis, hypothesis testing, and failure mode investigation. Load via skill() when encountering a bug, error, or unexpected behavior, or before making code changes to fix an issue. Also load when performing root cause analysis, hypothesis testing, or failure mode investigation. Systematic debugging is REQUIRED. User phrases: debug, investigate bug, root cause analysis, hypothesis testing, failure investigation"
 license: MIT
 compatibility: opencode
 ---

--- a/skills/test-driven-development/SKILL.md
+++ b/skills/test-driven-development/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: test-driven-development
-description: "Test-driven development skill that runs RED/GREEN cycles, writes behavioral enforcement tests, and generates regression test patterns. Dispatch when writing tests before implementation, or when adopting a test-first development approach. Also dispatch when running RED/GREEN cycles, writing behavioral enforcement tests, or generating regression test patterns. TDD is REQUIRED"
+description: "Test-driven development that runs RED/GREEN cycles, writes behavioral enforcement tests, and generates regression test patterns. Load via skill() when writing tests before implementation, or when adopting a test-first development approach. Also load when running RED/GREEN cycles, writing behavioral enforcement tests, or generating regression test patterns. TDD is REQUIRED. User phrases: write test, RED phase, GREEN phase, TDD, behavioral test, regression test"
 license: MIT
 compatibility: opencode
 ---

--- a/skills/using-git-worktrees/SKILL.md
+++ b/skills/using-git-worktrees/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: using-git-worktrees
-description: "Git worktree manager that creates isolated feature branch worktrees for parallel agent work. Dispatch when creating a feature branch or worktree for implementation. Also dispatch when setting up isolated git worktrees for parallel agent work or managing worktree lifecycle. Always invoke before git-workflow pre-work. Worktrees are REQUIRED — always use them"
+description: "Git worktree manager that creates isolated feature branch worktrees for parallel agent work. Load via skill() when creating a feature branch or worktree for implementation. Also load when setting up isolated git worktrees for parallel agent work or managing worktree lifecycle. Always invoke before git-workflow pre-work. Worktrees are REQUIRED — always use them. User phrases: create worktree, set up worktree, manage worktree, isolated branch"
 license: MIT
 compatibility: opencode
 ---

--- a/skills/verification-before-completion/SKILL.md
+++ b/skills/verification-before-completion/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: verification-before-completion
-description: "Completion verification gate that checks success criteria, produces evidence artifacts, and enforces live-source verification before any completion claim. Dispatch when claiming a task is complete, marking a step done, or closing an issue. Also dispatch when running verification checks against success criteria, producing evidence artifacts, or enforcing live-source verification. Verification is REQUIRED and not optional — MUST use before any completion claim — distinct from verification (general claim verification) and verification-enforcement (content generation)"
+description: "Completion verification gate that checks success criteria, produces evidence artifacts, and enforces live-source verification before any completion claim. Load via skill() when claiming a task is complete, marking a step done, or closing an issue. Also load when running verification checks against success criteria, producing evidence artifacts, or enforcing live-source verification. Verification is REQUIRED and not optional — MUST use before any completion claim. — distinct from verification (general claim verification) and verification-enforcement (content generation). User phrases: verify completion, check success criteria, produce evidence, close issue"
 license: MIT
 compatibility: opencode
 ---

--- a/skills/verification-enforcement/SKILL.md
+++ b/skills/verification-enforcement/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: verification-enforcement
-description: "Content generation verifier that collects evidence artifacts before generation and resolves unverified claims after. Dispatch when generating content that makes factual claims — specs, plans, runbooks, docs, or correspondence. Also dispatch when collecting evidence artifacts before generation, resolving unverified claims after generation, or enforcing proactive verification. Live-source verification before generation is REQUIRED — always mandatory, never optional — distinct from verification (general claim verification) and verification-before-completion (completion gate)"
+description: "Content generation verifier that collects evidence artifacts before generation and resolves unverified claims after. Load via skill() when generating content that makes factual claims — specs, plans, runbooks, docs, or correspondence. Also load when collecting evidence artifacts before generation, resolving unverified claims after generation, or enforcing proactive verification. Live-source verification before generation is REQUIRED — always mandatory, never optional. — distinct from verification (general claim verification) and verification-before-completion (completion gate). User phrases: verify content, collect evidence, resolve claims, enforce verification"
 license: MIT
 compatibility: opencode
 ---

--- a/skills/verification/SKILL.md
+++ b/skills/verification/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: verification
-description: "Claim verifier that produces PASS/FAIL/UNVERIFIED verdicts per claim with evidence artifacts using appropriate modalities. Dispatch when verifying claims against evidence using appropriate modalities. Also dispatch when producing PASS/FAIL/UNVERIFIED verdicts per claim with evidence artifacts, or enforcing verification honesty. Verification is REQUIRED — distinct from verification-before-completion (completion gate) and verification-enforcement (content generation)"
+description: "Claim verifier that produces PASS/FAIL/UNVERIFIED verdicts per claim with evidence artifacts using appropriate modalities. Load via skill() when verifying claims against evidence using appropriate modalities. Also load when producing PASS/FAIL/UNVERIFIED verdicts per claim with evidence artifacts, or enforcing verification honesty. Verification is REQUIRED. — distinct from verification-before-completion (completion gate) and verification-enforcement (content generation). User phrases: verify claim, check evidence, produce verdict, enforce honesty"
 license: MIT
 compatibility: opencode
 ---

--- a/skills/version-manager/SKILL.md
+++ b/skills/version-manager/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: version-manager
-description: "Version string scanner and semver bumper for discovering and updating version numbers across codebases. Dispatch when discovering version strings in a codebase or bumping versions for a release. Also dispatch when scanning for version patterns across multiple file formats or determining the next version from changelog categories. Version management is REQUIRED before every release — not optional"
+description: "Version string scanner and semver bumper for discovering and updating version numbers across codebases. Load via skill() when discovering version strings in a codebase or bumping versions for a release. Also load when scanning for version patterns across multiple file formats or determining the next version from changelog categories. Version management is REQUIRED before every release — not optional. User phrases: discover version, bump version, scan version patterns, determine next version"
 license: MIT
 compatibility: opencode
 ---

--- a/skills/writing-plans-creation/SKILL.md
+++ b/skills/writing-plans-creation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: writing-plans-creation
-description: "Implementation plan creator that breaks approved specs into phases, tasks, and work breakdowns. Dispatch when creating an implementation plan from an approved spec, breaking down work into phases, planning implementation steps, or creating task breakdowns. Also dispatch when retroactively creating a plan for an existing spec, or backfilling plan documentation. Triggers when: agent determines a plan creation is needed, agent needs to decompose a spec into phases, agent needs to create task breakdowns, agent needs to retroactively document a plan."
+description: "Implementation plan creator that breaks approved specs into phases, tasks, and work breakdowns. Load via skill() when creating an implementation plan from an approved spec, breaking down work into phases, planning implementation steps, or creating task breakdowns. Also load when retroactively creating a plan for an existing spec, or backfilling plan documentation. Plans MUST be created before implementation. User phrases: create plan, break down work, plan phases, create task breakdown"
 license: MIT
 provenance: AI-generated
 ---

--- a/skills/writing-plans-holistic/SKILL.md
+++ b/skills/writing-plans-holistic/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: writing-plans-holistic
-description: "Standalone holistic self-check for implementation plans. Dispatch when running a holistic quality check on a plan before completion, or verifying plan quality against the 11-dimension holistic gate. Triggers when: agent determines a plan quality check is needed, agent needs to verify plan completeness before routing to audit."
+description: "Standalone holistic self-check for implementation plans. Load via skill() when running a holistic quality check on a plan before completion, or verifying plan quality against the 11-dimension holistic gate. Holistic checks MUST be run before plan completion. User phrases: holistic check, verify plan quality, plan completeness check"
 license: MIT
 provenance: AI-generated
 ---

--- a/skills/writing-plans/SKILL.md
+++ b/skills/writing-plans/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: writing-plans
-description: "Implementation plan creator dispatcher that routes to sub-skills. Dispatch when creating an implementation plan from an approved spec, breaking down work into phases, planning implementation steps, or creating task breakdowns. Also dispatch when retroactively creating a plan for an existing spec, or backfilling plan documentation. Also dispatch when running holistic self-checks on plans before completion, or verifying plan quality against the 11-dimension holistic gate. Plans are REQUIRED. — distinct from plan (AI planning with PDDL/Z3) and plan-creation-pipeline (task()-dispatch pipeline)"
+description: "Implementation plan creator dispatcher that routes to sub-skills. Load via skill() when creating an implementation plan from an approved spec, breaking down work into phases, planning implementation steps, or creating task breakdowns. Also load when retroactively creating a plan for an existing spec, or backfilling plan documentation. Also load when running holistic self-checks on plans before completion, or verifying plan quality against the 11-dimension holistic gate. Plans are REQUIRED. — distinct from plan (AI planning with PDDL/Z3) and plan-creation-pipeline (task()-dispatch pipeline). User phrases: create plan, write implementation plan, break down work, plan phases"
 license: MIT
 compatibility: opencode
 provenance: AI-generated

--- a/tests-v2/behaviors/skill-description-pattern.sh
+++ b/tests-v2/behaviors/skill-description-pattern.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Behavioral test: skill-description-pattern
+# See .opencode/tests-v2/AGENTS.md for the test harness specification and paradigm.
+# This script is an artifact-only generator — it does NOT evaluate model output.
+#
+# Verifies the agent dispatches skills correctly with the new "Load via skill() when"
+# description pattern. Sends a real-domain task that should trigger skill dispatch.
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/helpers.sh"
+
+SCENARIO_NAME="skill-description-pattern"
+SCENARIO_PROMPT="Implement SC-3 from spec #1961 — rewrite SKILL.md descriptions to agent-intent pattern"
+
+behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT"
+exit 0


### PR DESCRIPTION
## Summary

Fixes four issues in a stacked branch:

### #1960 — Plugins fail under snap — bun cannot find git binary
- Added `resolveGitPath()` with `which git` + fallback to common paths (`/usr/bin/git`, `/usr/local/bin/git`, `/snap/bin/git`)
- All `execSync` and `Bun.$` git calls use resolved path instead of bare `"git"`
- Graceful degradation when no git binary found (log diagnostic, skip git ops, no crash)

### #1961 — Rewrite SKILL.md descriptions to agent-intent-oriented pattern
- All 60 SKILL.md descriptions rewritten to "Load via skill() when" language
- Updated `validate_skill_cards.py` to accept new pattern
- Updated `init_skill.py` template, `routing-only-template.md`, `skill-card-spec.md`
- Updated `session-enforcement.ts` comment
- Created behavioral enforcement test at `tests-v2/behaviors/skill-description-pattern.sh`

### #1964 — session-enforcement must install git hooks in submodules
- Added `getSubmodulePaths()` to enumerate registered submodules via `git submodule status`
- Added `resolveSubmoduleGitDir()` to handle both `.git` directory and `.git` file (worktree) submodule formats
- Propagates all hooks from `.opencode/hooks/` to each submodule's `.git/hooks/`

### #1968 — Gate per-turn git config watchdog to first-turn-only
- Moved the per-turn config mutation watchdog inside `if (isFirstTurn)` guard
- Baseline still captured at startup; comparison runs once on first turn only
- Eliminates 3-4 unnecessary git subprocess calls per message turn

## Outcome

All four fixes are implemented. Two commits on `feature/1960-1961-1964-plugin-skills-hooks`.

## Fixes

Fixes #1960, Fixes #1961, Fixes #1964, Fixes #1968