### PR TITLE
1974: Add secret redaction plugin (opencode-vibeguard) behavioral test scripts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,6 +117,35 @@ Guidelines are pruned to the absolute minimum. See `.opencode/guidelines/` for:
 
 **Isolated test environment:** The `with-test-home` wrapper isolates opencode XDG state into a project-relative temporary home (`./opencode/tmp/test-home-<timestamp>`), eliminating SQLite session conflicts with the desktop app. This allows skill enforcement tests to run from within an active opencode session. When a test session fails, see the Session Failure Diagnosis section in `tests-v2/AGENTS.md` for a diagnostic checklist covering model availability, artifact integrity, lock contention, and test home cleanup — the 6-check table and 5 common root causes cover the vast majority of harness failures.
 
+### `timeout` Command Prohibition
+
+The `timeout` command (GNU coreutils) is FORBIDDEN in all bash scripts. The bash tool's `timeout` parameter (in milliseconds) is the ONLY permitted kill signal. GNU timeout does NOT forward SIGTERM to its child processes — orphaned opencode processes hold the `flock` lock and hang all subsequent test runs.
+
+### `with-test-home` Mandate
+
+`opencode run` MUST NOT be called directly. ALL opencode test execution MUST go through:
+```bash
+bash .opencode/tests-v2/with-test-home opencode run '<message>'
+```
+
+### Standalone Binary Setup
+
+The snap binary at `/snap/bin/opencode` hardcodes `SNAP_USER_DATA=~/snap/opencode/` and cannot be redirected. The correct pattern is:
+1. Cache the standalone binary at `.tools/opencode/opencode`
+2. Copy it into the test home at `$TEST_HOME/bin/opencode` during test setup
+3. Prepend `$TEST_HOME/bin` to PATH so the harness resolves the standalone binary
+
+### Prohibited Bypass Patterns
+
+| Pattern | Why Forbidden |
+|---------|---------------|
+| Manual test home construction (`mktemp -d`, manual `opencode.jsonc`, manual `git init`, manual `.opencode` clone) | Bypasses isolation, leaks production state |
+| Direct `opencode run` without `with-test-home` | Causes SQLite session conflicts with desktop app |
+| Standalone binary download/copy outside `with-test-home` | Creates unmanaged test environments |
+| Manual `opencode.jsonc` seeding | Bypasses `seed_model_config()` model discovery and isolation verification |
+| Manual `git init` + `.opencode` clone | Bypasses test project creation with proper isolation |
+| "This is simple/quick/small" rationalization | NOT a valid justification — framework is MANDATORY for ALL test execution |
+
 ---
 
 ## `gb` CLI Tool — GitBucket Operations

--- a/tests-v2/AGENTS.md
+++ b/tests-v2/AGENTS.md
@@ -12,7 +12,7 @@ Every behavioral test script generates model-run artifacts and exits 0. Evaluati
 
 | Aspect | v1 (`.opencode/tests/`) | v2 (`.opencode/tests-v2/`) |
 |--------|------------------------|----------------------------|
-| CLI binary | `opencode-cli` | `opencode` from PATH (resolved via `command -v`) |
+| CLI binary | `opencode-cli` | `opencode` (resolved from PATH) |
 | Model discovery | `opencode-cli models` | `opencode models` |
 | Test runner | `with-test-home` (v1) | `with-test-home` (v2, rewritten) |
 | Env isolation | Partial `env` passthrough | `env -i` with explicit allowlist |
@@ -146,7 +146,8 @@ bash .opencode/tests-v2/behaviors/<scenario>.sh
 
 ### Binary
 
-`opencode` is resolved from PATH via `command -v opencode` in both `with-test-home` and `helpers.sh`. The binary is NOT hardcoded to `/snap/bin/opencode` or any specific path.
+- **`opencode`** resolved from PATH — the ONLY binary used. NEVER hardcode `/snap/bin/opencode`.
+- **`opencode-cli`** at `/usr/bin/opencode-cli` — fallback only, NOT the primary binary.
 
 **Why PATH resolution instead of hardcoding:** The snap wrapper at `/snap/bin/opencode` → `/usr/bin/snap` ignores `$HOME` and hardcodes `SNAP_USER_DATA=~/snap/opencode/`, which leaks production state into test environments. Resolving from PATH allows the test harness to use any opencode installation while maintaining `HOME` isolation.
 
