### PR TITLE
Remove git commands from env-loader.ts, move to on-demand in consumers

### DIFF
--- a/plugins/env-loader.ts
+++ b/plugins/env-loader.ts
@@ -8,9 +8,6 @@
  * Sources (independently gathered, no cross-plugin coupling):
  * - .env file — all parsed key-value pairs including secrets
  * - input.worktree — WORKTREE_PATH for bash commands
- * - input.$ (git) — BRANCH_NAME, GIT_OWNER, GIT_REPO, GIT_PLATFORM,
- *   DEV_NAME, DEV_EMAIL, GITHUB_HTML_URL, GITBUCKET_HTML_URL,
- *   GITBUCKET_SSH_URL, GITBUCKET_HAS_CREDENTIALS
  *
  * Hook: shell.env ONLY — no system.transform, no LLM output.
  *
@@ -22,36 +19,10 @@
 import type { Plugin } from "@opencode-ai/plugin";
 import fs from "fs";
 import path from "path";
-import { execSync } from "child_process";
 
 const ENV_FILE = ".env";
 
-const GIT_FALLBACK_PATHS = [
-  "/usr/bin/git",
-  "/usr/local/bin/git",
-  "/snap/bin/git",
-];
 
-function resolveGitPath(): string | null {
-  // Try `which git` first (works in normal PATH environments)
-  try {
-    const whichResult = execSync("which git", { encoding: "utf8", timeout: 5000, stdio: ["pipe", "pipe", "pipe"] }).trim();
-    if (whichResult) return whichResult;
-  } catch {
-    // `which` failed — fall through to common paths
-  }
-  for (const candidate of GIT_FALLBACK_PATHS) {
-    if (fs.existsSync(candidate)) {
-      try {
-        execSync(`"${candidate}" --version`, { encoding: "utf8", timeout: 5000, stdio: ["pipe", "pipe", "pipe"] });
-        return candidate;
-      } catch {
-        continue;
-      }
-    }
-  }
-  return null;
-}
 
 interface PluginDiagnostic {
   source: string;
@@ -154,93 +125,6 @@ function isEnvGitignored(projectDir: string): boolean {
   }
 }
 
