### PR TITLE
feat: trunk-tip verification gate + git-state merge verification

### DIFF
--- a/guidelines/000-critical-rules.md
+++ b/guidelines/000-critical-rules.md
@@ -204,6 +204,10 @@ The correct pattern:
 | **Skill card dispatched to sub-agent** | **critical-rules-XXX** | **Agent dispatches SKILL.md content (skill card) to sub-agent via task(); sub-agent receives orchestrator-level routing instructions it cannot execute** |
 
 
+### [critical-rules-XXX] CRITICAL VIOLATION — Starting work from non-trunk-tip state
+The parent repo MUST be on $DEFAULT_BRANCH at remote tracking tip, all submodules MUST be on $DEFAULT_BRANCH at remote tracking tip, there MUST be zero pending changes, and the submodule pointer MUST match the committed SHA before any work begins. Violation: HALT with blocker report. Discard all work and restart from clean trunk tip. This gate is enforced by `git-workflow-branch/tasks/trunk-tip-verification.md` and MUST be the first step of every pre-work task.
+
+
 ### Tier 2 — Process-Integrity (HALT — Quality Defects)
 
 Rules that prevent **quality defects**: skipped verification, inline work, skill bypass, monolithic implementation, verification failures, missing sub-issues. These yield to developer authorization.

--- a/skills/git-workflow-branch/tasks/pre-work.md
+++ b/skills/git-workflow-branch/tasks/pre-work.md
@@ -74,6 +74,12 @@ This is the FIRST and MOST CRITICAL rule. Before writing any code, editing any f
 
 ## Procedure
 
+### Step 0: Trunk-Tip Verification (**sub-agent**)
+
+**Mandatory first step before any work begins.** Verify the repository is at a clean trunk-tip state:
+
+- [ ] 0. **Trunk-tip verification (**sub-agent**).** `task(..., prompt: "execute trunk-tip-verification from git-workflow-branch")`. If BLOCKED, HALT with blocker report. Do NOT proceed to branch creation.
+
 ### Step 1: Verify Authorization Context
 
 **This task receives authorization context from orchestration layer. DO NOT re-check authorization.**

--- a/skills/git-workflow-branch/tasks/trunk-tip-verification.md
+++ b/skills/git-workflow-branch/tasks/trunk-tip-verification.md
@@ -1,0 +1,42 @@
+# Task: trunk-tip-verification
+
+## Purpose
+
+Verify the repository is at a clean trunk-tip state before any work begins. This gate MUST pass before any branch creation, file modification, or implementation work.
+
+## Procedure
+
+1. Verify parent repo is on `$DEFAULT_BRANCH`:
+   - `git branch --show-current` == `$DEFAULT_BRANCH`
+   - If not: return BLOCKED with `reason: PARENT_NOT_ON_TRUNK`
+
+2. Verify parent repo has zero pending changes:
+   - `git status --short` returns empty
+   - If not: return BLOCKED with `reason: PARENT_HAS_PENDING_CHANGES`
+
+3. Verify parent repo is at remote tracking tip:
+   - `git rev-parse $DEFAULT_BRANCH` == `git rev-parse origin/$DEFAULT_BRANCH`
+   - If not: return BLOCKED with `reason: PARENT_NOT_AT_REMOTE_TIP`
+
+4. For each submodule in `.gitmodules`:
+   a. Verify submodule is on `$DEFAULT_BRANCH`:
+      - `git -C <path> branch --show-current` == `$DEFAULT_BRANCH`
+      - If not: return BLOCKED with `reason: SUBMODULE_NOT_ON_TRUNK`
+   b. Verify submodule has zero pending changes:
+      - `git -C <path> status --short` returns empty
+      - If not: return BLOCKED with `reason: SUBMODULE_HAS_PENDING_CHANGES`
+   c. Verify submodule is at remote tracking tip:
+      - `git -C <path> rev-parse $DEFAULT_BRANCH` == `git -C <path> rev-parse origin/$DEFAULT_BRANCH`
+      - If not: return BLOCKED with `reason: SUBMODULE_NOT_AT_REMOTE_TIP`
+
+5. Verify submodule pointer matches committed SHA:
+   - `git submodule status` shows no `+` prefix (dirty pointer)
+   - If not: return BLOCKED with `reason: SUBMODULE_POINTER_DIRTY`
+
+6. Return PASS
+
+## Result Contract
+
+status: PASS | BLOCKED
+finding_summary: "Trunk tip verification: <summary>"
+blocker_reason: "<reason>"

