### PR TITLE
[SPEC-FIX] Test framework isolation, documentation, and change control

### DIFF
--- a/opencode.jsonc
+++ b/opencode.jsonc
@@ -134,7 +134,7 @@
       "enabled": true
     }
   },
-  "plugins": [
+  "plugin": [
     "opencode-vibeguard@0.1.0"
   ]
 }

--- a/opencode.jsonc
+++ b/opencode.jsonc
@@ -133,5 +133,8 @@
       "command": ["uvx", "--from", "git+https://github.com/michael-conrad/viewport-editor@v0.3.4", "viewport-editor"],
       "enabled": true
     }
-  }
+  },
+  "plugins": [
+    "opencode-vibeguard@0.1.0"
+  ]
 }

--- a/tests-v2/AGENTS.md
+++ b/tests-v2/AGENTS.md
@@ -12,12 +12,12 @@ Every behavioral test script generates model-run artifacts and exits 0. Evaluati
 
 | Aspect | v1 (`.opencode/tests/`) | v2 (`.opencode/tests-v2/`) |
 |--------|------------------------|----------------------------|
-| CLI binary | `opencode-cli` | `opencode` (`/snap/bin/opencode`) |
+| CLI binary | `opencode-cli` | `opencode` from PATH (resolved via `command -v`) |
 | Model discovery | `opencode-cli models` | `opencode models` |
 | Test runner | `with-test-home` (v1) | `with-test-home` (v2, rewritten) |
 | Env isolation | Partial `env` passthrough | `env -i` with explicit allowlist |
 | Smoke tests | Optional | Mandatory (`opencode models` + `opencode run "hello world"`) |
-| Test project | Flat test home | `{test_home}/project/` with `git init` + `.opencode` clone |
+| Test project | Flat test home | `{test_home}/project/` with `git init` + local `.opencode` checkout |
 
 ## Table of Contents
 
@@ -146,34 +146,79 @@ bash .opencode/tests-v2/behaviors/<scenario>.sh
 
 ### Binary
 
-- **`opencode`** at `/snap/bin/opencode` (v1.17.18) — the ONLY binary used
-- **`opencode-cli`** at `/usr/bin/opencode-cli` (v1.14.33) — NOT used in v2
+`opencode` is resolved from PATH via `command -v opencode` in both `with-test-home` and `helpers.sh`. The binary is NOT hardcoded to `/snap/bin/opencode` or any specific path.
 
-### `with-test-home` — XDG-Isolated Test Runner
+**Why PATH resolution instead of hardcoding:** The snap wrapper at `/snap/bin/opencode` → `/usr/bin/snap` ignores `$HOME` and hardcodes `SNAP_USER_DATA=~/snap/opencode/`, which leaks production state into test environments. Resolving from PATH allows the test harness to use any opencode installation while maintaining `HOME` isolation.
 
-**MUST be used for ALL opencode testing.** Never run `opencode run` directly — it causes SQLite session conflicts with the desktop app.
+**DO NOT hardcode a specific binary path.** If the binary location changes, update the PATH, not the script.
 
-The wrapper creates an isolated temporary home directory (`tmp/test-home-<timestamp>`) with clean XDG state.
+### `with-test-home` — Fully Isolated Test Runner
 