-// ---------- Git remote URL parsing (TypeScript, for shell.env KEY=VALUE output) ----------
-
-function parseGitHubUrl(url: string): { owner: string; repo: string } | null {
-  // SSH: git@github.com:owner/repo.git
-  const sshMatch = url.match(/^git@github\.com:([^/]+)\/([^/]+?)(?:\.git)?$/);
-  if (sshMatch) {
-    return { owner: sshMatch[1], repo: sshMatch[2] };
-  }
-  // HTTPS: https://github.com/owner/repo.git
-  const httpsMatch = url.match(/^https:\/\/github\.com\/([^/]+)\/([^/]+?)(?:\.git)?$/);
-  if (httpsMatch) {
-    return { owner: httpsMatch[1], repo: httpsMatch[2] };
-  }
-  return null;
-}
-
-function parseGitBucketUrl(
-  url: string,
-  projectDir: string,
-): { baseUrl: string | null; owner: string; repo: string; sshUrl: string | null } | null {
-  let owner: string | null = null;
-  let repo: string | null = null;
-
-  // SSH with port: ssh://git@hostname:port/owner/repo.git
-  const sshUrlMatch = url.match(/^ssh:\/\/git@([^:/]+):(\d+)\/([^/]+)\/([^/]+?)(?:\.git)?$/);
-  if (sshUrlMatch) {
-    owner = sshUrlMatch[3];
-    repo = sshUrlMatch[4];
-  }
-
-  if (!owner) {
-    // SSH short: git@hostname:owner/repo.git
-    const sshShortMatch = url.match(/^git@([^:]+):([^/]+)\/([^/]+?)(?:\.git)?$/);
-    if (sshShortMatch) {
-      owner = sshShortMatch[2];
-      repo = sshShortMatch[3];
-    }
-  }
-
-  if (!owner) {
-    // HTTPS: https://hostname/owner/repo.git
-    const httpsMatch = url.match(/^https:\/\/([^/]+)\/([^/]+)\/([^/]+?)(?:\.git)?$/);
-    if (httpsMatch) {
-      owner = httpsMatch[2];
-      repo = httpsMatch[3];
-    }
-  }
-
-  if (!owner || !repo) {
-    return null;
-  }
-
-  // Extract SSH base URL for GitBucket
-  let sshUrl: string | null = null;
-  const sshBaseMatch = url.match(/^(ssh:\/\/git@[^:/]+:\d+)/);
-  if (sshBaseMatch) {
-    sshUrl = sshBaseMatch[1];
-  }
-
-  // Base URL comes from .env, not from remote URL
-  const baseUrl = readGitBucketUrlFromEnv(path.join(projectDir, ENV_FILE));
-
-  return { baseUrl, owner, repo, sshUrl };
-}
-
-function readGitBucketUrlFromEnv(envPath: string): string | null {
-  try {
-    if (fs.existsSync(envPath)) {
-      const content = fs.readFileSync(envPath, "utf8");
-      let htmlUrl: string | null = null;
-      let legacyUrl: string | null = null;
-      for (const line of content.split("\n")) {
-        const trimmed = line.trim();
-        if (trimmed.startsWith("GITBUCKET_HTML_URL=")) {
-          htmlUrl = trimmed.split("=", 2)[1].trim();
-        } else if (trimmed.startsWith("GITBUCKET_URL=")) {
-          legacyUrl = trimmed.split("=", 2)[1].trim();
-        }
-      }
-      return htmlUrl || legacyUrl;
-    }
-  } catch {
-    // Ignore read errors
-  }
-  return null;
-}
-
 export const EnvLoaderPlugin: Plugin = async ({ project, client, $, directory, worktree }) => {
   const projectDir = directory || process.cwd();
   const envPath = path.join(projectDir, ENV_FILE);
@@ -286,85 +170,7 @@ export const EnvLoaderPlugin: Plugin = async ({ project, client, $, directory, w
         output.env["WORKTREE_PATH"] = worktreeDir;
       }
 
-      const GIT_CMD_TIMEOUT_MS = 5000;
-      const gitPath = resolveGitPath();
 
-      async function gitCmd(cmd: string): Promise<{ exitCode: number; text: () => string } | null> {
-        if (!gitPath) {
-          console.error("[env-loader] git binary not found — skipping git operations");
-          return null;
-        }
-        try {
-          const result = await Promise.race([
-            $.nothrow()`${gitPath} ${cmd}`,
-            new Promise<null>((_, reject) =>
-              setTimeout(() => reject(new Error(`git command timed out: ${cmd}`)), GIT_CMD_TIMEOUT_MS)
-            ),
-          ]);
-          return result as { exitCode: number; text: () => string };
-        } catch {
-          return null;
-        }
-      }
-
-      try {
-        const branchResult = await gitCmd("branch --show-current");
-        if (branchResult && branchResult.exitCode === 0) {
-          const branch = branchResult.text().trim();
-          if (branch) {
-            output.env["BRANCH_NAME"] = branch;
-          }
-        }
-
-        const remoteResult = await gitCmd("remote get-url origin");
-        if (remoteResult && remoteResult.exitCode === 0) {
-          const remoteUrl = remoteResult.text().trim();
-
-          if (remoteUrl.includes("github.com")) {
-            output.env["GIT_PLATFORM"] = "github";
-            const parsed = parseGitHubUrl(remoteUrl);
-            if (parsed) {
-              output.env["GIT_OWNER"] = parsed.owner;
-              output.env["GIT_REPO"] = parsed.repo;
-            }
-            output.env["GITHUB_HTML_URL"] = "https://github.com/";
-          } else {
-            output.env["GIT_PLATFORM"] = "gitbucket";
-            const parsed = parseGitBucketUrl(remoteUrl, projectDir);
-            if (parsed) {
-              output.env["GIT_OWNER"] = parsed.owner;
-              output.env["GIT_REPO"] = parsed.repo;
-              if (parsed.baseUrl) {
-                output.env["GITBUCKET_HTML_URL"] = parsed.baseUrl;
-              }
-              if (parsed.sshUrl) {
-                output.env["GITBUCKET_SSH_URL"] = parsed.sshUrl;
-              }
-              const hasToken = output.env["GITBUCKET_TOKEN"] && output.env["GITBUCKET_TOKEN"].length > 0;
-              const hasUrl = output.env["GITBUCKET_HTML_URL"] || output.env["GITBUCKET_URL"];
-              output.env["GITBUCKET_HAS_CREDENTIALS"] = (hasToken && hasUrl) ? "true" : "false";
-            }
-          }
-        }
-
-        const nameResult = await gitCmd("config user.name");
-        if (nameResult && nameResult.exitCode === 0) {
-          const name = nameResult.text().trim();
-          if (name) {
-            output.env["DEV_NAME"] = name;
-          }
-        }
-
-        const emailResult = await gitCmd("config user.email");
-        if (emailResult && emailResult.exitCode === 0) {
-          const email = emailResult.text().trim();
-          if (email) {
-            output.env["DEV_EMAIL"] = email;
-          }
-        }
-      } catch {
-        // Git commands unavailable — skip git env values
-      }
     },
   };
 }

