### PR TITLE
Add test framework discipline section to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,6 +117,35 @@ Guidelines are pruned to the absolute minimum. See `.opencode/guidelines/` for:
 
 **Isolated test environment:** The `with-test-home` wrapper isolates opencode XDG state into a project-relative temporary home (`./opencode/tmp/test-home-<timestamp>`), eliminating SQLite session conflicts with the desktop app. This allows skill enforcement tests to run from within an active opencode session. When a test session fails, see the Session Failure Diagnosis section in `tests-v2/AGENTS.md` for a diagnostic checklist covering model availability, artifact integrity, lock contention, and test home cleanup — the 6-check table and 5 common root causes cover the vast majority of harness failures.
 
+### `timeout` Command Prohibition
+
+The `timeout` command (GNU coreutils) is FORBIDDEN in all bash scripts. The bash tool's `timeout` parameter (in milliseconds) is the ONLY permitted kill signal. GNU timeout does NOT forward SIGTERM to its child processes — orphaned opencode processes hold the `flock` lock and hang all subsequent test runs.
+
+### `with-test-home` Mandate
+
+`opencode run` MUST NOT be called directly. ALL opencode test execution MUST go through:
+```bash
+bash .opencode/tests-v2/with-test-home opencode run '<message>'
+```
+
+### Standalone Binary Setup
+
+The snap binary at `/snap/bin/opencode` hardcodes `SNAP_USER_DATA=~/snap/opencode/` and cannot be redirected. The correct pattern is:
+1. Cache the standalone binary at `.tools/opencode/opencode`
+2. Copy it into the test home at `$TEST_HOME/bin/opencode` during test setup
+3. Prepend `$TEST_HOME/bin` to PATH so the harness resolves the standalone binary
+
+### Prohibited Bypass Patterns
+
+| Pattern | Why Forbidden |
+|---------|---------------|
+| Manual test home construction (`mktemp -d`, manual `opencode.jsonc`, manual `git init`, manual `.opencode` clone) | Bypasses isolation, leaks production state |
+| Direct `opencode run` without `with-test-home` | Causes SQLite session conflicts with desktop app |
+| Standalone binary download/copy outside `with-test-home` | Creates unmanaged test environments |
+| Manual `opencode.jsonc` seeding | Bypasses `seed_model_config()` model discovery and isolation verification |
+| Manual `git init` + `.opencode` clone | Bypasses test project creation with proper isolation |
+| "This is simple/quick/small" rationalization | NOT a valid justification — framework is MANDATORY for ALL test execution |
+
 ---
 
 ## `gb` CLI Tool — GitBucket Operations


### PR DESCRIPTION
## Summary

Adds a consolidated Test Framework Discipline section to `.opencode/AGENTS.md` documenting mandatory test execution rules.

## Outcome

New `## Test Framework Discipline — MANDATORY` section with:
- **`timeout` Command Prohibition** — GNU coreutils `timeout` is FORBIDDEN in all bash scripts. The bash tool's `timeout` parameter (milliseconds) is the only permitted kill signal.
- **`with-test-home` Mandate** — `opencode run` MUST NOT be called directly. ALL opencode test execution MUST go through `bash .opencode/tests-v2/with-test-home opencode run '<message>'`.
- **Standalone Binary Setup** — Cache at `.tools/opencode/opencode`, copy to `$TEST_HOME/bin/opencode` during test setup, prepend `$TEST_HOME/bin` to PATH.
- **Prohibited Bypass Patterns** — Table covering manual test home construction, direct `opencode run`, standalone binary download outside harness, manual `opencode.jsonc` seeding, manual `git init` + `.opencode` clone, and "this is simple/quick/small" rationalization.

## Fixes

Part of opencode-config#305