-**Environment variable isolation** — uses `env -i` with ONLY these vars:
-- `HOME`, `PWD`, `XDG_CONFIG_HOME`, `XDG_CACHE_HOME`, `XDG_RUNTIME_DIR`, `XDG_DATA_HOME`, `XDG_STATE_HOME`
-- `PATH` (parent env)
-- `SHELL`, `USER`, `LOGNAME`, `LANG`, `TERM` (parent env)
-- `GB_TOKEN` (parent env, if set)
+**MUST be used for ALL opencode testing.** Never run `opencode run` directly — it causes SQLite session conflicts with the desktop app and leaks production state.
+
+The wrapper creates an isolated temporary home directory (`tmp/test-home-<timestamp>`) with clean XDG state and runs commands inside a `env -i` subshell.
+
+#### Environment Variable Isolation
+
+Uses `env -i` with an explicit allowlist. Only these variables are passed through:
+
+| Variable | Source | Purpose |
+|----------|--------|---------|
+| `HOME` | Set to test home | Isolates snap data, XDG state, and all home-directory config |
+| `PATH` | Parent env | Allows opencode and other tools to be found |
+| `XDG_CONFIG_HOME` | Set to test home | Isolates opencode config |
+| `XDG_CACHE_HOME` | Set to test home | Isolates cache |
+| `XDG_RUNTIME_DIR` | Set to test home | Isolates runtime files |
+| `XDG_DATA_HOME` | Set to test home | Isolates data (SQLite DB, repos) |
+| `XDG_STATE_HOME` | Set to test home | Isolates state (locks) |
+| `SNAP_USER_DATA` | Set to test home | Overrides snap's hardcoded `~/snap/opencode/` to prevent production DB pollution |
+| `SNAP_USER_COMMON` | Set to test home | Overrides snap's common data directory |
+| `GIT_CONFIG_NOSYSTEM` | `1` | Prevents system git config from leaking |
+| `SHELL` | Parent env | Required by some tools |
+| `USER` | Parent env | Required by some tools |
+| `LOGNAME` | Parent env | Required by some tools |
+| `LANG` | Parent env | Locale |
+| `TERM` | Parent env | Terminal type |
+| `GB_TOKEN` | Parent env (if set) | GitBucket API token |
 
 **FORBIDDEN** — no `GITHUB_TOKEN`, `GH_TOKEN`, `OPENCODE_CONFIG_CONTENT`, `NODE_ENV`, `VIRTUAL_ENV`, `CONDA_DEFAULT_ENV`, or shell-specific vars.
+
+#### Working Directory
+
+The command runs from `TEST_PROJECT` (the test project directory inside the test home). This ensures opencode discovers the test project's `.opencode/` as its project root, not the production project's.
+
+#### Local Submodule Checkout
+
+`.opencode/` is checked out locally via `cp -a` from the parent repo, NOT cloned from remote. This ensures the test environment sees unmerged feature branch changes. The checkout includes all feature branch modifications (config files, test scripts, etc.).
+
+#### Model Config Generation
+
+`seed_model_config()` generates a minimal `opencode.jsonc` by querying the Ollama API (`curl http://localhost:11434/api/tags`) for available models. It does NOT copy the production `opencode.jsonc` — that file contains secrets, API keys, and environment-specific settings that must not leak into test environments.
+
+#### Isolation Verification Procedure
+
+After running `with-test-home --setup`, verify isolation by inspecting the SQLite DB:
+
+```bash
+sqlite3 $TEST_HOME/.local/share/opencode/opencode.db "SELECT worktree FROM project;"
+# Expected: /path/to/tmp/test-home-<timestamp>/project
+# NOT:      /home/user/git/production-project
+```
+
+The `project.worktree` field MUST contain the test project path (under `tmp/test-home-*`), not the production project path. If it contains the production path, isolation is broken.
 
 ### Test Environment Setup Steps
 
 1. Create test home directory at `{project_root}/tmp/test-home-{timestamp}`