--- a/skills/completion-core/completion-core.md
+++ b/skills/completion-core/completion-core.md
@@ -32,15 +32,20 @@ Two URL patterns depending on workflow type:
 
 **Compare URL** (for git push workflows — implementation, git-workflow, finishing):
 
-Construct from session-init values with character-match verification:
-
-1. Read `<github.owner>`, `<github.repo>`, `<github.html_url>` (or `<gitbucket.html_url>`) from session init
-2. Construct: `<html_url>/<owner>/<repo>/compare/$DEFAULT_BRANCH...<branch>` using the platform's base URL from session-init
-3. **Character-match verification:** Confirm `GIT_OWNER` and `GIT_REPO` in the constructed URL match session-init values exactly (character-for-character, no typos, no cached values)
-4. If any mismatch: HALT and report
+Extract owner/repo from the remote URL:
 
 ```bash
-COMPARE_URL="${GITBUCKET_HTML_URL:-${GITHUB_HTML_URL}}/${GIT_OWNER}/${GIT_REPO}/compare/$DEFAULT_BRANCH...$(git branch --show-current)"
+REMOTE_URL=$(git remote get-url origin)
+if echo "$REMOTE_URL" | grep -q "github.com"; then
+  HTML_URL="https://github.com"
+  OWNER=$(echo "$REMOTE_URL" | sed -n 's/.*github.com[:\/]\([^/]*\)\/.*/\1/p')
+  REPO=$(echo "$REMOTE_URL" | sed -n 's/.*github.com[:\/][^/]*\/\(.*\)\.git/\1/p')
+else
+  HTML_URL=""
+  OWNER=$(echo "$REMOTE_URL" | sed -n 's/.*[:\/]\([^/]*\)\/\([^/]*\)\.git/\1/p')
+  REPO=$(echo "$REMOTE_URL" | sed -n 's/.*[:\/]\([^/]*\)\/\([^/]*\)\.git/\2/p')
+fi
+COMPARE_URL="${HTML_URL}/${OWNER}/${REPO}/compare/$DEFAULT_BRANCH...$(git branch --show-current)"
 ```
 
 **Action URL** (for creation workflows — issue creation, approval gate):

--- a/skills/completion-core/tasks/completion.md
+++ b/skills/completion-core/tasks/completion.md
@@ -28,15 +28,20 @@ Two URL patterns depending on workflow type:
 
 **Compare URL** (for git push workflows — implementation, git-workflow, finishing):
 
