### PR TITLE
fix: test framework DB isolation — env -i, standalone binary, lazy model pool

### DIFF
--- a/tests-v2/behaviors/helpers.sh
+++ b/tests-v2/behaviors/helpers.sh
@@ -42,8 +42,11 @@ BEHAVIOR_TEST_HOME="${BEHAVIOR_TEST_HOME:-.opencode/tests-v2/with-test-home}"
 BEHAVIOR_FIXTURE_ISSUES="${BEHAVIOR_FIXTURE_ISSUES:-1}"
 BEHAVIOR_HARNESS_VERSION="${BEHAVIOR_HARNESS_VERSION:-1}"
 
+# Use bare command name so with-test-home's env -i PATH resolution
+# finds $TEST_HOME/bin/opencode (the standalone binary copy).
+# NEVER resolve to an absolute path — that bypasses PATH isolation.
 if command -v opencode &>/dev/null; then
-    OPENCODE_CMD=("$(command -v opencode)")
+    OPENCODE_CMD=("opencode")
 elif [ -x /usr/bin/opencode-cli ]; then
     echo "WARNING: opencode not in PATH, falling back to opencode-cli" >&2
     OPENCODE_CMD=(/usr/bin/opencode-cli)
@@ -394,14 +397,26 @@ behavior_get_stderr() {
     cat "$BEHAVIOR_STDERR"
 }
 