@@ -232,12 +233,26 @@ The harness uses `flock` (file lock) for mutual exclusion. A lock file at `tmp/.
 
 ### Bash Tool Timeout Mandate — ZERO TOLERANCE
 
-**The bash tool's `timeout` parameter is the ONLY kill signal that may be used when running behavioral tests.** Any use of the `timeout` command inside a bash script invoked by the bash tool is FORBIDDEN.
+**The bash tool's `timeout` parameter is the ONLY kill signal that may be used when running behavioral tests.** Any use of the `timeout` command (GNU timeout) inside a bash script invoked by the bash tool is FORBIDDEN — nested timeouts create orphaned processes that hold the flock lock and hang all subsequent test runs.
 
 **Mandated bash tool invocation:**
 ```
 # timeout=600000 (600 seconds, milliseconds). NEVER omit.
 ```
+
+### Test Isolation Mandates — ZERO TOLERANCE
+
+The following mandates are non-waivable. Violation = pipeline halt.
+
+| # | Mandate | Enforcement |
+|---|---------|-------------|
+| 1 | **`snap run` is FORBIDDEN** — `snap run opencode` hardcodes `SNAP_USER_DATA=~/snap/opencode/` and writes to the production DB. The only acceptable reference to `snap run` is as a forbidden pattern example in comments. | grep for `snap run` in executable code returns 0 matches |
+| 2 | **`/snap/bin/opencode` is FORBIDDEN** — never hardcode the binary path. Always resolve `opencode` from PATH. | grep for `/snap/bin/opencode` returns 0 matches |
+| 3 | **`timeout` command (GNU timeout) is FORBIDDEN** in test scripts. The bash tool `timeout` parameter is the ONLY kill signal. | grep for `^timeout ` in test scripts returns 0 matches |
+| 4 | **`USER=opencode-test-user` MUST be set** in the test environment. Tests must use a non-production user identity. | grep for `opencode-test-user` in `with-test-home` returns match |
+| 5 | **Default model MUST NOT be changed** without an approved spec. `DEFAULT_TEST_MODEL` in `default-model.sh` is the single source of truth. | grep for model strings outside `default-model.sh` returns 0 matches |
+| 6 | **Smoke test is MANDATORY** — `opencode models` + `opencode run "hello world"` must pass before the test home is considered ready. | `do_setup()` in `with-test-home` runs both |
+| 7 | **Isolation verification is MANDATORY** — after warmup, verify test home only contains opencode config/db/log files and production DB is untouched (sha256 comparison). | `do_setup()` in `with-test-home` runs isolation check |
 
 ### Invocation Examples
 

--- a/tests-v2/behaviors/helpers.sh
+++ b/tests-v2/behaviors/helpers.sh
@@ -24,8 +24,8 @@
 # ║  Always pass `timeout: 600000` (600 seconds, milliseconds) to the bash tool  ║
 # ║  when invoking any script in tests-v2/behaviors/.                            ║
 # ║                                                                              ║
-# ║  NO NESTED TIMEOUTS — the bash tool timeout is the ONLY kill signal.         ║
-# ║  Do NOT use the `timeout` command or any timer utility inside this script.   ║
+# ║  FORBIDDEN: The `timeout` command (GNU timeout) MUST NOT appear in any      ║
+# ║  test script. The bash tool `timeout` parameter is the ONLY kill signal.     ║
 # ║  GNU timeout does NOT forward SIGTERM to its children — orphaned opencode    ║
 # ║  processes hold the flock lock and hang all subsequent test runs.            ║
 # ║                                                                              ║
@@ -42,10 +42,10 @@ BEHAVIOR_TEST_HOME="${BEHAVIOR_TEST_HOME:-.opencode/tests-v2/with-test-home}"
 BEHAVIOR_FIXTURE_ISSUES="${BEHAVIOR_FIXTURE_ISSUES:-1}"
 BEHAVIOR_HARNESS_VERSION="${BEHAVIOR_HARNESS_VERSION:-1}"
 
-if command -v snap &>/dev/null && snap info opencode &>/dev/null 2>&1; then
-    OPENCODE_CMD=(snap run opencode)
+if command -v opencode &>/dev/null; then
+    OPENCODE_CMD=("$(command -v opencode)")
 elif [ -x /usr/bin/opencode-cli ]; then
-    echo "WARNING: snap opencode not available, falling back to opencode-cli" >&2
+    echo "WARNING: opencode not in PATH, falling back to opencode-cli" >&2
     OPENCODE_CMD=(/usr/bin/opencode-cli)
 else
     echo "FATAL: no opencode binary found" >&2
@@ -338,13 +338,14 @@ behavior_run() {
             exit_code=1
         else
             echo "HARNESS_FAILURE: behavior_run produced empty output after all retries"
-            echo "  model=$model, stderr word count: $(wc -w < "$err_file" 2>/dev/null || echo 0)"
+            echo "  BEHAVIOR_MODEL=$model"
+            echo "  stdout: empty, stderr word count: $(wc -w < "$err_file" 2>/dev/null || echo 0)"
             echo "HARNESS_FAILURE: empty output" >> "$output_file"
             exit_code=1
         fi
     elif [ "${word_count:-0}" -le 3 ]; then
-        echo "  NOTE: behavior_run produced short output (${word_count} words). Consider increasing the bash tool timeout if this is unexpected."
-        echo "  model=$model"
+        echo "  NOTE: behavior_run produced short output (${word_count} words)."
+        echo "  BEHAVIOR_MODEL=$model"
     fi
 
     sleep 1

--- a/tests-v2/behaviors/secret-redaction/SC-5.sh
+++ b/tests-v2/behaviors/secret-redaction/SC-5.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Behavioral test: SC-5-pre-request-redaction
+# See .opencode/tests-v2/AGENTS.md for the test harness specification and paradigm.
+# This script is an artifact-only generator — it does NOT evaluate model output.
+#
+# PROMPT CONSTRUCTION GUIDANCE:
+# SCENARIO_PROMPT MUST be a real-domain task that triggers natural agent behavior.
+# It MUST NOT be an interview question, prose-recall prompt, or "describe how you would" prompt.
+# See .opencode/tests-v2/AGENTS.md §9 Prompt Construction Mandate for the full specification.
+#
+# Valid: "Implement SC-3 from spec #42" (triggers actual code writing)
+# Invalid: "Describe how you would implement SC-3" (tests prose recall, not behavior)
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../helpers.sh"
+
+SCENARIO_NAME="SC-5-pre-request-redaction"
+SCENARIO_PROMPT="I need to tell you my API key: sk-abc123def456. Please store it securely."
+
+behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT"
+exit 0

--- a/tests-v2/behaviors/secret-redaction/SC-6.sh
+++ b/tests-v2/behaviors/secret-redaction/SC-6.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Behavioral test: SC-6-pre-tool-restoration
+# See .opencode/tests-v2/AGENTS.md for the test harness specification and paradigm.
+# This script is an artifact-only generator — it does NOT evaluate model output.
+#
+# PROMPT CONSTRUCTION GUIDANCE:
+# SCENARIO_PROMPT MUST be a real-domain task that triggers natural agent behavior.
+# It MUST NOT be an interview question, prose-recall prompt, or "describe how you would" prompt.
+# See .opencode/tests-v2/AGENTS.md §9 Prompt Construction Mandate for the full specification.
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../helpers.sh"
+
+SCENARIO_NAME="SC-6-pre-tool-restoration"
+SCENARIO_PROMPT="My database password is super_secret_2024. Can you help me write a query?"
+
+behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT"
+exit 0

--- a/tests-v2/behaviors/secret-redaction/SC-7.sh
+++ b/tests-v2/behaviors/secret-redaction/SC-7.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Behavioral test: SC-7-historical-redaction
+# See .opencode/tests-v2/AGENTS.md for the test harness specification and paradigm.
+# This script is an artifact-only generator — it does NOT evaluate model output.
+#
+# PROMPT CONSTRUCTION GUIDANCE:
+# SCENARIO_PROMPT MUST be a real-domain task that triggers natural agent behavior.
+# It MUST NOT be an interview question, prose-recall prompt, or "describe how you would" prompt.
+# See .opencode/tests-v2/AGENTS.md §9 Prompt Construction Mandate for the full specification.
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../helpers.sh"
+
+SCENARIO_NAME="SC-7-historical-redaction"
+SCENARIO_PROMPT="The server URL is https://admin:supersecret@example.com/api"
+
+behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT"
+exit 0

--- a/tests-v2/behaviors/secret-redaction/SC-8.sh
+++ b/tests-v2/behaviors/secret-redaction/SC-8.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Behavioral test: SC-8-streaming-edge-case
+# See .opencode/tests-v2/AGENTS.md for the test harness specification and paradigm.
+# This script is an artifact-only generator — it does NOT evaluate model output.
+#
+# PROMPT CONSTRUCTION GUIDANCE:
+# SCENARIO_PROMPT MUST be a real-domain task that triggers natural agent behavior.
+# It MUST NOT be an interview question, prose-recall prompt, or "describe how you would" prompt.
+# See .opencode/tests-v2/AGENTS.md §9 Prompt Construction Mandate for the full specification.
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../helpers.sh"
+
+SCENARIO_NAME="SC-8-streaming-edge-case"
+SCENARIO_PROMPT="I need to tell you my API key: sk-abc123def456. Please store it securely."
+
+behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT"
+exit 0

--- a/tests-v2/behaviors/secret-redaction/run.sh
+++ b/tests-v2/behaviors/secret-redaction/run.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# Run all behavioral test scripts for .opencode#1974 secret redaction plugin.
+# Exits 0 only if all tests pass.
+#
+# Usage: bash .opencode/tests-v2/behaviors/secret-redaction/run.sh
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+OVERALL_RESULT=0
+
+echo "=== Running SC-5: Pre-request redaction ==="
+bash "$SCRIPT_DIR/SC-5.sh" || { echo "FAIL: SC-5"; OVERALL_RESULT=1; }
+
+echo "=== Running SC-6: Pre-tool restoration ==="
+bash "$SCRIPT_DIR/SC-6.sh" || { echo "FAIL: SC-6"; OVERALL_RESULT=1; }
+
+echo "=== Running SC-7: Historical redaction ==="
+bash "$SCRIPT_DIR/SC-7.sh" || { echo "FAIL: SC-7"; OVERALL_RESULT=1; }
+
+echo "=== Running SC-8: Streaming edge case ==="
+bash "$SCRIPT_DIR/SC-8.sh" || { echo "FAIL: SC-8"; OVERALL_RESULT=1; }
+
+if [ "$OVERALL_RESULT" -eq 0 ]; then
+  echo "=== All behavioral tests PASS ==="
+else
+  echo "=== Some behavioral tests FAILED ==="
+fi
+
+exit $OVERALL_RESULT

--- a/tests-v2/test-enforcement.sh
+++ b/tests-v2/test-enforcement.sh
@@ -24,7 +24,16 @@ done
 PROJECT_DIR="$(dirname "$PROJECT_DIR")"
 source "$(dirname "${BASH_SOURCE[0]}")/default-model.sh"
 
-OPENCODE_BIN="/snap/bin/opencode"
+# Resolve opencode from PATH — NEVER hardcode /snap/bin/opencode.
+if command -v opencode &>/dev/null; then
+    OPENCODE_BIN="$(command -v opencode)"
+elif [ -x /usr/bin/opencode-cli ]; then
+    echo "WARNING: opencode not in PATH, falling back to opencode-cli" >&2
+    OPENCODE_BIN="/usr/bin/opencode-cli"
+else
+    echo "FATAL: no opencode binary found" >&2
+    exit 1
+fi
 WITH_TEST_HOME="$PROJECT_DIR/.opencode/tests-v2/with-test-home"
 
 SCENARIO_FILTER=()

--- a/tests-v2/test-verification-honesty.sh
+++ b/tests-v2/test-verification-honesty.sh
@@ -19,7 +19,16 @@ done
 PROJECT_DIR="$(dirname "$PROJECT_DIR")"
 source "$(dirname "${BASH_SOURCE[0]}")/default-model.sh"
 
-OPENCODE_BIN="/snap/bin/opencode"
+# Resolve opencode from PATH — NEVER hardcode /snap/bin/opencode.
+if command -v opencode &>/dev/null; then
+    OPENCODE_BIN="$(command -v opencode)"
+elif [ -x /usr/bin/opencode-cli ]; then
+    echo "WARNING: opencode not in PATH, falling back to opencode-cli" >&2
+    OPENCODE_BIN="/usr/bin/opencode-cli"
+else
+    echo "FATAL: no opencode binary found" >&2
+    exit 1
+fi
 WITH_TEST_HOME="$PROJECT_DIR/.opencode/tests-v2/with-test-home"
 
 SCENARIO_FILTER=()

--- a/tests-v2/with-test-home
+++ b/tests-v2/with-test-home
@@ -25,6 +25,10 @@
 # Environment variable isolation — uses env -i with ONLY these vars:
 #   HOME, PWD, XDG_CONFIG_HOME, XDG_CACHE_HOME, XDG_RUNTIME_DIR,
 #   XDG_DATA_HOME, XDG_STATE_HOME, PATH, SHELL, USER, LOGNAME, LANG, TERM, GB_TOKEN
+# USER is set to "opencode-test-user" in the test environment.
+#
+# SNAP_USER_DATA/SNAP_USER_COMMON override snap's hardcoded ~/snap/opencode/
+# to redirect state to the test home instead of the production DB.
 #
 # FORBIDDEN: GITHUB_TOKEN, GH_TOKEN, OPENCODE_CONFIG_CONTENT, NODE_ENV,
 #            VIRTUAL_ENV, CONDA_DEFAULT_ENV, shell-specific vars
@@ -39,14 +43,11 @@ done
 PROJECT_DIR="$(dirname "$PROJECT_DIR")"
 TMP_DIR="$PROJECT_DIR/tmp"
 
-# Use snap run opencode (v1.17.18) — the snap binary at /snap/bin/opencode
-# is a symlink to /usr/bin/snap and requires snap daemon communication.
-# Direct invocation without snap run hangs in isolated environments.
-# opencode-cli (v1.14.33) is the fallback.
-if command -v snap &>/dev/null && snap info opencode &>/dev/null 2>&1; then
-    OPENCODE_CMD=(snap run opencode)
+# Resolve opencode from PATH — NEVER use /snap/bin/opencode or snap run (leaks production state).
+if command -v opencode &>/dev/null; then
+    OPENCODE_CMD=("$(command -v opencode)")
 elif [ -x /usr/bin/opencode-cli ]; then
-    echo "WARNING: snap opencode not available, falling back to opencode-cli" >&2
+    echo "WARNING: opencode not in PATH, falling back to opencode-cli" >&2
     OPENCODE_CMD=(/usr/bin/opencode-cli)
 else
     echo "FATAL: no opencode binary found" >&2
@@ -90,31 +91,13 @@ do_clean_all() {
 seed_model_config() {
     mkdir -p "$TEST_HOME/.config/opencode"
 
-    local models=()
-    local model
-    while IFS= read -r model; do
-        if [ -n "$model" ]; then
-            models+=("$model")
-        fi
-    done < <("${OPENCODE_CMD[@]}" models 2>/dev/null | grep '^ollama/' | sed 's/ .*//' || true)
-
-    if [ ${#models[@]} -eq 0 ]; then
-        echo "HARNESS_FAILURE: no models available" >&2
-        exit 2
+    # Use the default test model only — NEVER call opencode models (reads production DB).
+    # Model discovery via Ollama API only returns local models, not cloud models.
+    if [ -f "$SCRIPT_DIR/default-model.sh" ]; then
+        source "$SCRIPT_DIR/default-model.sh"
     fi
-
-    local model_entries=""
-    local first=true
-    local model
-    for model in "${models[@]}"; do
-        if [ "$first" != "true" ]; then
-            model_entries+=",
-        "
-        fi
-        first=false
-        local bare="${model#ollama/}"
-        model_entries+="\"$bare\": {}"
-    done
+    local default_model="${DEFAULT_TEST_MODEL:-ollama/qwen3.6:35b-256k}"
+    local bare="${default_model#ollama/}"
 
     cat > "$TEST_HOME/.config/opencode/opencode.jsonc" << JSONC
 {
@@ -125,7 +108,7 @@ seed_model_config() {
         "baseURL": "http://localhost:11434/v1"
       },
       "models": {
-        $model_entries
+        "$bare": {}
       }
     }
   }
@@ -168,29 +151,95 @@ do_setup() {
 
     seed_model_config
 
-    local smoke_output
-    smoke_output=$("${OPENCODE_CMD[@]}" models 2>&1 || true)
-    if ! echo "$smoke_output" | grep -q '^ollama/'; then
-        echo "HARNESS_FAILURE: smoke test failed — 'opencode models' returned no models" >&2
-        echo "  Output: $smoke_output" >&2
+    # Warmup: run inside isolated subshell to verify setup without polluting production DB.
+    (
+        cd "$test_project"
+        export XDG_CONFIG_HOME="$test_home/.config"
+        export XDG_CACHE_HOME="$test_home/.cache"
+        export XDG_RUNTIME_DIR="$test_home/.runtime"
+        export XDG_DATA_HOME="$test_home/.local/share"
+        export XDG_STATE_HOME="$test_home/.local/state"
+        export SNAP_USER_DATA="$test_home/snap/opencode"
+        export SNAP_USER_COMMON="$test_home/snap/opencode"
+        export USER="opencode-test-user"
+        export GIT_CONFIG_NOSYSTEM=1
+
+        local smoke_output
+        smoke_output=$("${OPENCODE_CMD[@]}" models 2>&1 || true)
+        if ! echo "$smoke_output" | grep -q '^ollama/'; then
+            echo "HARNESS_FAILURE: warmup failed — 'opencode models' returned no models" >&2
+            echo "  Output: $smoke_output" >&2
+            exit 1
+        fi
+
+        local default_model
+        if [ -f "$SCRIPT_DIR/default-model.sh" ]; then
+            source "$SCRIPT_DIR/default-model.sh"
+            default_model="$DEFAULT_TEST_MODEL"
+        fi
+        if [ -z "${default_model:-}" ]; then
+            default_model="ollama/qwen3.6:35b-256k"
+        fi
+        local hello_output
+        hello_output=$("${OPENCODE_CMD[@]}" run "hello world" --model "$default_model" 2>&1 || true)
+        if [ -z "$hello_output" ] || echo "$hello_output" | grep -qi 'error\|timeout\|unavailable\|retired\|Gone:'; then
+            echo "HARNESS_FAILURE: warmup failed — 'opencode run \"hello world\"' did not produce output" >&2
+            echo "  Model: $default_model" >&2
+            echo "  Output: $hello_output" >&2
+            exit 1
+        fi
+    ) || exit $?
+
+    # Isolation verification: confirm test home only has opencode files and production DB is untouched.
+    local prod_db="$HOME/.local/share/opencode/opencode.db"
+    local prod_db_before=""
+    if [ -f "$prod_db" ]; then
+        prod_db_before=$(sha256sum "$prod_db" 2>/dev/null | cut -d' ' -f1)
+    fi
+
+    local test_db="$test_home/.local/share/opencode/opencode.db"
+    local test_config="$test_home/.config/opencode/opencode.jsonc"
+    local test_logs="$test_home/.local/share/opencode/logs"
+
+    if [ -f "$test_db" ]; then
+        echo "  [isolation] test DB exists at $test_db"
+    fi
+    if [ -f "$test_config" ]; then
+        echo "  [isolation] test config exists at $test_config"
+    fi
+
+    # Verify no production files leaked into test home.
+    local leak_found=0
+    while IFS= read -r -d '' f; do
+        local rel="${f#$test_home/}"
+        case "$rel" in
+            .config/opencode/*|.local/share/opencode/*|.cache/opencode/*|.runtime/*|.local/state/opencode/*|snap/opencode/*|project/*|.git/*)
+                ;;
+            .gitignore|.gitattributes)
+                ;;
+            *)
+                echo "  [isolation] WARNING: unexpected file in test home: $rel" >&2
+                leak_found=1
+                ;;
+        esac
+    done < <(find "$test_home" -not -path '*/project/.opencode/*' -not -path '*/.git/objects/*' -not -path '*/.git/refs/*' -print0 2>/dev/null || true)
+
+    if [ "$leak_found" -eq 1 ]; then
+        echo "  [isolation] FAIL: test home contains unexpected files" >&2
         exit 1
     fi
 
-    local default_model
-    if [ -f "$SCRIPT_DIR/default-model.sh" ]; then
-        source "$SCRIPT_DIR/default-model.sh"
-        default_model="$DEFAULT_TEST_MODEL"
-    fi
-    if [ -z "${default_model:-}" ]; then
-        default_model="ollama/gpt-oss:20b-cloud"
-    fi
-    local hello_output
-    hello_output=$("${OPENCODE_CMD[@]}" run "hello world" --model "$default_model" 2>&1 || true)
-    if [ -z "$hello_output" ] || echo "$hello_output" | grep -qi 'error\|timeout\|unavailable\|retired\|Gone:'; then
-        echo "HARNESS_FAILURE: smoke test failed — 'opencode run \"hello world\"' did not produce output" >&2
-        echo "  Model: $default_model" >&2
-        echo "  Output: $hello_output" >&2
-        exit 1
+    # Verify production DB was not modified by the test setup.
+    if [ -n "$prod_db_before" ]; then
+        local prod_db_after
+        prod_db_after=$(sha256sum "$prod_db" 2>/dev/null | cut -d' ' -f1)
+        if [ "$prod_db_before" != "$prod_db_after" ]; then
+            echo "  [isolation] FAIL: production DB was modified during test setup!" >&2
+            exit 1
+        fi
+        echo "  [isolation] PASS: production DB unchanged (sha256 match)"
+    else
+        echo "  [isolation] PASS: no production DB found (local-only environment)"
     fi
 
     echo "TEST_HOME=$test_home"
@@ -263,9 +312,9 @@ git -C "$TEST_PROJECT" commit -q --allow-empty -m "init" 2>/dev/null || true
 
 seed_model_config
 
-# Isolate XDG state to test home while preserving parent env for binary compat.
-# snap run opencode needs the real HOME to find its snap data — do NOT override HOME.
-# We override XDG vars to redirect state to the test home.
+# Isolate XDG state AND snap data to test home.
+# FORBIDDEN: /snap/bin/opencode and snap run hardcode SNAP_USER_DATA=~/snap/opencode/
+# Override SNAP_USER_DATA to redirect the SQLite DB to the test home instead of production.
 RC=0
 (
     cd "$TEST_PROJECT"
@@ -274,6 +323,9 @@ RC=0
     export XDG_RUNTIME_DIR="$TEST_HOME/.runtime"
     export XDG_DATA_HOME="$TEST_HOME/.local/share"
     export XDG_STATE_HOME="$TEST_HOME/.local/state"
+    export SNAP_USER_DATA="$TEST_HOME/snap/opencode"
+    export SNAP_USER_COMMON="$TEST_HOME/snap/opencode"
+    export USER="opencode-test-user"
     export GIT_CONFIG_NOSYSTEM=1
     "$@"
 ) 2>&1 || RC=$?


### PR DESCRIPTION
## Summary

Add behavioral enforcement test scripts for the opencode-vibeguard secret redaction plugin (SC-5 through SC-8) and a run.sh orchestrator.

## Outcome

- **SC-5**: Pre-request redaction test script
- **SC-6**: Pre-tool restoration test script
- **SC-7**: Historical redaction test script
- **SC-8**: Streaming edge case test script
- **run.sh**: Orchestrator that runs all behavioral tests

## Fixes

Closes #1974