--- a/skills/git-workflow-cleanup/tasks/check-pr.md
+++ b/skills/git-workflow-cleanup/tasks/check-pr.md
@@ -50,10 +50,11 @@ For each merged PR, perform a full mergeability diagnosis using the 6-field chec
 | `created_at` | PR API response | Creation timestamp |
 | `state` | PR API response | PR state (`open`, `closed`) |
 | `merged` | PR API response | Whether PR was already merged |
+| `merge_commit_sha` | PR API response | Merge commit SHA for git log verification |
 
 ### Step 2.1: Read Mergeability Fields
 
-- [ ] For each merged PR, read all 6 fields via the platform-appropriate API (use `github.platform` from session-init: `github` → `github_pull_request_read(method=get, pullNumber=<N>)` for `mergeable`, `base.sha`, `updated_at`, `created_at`, `state`, `merged`; `gitbucket` → `gb pr view <N>` for equivalent fields; `local` → N/A)
+- [ ] For each merged PR, read all 7 fields via the platform-appropriate API (use `github.platform` from session-init: `github` → `github_pull_request_read(method=get, pullNumber=<N>)` for `mergeable`, `base.sha`, `updated_at`, `created_at`, `state`, `merged`, `merge_commit_sha`; `gitbucket` → `gb pr view <N>` for equivalent fields; `local` → N/A)
 
 ### Step 2.2: Diagnose `mergeable` Status
 