-2. Set XDG vars to test home paths
-3. Set `PATH` to parent env PATH only
-4. Create test sub-folder: `{test_home}/project/`
-5. `git init` the test sub-folder
-6. Clone `.opencode/` submodule from remote into the test project
-7. Seed `opencode.jsonc` config with available models
-8. Run `opencode models` to verify CLI works (smoke test)
-9. Run `opencode run "hello world"` to verify model works (smoke test)
+2. Set `HOME` and all XDG vars to test home paths
+3. Set `SNAP_USER_DATA`/`SNAP_USER_COMMON` to test home paths (overrides snap's hardcoded `~/snap/opencode/`)
+4. Set `PATH` to parent env PATH only
+5. Create test sub-folder: `{test_home}/project/`
+6. `git init` the test sub-folder
+7. Checkout `.opencode/` locally via `cp -a` from parent repo (NOT cloned from remote)
+8. Seed `opencode.jsonc` config by querying Ollama API for available models
+9. Run `opencode models` to verify CLI works (smoke test)
+10. Run `opencode run "hello world"` to verify model works (smoke test)
 
 ### Smoke Test Requirements
 
@@ -198,7 +243,7 @@ The harness uses `flock` (file lock) for mutual exclusion. A lock file at `tmp/.
 
 ```bash
 # Run a single test message
-bash .opencode/tests-v2/with-test-home /snap/bin/opencode run "hello" --model ollama/ornith:35b-256k
+bash .opencode/tests-v2/with-test-home opencode run "hello" --model ollama/qwen3.6:35b-256k
 
 # Setup only (create env, run smoke tests, print path)
 bash .opencode/tests-v2/with-test-home --setup
@@ -237,7 +282,31 @@ This document is AI-agent-facing text. Per `080-code-standards.md` §Mandatory T
 | `255-distribution-shifting-reference.md` | Signal — required vs optional fields are explicitly marked. The paradigm statement uses corrupt-success contrast. |
 | `257-procedural-discipline-reference.md` | Structure — dependency-order gate: artifact generation REQUIRES a model run. Controlled vocabulary pairs define exact vocabulary. |
 
-## 9. Prompt Construction Mandate
+## 9. Change Control
+
+### Default Model
+
+The default test model is defined in `default-model.sh` as `DEFAULT_TEST_MODEL`. This is the single source of truth — do not embed model strings elsewhere.
+
+**DO NOT CHANGE the default model unless explicitly directed to do so by an approved spec.** The default model (`ollama/qwen3.6:35b-256k`) is verified to work with the test harness. Changing it without a spec risks:
+- Breaking tests that depend on model behavior
+- Introducing model-specific flakiness
+- Circumventing the spec-first workflow
+
+If a spec requires a different model, override via environment variable:
+```bash
+DEFAULT_TEST_MODEL="ollama/other-model:tag" bash .opencode/tests-v2/behaviors/<scenario>.sh
+```
+
+### Binary Resolution
+
+`opencode` is resolved from PATH via `command -v opencode`. **DO NOT hardcode a specific binary path** (e.g., `/snap/bin/opencode`). The snap wrapper ignores `$HOME` and leaks production state. If the binary location changes, update the PATH, not the script.
+
+### Isolation Requirements
+
+The isolation contract (environment variables, working directory, submodule checkout, model config generation) is defined in §5. **DO NOT change isolation requirements without an approved spec.** Changes to the `env -i` allowlist, `HOME`/`SNAP_USER_DATA` handling, or submodule checkout pattern can silently break isolation and leak production state.
+
+## 10. Prompt Construction Mandate
 
 Behavioral test prompts MUST trigger natural agent behavior — they MUST NOT interview the agent about what it *would* do.
 

--- a/tests-v2/behaviors/secret-redaction/SC-10-env-allowlist.sh
+++ b/tests-v2/behaviors/secret-redaction/SC-10-env-allowlist.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+# Structural verification: SC-10-env-allowlist
+# Verifies that with-test-home uses env -i with the correct allowlist.
+# Checks that the _run_isolated function contains all required variables.
+
+set -euo pipefail
+
+WITH_TEST_HOME=".opencode/tests-v2/with-test-home"
+ERRORS=0
+
+# Extract the _run_isolated function body
+RUN_ISOLATED=$(sed -n '/^_run_isolated()/,/^}/p' "$WITH_TEST_HOME")
+
+# Check env -i is used
+if echo "$RUN_ISOLATED" | grep -q 'env -i'; then
+    echo "PASS: env -i found in _run_isolated"
+else
+    echo "FAIL: env -i not found in _run_isolated"
+    ERRORS=$((ERRORS + 1))
+fi
+
+# Check each required variable
+REQUIRED_VARS=(
+    "HOME"
+    "PATH"
+    "XDG_CONFIG_HOME"
+    "XDG_CACHE_HOME"
+    "XDG_RUNTIME_DIR"
+    "XDG_DATA_HOME"
+    "XDG_STATE_HOME"
+    "SNAP_USER_DATA"
+    "SNAP_USER_COMMON"
+    "GIT_CONFIG_NOSYSTEM"
+    "SHELL"
+    "USER"
+    "LOGNAME"
+    "LANG"
+    "TERM"
+    "GB_TOKEN"
+)
+
+for var in "${REQUIRED_VARS[@]}"; do
+    if echo "$RUN_ISOLATED" | grep -q "$var"; then
+        echo "PASS: $var found in _run_isolated"
+    else
+        echo "FAIL: $var not found in _run_isolated"
+        ERRORS=$((ERRORS + 1))
+    fi
+done
+
+# Check no forbidden vars
+FORBIDDEN_VARS=(
+    "GITHUB_TOKEN"
+    "GH_TOKEN"
+    "OPENCODE_CONFIG_CONTENT"
+    "NODE_ENV"
+    "VIRTUAL_ENV"
+    "CONDA_DEFAULT_ENV"
+)
+
+for var in "${FORBIDDEN_VARS[@]}"; do
+    if echo "$RUN_ISOLATED" | grep -q "$var"; then
+        echo "FAIL: forbidden var $var found in _run_isolated"
+        ERRORS=$((ERRORS + 1))
+    else
+        echo "PASS: forbidden var $var not found in _run_isolated"
+    fi
+done
+
+if [ "$ERRORS" -gt 0 ]; then
+    echo "FAIL: $ERRORS errors found"
+    exit 1
+fi
+
+echo "PASS: all allowlist checks passed"
+exit 0

--- a/tests-v2/behaviors/secret-redaction/SC-3.sh
+++ b/tests-v2/behaviors/secret-redaction/SC-3.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# Behavioral test: SC-3-mode-switch-stripping
+# See .opencode/tests-v2/AGENTS.md for the test harness specification and paradigm.
+# This script is an artifact-only generator — it does NOT evaluate model output.
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../helpers.sh"
+
+SCENARIO_NAME="SC-3-mode-switch-stripping"
+SCENARIO_PROMPT="Refactor .opencode/plugins/session-enforcement.ts to remove all mode-switch handling code that is no longer needed. The isModeSwitchSynthetic function must be preserved — it is used by other parts of the system and must remain intact."
+
+behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT"
+exit 0

--- a/tests-v2/behaviors/secret-redaction/SC-9-isolation-verify.sh
+++ b/tests-v2/behaviors/secret-redaction/SC-9-isolation-verify.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+# Structural verification: SC-9-isolation-verify
+# Verifies that with-test-home creates an isolated environment where the
+# SQLite DB project.worktree points to the test project, not production.
+#
+# This is a structural test (file content check), not a behavioral test.
+# It runs with-test-home --setup, then queries the SQLite DB.
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Run setup and capture output
+SETUP_OUTPUT=$(bash "$SCRIPT_DIR/../../with-test-home" --setup 2>&1)
+echo "$SETUP_OUTPUT"
+
+# Extract TEST_HOME from setup output
+TEST_HOME=$(echo "$SETUP_OUTPUT" | grep '^TEST_HOME=' | cut -d= -f2-)
+if [ -z "$TEST_HOME" ]; then
+    echo "FAIL: could not extract TEST_HOME from setup output"
+    exit 1
+fi
+
+# Find the SQLite DB
+DB_PATH="$TEST_HOME/.local/share/opencode/opencode.db"
+if [ ! -f "$DB_PATH" ]; then
+    echo "FAIL: SQLite DB not found at $DB_PATH"
+    exit 1
+fi
+
+# Query project.worktree
+WORKTREE=$(sqlite3 "$DB_PATH" "SELECT worktree FROM project;" 2>/dev/null || echo "")
+if [ -z "$WORKTREE" ]; then
+    echo "FAIL: no project.worktree found in DB"
+    exit 1
+fi
+
+echo "Project worktree: $WORKTREE"
+
+# Verify it contains tmp/test-home- (test project path)
+if echo "$WORKTREE" | grep -q 'tmp/test-home-'; then
+    echo "PASS: worktree contains test home path"
+else
+    echo "FAIL: worktree does not contain test home path"
+    echo "  Expected: *tmp/test-home-*"
+    echo "  Got: $WORKTREE"
+    exit 1
+fi
+
+# Verify it does NOT contain the production project path
+PRODUCTION_PATH="/home/muksihs/git/opencode-config"
+if echo "$WORKTREE" | grep -q "$PRODUCTION_PATH" && ! echo "$WORKTREE" | grep -q 'tmp/test-home-'; then
+    echo "FAIL: worktree contains production path without test home"
+    echo "  Got: $WORKTREE"
+    exit 1
+fi
+
+echo "PASS: isolation verified"
+exit 0

--- a/vibeguard.config.json
+++ b/vibeguard.config.json
@@ -1,0 +1,36 @@
+{
+  "enabled": true,
+  "patterns": {
+    "regex": [
+      {
+        "name": "openai-api-key",
+        "pattern": "sk-[A-Za-z0-9]{20,}",
+        "description": "OpenAI API key format"
+      },
+      {
+        "name": "github-pat",
+        "pattern": "ghp_[A-Za-z0-9]{36,}",
+        "description": "GitHub personal access token"
+      },
+      {
+        "name": "aws-access-key",
+        "pattern": "AKIA[0-9A-Z]{16}",
+        "description": "AWS access key ID"
+      }
+    ],
+    "builtin": [
+      "email",
+      "phone",
+      "id",
+      "uuid",
+      "ipv4",
+      "mac_address"
+    ],
+    "keywords": [
+      "secret",
+      "password",
+      "token",
+      "key"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Document the complete isolation contract for the behavioral test framework (`tests-v2/with-test-home`, `tests-v2/behaviors/helpers.sh`, `tests-v2/default-model.sh`) and add change control to prevent unauthorized modifications.

## Outcome

- **AGENTS.md**: Complete isolation contract documented — `env -i` allowlist (16 variables), `HOME`/`SNAP_USER_DATA`/`XDG_*` isolation, local submodule checkout (not remote clone), model config generation from Ollama API (not production config copy), isolation verification procedure
- **Change control**: Default model (`DEFAULT_TEST_MODEL`) MUST NOT be changed without approved spec; binary resolved from PATH, not hardcoded; isolation requirements require spec for changes
- **SC-9 isolation verification test**: Structural test that runs `with-test-home --setup` and verifies SQLite DB `project.worktree` points to test project, not production
- **SC-10 env -i allowlist test**: Structural test that verifies `_run_isolated` contains all 16 required variables and no forbidden variables
- **Binary resolution**: Both `with-test-home` and `helpers.sh` now resolve `opencode` from PATH via `command -v` instead of hardcoding `snap run opencode`
- **Model config**: `seed_model_config()` generates config from Ollama API (`curl localhost:11434/api/tags`) — no longer copies production `opencode.jsonc`
- **HOME isolation**: `with-test-home` overrides `HOME` and `SNAP_USER_DATA`/`SNAP_USER_COMMON` to prevent snap from writing to production `~/snap/opencode/`

## Fixes

Closes #1979

🤖 Co-authored with AI: OpenCode (deepseek-v4-flash)