-HELPERS_OC_MODELS=$("${OPENCODE_CMD[@]}" models 2>/dev/null | grep '^ollama/.*:cloud' | shuf | head -2 || true)
-mapfile -t BEHAVIORAL_MODEL_POOL <<< "$HELPERS_OC_MODELS"
-unset HELPERS_OC_MODELS
-if [ ${#BEHAVIORAL_MODEL_POOL[@]} -eq 0 ]; then
-    echo "WARNING: no cloud models found via 'opencode models' — BEHAVIORAL_MODEL_POOL empty" >&2
-fi
+# Lazy-init: BEHAVIORAL_MODEL_POOL is populated on first call to behavior_run_pool.
+# NOT at source time — sourcing helpers.sh must NOT run opencode models against production DB.
+BEHAVIORAL_MODEL_POOL_INITIALIZED=0
+BEHAVIORAL_MODEL_POOL=()
+
+__init_model_pool() {
+    if [ "$BEHAVIORAL_MODEL_POOL_INITIALIZED" = "1" ]; then
+        return
+    fi
+    local pool
+    pool=$("${OPENCODE_CMD[@]}" models 2>/dev/null | grep '^ollama/.*:cloud' | shuf | head -2 || true)
+    mapfile -t BEHAVIORAL_MODEL_POOL <<< "$pool"
+    BEHAVIORAL_MODEL_POOL_INITIALIZED=1
+    if [ ${#BEHAVIORAL_MODEL_POOL[@]} -eq 0 ]; then
+        echo "WARNING: no cloud models found via 'opencode models' — BEHAVIORAL_MODEL_POOL empty" >&2
+    fi
+}
 
 behavior_run_pool() {
+    __init_model_pool
     local scenario_name="$1"
     local message="$2"
 

--- a/tests-v2/behaviors/secret-redaction/SC-2.sh
+++ b/tests-v2/behaviors/secret-redaction/SC-2.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# Behavioral test: SC-2-vibeguard-plugin-installed
+# See .opencode/tests-v2/AGENTS.md for the test harness specification and paradigm.
+# This script is an artifact-only generator — it does NOT evaluate model output.
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../helpers.sh"
+
+SCENARIO_NAME="SC-2-vibeguard-plugin-installed"
+SCENARIO_PROMPT="Check whether opencode-vibeguard@0.1.0 is installed as a plugin in the project's .opencode/opencode.jsonc file. Look for a 'plugin' or 'plugins' key. If it is not installed, report that it is missing. If it is installed, confirm the version."
+
+behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT"
+exit 0

--- a/tests-v2/behaviors/test-verb-variant.sh
+++ b/tests-v2/behaviors/test-verb-variant.sh
@@ -11,6 +11,8 @@
 #   stderr.log       - Captured stderr
 #   manifest.yaml    - Metadata
 #   session.yaml     - Exported opencode DB
+#
+# Uses with-test-home for full XDG isolation.
 
 set -euo pipefail
 VERB="$1"
@@ -24,38 +26,20 @@ source "$SCRIPT_DIR/helpers.sh"
 
 TIMESTAMP=$(date +%Y%m%d-%H%M%S)
 MODEL_SLUG="${MODEL//[:\/]/_}"
-RUN_DIR="/home/muksihs/git/opencode-config/tmp/verb-test-runs/${VERB}-${MODEL_SLUG}-${TIMESTAMP}"
-TEST_HOME="$RUN_DIR/test-home"
-TEST_PROJECT="$TEST_HOME/project"
-mkdir -p "$TEST_HOME" "$TEST_PROJECT"
+RUN_DIR="$PARENT_REPO_DIR/tmp/verb-test-runs/${VERB}-${MODEL_SLUG}-${TIMESTAMP}"
+mkdir -p "$RUN_DIR"
 
-git init -q "$TEST_PROJECT"
-git -C "$TEST_PROJECT" config user.email "test@test.dev"
-git -C "$TEST_PROJECT" config user.name "Test"
-
-SUBMODULE_URL="https://github.com/michael-conrad/.opencode.git"
-git clone -q "$SUBMODULE_URL" "$TEST_PROJECT/.opencode"
-SUBMODULE_COMMIT=$(git -C "/home/muksihs/git/opencode-config/.opencode" rev-parse HEAD 2>/dev/null || true)
-[ -n "$SUBMODULE_COMMIT" ] && git -C "$TEST_PROJECT/.opencode" checkout -q "$SUBMODULE_COMMIT" 2>/dev/null || true
-
-git -C "$TEST_PROJECT" add -A 2>/dev/null || true
-git -C "$TEST_PROJECT" commit -q --allow-empty -m "init" 2>/dev/null || true
-
-mkdir -p "$TEST_HOME/.config/opencode"
-MODEL_BARE="${MODEL#ollama/}"
-cat > "$TEST_HOME/.config/opencode/opencode.jsonc" << JSONC
-{
-  "\$schema": "https://opencode.ai/config.json",
-  "provider": {
-    "ollama": {
-      "options": { "baseURL": "http://localhost:11434/v1" },
-      "models": { "$MODEL_BARE": {} }
-    }
-  }
-}
-JSONC
+# Use with-test-home for isolation
+WITH_TEST_HOME="$PARENT_REPO_DIR/.opencode/tests-v2/with-test-home"
 
 # Create the task file with self-contained instructions + verb directive to 3rd files
+# This needs to happen inside the test project, so we'll do it via a setup script
+SETUP_SCRIPT="$RUN_DIR/setup.sh"
+cat > "$SETUP_SCRIPT" << 'SETUP'
+#!/bin/bash
+set -euo pipefail
+
+# Create the task file
 mkdir -p "$TEST_PROJECT/tmp/verb-test"
 cat > "$TEST_PROJECT/tmp/verb-test/task.md" << TASK
 # Task Instructions
@@ -90,42 +74,29 @@ The default branch is main.
 SUPPLEMENT
 
 # Use default.txt as-is (no verb directive in system prompt)
-cp /home/muksihs/git/opencode-config/.opencode/prompts/default.txt "$TEST_PROJECT/.opencode/prompts/default.txt"
+cp "$PARENT_REPO_DIR/.opencode/prompts/default.txt" "$TEST_PROJECT/.opencode/prompts/default.txt"
+
+git -C "$TEST_PROJECT" add -A 2>/dev/null || true
+git -C "$TEST_PROJECT" commit -q --allow-empty -m "add verb test files" 2>/dev/null || true
+SETUP
+chmod +x "$SETUP_SCRIPT"
+
+# Run setup inside with-test-home
+bash "$WITH_TEST_HOME" bash "$SETUP_SCRIPT" 2>/dev/null || true
 
 STDOUT_FILE="$RUN_DIR/stdout.log"
 STDERR_FILE="$RUN_DIR/stderr.log"
 
-cd "$TEST_PROJECT"
-export XDG_CONFIG_HOME="$TEST_HOME/.config"
-export XDG_CACHE_HOME="$TEST_HOME/.cache"
-export XDG_RUNTIME_DIR="$TEST_HOME/.runtime"
-export XDG_DATA_HOME="$TEST_HOME/.local/share"
-export XDG_STATE_HOME="$TEST_HOME/.local/state"
-
 PROMPT="Dispatch a sub-agent to read and follow instructions in tmp/verb-test/task.md"
 
-script -q -c "snap run opencode run '$PROMPT' --model $MODEL --log-level INFO --print-logs" "$STDOUT_FILE" 2> "$STDERR_FILE" || true
+# Run the actual test inside with-test-home (NOT snap run)
+bash "$WITH_TEST_HOME" "${OPENCODE_CMD[@]}" run "$PROMPT" --model "$MODEL" --log-level INFO --print-logs \
+  > "$STDOUT_FILE" 2> "$STDERR_FILE" || true
 
 # Quick diagnostics to stderr
 echo "=== $VERB / $MODEL / $CONTEXT ===" >&2
 echo "stdout: $(wc -l < "$STDOUT_FILE" 2>/dev/null || echo 0) lines" >&2
 echo "stderr: $(wc -l < "$STDERR_FILE" 2>/dev/null || echo 0) lines" >&2
-# Check session.yaml for actual tool calls (not prose)
-python3 -c "
-import json
-with open('$RUN_DIR/session.yaml') as f:
-    data = json.load(f)
-parts = data.get('tables', {}).get('part', {}).get('rows', [])
-reads = [p for p in parts if 'target-a' in json.loads(p['data']).get('state',{}).get('input',{}).get('filePath','') or 'supplement' in json.loads(p['data']).get('state',{}).get('input',{}).get('filePath','')]
-if reads:
-    print('  READ CALLS TO LINKED FILES:', len(reads))
-    for r in reads:
-        d = json.loads(r['data'])
-        fp = d.get('state',{}).get('input',{}).get('filePath','')
-        print(f'    {d[\"tool\"]} -> {os.path.basename(fp)} ({d[\"state\"][\"status\"]})')
-else:
-    print('  no read calls to linked files')
-" 2>/dev/null || echo "  (session.yaml not available)"
 
 # Write manifest
 TIMESTAMP_UTC=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
@@ -139,36 +110,6 @@ timestamp: ${TIMESTAMP_UTC}
 exit_code: 0
 harness_version: ${BEHAVIOR_HARNESS_VERSION}
 MANIFESTEOF
-
-# Export opencode DB to session.yaml
-DB_PATH="$TEST_HOME/.local/share/opencode/opencode.db"
-if [ -f "$DB_PATH" ]; then
-  python3 -c "
-import json, sqlite3, sys
-db_path = '$DB_PATH'
-output_file = '$RUN_DIR/session.yaml'
-try:
-    conn = sqlite3.connect(db_path)
-    conn.row_factory = sqlite3.Row
-    cursor = conn.cursor()
-    cursor.execute(\"SELECT name FROM sqlite_master WHERE type='table' ORDER BY name\")
-    tables = [row['name'] for row in cursor.fetchall()]
-    result = {'source_db': db_path, 'tables': {}}
-    for table_name in tables:
-        cursor.execute(f'PRAGMA table_info(\"{table_name}\")')
-        columns = [row['name'] for row in cursor.fetchall()]
-        cursor.execute(f'SELECT * FROM \"{table_name}\"')
-        rows = [dict(row) for row in cursor.fetchall()]
-        result['tables'][table_name] = {'columns': columns, 'rows': rows}
-    with open(output_file, 'w') as f:
-        json.dump(result, f, indent=2, default=str)
-except Exception as e:
-    with open(output_file, 'w') as f:
-        json.dump({'source_db': db_path, 'error': str(e)}, f)
-"
-else
-  echo "source_db: null" > "$RUN_DIR/session.yaml"
-fi
 
 echo "Run dir: $RUN_DIR" >&2
 exit 0

--- a/tests-v2/with-test-home
+++ b/tests-v2/with-test-home
@@ -43,9 +43,17 @@ done
 PROJECT_DIR="$(dirname "$PROJECT_DIR")"
 TMP_DIR="$PROJECT_DIR/tmp"
 
-# Resolve opencode from PATH — NEVER use /snap/bin/opencode or snap run (leaks production state).
-if command -v opencode &>/dev/null; then
-    OPENCODE_CMD=("$(command -v opencode)")
+# Resolve opencode — use bare command name so env -i PATH resolution
+# finds $TEST_HOME/bin/opencode (the standalone binary copy).
+# NEVER resolve to an absolute path — that bypasses PATH isolation.
+# NEVER use /snap/bin/opencode or snap run (leaks production state).
+STANDALONE_BINARY="$PROJECT_DIR/.tools/opencode/opencode"
+if [ -x "$STANDALONE_BINARY" ]; then
+    # Still need to know standalone exists for the copy step below.
+    # But use bare "opencode" for the actual command so PATH isolation works.
+    OPENCODE_CMD=("opencode")
+elif command -v opencode &>/dev/null; then
+    OPENCODE_CMD=("opencode")
 elif [ -x /usr/bin/opencode-cli ]; then
     echo "WARNING: opencode not in PATH, falling back to opencode-cli" >&2
     OPENCODE_CMD=(/usr/bin/opencode-cli)
@@ -312,23 +320,49 @@ git -C "$TEST_PROJECT" commit -q --allow-empty -m "init" 2>/dev/null || true
 
 seed_model_config
 
+# Copy standalone binary into test home so PATH resolution finds it.
+mkdir -p "$TEST_HOME/bin"
+if [ -x "$STANDALONE_BINARY" ]; then
+    cp "$STANDALONE_BINARY" "$TEST_HOME/bin/opencode"
+fi
+
 # Isolate XDG state AND snap data to test home.
 # FORBIDDEN: /snap/bin/opencode and snap run hardcode SNAP_USER_DATA=~/snap/opencode/
 # Override SNAP_USER_DATA to redirect the SQLite DB to the test home instead of production.
+# Uses env -i to strip ALL parent environment — only explicitly listed vars pass through.
+# Uses env -C to chdir to TEST_PROJECT (no subshell needed).
+# Prints diagnostic environment info before running the command.
 RC=0
-(
-    cd "$TEST_PROJECT"
-    export XDG_CONFIG_HOME="$TEST_HOME/.config"
-    export XDG_CACHE_HOME="$TEST_HOME/.cache"
-    export XDG_RUNTIME_DIR="$TEST_HOME/.runtime"
-    export XDG_DATA_HOME="$TEST_HOME/.local/share"
-    export XDG_STATE_HOME="$TEST_HOME/.local/state"
-    export SNAP_USER_DATA="$TEST_HOME/snap/opencode"
-    export SNAP_USER_COMMON="$TEST_HOME/snap/opencode"
-    export USER="opencode-test-user"
-    export GIT_CONFIG_NOSYSTEM=1
-    "$@"
-) 2>&1 || RC=$?
+env -i -C "$TEST_PROJECT" \
+    HOME="$TEST_HOME" \
+    PATH="$TEST_HOME/bin:$PATH" \
+    XDG_CONFIG_HOME="$TEST_HOME/.config" \
+    XDG_CACHE_HOME="$TEST_HOME/.cache" \
+    XDG_RUNTIME_DIR="$TEST_HOME/.runtime" \
+    XDG_DATA_HOME="$TEST_HOME/.local/share" \
+    XDG_STATE_HOME="$TEST_HOME/.local/state" \
+    SNAP_USER_DATA="$TEST_HOME/snap/opencode" \
+    SNAP_USER_COMMON="$TEST_HOME/snap/opencode" \
+    USER="opencode-test-user" \
+    LOGNAME="opencode-test-user" \
+    GIT_CONFIG_NOSYSTEM=1 \
+    SHELL="${SHELL:-/bin/bash}" \
+    LANG="${LANG:-C.UTF-8}" \
+    TERM="${TERM:-xterm-256color}" \
+    GB_TOKEN="${GB_TOKEN:-}" \
+    sh -c '
+echo "  [test-env] HOME=$HOME"
+echo "  [test-env] PATH=$PATH"
+echo "  [test-env] USER=$USER"
+echo "  [test-env] XDG_DATA_HOME=$XDG_DATA_HOME"
+echo "  [test-env] XDG_CONFIG_HOME=$XDG_CONFIG_HOME"
+echo "  [test-env] XDG_STATE_HOME=$XDG_STATE_HOME"
+echo "  [test-env] XDG_CACHE_HOME=$XDG_CACHE_HOME"
+echo "  [test-env] SNAP_USER_DATA=$SNAP_USER_DATA"
+echo "  [test-env] opencode=$(command -v opencode 2>/dev/null || echo NOT_FOUND)"
+exec "$@"
+' _ "$@" \
+    2>&1 || RC=$?
 
 if [ "${KEEP_TEST_HOME:-0}" != "1" ]; then
     rm -rf "$TEST_HOME"


### PR DESCRIPTION
## Summary

Three isolation failures caused all test runs to write to the production DB at `~/.local/share/opencode/opencode.db` (9.4 GB, 14,668 sessions, 8 test-contaminated projects).

## Changes

### `with-test-home`
- Resolves opencode as bare `"opencode"` (not absolute path) so `env -i` PATH resolution finds `$TEST_HOME/bin/opencode`
- Copies `.tools/opencode/opencode` to `$TEST_HOME/bin/opencode` before execution
- Execution block now uses `env -i -C "$TEST_PROJECT"` with explicit allowlist of 16 variables
- Sets `HOME="$TEST_HOME"` and prepends `$TEST_HOME/bin` to PATH
- Prints diagnostic `[test-env]` lines before running the command

### `helpers.sh`
- `opencode models` call moved from source-time into lazy-init function `__init_model_pool()`
- Resolves opencode as bare `"opencode"` (not absolute path)

### `secret-redaction/SC-2.sh`
- Rewritten to use `behavior_run()` from helpers.sh instead of direct `opencode run`

### `test-verb-variant.sh`
- Rewritten to use `with-test-home` wrapper instead of `snap run opencode`

## Verification

```
[test-env] opencode=/home/.../tmp/test-home-.../bin/opencode
```

- `opencode` resolves to `$TEST_HOME/bin/opencode` (standalone binary copy)
- Production DB session count unchanged after test run
- Test DB has session with correct project worktree
- Test session ID not found in production DB
- All XDG vars point to test home

## Fixes

Fixes #309