@@ -95,7 +96,7 @@ For each merged PR, perform a full mergeability diagnosis using the 6-field chec
   - Computation triggered: yes|no (if updated_at == created_at)
   - Action required: <none|rebase needed|conflict resolution|wait for computation>
   ```
-- [ ] Verify the merge commit exists in local trunk history: `git log --oneline "$DEFAULT_BRANCH" | grep <merge_sha>`
+- [ ] Verify the merge commit exists in local trunk history: `git log --oneline "$DEFAULT_BRANCH" | grep "$merge_commit_sha"`
 - [ ] Report PASS/FAIL per PR with evidence artifact
 
 ## Phase 3: Close Linked Issues

--- a/skills/git-workflow-cleanup/tasks/cleanup.md
+++ b/skills/git-workflow-cleanup/tasks/cleanup.md
@@ -91,6 +91,15 @@ Before any cleanup operations, detect and build routing context for submodules u
 Verifies PR merge via GitHub API, runs SC-verification gate, phase-completion gate, and rebase pending PRs.
 
 
+### Step 1.1: PR-to-Spec Cross-Reference
+
+After merge verification, cross-reference PR changed files against the spec's affected files to confirm the PR actually addresses the spec's scope.
+
+- [ ] 1. Read PR changed files via `github_pull_request_read(method="get_files", ...)`
+- [ ] 2. Read spec issue body to extract affected files
+- [ ] 3. Verify intersection: PR files must overlap with spec affected files
+- [ ] 4. If no overlap: report VERIFICATION-GAP and HALT
+
 ### Step 1.5: Post-Merge Release Detection
 
 If the merged PR was a release PR (detected via branch name pattern `release/` or PR label), dispatch release-promoter tasks:
@@ -365,6 +374,7 @@ Each verification point requires a tool call for evidence. Assertions without to
 | Local dev synced | `git log --oneline -1 "$DEFAULT_BRANCH"` equals remote | Hashes match exactly | VERIFICATION-GAP → re-pull |
 | Sub-issues closed | `issue-operations -> read-sub-issues (github_issue_read(method=get_sub_issues, ...)` | All state=closed | VERIFICATION-GAP → close or investigate | <!-- Routes through issue-operations per SPEC #683 -->
 | All repos at dev tip | `git -C $REPO_PATH rev-parse "$DEFAULT_BRANCH"` vs `rev-parse origin/"$DEFAULT_BRANCH"` for parent + each submodule | Every repo's local dev HEAD matches origin/dev | VERIFICATION-GAP → report which repo diverged, flag for human review |
+| Merge commit verified | `git log --oneline "$DEFAULT_BRANCH" \| grep <merge_sha>` | Must return match | VERIFICATION-GAP → HALT |
 
 ## Sub-Task Files
 

--- a/skills/git-workflow-cleanup/tasks/cleanup/verify-merge.md
+++ b/skills/git-workflow-cleanup/tasks/cleanup/verify-merge.md
@@ -44,6 +44,43 @@ if pr.get("merged_at") is None:
 - EVIDENCE: `merged_by` = pr.get("merged_by") — Should be populated
 - EVIDENCE: `state` = pr.get("state") — "closed" for merged PRs
 
+**Git log merge commit verification:**
+
+```python
+# After confirming merged_at is not None, verify merge commit exists in trunk history
+merge_commit_sha = pr.get("merge_commit_sha")
+if merge_commit_sha:
+    git_log_check = `git log --oneline "$DEFAULT_BRANCH" | grep "$merge_commit_sha"`
+    if not git_log_check:
+        report = f"Merge commit {merge_commit_sha} not found in trunk history. Possible force-push or revert."
+        return report
+```
+
+**Branch reachability check:**
+
+```python
+# Verify feature branch commits are reachable from trunk
+branch_name = "<feature_branch_name>"
+reachable = `git branch --merged "$DEFAULT_BRANCH" | grep "$branch_name"`
+if not reachable:
+    report = f"Branch {branch_name} is not reachable from trunk. Skipping branch deletion."
+    return report
+```
+
+**PR-to-spec cross-reference:**
+
+```python
+# Cross-reference PR changed files against spec affected files
+pr_files = github_pull_request_read(method="get_files", owner=owner, repo=repo, pullNumber=N)
+spec_issue = github_issue_read(method="get", owner=owner, repo=repo, issue_number=<spec_issue>)
+# Extract affected files from spec body
+spec_files = extract_affected_files(spec_issue["body"])
+# Verify PR files intersect with spec files
+if not set(pr_files) & set(spec_files):
+    report = f"PR #{pullNumber} changed files do not intersect with spec affected files. Possible incorrect PR-to-issue mapping."
+    return report
+```
+
 **Structured output context (MANDATORY):** After verification, produce a structured output that the orchestration layer passes to `issue-closure`:
 
 ```yaml

--- a/tools/session-init
+++ b/tools/session-init
@@ -364,6 +364,65 @@ def collect_repo_info() -> list[dict[str, str]]:
     return entries
 
 
+def get_default_branch() -> str:
+    """Determine the default branch name from remote HEAD or fallback to 'main'."""
+    branch = run_git_command(["rev-parse", "--abbrev-ref", "origin/HEAD"])
+    if branch and branch.startswith("origin/"):
+        return branch[len("origin/"):]
+    return "main"
+
+
+def check_trunk_tip_status() -> dict:
+    """Check trunk tip status for the repo and its submodules.
+
+    Returns a dict with:
+        trunk_clean: bool — current branch is default and working tree is clean
+        parent_branch: str — current branch name
+        parent_clean: bool — working tree has no uncommitted changes
+        parent_at_tip: bool — current branch is at remote tracking tip
+        submodules_clean: list[dict] — per-submodule status
+    """
+    default_branch = get_default_branch()
+    current_branch = get_current_branch() or "unknown"
+    on_default = current_branch == default_branch
+
+    status_output = run_git_command(["status", "--short"])
+    parent_clean = status_output == "" or status_output is None
+
+    local_sha = run_git_command(["rev-parse", default_branch])
+    remote_sha = run_git_command(["rev-parse", f"origin/{default_branch}"])
+    parent_at_tip = (
+        local_sha is not None
+        and remote_sha is not None
+        and local_sha == remote_sha
+    )
+
+    trunk_clean = on_default and parent_clean and parent_at_tip
+
+    submodules_clean: list[dict] = []
+    submodule_status = run_git_command(["submodule", "status"])
+    if submodule_status:
+        for line in submodule_status.splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            prefix = line[0] if line else " "
+            path = line[1:].strip().split()[0] if len(line) > 1 else ""
+            is_dirty = prefix == "+"
+            submodules_clean.append({
+                "path": path,
+                "dirty": is_dirty,
+            })
+
+    return {
+        "trunk_clean": trunk_clean,
+        "parent_branch": current_branch,
+        "parent_clean": parent_clean,
+        "parent_at_tip": parent_at_tip,
+        "submodules_clean": submodules_clean,
+    }
+
+
 def get_source_hooks_dir() -> str | None:
     """Find the .opencode/hooks/ directory or None if missing."""
     hooks_dir = os.path.join(os.getcwd(), ".opencode", "hooks")
@@ -765,6 +824,22 @@ def main() -> int:
         print(f"  repo: {entry['repo']}")
         print(f"  platform: {entry['platform']}")
         print(f"  url: {entry['url']}")
+
+    # Emit ## Trunk Tip Status section
+    trunk_status = check_trunk_tip_status()
+    print("## Trunk Tip Status")
+    print(f"trunk_clean: {str(trunk_status['trunk_clean']).lower()}")
+    print(f"parent_branch: {trunk_status['parent_branch']}")
+    print(f"parent_clean: {str(trunk_status['parent_clean']).lower()}")
+    print(f"parent_at_tip: {str(trunk_status['parent_at_tip']).lower()}")
+    submodules = trunk_status["submodules_clean"]
+    if submodules:
+        print("submodules_clean:")
+        for sm in submodules:
+            print(f"  - path: {sm['path']}")
+            print(f"    dirty: {str(sm['dirty']).lower()}")
+    else:
+        print("submodules_clean: []")
 
     # Emit project_root — absolute top-level git root for submodule-aware path resolution
     project_root = run_git_command(["rev-parse", "--show-toplevel"])


### PR DESCRIPTION
## Summary

Two specs implemented in one branch (stacked PR):

### #1996 — Mandatory trunk-tip verification gate
Every session MUST start from clean trunk tip. New `trunk-tip-verification.md` task card enforces: parent on `$DEFAULT_BRANCH`, zero pending changes, at remote tip, submodules at trunk tip, submodule pointer matches committed SHA.

### #1999 — Cleanup workflow must verify merge via git state, not PR metadata
Adds `merge_commit_sha` extraction, git log merge commit verification, `git branch --merged` reachability check, and PR-to-spec cross-reference to the cleanup workflow.

## Changes

| File | Change |
|------|--------|
| `skills/git-workflow-branch/tasks/trunk-tip-verification.md` | **CREATE** — New task card with 6-step trunk-tip verification procedure |
| `skills/git-workflow-branch/tasks/pre-work.md` | Add step 0: trunk-tip verification before branch creation |
| `guidelines/000-critical-rules.md` | Add critical violation for non-trunk-tip state |
| `tools/session-init` | Add `## Trunk Tip Status` section with `trunk_clean`, `parent_branch`, `parent_clean`, `parent_at_tip`, `submodules_clean` |
| `skills/git-workflow-cleanup/tasks/check-pr.md` | Add `merge_commit_sha` to mergeability diagnosis; fix Step 2.5 git log check |
| `skills/git-workflow-cleanup/tasks/cleanup/verify-merge.md` | Add git log merge commit verification, branch reachability check, PR-to-spec cross-reference |
| `skills/git-workflow-cleanup/tasks/cleanup.md` | Add merge commit verification row to Live Verification Table; add Step 1.1 PR-to-spec cross-reference |

## SC Coverage

- **SC-1 through SC-6** (#1996): trunk-tip-verification.md exists with all 6 verification steps
- **SC-7** (#1996): pre-work.md calls trunk-tip-verification as step 0
- **SC-8** (#1996): 000-critical-rules.md contains non-trunk-tip violation entry
- **SC-9** (#1996): session-init emits `trunk_clean` field
- **SC-1** (#1999): check-pr.md extracts `merge_commit_sha`
- **SC-2** (#1999): check-pr.md Step 2.5 uses `merge_commit_sha` in git log
- **SC-3** (#1999): verify-merge.md runs git log after merged_at check
- **SC-4** (#1999): verify-merge.md runs `git branch --merged`
- **SC-5** (#1999): verify-merge.md PR-to-spec cross-reference
- **SC-6** (#1999): cleanup.md Live Verification Table merge commit row

## Behavioral Tests

SC-7, SC-8, SC-9 (#1999) require behavioral tests that run `opencode run` with a "pr merged" prompt. These are deferred — the test infrastructure requires a real model and a test repo with a merged PR. The task file changes (SC-1 through SC-6) are complete and verified.

Fixes #1996, #1999

🤖 Co-authored with AI: OpenCode (deepseek-v4-flash)