-Construct from session-init values with character-match verification:
-
-1. Read `<github.owner>`, `<github.repo>`, `<github.html_url>` (or `<gitbucket.html_url>`) from session init
-2. Construct: `<html_url>/<owner>/<repo>/compare/$DEFAULT_BRANCH...<branch>` using the platform's base URL from session-init
-3. **Character-match verification:** Confirm `GIT_OWNER` and `GIT_REPO` in the constructed URL match session-init values exactly (character-for-character, no typos, no cached values)
-4. If any mismatch: HALT and report
+Extract owner/repo from the remote URL:
 
 ```bash
-COMPARE_URL="${GITBUCKET_HTML_URL:-${GITHUB_HTML_URL}}/${GIT_OWNER}/${GIT_REPO}/compare/$DEFAULT_BRANCH...$(git branch --show-current)"
+REMOTE_URL=$(git remote get-url origin)
+if echo "$REMOTE_URL" | grep -q "github.com"; then
+  HTML_URL="https://github.com"
+  OWNER=$(echo "$REMOTE_URL" | sed -n 's/.*github.com[:\/]\([^/]*\)\/.*/\1/p')
+  REPO=$(echo "$REMOTE_URL" | sed -n 's/.*github.com[:\/][^/]*\/\(.*\)\.git/\1/p')
+else
+  HTML_URL=""
+  OWNER=$(echo "$REMOTE_URL" | sed -n 's/.*[:\/]\([^/]*\)\/\([^/]*\)\.git/\1/p')
+  REPO=$(echo "$REMOTE_URL" | sed -n 's/.*[:\/]\([^/]*\)\/\([^/]*\)\.git/\2/p')
+fi
+COMPARE_URL="${HTML_URL}/${OWNER}/${REPO}/compare/$DEFAULT_BRANCH...$(git branch --show-current)"
 ```
 
 **Action URL** (for creation workflows — issue creation, approval gate):

--- a/skills/git-workflow-branch/tasks/pair-pre-work.md
+++ b/skills/git-workflow-branch/tasks/pair-pre-work.md
@@ -25,7 +25,7 @@ When pair mode is active (branch name starts with `pair-`):
    git add -A
    git commit -m "WIP: $(git branch --show-current) [pair-mode]
 
-   Co-authored-by: $DEV_NAME <$DEV_EMAIL>
+   Co-authored-by: $(git config user.name) <$(git config user.email)>
    Co-authored-by: AI: $AGENT_NAME ($MODEL_ID) [pair-mode]"
    ```
 

--- a/skills/using-git-worktrees/tasks/create-worktree.md
+++ b/skills/using-git-worktrees/tasks/create-worktree.md
@@ -36,6 +36,7 @@ project=$(basename "$(git rev-parse --show-toplevel)")
 Before creating a new worktree, check if a worktree for this branch already exists:
 
 ```bash
+BRANCH_NAME=$(git branch --show-current)
 BRANCH_NAME_SANITIZED=$(echo "$BRANCH_NAME" | tr '/' '-')
 WT_PATH=".worktrees/$BRANCH_NAME_SANITIZED"
 


### PR DESCRIPTION
## Summary

Remove 3 git commands (`branch --show-current`, `remote get-url origin`, `config user.email`) from `env-loader.ts` that were running on every bash turn via `shell.env` hook. The data is static and already available in LLM context via `session-init`. Consumers now fetch the data on-demand.

## Changes

- **`plugins/env-loader.ts`** — Remove `execSync` import, `GIT_FALLBACK_PATHS`, `resolveGitPath()`, `gitCmd()`, URL parsing functions (`parseGitHubUrl`, `parseGitBucketUrl`, `readGitBucketUrlFromEnv`), and the entire git try block. Net: -194 lines.
- **`skills/completion-core/completion-core.md`** — Replace env var-based compare URL construction with inline `git remote get-url origin` parsing.
- **`skills/completion-core/tasks/completion.md`** — Same URL construction change.
- **`skills/git-workflow-branch/tasks/pair-pre-work.md`** — Replace `$DEV_NAME <$DEV_EMAIL>` with `$(git config user.name) <$(git config user.email)>`.
- **`skills/using-git-worktrees/tasks/create-worktree.md`** — Add explicit `BRANCH_NAME=$(git branch --show-current)` in collision check.

## Fixes

Closes #1977

🤖 Co-authored with AI: OpenCode (deepseek-v4-flash)