### PR TITLE
fix: resolveGitPath() uses POSIX command -v, lazy init; env-loader gitCmd wraps in sh -c

### DIFF
--- a/plugins/env-loader.ts
+++ b/plugins/env-loader.ts
@@ -32,19 +32,26 @@ const GIT_FALLBACK_PATHS = [
   "/snap/bin/git",
 ];
 
+let _gitPath: string | null = null;
+
 function resolveGitPath(): string | null {
-  // Try `which git` first (works in normal PATH environments)
+  if (_gitPath !== null) return _gitPath;
+  // Try `command -v git` first (POSIX-standard, available on all Unix-like systems)
   try {
-    const whichResult = execSync("which git", { encoding: "utf8", timeout: 5000, stdio: ["pipe", "pipe", "pipe"] }).trim();
-    if (whichResult) return whichResult;
+    const result = execSync("command -v git", { encoding: "utf8", timeout: 5000, stdio: ["pipe", "pipe", "pipe"] }).trim();
+    if (result) {
+      _gitPath = result;
+      return _gitPath;
+    }
   } catch {
-    // `which` failed — fall through to common paths
+    // `command -v` failed — fall through to common paths
   }
   for (const candidate of GIT_FALLBACK_PATHS) {
     if (fs.existsSync(candidate)) {
       try {
         execSync(`"${candidate}" --version`, { encoding: "utf8", timeout: 5000, stdio: ["pipe", "pipe", "pipe"] });
-        return candidate;
+        _gitPath = candidate;
+        return _gitPath;
       } catch {
         continue;
       }
@@ -296,7 +303,7 @@ export const EnvLoaderPlugin: Plugin = async ({ project, client, $, directory, w
         }
         try {
           const result = await Promise.race([
-            $.nothrow()`${gitPath} ${cmd}`,
+            $.nothrow()`sh -c "${gitPath} ${cmd}"`,
             new Promise<null>((_, reject) =>
               setTimeout(() => reject(new Error(`git command timed out: ${cmd}`)), GIT_CMD_TIMEOUT_MS)
             ),

--- a/plugins/session-enforcement.ts
+++ b/plugins/session-enforcement.ts
@@ -37,19 +37,26 @@ const GIT_FALLBACK_PATHS = [
   "/snap/bin/git",
 ];
 
+let gitPath: string | null = null;
+
 function resolveGitPath(): string | null {
-  // Try `which git` first (works in normal PATH environments)
+  if (gitPath !== null) return gitPath;
+  // Try `command -v git` first (POSIX-standard, available on all Unix-like systems)
   try {
-    const whichResult = execSync("which git", { encoding: "utf8", timeout: 5000, stdio: ["pipe", "pipe", "pipe"] }).trim();
-    if (whichResult) return whichResult;
+    const result = execSync("command -v git", { encoding: "utf8", timeout: 5000, stdio: ["pipe", "pipe", "pipe"] }).trim();
+    if (result) {
+      gitPath = result;
+      return gitPath;
+    }
   } catch {
-    // `which` failed — fall through to common paths
+    // `command -v` failed — fall through to common paths
   }
   for (const candidate of GIT_FALLBACK_PATHS) {
     if (fs.existsSync(candidate)) {
       try {
         execSync(`"${candidate}" --version`, { encoding: "utf8", timeout: 5000, stdio: ["pipe", "pipe", "pipe"] });
-        return candidate;
+        gitPath = candidate;
+        return gitPath;
       } catch {
         continue;
       }
@@ -57,8 +64,6 @@ function resolveGitPath(): string | null {
   }
   return null;
 }
-
-const gitPath = resolveGitPath();
 
 interface GitConfigBaseline {
   configHash: string;


### PR DESCRIPTION
## Summary

Fixes two bugs in plugin git command execution that produced `"... is not a git command"` errors.

## Changes

### Bug 1: `resolveGitPath()` used non-POSIX `which git`

Both `session-enforcement.ts` and `env-loader.ts` used `execSync("which git", ...)` — `which` is non-POSIX and unavailable on minimal systems (Docker, some Linux distros). Replaced with POSIX `command -v git`. Made lazy-initialized (not at module scope) to prevent module load failures.

### Bug 2: `env-loader.ts` `gitCmd()` passed multi-word args as single argument

`$.nothrow()`\`${gitPath} ${cmd}\`` — when `cmd = "branch --show-current"`, the tagged template passed the entire string as one argument. Git saw `"branch --show-current"` (with embedded space) as a single command name. Fixed by wrapping in `sh -c` so the shell properly splits arguments.

## Files Changed

- `plugins/session-enforcement.ts` — `which` → `command -v`, lazy init, removed module-scope `const gitPath = resolveGitPath()`
- `plugins/env-loader.ts` — same `resolveGitPath()` fix, `gitCmd()` wraps in `sh -c`

Fixes #1972
