### PR TITLE
[SPEC-FIX] writing-plans workflow defects + plan template pipeline mandate + spec-creation pipeline enforcement (#1962, #2009)

### DIFF
--- a/guidelines/000-critical-rules.md
+++ b/guidelines/000-critical-rules.md
@@ -38,6 +38,10 @@ Rules that prevent **irreversible harm**: data loss, security breach, production
 Load [§1](guidelines/020-go-prohibitions.md). ONLY "approved"/"go" authorize action.
 
 
+### [critical-rules-XXX] CRITICAL VIOLATION — Direct `github_issue_write` for spec content bypasses spec-creation pipeline
+Direct `github_issue_write` for spec content bypasses the mandatory spec-creation pipeline. ALL spec creation MUST route through `skill({name: "spec-creation"})` → `task()`. Direct `github_issue_write` for spec content is a CRITICAL VIOLATION — never overridable, never waivable. Tier 1.
+
+
 ### [critical-rules-006] CRITICAL VIOLATION — Routing-bypass rationalization as self-authorization variant
 The pattern "agent recognizes matching skill, deliberates about whether skill is needed, constructs carveout justification, executes bypass" is explicitly classified as a self-authorization variant. Any agent that matches a skill trigger but self-classifies into a "read-only" or "simple lookup" exemption and bypasses dispatch has committed a routing-bypass self-authorization violation. Load [§1](guidelines/020-go-prohibitions.md).
 
@@ -212,8 +216,6 @@ The parent repo MUST be on $DEFAULT_BRANCH at remote tracking tip, all submodule
 
 Rules that prevent **quality defects**: skipped verification, inline work, skill bypass, monolithic implementation, verification failures, missing sub-issues. These yield to developer authorization.
 ### [critical-rules-XXX] CRITICAL VIOLATION — Sub-agent task cards MUST NOT contain task() or skill() calls. Only orchestrator-level SKILL.md files may contain dispatch instructions. A task card that contains a task() or skill() call is structurally defective — the sub-agent cannot execute it. This applies to ALL task cards across ALL skills. Violation: HALT with blocker report.
-### [critical-rules-XXX] CRITICAL VIOLATION — Direct `github_issue_write` for spec content bypasses spec-creation pipeline
-Using `github_issue_write` to write spec content directly instead of dispatching to `skill({name: "spec-creation"})` → `task()` is a Tier 2 violation. The spec-creation pipeline exists and is functional — the orchestrator MUST route through it. Direct writes produce defective deliverables lacking analytical artifacts, SC coverage YAML, verification consistency contracts, lifecycle manifests, holistic self-checks, and spec audits. Violation: HALT with blocker report. Load [spec-creation skill](skills/spec-creation/SKILL.md).
 ### [critical-rules-XXX] CRITICAL VIOLATION — Behavioral tests MUST be executed, not just created
 Creating a behavioral test file and claiming PASS without running it is a Tier 2 violation. Behavioral tests MUST be executed via `bash tests-v2/behaviors/<scenario>.sh` and produce non-empty artifact directories (stdout.log, stderr.log, manifest.yaml) before the corresponding SC can be claimed PASS. File existence alone is structural evidence — behavioral SCs require behavioral evidence (test execution with output inspection). Violation: HALT with blocker report.
 

--- a/skills/audit/tasks/behavioral-sc-evaluator.md
+++ b/skills/audit/tasks/behavioral-sc-evaluator.md
@@ -1,0 +1,50 @@
+<!-- SPDX-FileCopyrightText: 2026 michael-conrad -->
+<!-- SPDX-License-Identifier: MIT -->
+<!-- Provenance: AI-generated -->
+
+# Task: behavioral-sc-evaluator
+
+## Purpose
+
+Clean-room evaluation of behavioral SC evidence. Receives ONLY an artifact directory path. Reads raw test output (stdout.log, stderr.log) and renders binary PASS/FAIL per SC. No orchestrator context, no expected outcomes, no cached results.
+
+## Entry Criteria
+
+- Artifact directory path provided (no other context)
+- Artifact directory contains at minimum `stdout.log` and `stderr.log`
+- SC criteria provided inline (the SC text to evaluate against)
+
+## Exit Criteria
+
+- Binary PASS/FAIL verdict per SC
+- Verdict based on actual agent behavior in stdout.log/stderr.log, NOT file existence
+- Result contract returned with `status: DONE` and `finding_summary`
+
+## Procedure
+
+### Step 1: Read Artifacts
+
+- [ ] 1. Read `stdout.log` — full agent prose output
+- [ ] 2. Read `stderr.log` — tool dispatch trace
+- [ ] 3. Read `manifest.yaml` — scenario metadata
+
+### Step 2: Evaluate Each SC
+
+For each SC criterion provided:
+
+- [ ] 1. Read the agent's actual actions from stdout.log and stderr.log
+- [ ] 2. Determine: did the agent's behavior satisfy the SC criterion?
+- [ ] 3. File-existence alone is NEVER sufficient — the agent must have taken the correct action
+- [ ] 4. Render binary verdict: PASS (100% clean, no caveats) or FAIL (anything else)
+
+### Step 3: Return Result Contract
+
+```yaml
+status: DONE
+artifact_path: "<artifact directory path>"
+summary: "Evaluated {N} behavioral SCs: {M} PASS, {K} FAIL"
+per_sc:
+  - sc_id: "<SC-N>"
+    verdict: PASS|FAIL
+    justification: "<1-2 sentence explanation based on actual agent output>"
+```

--- a/skills/audit/tasks/coherence-maintenance-evaluator.md
+++ b/skills/audit/tasks/coherence-maintenance-evaluator.md
@@ -48,8 +48,10 @@ Evaluator role for the coherence-maintenance DiMo chain. Reads `evidence.yaml` (
 - Each verdict backed by evidence from `evidence.yaml` and validation from `reasoning.yaml`
 - Drift classified as controlled or uncontrolled per criterion
 - Migration candidates evaluated for completeness
+- Behavioral SCs evaluated via clean-room `behavioral-sc-evaluator` sub-agent — never from evaluator's own context
+- File-existence alone is NEVER sufficient evidence for behavioral SCs
 - Self-consistency gate applied — no hedging language in PASS explanations
-- Overall verdict computed: PASS if all criteria PASS, FAIL otherwise
+- Overall verdict computed: PASS if all criteria PASS and all behavioral SCs PASS, FAIL otherwise
 - No re-collection of evidence — judgments only
 
 ## Procedure
@@ -298,7 +300,37 @@ state_analysis_evaluation:
 
 **Note:** State analysis absence is NOT a FAIL condition for the overall verdict. It reduces confidence but does not block PASS.
 
-### Step 9: Compute Overall Verdict
+### Step 9: Evaluate Behavioral SCs via Clean-Room Sub-Agent
+
+For each behavioral success criterion identified in the spec, dispatch a clean-room sub-agent to evaluate the behavioral evidence. The evaluator MUST NOT evaluate behavioral SCs from its own context — only the clean-room sub-agent may render a verdict.
+
+- [ ] 1. From `evidence.yaml` → `spec_scs`, identify all SCs with `evidence_type: behavioral`
+- [ ] 2. For each behavioral SC:
+  - [ ] 2a. Dispatch `behavioral-sc-evaluator` via `task()` with ONLY the artifact directory path (`{artifact_evidence_dir}`) and the SC criterion text — no orchestrator reasoning, no expected outcomes, no cached results
+  - [ ] 2b. Collect the result contract from the clean-room sub-agent
+  - [ ] 2c. If the sub-agent returns `status: BLOCKED` with `reason: PRELOADED_CONTEXT_REJECTED`, re-task with the same minimal context (max 2 retries)
+- [ ] 3. For each behavioral SC verdict from the clean-room sub-agent:
+  - [ ] 3a. If verdict is FAIL → the evaluator's verdict for that SC is FAIL
+  - [ ] 3b. If verdict is PASS → the evaluator's verdict for that SC is PASS
+  - [ ] 3c. File-existence alone is NEVER sufficient evidence for behavioral SCs — if the clean-room sub-agent reports PASS based on file existence, the evaluator MUST downgrade to FAIL
+- [ ] 4. Record behavioral SC verdicts:
+
+```yaml
+behavioral_sc_evaluation:
+  total_behavioral_scs: <N>
+  clean_room_passes: <N>
+  clean_room_fails: <N>
+  per_sc:
+    - sc_id: "<SC-N>"
+      clean_room_verdict: PASS | FAIL
+      evaluator_verdict: PASS | FAIL
+      justification: "<from clean-room sub-agent>"
+  file_existence_downgrades: <N>
+```
+
+- [ ] 5. If any behavioral SC has a FAIL verdict, the overall verdict MUST be FAIL regardless of CM-1 through CM-5 results
+
+### Step 10: Compute Overall Verdict
 
 Compute the overall coherence maintenance verdict from per-criterion results:
 
@@ -319,7 +351,7 @@ coherence_health:
   overall_score: <float 0.0-1.0>
 ```
 
-### Step 10: Apply Self-Consistency Gate
+### Step 11: Apply Self-Consistency Gate
 
 Before accepting the verdict, run a self-consistency check on every criterion entry:
 
@@ -418,10 +450,11 @@ Every step in this task is a mandatory dependency. Skipping any step produces an
 - [ ] 6. Evaluate CM-4 (Cross-Reference Consistency) → INVALID if skipped
 - [ ] 7. Evaluate CM-5 (Migration Candidate Identification) → INVALID if skipped
 - [ ] 8. Evaluate State Analysis Evidence → INVALID if skipped
-- [ ] 9. Compute Overall Verdict → INVALID if skipped
-- [ ] 10. Apply Self-Consistency Gate → INVALID if skipped
-- [ ] 11. Write verdict.yaml → INVALID if skipped
-- [ ] 12. Return Frugal Result Contract → INVALID if skipped
+- [ ] 9. Evaluate Behavioral SCs via Clean-Room Sub-Agent → INVALID if skipped
+- [ ] 10. Compute Overall Verdict → INVALID if skipped
+- [ ] 11. Apply Self-Consistency Gate → INVALID if skipped
+- [ ] 12. Write verdict.yaml → INVALID if skipped
+- [ ] 13. Return Frugal Result Contract → INVALID if skipped
 
 ## Error Handling
 

--- a/skills/audit/tasks/concern-separation-evaluator.md
+++ b/skills/audit/tasks/concern-separation-evaluator.md
@@ -356,6 +356,36 @@ self_consistency:
 
 - [ ] 3. Update `all_criteria_pass` to `false` and `remediation_required` to `true` if any downgrade occurred
 
+### Step 15.5: Evaluate Behavioral SCs via Clean-Room Sub-Agent
+
+For each SC in the spec that has evidence type `behavioral`, dispatch a clean-room sub-agent to evaluate the behavioral test artifacts. The evaluator MUST NOT rely on file-existence alone — it must read actual agent output.
+
+- [ ] 1. Identify all behavioral SCs from the spec's SC table (evidence type = `behavioral`)
+- [ ] 2. For each behavioral SC, dispatch `behavioral-sc-evaluator` via `task()` with ONLY the artifact directory path:
+  ```yaml
+  task(
+    subagent_type: "general",
+    prompt: "execute behavioral-sc-evaluator task from audit",
+    context: {
+      artifact_dir: "{project_root}/tmp/{issue-N}/artifacts/behavioral-evidence-{sc_id}/",
+      sc_id: "<SC-N>",
+      sc_criterion: "<criterion text>"
+    }
+  )
+  ```
+- [ ] 3. If the clean-room sub-agent returns `verdict: FAIL` for any behavioral SC, the evaluator verdict for that SC is FAIL (not PASS)
+- [ ] 4. File-existence alone is NEVER sufficient evidence for behavioral SCs — the sub-agent must read `stdout.log` and `stderr.log` to verify the agent's actual actions
+- [ ] 5. Record the behavioral SC verdicts in the per_criterion section alongside CS-1 through CS-ROUTING
+
+```yaml
+behavioral_sc_evaluations:
+  - sc_id: "<SC-N>"
+    verdict: "PASS|FAIL"
+    artifact_dir: "{project_root}/tmp/{issue-N}/artifacts/behavioral-evidence-{sc_id}/"
+    sub_agent_verdict: "PASS|FAIL"
+    explanation: "<1-2 sentence summary of clean-room evaluation>"
+```
+
 ### Step 16: Write verdict.yaml
 
 Write the full verdict to `{project_root}/tmp/{issue-N}/artifacts/concern-separation/verdict.yaml`:

--- a/skills/audit/tasks/content-audit-evaluator.md
+++ b/skills/audit/tasks/content-audit-evaluator.md
@@ -408,6 +408,45 @@ issue_impact:
       reason: "<description>"
 ```
 
+
+### Step 13: Evaluate Behavioral SCs via Clean-Room Sub-Agent
+
+For each behavioral SC in the spec, dispatch a clean-room sub-agent to evaluate the test artifacts:
+
+- [ ] 1. Identify all behavioral SCs from the spec's success criteria table (evidence type `behavioral`)
+- [ ] 2. For each behavioral SC, dispatch `behavioral-sc-evaluator` via `task()` with ONLY the artifact directory path:
+
+```yaml
+task(
+  prompt: "execute behavioral-sc-evaluator task from audit"
+  context: {
+    artifact_dir: "<path to behavioral test artifact directory>",
+    sc_id: "<SC-N>",
+    sc_criterion: "<exact SC text from spec>"
+  }
+)
+```
+
+- [ ] 3. The clean-room sub-agent receives ONLY the artifact directory path and SC criterion — NO orchestrator reasoning, expected outcomes, or cached results
+- [ ] 4. If the clean-room sub-agent returns `status: DONE` with `verdict: PASS` → the evaluator verdict for that SC is PASS
+- [ ] 5. If the clean-room sub-agent returns `status: DONE` with `verdict: FAIL` → the evaluator verdict for that SC is FAIL
+- [ ] 6. If the clean-room sub-agent returns `status: BLOCKED` or errors → the evaluator verdict for that SC is FAIL
+- [ ] 7. File-existence alone is NEVER sufficient evidence for behavioral SCs — the sub-agent must evaluate actual agent behavior from stdout.log and stderr.log
+- [ ] 8. Record behavioral SC verdicts:
+
+```yaml
+behavioral_sc_evaluation:
+  scs_evaluated: <N>
+  scs_pass: <N>
+  scs_fail: <N>
+  per_sc:
+    - sc_id: "<SC-N>"
+      verdict: "PASS | FAIL"
+      artifact_dir: "<path>"
+      justification: "<1-2 sentence summary from sub-agent result>"
+```
+
+- [ ] 9. If ANY behavioral SC returns FAIL, set `all_claims_pass: false` in the final verdict regardless of other domain verdicts
 ### Step 12: Process Verdicts
 
 Compile all per-claim verdicts and apply consensus rules:
@@ -418,7 +457,7 @@ Compile all per-claim verdicts and apply consensus rules:
 - [ ] 4. Count total, pass, fail, and fabricated verdicts
 - [ ] 5. Compute `all_claims_pass: true` only if every claim is PASS
 
-### Step 13: Apply Self-Consistency Gate
+### Step 14: Apply Self-Consistency Gate
 
 Apply a self-consistency check to every PASS verdict:
 
@@ -438,7 +477,7 @@ self_consistency_downgrades:
     hedging_phrase: "<matched phrase>"
 ```
 
-### Step 14: Write verdict.yaml
+### Step 15: Write verdict.yaml
 
 Write the complete verdict to `{artifact_evidence_dir}/verdict.yaml`:
 
@@ -496,7 +535,7 @@ self_consistency_downgrades:
 - [ ] 2. Write `verdict.yaml` with the complete verdict structure
 - [ ] 3. Verify the file was written and is non-empty
 
-### Step 15: Return Frugal Result Contract
+### Step 16: Return Frugal Result Contract
 
 ```yaml
 status: DONE | FAIL
@@ -539,9 +578,10 @@ Every step in this task is a mandatory dependency. Skipping any step produces an
 - [ ] 10. Evaluate Source Data Inventory → INVALID if skipped
 - [ ] 11. Evaluate Issues from upstream reasoning role → INVALID if skipped
 - [ ] 12. Process Verdicts → INVALID if skipped
-- [ ] 13. Apply Self-Consistency Gate → INVALID if skipped
-- [ ] 14. Write verdict.yaml → INVALID if skipped
-- [ ] 15. Return Frugal Result Contract → INVALID if skipped
+- [ ] 13. Evaluate Behavioral SCs via Clean-Room Sub-Agent → INVALID if skipped
+- [ ] 14. Apply Self-Consistency Gate → INVALID if skipped
+- [ ] 15. Write verdict.yaml → INVALID if skipped
+- [ ] 16. Return Frugal Result Contract → INVALID if skipped
 
 ## Error Handling
 

--- a/skills/audit/tasks/drift-detection-evaluator.md
+++ b/skills/audit/tasks/drift-detection-evaluator.md
@@ -318,7 +318,45 @@ dd_structural_fail:
       reason: "Structural evidence (file existence) does not verify behavioral correctness"
 ```
 
-### Step 11: Classify Drift Severity
+### Step 11: Evaluate Behavioral SCs via Clean-Room Sub-Agent
+
+For each SC in the spec whose evidence type is `behavioral`, dispatch a clean-room sub-agent to evaluate the actual agent behavior from test artifacts. The evaluator MUST NOT rely on file-existence or structural checks for behavioral SCs.
+
+- [ ] 1. Read the spec's Success Criteria table from Step 3 to identify all SCs with evidence type `behavioral`
+- [ ] 2. For each behavioral SC, dispatch `behavioral-sc-evaluator` via `task()` with ONLY the artifact directory path and the SC criterion text:
+
+```yaml
+task_context:
+  artifact_path: "<artifact_evidence_dir>"
+  sc_criteria:
+    - sc_id: "<SC-N>"
+      criterion: "<criterion text from spec>"
+```
+
+- [ ] 3. The clean-room sub-agent receives ONLY the artifact directory path and SC criteria — no orchestrator reasoning, no expected outcomes, no cached results
+- [ ] 4. Collect the result contract from each `behavioral-sc-evaluator` dispatch
+- [ ] 5. For each behavioral SC:
+  - If the clean-room sub-agent returns `verdict: PASS` → the evaluator verdict for that SC is PASS
+  - If the clean-room sub-agent returns `verdict: FAIL` → the evaluator verdict for that SC is FAIL
+  - If the clean-room sub-agent returns `status: BLOCKED` → the evaluator verdict for that SC is FAIL with `CLEAN_ROOM_BLOCKED` classification
+- [ ] 6. File-existence alone is NEVER sufficient evidence for behavioral SCs — if the only evidence available is structural (stdout.log/stderr.log do not exist or are empty), the verdict is FAIL
+- [ ] 7. Record behavioral SC evaluation results:
+
+```yaml
+behavioral_sc_evaluation:
+  total_behavioral_scs: <N>
+  pass: <N>
+  fail: <N>
+  per_sc:
+    - sc_id: "<SC-N>"
+      verdict: "PASS|FAIL"
+      clean_room_verdict: "PASS|FAIL"
+      justification: "<from clean-room sub-agent result>"
+```
+
+- [ ] 8. Aggregate: if ANY behavioral SC receives a FAIL verdict from the clean-room sub-agent, the overall drift detection verdict is FAIL
+
+### Step 12: Classify Drift Severity
 
 For each FAIL criterion, classify drift severity:
 
@@ -331,12 +369,12 @@ For each FAIL criterion, classify drift severity:
 | MISSING_EDGE_CASE | MEDIUM | Edge case not implemented |
 | STRUCTURAL_EVIDENCE | HIGH | Behavioral SC evaluated with structural evidence only |
 
-- [ ] 1. For each FAIL finding across DD-1 through DD-5 and DD-STRUCTURAL-FAIL, assign a severity
+- [ ] 1. For each FAIL finding across DD-1 through DD-5, DD-STRUCTURAL-FAIL, and behavioral SC evaluation, assign a severity
 - [ ] 2. HIGH severity findings block implementation — must be resolved before proceeding
 - [ ] 3. MEDIUM severity findings require attention but may not block
 - [ ] 4. LOW severity findings are informational
 
-### Step 12: Generate Bidirectional Findings
+### Step 13: Generate Bidirectional Findings
 
 Generate findings ONLY for FAIL criteria. PASS criteria MUST NOT appear in the findings table.
 
@@ -364,16 +402,16 @@ bidirectional_findings:
       - "<option 2>"
 ```
 
-### Step 13: Process Verdicts
+### Step 14: Process Verdicts
 
 Compile all per-criterion verdicts and apply consensus rules:
 
-- [ ] 1. Collect all verdicts from Steps 5-10 into a single `per_criterion` array
+- [ ] 1. Collect all verdicts from Steps 5-11 into a single `per_criterion` array
 - [ ] 2. Each entry must include: `criterion_id`, `result`, `evidence`, `explanation`, `remediation`, `drift_type`, `severity`
 - [ ] 3. Count total, pass, and fail verdicts
 - [ ] 4. Determine overall verdict: PASS if ALL criteria pass; FAIL if any criterion fails
 
-### Step 14: Apply Self-Consistency Gate
+### Step 15: Apply Self-Consistency Gate
 
 Apply a self-consistency check to every PASS verdict:
 
@@ -401,7 +439,7 @@ for each entry in per_criterion:
         break
 ```
 
-### Step 15: Write verdict.yaml
+### Step 16: Write verdict.yaml
 
 Write the complete verdict to `{artifact_evidence_dir}/verdict.yaml`:
 
@@ -432,6 +470,15 @@ dd3_extra_implementation: {...}
 dd4_signature_match: {...}
 dd5_edge_cases: {...}
 dd_structural_fail: {...}
+behavioral_sc_evaluation:
+  total_behavioral_scs: <N>
+  pass: <N>
+  fail: <N>
+  per_sc:
+    - sc_id: "<SC-N>"
+      verdict: "PASS|FAIL"
+      clean_room_verdict: "PASS|FAIL"
+      justification: "<from clean-room sub-agent result>"
 drift_summary:
   spec_drift_count: <N>
   code_drift_count: <N>
@@ -454,7 +501,7 @@ bidirectional_findings:
 - [ ] 2. Write `verdict.yaml` with the complete verdict structure
 - [ ] 3. Verify the file was written and is non-empty
 
-### Step 16: Return Frugal Result Contract
+### Step 17: Return Frugal Result Contract
 
 Return only routing-significant data:
 
@@ -491,12 +538,13 @@ Every step in this task is a mandatory dependency. Skipping any step produces an
 - [ ] 8. Evaluate DD-4 — Function Signatures Match → INVALID if skipped
 - [ ] 9. Evaluate DD-5 — Edge Cases Covered → INVALID if skipped
 - [ ] 10. Evaluate DD-STRUCTURAL-FAIL → INVALID if skipped
-- [ ] 11. Classify Drift Severity → INVALID if skipped
-- [ ] 12. Generate Bidirectional Findings → INVALID if skipped
-- [ ] 13. Process Verdicts → INVALID if skipped
-- [ ] 14. Apply Self-Consistency Gate → INVALID if skipped
-- [ ] 15. Write verdict.yaml → INVALID if skipped
-- [ ] 16. Return Frugal Result Contract → INVALID if skipped
+- [ ] 11. Evaluate Behavioral SCs via Clean-Room Sub-Agent → INVALID if skipped
+- [ ] 12. Classify Drift Severity → INVALID if skipped
+- [ ] 13. Generate Bidirectional Findings → INVALID if skipped
+- [ ] 14. Process Verdicts → INVALID if skipped
+- [ ] 15. Apply Self-Consistency Gate → INVALID if skipped
+- [ ] 16. Write verdict.yaml → INVALID if skipped
+- [ ] 17. Return Frugal Result Contract → INVALID if skipped
 
 ## Error Handling
 

--- a/skills/audit/tasks/guideline-audit-evaluator.md
+++ b/skills/audit/tasks/guideline-audit-evaluator.md
@@ -49,9 +49,10 @@ Evaluator role for the guideline-audit DiMo chain. Reads `evidence.yaml` (Invest
 - `verdict.yaml` written to `{artifact_evidence_dir}/verdict.yaml`
 - Every criterion evaluated with binary PASS/FAIL — no INCONCLUSIVE, no "PASS with concerns"
 - GA-1 through GA-6 criteria evaluated using validated evidence from `reasoning.yaml`
+- Behavioral SCs evaluated via clean-room `behavioral-sc-evaluator` sub-agent — NOT self-evaluated
 - Self-consistency gate applied to all PASS verdicts
 - Bidirectional findings generated for FAIL criteria
-- No new evidence collected — all evaluation based on upstream artifacts
+- No new evidence collected — all evaluation based on upstream artifacts or clean-room sub-agent output
 
 ## Procedure
 
@@ -385,16 +386,27 @@ ga_6_evaluation:
   remediation: "<if FAIL, what to fix>"
 ```
 
-### Step 9: Process Verdicts
+### Step 9: Evaluate Behavioral SCs via Clean-Room Sub-Agent
+
+For each behavioral SC identified in the spec, dispatch a clean-room sub-agent to evaluate the behavioral evidence. The evaluator MUST NOT evaluate behavioral SCs itself — it MUST delegate to the clean-room sub-agent.
+
+- [ ] 1. Identify all behavioral SCs from the spec's success criteria table (those with `evidence_type: behavioral`)
+- [ ] 2. For each behavioral SC, dispatch `behavioral-sc-evaluator` via `task()` with ONLY the artifact directory path and the SC criterion text — no orchestrator reasoning, no expected outcomes, no cached results
+- [ ] 3. Collect the result contract from each clean-room sub-agent dispatch
+- [ ] 4. If the clean-room sub-agent returns FAIL for any behavioral SC, the evaluator verdict for that SC is FAIL — do NOT override or soft-pass
+- [ ] 5. File-existence alone is NEVER sufficient evidence for behavioral SCs — the clean-room sub-agent must evaluate actual agent behavior from stdout.log and stderr.log
+- [ ] 6. Record each behavioral SC verdict in the per_criterion array alongside GA-1 through GA-6 verdicts
+
+### Step 10: Process Verdicts
 
 Compile all per-criterion verdicts and apply consensus rules:
 
-- [ ] 1. Collect all verdicts from Steps 3-8 into a single `per_criterion` array
+- [ ] 1. Collect all verdicts from Steps 3-8 and Step 9 (behavioral SCs) into a single `per_criterion` array
 - [ ] 2. Each entry must include: `criterion_id`, `result`, `evidence`, `explanation`, `remediation`, `next_step`, `tool_calls_made`
 - [ ] 3. `next_step` is `"proceed"` when result is PASS, `"remediate"` when result is FAIL
 - [ ] 4. Count total, pass, and fail verdicts
 
-### Step 10: Apply Self-Consistency Gate
+### Step 11: Apply Self-Consistency Gate
 
 Apply a self-consistency check to every PASS verdict:
 
@@ -404,7 +416,7 @@ Apply a self-consistency check to every PASS verdict:
   - A PASS verdict must be strictly confirmatory with no critique or hedging
 - [ ] 2. Re-count pass/fail after self-consistency downgrades
 
-### Step 11: Generate Bidirectional Findings
+### Step 12: Generate Bidirectional Findings
 
 Generate findings ONLY for FAIL criteria. PASS criteria MUST NOT appear in the findings table.
 
@@ -421,7 +433,7 @@ Generate findings ONLY for FAIL criteria. PASS criteria MUST NOT appear in the f
 - [ ] 2. Present revision options for developer decision
 - [ ] 3. Include specific remediation guidance for each FAIL
 
-### Step 12: Write verdict.yaml
+### Step 13: Write verdict.yaml
 
 Write the complete verdict to `{artifact_evidence_dir}/verdict.yaml`:
 
@@ -499,7 +511,7 @@ bidirectional_findings:
     revision_option: "<guidance>"
 ```
 
-### Step 13: Return Frugal Result Contract
+### Step 14: Return Frugal Result Contract
 
 ```yaml
 status: DONE | FAIL
@@ -522,11 +534,12 @@ Every step in this task is a mandatory dependency. Skipping any step produces an
 - [ ] 6. Evaluate GA-4 (No Redundant Cross-File References) → INVALID if skipped
 - [ ] 7. Evaluate GA-5 (Context Fits in LLM Window) → INVALID if skipped
 - [ ] 8. Evaluate GA-6 (File Organization Logical) → INVALID if skipped
-- [ ] 9. Process Verdicts → INVALID if skipped
-- [ ] 10. Apply Self-Consistency Gate → INVALID if skipped
-- [ ] 11. Generate Bidirectional Findings → INVALID if skipped
-- [ ] 12. Write verdict.yaml → INVALID if skipped
-- [ ] 13. Return Frugal Result Contract → INVALID if skipped
+- [ ] 9. Evaluate Behavioral SCs via Clean-Room Sub-Agent → INVALID if skipped
+- [ ] 10. Process Verdicts → INVALID if skipped
+- [ ] 11. Apply Self-Consistency Gate → INVALID if skipped
+- [ ] 12. Generate Bidirectional Findings → INVALID if skipped
+- [ ] 13. Write verdict.yaml → INVALID if skipped
+- [ ] 14. Return Frugal Result Contract → INVALID if skipped
 
 ## Error Handling
 
@@ -548,6 +561,7 @@ Every step in this task is a mandatory dependency. Skipping any step produces an
 
 - `tasks/guideline-audit-investigator.md` — Investigator role (produces the evidence.yaml consumed by this task)
 - `tasks/guideline-audit-validator.md` — upstream reasoning role role (produces the reasoning.yaml consumed by this task)
+- `tasks/behavioral-sc-evaluator.md` — Clean-room sub-agent for evaluating behavioral SC evidence
 - `tasks/cross-validate.md` — Arbiter role (consumes this task's verdict.yaml)
 - `SKILL.md` — DiMo Role Chain Dispatch specification
 - `000-critical-rules.md` — guideline standards and critical rule definitions

--- a/skills/audit/tasks/plan-fidelity-evaluator.md
+++ b/skills/audit/tasks/plan-fidelity-evaluator.md
@@ -279,6 +279,38 @@ Before writing verdict.yaml, run the self-consistency gate on every criterion:
 - [ ] 2. If `result: "FAIL"` and `explanation` contains no hedging or critique, the verdict stands — no upgrade to PASS
 - [ ] 3. Log the self-consistency check result in the verdict YAML under `self_consistency_gate: { triggered: true|false, downgraded_criteria: ["<criterion IDs>"] }`
 
+### Step 12.5: Behavioral SC Clean-Room Evaluation
+
+For each behavioral SC identified in the evaluation criteria, dispatch a clean-room sub-agent to evaluate the behavioral evidence independently. The evaluator MUST NOT use file-existence or structural checks as evidence for behavioral SCs.
+
+- [ ] 1. **Identify behavioral SCs** — scan the evaluation criteria for SCs with `behavioral` evidence type. These require clean-room evaluation.
+- [ ] 2. **For each behavioral SC**, dispatch `behavioral-sc-evaluator` via `task()` with ONLY the artifact directory path and the SC criterion text:
+  - `artifact_path`: `{project_root}/tmp/{issue-N}/artifacts/plan-fidelity/`
+  - `sc_criteria`: the behavioral SC text to evaluate against
+  - MUST NOT include orchestrator reasoning, expected outcomes, or cached results
+- [ ] 3. **Collect result contract** — the clean-room sub-agent returns:
+  ```yaml
+  status: DONE
+  artifact_path: "<artifact directory path>"
+  summary: "Evaluated {N} behavioral SCs: {M} PASS, {K} FAIL"
+  per_sc:
+    - sc_id: "<SC-N>"
+      verdict: PASS|FAIL
+      justification: "<1-2 sentence explanation based on actual agent output>"
+  ```
+- [ ] 4. **Apply clean-room verdict** — for each behavioral SC:
+  - If clean-room sub-agent returns `PASS` → evaluator verdict for that SC is `PASS`
+  - If clean-room sub-agent returns `FAIL` → evaluator verdict for that SC is `FAIL` (overrides any upstream evidence)
+  - If clean-room sub-agent returns `BLOCKED` → evaluator verdict for that SC is `FAIL` with `remediation: "Clean-room evaluation blocked — behavioral evidence could not be assessed"`
+- [ ] 5. **File-existence is NOT sufficient** — if the only evidence for a behavioral SC is that a file exists (stdout.log, stderr.log, or any artifact), the verdict MUST be `FAIL`. Behavioral SCs require behavioral evidence: the agent must have taken the correct action, not just produced output files.
+- [ ] 6. **Log behavioral evaluation** — record the clean-room evaluation results in the verdict YAML under `behavioral_sc_evaluation`:
+  ```yaml
+  behavioral_sc_evaluation:
+    - sc_id: "<SC-N>"
+      clean_room_verdict: PASS|FAIL
+      justification: "<from clean-room sub-agent>"
+  ```
+
 ### Step 13: Write verdict.yaml
 
 Write the complete verdict to `{project_root}/tmp/{issue-N}/artifacts/plan-fidelity/verdict.yaml`:

--- a/skills/audit/tasks/plan-fidelity-evaluator.md
+++ b/skills/audit/tasks/plan-fidelity-evaluator.md
@@ -127,6 +127,7 @@ Evaluate each criterion against the validated evidence. Expected values referenc
 | PF-ONE-STEP | One-step-at-a-time protocol admonishment present at top of plan | FAIL if missing |
 | PF-DELEGATION | Undefined delegation targets | Checks that every "delegate to", "unified", "merged into", or "replaced by" reference in the spec has a corresponding concrete definition in the plan — specific file changes, routing table updates, cross-reference updates, and capability migration. If any delegation reference lacks concrete plan definitions, the criterion FAILs. |
 | PF-SEQUENCE-MATCHES | Gate sequence matches pipeline source — missing gates are automatic FAIL with no remediation path | Gate sequence matches Load [implementation-pipeline SKILL.md](skills/implementation-pipeline/SKILL.md) dispatch routing table — read dynamically, not hardcoded. Any missing gate is automatic FAIL — the plan MUST be regenerated, not patched. |
+| PF-PIPELINE-COMPLETENESS | All 19 mandatory pipeline stages present in plan | Plan MUST include all of: assemble-work, sc-coherence-gate, pre-red-baseline, red-phase, z3-check-red, red-doublecheck, green-phase, z3-check-green, green-doublecheck, checkpoint-tag-create, checkpoint-commit, green-vbc, sc-count-gate, pre-pr-gate, audit, cross-validate, regression-check, review-prep, create-pr, exec-summary. Missing any stage → FAIL. |
 
 ### Step 4: Evaluate Each Criterion
 

--- a/skills/audit/tasks/spec-audit-evaluator.md
+++ b/skills/audit/tasks/spec-audit-evaluator.md
@@ -607,16 +607,48 @@ When the spec being audited is a skill card (SKILL.md file), evaluate the SC-SEM
 
 - [ ] 4. For each SC-SEM criterion, render PASS or FAIL with explanation and remediation guidance
 
-### Step 16: Process Verdicts
+### Step 16: Evaluate Behavioral SCs via Clean-Room Sub-Agent
+
+For each SC whose declared evidence type is `behavioral`, the evaluator MUST NOT render a verdict from upstream artifacts alone. Behavioral SCs require clean-room evaluation of actual test execution output.
+
+- [ ] 1. Identify all SCs with `declared_evidence_type: behavioral` from `determinism_validation.evidence_type_declarations` in `reasoning.yaml`
+- [ ] 2. For each behavioral SC, dispatch `behavioral-sc-evaluator` via `task()` with ONLY the artifact directory path:
+
+```yaml
+prompt: "Evaluate behavioral SCs from artifact directory: {artifact_evidence_dir}"
+```
+
+The sub-agent receives:
+- The artifact directory path (containing `stdout.log`, `stderr.log`, `manifest.yaml`)
+- The SC criteria text inline
+- NO orchestrator reasoning, expected outcomes, or cached results
+
+- [ ] 3. Collect the result contract from each clean-room sub-agent dispatch
+- [ ] 4. If the clean-room sub-agent returns `verdict: FAIL` for any SC, the evaluator's verdict for that SC is FAIL — regardless of what upstream evidence suggests
+- [ ] 5. File-existence alone is NEVER sufficient evidence for behavioral SCs. If the artifact directory exists but the clean-room sub-agent judges the agent's actions did not satisfy the SC, the verdict is FAIL
+- [ ] 6. Record the behavioral SC verdicts in the per-criterion array with `evidence: "clean-room behavioral-sc-evaluator"`
+
+Record results:
+
+```yaml
+behavioral_sc_evaluation:
+  - sc_id: "<SC-N>"
+    declared_evidence_type: behavioral
+    clean_room_verdict: "PASS|FAIL"
+    evaluator_verdict: "PASS|FAIL"
+    evidence: "clean-room behavioral-sc-evaluator at {artifact_evidence_dir}"
+```
+
+### Step 17: Process Verdicts
 
 Compile all per-criterion verdicts and apply consensus rules:
 
-- [ ] 1. Collect all verdicts from Steps 4-15 into a single `per_criterion` array
+- [ ] 1. Collect all verdicts from Steps 4-16 into a single `per_criterion` array
 - [ ] 2. Each entry must include: `criterion_id`, `declared_evidence_type`, `result`, `evidence`, `explanation`, `remediation`, `next_step`, `tool_calls_made`
 - [ ] 3. `next_step` is `"proceed"` when result is PASS, `"remediate"` when result is FAIL
 - [ ] 4. Count total, pass, and fail verdicts
 
-### Step 17: Apply Self-Consistency Gate
+### Step 18: Apply Self-Consistency Gate
 
 Apply a self-consistency check to every PASS verdict:
 
@@ -626,7 +658,7 @@ Apply a self-consistency check to every PASS verdict:
   - A PASS verdict must be strictly confirmatory with no critique or hedging
 - [ ] 2. Re-count pass/fail after self-consistency downgrades
 
-### Step 18: Generate Bidirectional Findings
+### Step 19: Generate Bidirectional Findings
 
 Generate findings ONLY for FAIL criteria. PASS criteria MUST NOT appear in the findings table.
 
@@ -641,7 +673,7 @@ Generate findings ONLY for FAIL criteria. PASS criteria MUST NOT appear in the f
 - [ ] 2. Present revision options for developer decision
 - [ ] 3. Include specific remediation guidance for each FAIL
 
-### Step 19: Write verdict.yaml
+### Step 20: Write verdict.yaml
 
 Write the complete verdict to `{artifact_evidence_dir}/verdict.yaml`:
 
@@ -687,7 +719,7 @@ bidirectional_findings:
     revision_option: "<guidance>"
 ```
 
-### Step 20: Return Frugal Result Contract
+### Step 21: Return Frugal Result Contract
 
 ```yaml
 status: DONE | FAIL
@@ -718,11 +750,12 @@ Every step in this task is a mandatory dependency. Skipping any step produces an
 - [ ] 13. Evaluate Cross-Reference Completeness (A9) → INVALID if skipped
 - [ ] 14. Evaluate Analytical Artifact Criteria → INVALID if skipped
 - [ ] 15. Evaluate Semantic Auditor Criteria (SC-SEM) → INVALID if skipped for skill card audits; N/A for non-skill-card audits
-- [ ] 16. Process Verdicts → INVALID if skipped
-- [ ] 17. Apply Self-Consistency Gate → INVALID if skipped
-- [ ] 18. Generate Bidirectional Findings → INVALID if skipped
-- [ ] 19. Write verdict.yaml → INVALID if skipped
-- [ ] 20. Return Frugal Result Contract → INVALID if skipped
+- [ ] 16. Evaluate Behavioral SCs via Clean-Room Sub-Agent → INVALID if skipped (behavioral SCs without clean-room evaluation are EVIDENCE_TYPE_MISMATCH)
+- [ ] 17. Process Verdicts → INVALID if skipped
+- [ ] 18. Apply Self-Consistency Gate → INVALID if skipped
+- [ ] 19. Generate Bidirectional Findings → INVALID if skipped
+- [ ] 20. Write verdict.yaml → INVALID if skipped
+- [ ] 21. Return Frugal Result Contract → INVALID if skipped
 
 ## Error Handling
 
@@ -745,6 +778,7 @@ Every step in this task is a mandatory dependency. Skipping any step produces an
 - `tasks/spec-audit-investigator.md` — Investigator role (produces the evidence.yaml consumed by this task)
 - `tasks/spec-audit-validator.md` — upstream reasoning role role (produces the reasoning.yaml consumed by this task)
 - `tasks/cross-validate.md` — Arbiter role (consumes this task's verdict.yaml)
+- `tasks/behavioral-sc-evaluator.md` — Clean-room sub-agent for behavioral SC evaluation
 - `SKILL.md` — DiMo Role Chain Dispatch specification
 - `.opencode/reference/holistic-dimensions.yaml` — 11 holistic dimensions definitions
 - Load [Evidence Type Taxonomy](guidelines/080-code-standards.md) — evidence type declarations

--- a/skills/audit/tasks/test-quality-audit-evaluator.md
+++ b/skills/audit/tasks/test-quality-audit-evaluator.md
@@ -321,16 +321,52 @@ evidence_type_compliance:
     finding: "<brief finding>"
 ```
 
-### Step 11: Process Verdicts
+### Step 11: Evaluate Behavioral SCs via Clean-Room Sub-Agent
+
+For each SC with declared evidence type `behavioral`, dispatch a clean-room sub-agent to evaluate the behavioral evidence artifacts. File-existence alone is NOT sufficient evidence for behavioral SCs.
+
+- [ ] 1. Read the SC table from Step 3 to identify all SCs with declared evidence type `behavioral`
+- [ ] 2. For each behavioral SC, dispatch `behavioral-sc-evaluator` via `task()` with ONLY the artifact directory path:
+
+```yaml
+task(
+  subagent_type="general",
+  prompt: "execute behavioral-sc-evaluator task from audit",
+  context: {
+    artifact_evidence_dir: "<artifact_evidence_dir>",
+    sc_id: "<SC-N>",
+    worktree.path: "<if set>",
+    github.owner: "<from session>",
+    github.repo: "<from session>"
+  }
+)
+```
+
+- [ ] 3. Collect the result contract from each clean-room sub-agent dispatch
+- [ ] 4. If the clean-room sub-agent returns `status: FAIL` for any behavioral SC, the evaluator verdict for that SC is FAIL — do NOT override with PASS
+- [ ] 5. If the clean-room sub-agent returns `status: DONE` with PASS, the evaluator verdict for that SC is PASS
+- [ ] 6. If the clean-room sub-agent returns `status: BLOCKED` (e.g., no behavioral evidence artifacts found), the evaluator verdict for that SC is FAIL — file-existence alone is NOT sufficient evidence for behavioral SCs
+- [ ] 7. Record each behavioral SC verdict:
+
+```yaml
+behavioral_sc_evaluation:
+  - sc_id: "SC-N"
+    clean_room_verdict: "PASS|FAIL"
+    evaluator_verdict: "PASS|FAIL"
+    artifact_path: "<artifact_evidence_dir>"
+    finding: "<brief finding>"
+```
+
+### Step 12: Process Verdicts
 
 Compile all per-criterion verdicts and apply consensus rules:
 
-- [ ] 1. Collect all verdicts from Steps 4-10 into a single `per_criterion` array
+- [ ] 1. Collect all verdicts from Steps 4-11 into a single `per_criterion` array
 - [ ] 2. Each entry must include: `criterion_id`, `result`, `evidence_source`, `finding`, `remediation`, `recommendation`
 - [ ] 3. Count total, pass, and fail verdicts
 - [ ] 4. Determine `all_criteria_pass` and `remediation_required`
 
-### Step 12: Apply Self-Consistency Gate
+### Step 13: Apply Self-Consistency Gate
 
 Apply a self-consistency check to every PASS verdict:
 
@@ -341,7 +377,7 @@ Apply a self-consistency check to every PASS verdict:
 - [ ] 2. Re-count pass/fail after self-consistency downgrades
 - [ ] 3. Log downgrades in a `self_consistency_downgrades` field
 
-### Step 13: Write verdict.yaml
+### Step 14: Write verdict.yaml
 
 Write the complete verdict to `{artifact_evidence_dir}/verdict.yaml`:
 
@@ -403,7 +439,7 @@ self_consistency_downgrades:
     hedging_phrase: "<matched phrase>"
 ```
 
-### Step 14: Return Frugal Result Contract
+### Step 15: Return Frugal Result Contract
 
 ```yaml
 status: DONE | FAIL
@@ -428,10 +464,11 @@ Every step in this task is a mandatory dependency. Skipping any step produces an
 - [ ] 8. Evaluate RED Evidence (TQ-5) → INVALID if skipped
 - [ ] 9. Evaluate Sequential TDD (TQ-6) → INVALID if skipped
 - [ ] 10. Evaluate Evidence Type Compliance → INVALID if skipped
-- [ ] 11. Process Verdicts → INVALID if skipped
-- [ ] 12. Apply Self-Consistency Gate → INVALID if skipped
-- [ ] 13. Write verdict.yaml → INVALID if skipped
-- [ ] 14. Return Frugal Result Contract → INVALID if skipped
+- [ ] 11. Evaluate Behavioral SCs via Clean-Room Sub-Agent → INVALID if skipped
+- [ ] 12. Process Verdicts → INVALID if skipped
+- [ ] 13. Apply Self-Consistency Gate → INVALID if skipped
+- [ ] 14. Write verdict.yaml → INVALID if skipped
+- [ ] 15. Return Frugal Result Contract → INVALID if skipped
 
 ## Error Handling
 

--- a/skills/audit/tasks/verification-audit-evaluator.md
+++ b/skills/audit/tasks/verification-audit-evaluator.md
@@ -156,19 +156,22 @@ For each SC with valid evidence, evaluate whether the evidence demonstrates the 
 - **Structural SC**: Verify the file exists with expected content. Read the evidence artifact and confirm the file path, existence, and content match the SC criterion.
 - **String SC**: Verify the expected pattern is present. Read the evidence artifact and confirm the grep/pattern match result satisfies the SC criterion.
 - **Semantic SC**: Read the evidence artifact and apply analytical judgment. Does the implementation's intent and meaning satisfy the SC criterion? This requires reading the evidence content and reasoning about whether the implementation achieves the SC's intent.
-- **Behavioral SC**: Read the behavioral test output (session logs, stderr/stdout captures, YAML verdicts). Does the test execution output confirm the agent's behavior matches the SC criterion? Look for tool-call evidence, dispatch traces, and behavioral assertions in the test output.
+- **Behavioral SC**: Evaluation is delegated to a clean-room sub-agent via Step 5a. The evaluator does NOT evaluate behavioral SCs inline — it dispatches to `behavioral-sc-evaluator` and uses the returned verdict.
+
+### Step 5a: Clean-Room Dispatch for Behavioral SCs
+
+For each behavioral SC identified in Step 3, the evaluator MUST NOT evaluate the evidence inline. Instead, it dispatches a clean-room sub-agent:
+
+- [ ] 1. For each behavioral SC, collect the artifact directory path from `artifact_evidence_dir`
+- [ ] 2. Dispatch `behavioral-sc-evaluator` via `task()` with ONLY the artifact directory path and the SC criterion text — no orchestrator reasoning, no expected outcomes, no cached results
+- [ ] 3. Receive the result contract from the clean-room sub-agent
+- [ ] 4. If the clean-room sub-agent returns `verdict: FAIL` for any SC, the evaluator's verdict for that SC is FAIL (not PASS)
+- [ ] 5. File-existence alone is NOT sufficient evidence for behavioral SCs — the clean-room sub-agent must confirm the agent took the correct action
+- [ ] 6. If the clean-room sub-agent returns `status: BLOCKED` or produces no result, the evaluator verdict for that SC is FAIL with reason `CLEAN_ROOM_EVALUATION_FAILED`
+
+The clean-room sub-agent's verdict is authoritative for behavioral SCs. The evaluator does NOT override a PASS from the clean-room sub-agent, but MUST override a FAIL from the clean-room sub-agent into the evaluator's verdict.
 
 #### Verdict Rules
-
-| Condition | Verdict |
-|-----------|---------|
-| Evidence 100% confirms SC is satisfied, no caveats | PASS |
-| Evidence partially confirms, any uncertainty, any caveat | FAIL |
-| Evidence contradicts the SC criterion | FAIL |
-| Evidence is absent for this SC | FAIL |
-| Evidence type does not match declared type | FAIL |
-| upstream reasoning role flagged validation issues for this SC | FAIL |
-| Any hedging language in evidence explanation | FAIL |
 
 ### Step 6: Verify Evidence Type Compliance
 

--- a/skills/spec-creation-validation/tasks/create.md
+++ b/skills/spec-creation-validation/tasks/create.md
@@ -460,6 +460,12 @@ Assemble the final spec with acceptance criteria, ambiguity elimination, and del
 
     **🚫 FORBIDDEN:** Declaring a runtime-behavioral change as `structural` or `string` evidence type. The classification question is substrate-determined — the code path either executes at runtime or it does not.
 
+    **Presumptive runtime-behavioral file types:** The following file types ALWAYS affect runtime agent behavior and MUST be classified as `behavioral` unless the agent can prove otherwise:
+    - `SKILL.md` — Trigger Dispatch Tables, Invocation sections, DISPATCH_GATE protocols control agent dispatch decisions
+    - `tasks/*.md` — Task file procedures control sub-agent execution behavior
+    - `guidelines/*.md` — Enforcement blocks, critical violation sections, and procedural rules control agent compliance
+    - `enforcement/*.md` — Enforcement gate definitions control pipeline routing
+
     **Remediation:** If the agent classifies an SC as structural/string for a runtime-behavioral change, the VbC pre-flight classification gate will uplift it to behavioral anyway. Classifying correctly at authorship time prevents downstream rework.
 
     **Authority:** Load [critical-rules-BEH-EV](guidelines/000-critical-rules.md), Load [Evidence Type Taxonomy](guidelines/080-code-standards.md)

--- a/skills/writing-plans-creation/SKILL.md
+++ b/skills/writing-plans-creation/SKILL.md
@@ -11,29 +11,6 @@ provenance: AI-generated
 
 Creates implementation plans from approved specs. Breaks work into phases, tasks, and work breakdowns. Supports retroactive plan creation for existing specs.
 
-## Trigger Dispatch Table
-
-| User says / Context | Task | Dispatch | Context passed |
-|---------------------|------|----------|----------------|
-| "verify spec approved" / "check spec approval" | `verify-spec-approved` | `sub-task` | {spec_issue_number} |
-| "research evidence" / "gather evidence" | `research` | `sub-task` | {spec_issue_number, spec_body} |
-| "artifact validation" / "validate artifacts" | `artifact-validation` | `sub-task` | {spec_issue_number, project_root, path} |
-| "readiness gate" / "check readiness" | `readiness` | `sub-task` | {spec_issue_number, research_output} |
-| "structure phases" / "define phases" | `structure` | `sub-task` | {spec_issue_number, readiness_output} |
-| "solve constraints" / "z3 solve" | `solve` | `sub-task` | {spec_issue_number, structure_output} |
-| "write plan" / "generate plan" | `write` | `sub-task` | {spec_issue_number, solve_output} |
-| "revisit plan" / "resolve conflicts" | `revisit` | `sub-task` | {spec_issue_number, write_output} |
-| "validate plan" / "check plan" | `validate` | `sub-task` | {spec_issue_number, plan_file_path} |
-| "audit fidelity" / "fidelity audit" | `audit-fidelity` | `sub-task` | {spec_issue_number, plan_file_path, audit_phase} |
-| "audit concern" / "concern audit" | `audit-concern` | `sub-task` | {spec_issue_number, plan_file_path, audit_phase} |
-| "complete plan" / "finish plan" | `completion` | `sub-task` | {workflow_state} |
-| "retroactive plan" / "retroactive" | `retroactive` | `sub-task` | {spec_issue_number} |
-| "clean-room plan" / "independent plan" | `clean-room` | `sub-task` | {problem_statement} |
-| "pre-plan readiness" / "prerequisites check" | `pre-plan-readiness` | `sub-task` | {spec_issue_number} |
-| "operating protocol" / "workflow docs" | `operating-protocol` | `sub-task` | {spec_issue_number} |
-| "update plan" / "plan update" | `update` | `sub-task` | {spec_issue_number, plan_issue_number} |
-| "holistic check" / "self-check" | `holistic-self-check` | `sub-task` | {plan_context} |
-
 ## Tasks
 
 - artifact-validation.md
@@ -62,32 +39,3 @@ Creates implementation plans from approved specs. Breaks work into phases, tasks
 ## Cross-References
 
 Parent skill: `writing-plans`. Sub-skill: `writing-plans-holistic`. Skills: `spec-creation`, `approval-gate`, `implementation-pipeline`.
-
-## Invocation
-
-`skill({name: "writing-plans-creation"})` — orchestrator dispatches pipeline steps to sub-agents via `task()`.
-
-**DISPATCH GATE — Pipeline steps dispatch to sub-agents.** The orchestrator routes each step to a clean-room sub-agent via `task()`. The orchestrator reads each step procedure from its task file and dispatches it. When external skills are needed (e.g., audit for fidelity/concern audits), invoke them via `skill({name: "..."})` with the appropriate task, dispatched to a sub-agent.
-
-| Task | Canonical Dispatch String |
-|------|--------------------------|
-| `verify-spec-approved` | `task(..., prompt: "execute verify-spec-approved from writing-plans-creation. Read \`writing-plans-creation/tasks/pre-plan-readiness.md\` first")` |
-| `research` | `task(..., prompt: "execute research from writing-plans-creation. Read \`writing-plans-creation/tasks/research.md\` first")` |
-| `artifact-validation` | `task(..., prompt: "execute artifact-validation from writing-plans-creation. Read \`writing-plans-creation/tasks/artifact-validation.md\` first")` |
-| `readiness` | `task(..., prompt: "execute readiness from writing-plans-creation. Read \`writing-plans-creation/tasks/readiness.md\` first")` |
-| `structure` | `task(..., prompt: "execute structure from writing-plans-creation. Read \`writing-plans-creation/tasks/structure.md\` first")` |
-| `solve` | `task(..., prompt: "execute solve from writing-plans-creation. Read \`writing-plans-creation/tasks/solve.md\` first")` |
-| `write` | `task(..., prompt: "execute write from writing-plans-creation. Read \`writing-plans-creation/tasks/write.md\` first")` |
-| `revisit` | `task(..., prompt: "execute revisit from writing-plans-creation. Read \`writing-plans-creation/tasks/revisit.md\` first")` |
-| `validate` | `task(..., prompt: "execute validate from writing-plans-creation. Read \`writing-plans-creation/tasks/validate.md\` first")` |
-| `audit-fidelity` | `task(..., prompt: "execute audit-fidelity from writing-plans-creation. Read \`writing-plans-creation/tasks/audit-fidelity.md\` first")` |
-| `audit-concern` | `task(..., prompt: "execute audit-concern from writing-plans-creation. Read \`writing-plans-creation/tasks/audit-concern.md\` first")` |
-| `completion` | `task(..., prompt: "execute completion from writing-plans-creation. Read \`writing-plans-creation/tasks/completion.md\` first")` |
-| `retroactive` | `task(..., prompt: "execute retroactive from writing-plans-creation. Read \`writing-plans-creation/tasks/retroactive.md\` first")` |
-| `clean-room` | `task(..., prompt: "execute clean-room from writing-plans-creation. Read \`writing-plans-creation/tasks/clean-room.md\` first")` |
-| `pre-plan-readiness` | `task(..., prompt: "execute pre-plan-readiness from writing-plans-creation. Read \`writing-plans-creation/tasks/pre-plan-readiness.md\` first")` |
-| `operating-protocol` | `task(..., prompt: "execute operating-protocol from writing-plans-creation. Read \`writing-plans-creation/tasks/operating-protocol.md\` first")` |
-| `update` | `task(..., prompt: "execute update from writing-plans-creation. Read \`writing-plans-creation/tasks/update.md\` first")` |
-| `holistic-self-check` | `task(..., prompt: "execute holistic-self-check from writing-plans-creation. Read \`writing-plans-holistic/tasks/holistic-self-check.md\` first")` |
-
-**CLI equivalent (for human TUI use):** `` `skill({name: "writing-plans-creation"})` ``

--- a/skills/writing-plans-creation/SKILL.md
+++ b/skills/writing-plans-creation/SKILL.md
@@ -10,8 +10,6 @@ Task files for the writing-plans creation pipeline. Consumed by the `writing-pla
 - clean-room.md
 - completion.md
 - create.md
-- handoffs/ (directory)
-- operating-protocol.md
 - pre-plan-readiness.md
 - readiness.md
 - research.md

--- a/skills/writing-plans-creation/SKILL.md
+++ b/skills/writing-plans-creation/SKILL.md
@@ -1,15 +1,6 @@
----
-name: writing-plans-creation
-description: "Implementation plan creator that breaks approved specs into phases, tasks, and work breakdowns. Load via skill() when creating an implementation plan from an approved spec, breaking down work into phases, planning implementation steps, or creating task breakdowns. Also load when retroactively creating a plan for an existing spec, or backfilling plan documentation. Plans MUST be created before implementation. User phrases: create plan, break down work, plan phases, create task breakdown"
-license: MIT
-provenance: AI-generated
----
+# Task Container: writing-plans-creation
 
-# Skill: writing-plans-creation
-
-## Overview
-
-Creates implementation plans from approved specs. Breaks work into phases, tasks, and work breakdowns. Supports retroactive plan creation for existing specs.
+Task files for the writing-plans creation pipeline. Consumed by the `writing-plans` orchestrator. Not directly dispatchable — route through `writing-plans` skill.
 
 ## Tasks
 
@@ -31,11 +22,3 @@ Creates implementation plans from approved specs. Breaks work into phases, tasks
 - update.md
 - validate.md
 - write.md
-
-## Contracts
-
-- contracts/ (contract templates — see contracts/INDEX.md for mapping)
-
-## Cross-References
-
-Parent skill: `writing-plans`. Sub-skill: `writing-plans-holistic`. Skills: `spec-creation`, `approval-gate`, `implementation-pipeline`.

--- a/skills/writing-plans-creation/SKILL.md
+++ b/skills/writing-plans-creation/SKILL.md
@@ -11,6 +11,29 @@ provenance: AI-generated
 
 Creates implementation plans from approved specs. Breaks work into phases, tasks, and work breakdowns. Supports retroactive plan creation for existing specs.
 
+## Trigger Dispatch Table
+
+| User says / Context | Task | Dispatch | Context passed |
+|---------------------|------|----------|----------------|
+| "verify spec approved" / "check spec approval" | `verify-spec-approved` | `sub-task` | {spec_issue_number} |
+| "research evidence" / "gather evidence" | `research` | `sub-task` | {spec_issue_number, spec_body} |
+| "artifact validation" / "validate artifacts" | `artifact-validation` | `sub-task` | {spec_issue_number, project_root, path} |
+| "readiness gate" / "check readiness" | `readiness` | `sub-task` | {spec_issue_number, research_output} |
+| "structure phases" / "define phases" | `structure` | `sub-task` | {spec_issue_number, readiness_output} |
+| "solve constraints" / "z3 solve" | `solve` | `sub-task` | {spec_issue_number, structure_output} |
+| "write plan" / "generate plan" | `write` | `sub-task` | {spec_issue_number, solve_output} |
+| "revisit plan" / "resolve conflicts" | `revisit` | `sub-task` | {spec_issue_number, write_output} |
+| "validate plan" / "check plan" | `validate` | `sub-task` | {spec_issue_number, plan_file_path} |
+| "audit fidelity" / "fidelity audit" | `audit-fidelity` | `sub-task` | {spec_issue_number, plan_file_path, audit_phase} |
+| "audit concern" / "concern audit" | `audit-concern` | `sub-task` | {spec_issue_number, plan_file_path, audit_phase} |
+| "complete plan" / "finish plan" | `completion` | `sub-task` | {workflow_state} |
+| "retroactive plan" / "retroactive" | `retroactive` | `sub-task` | {spec_issue_number} |
+| "clean-room plan" / "independent plan" | `clean-room` | `sub-task` | {problem_statement} |
+| "pre-plan readiness" / "prerequisites check" | `pre-plan-readiness` | `sub-task` | {spec_issue_number} |
+| "operating protocol" / "workflow docs" | `operating-protocol` | `sub-task` | {spec_issue_number} |
+| "update plan" / "plan update" | `update` | `sub-task` | {spec_issue_number, plan_issue_number} |
+| "holistic check" / "self-check" | `holistic-self-check` | `sub-task` | {plan_context} |
+
 ## Tasks
 
 - artifact-validation.md
@@ -39,3 +62,32 @@ Creates implementation plans from approved specs. Breaks work into phases, tasks
 ## Cross-References
 
 Parent skill: `writing-plans`. Sub-skill: `writing-plans-holistic`. Skills: `spec-creation`, `approval-gate`, `implementation-pipeline`.
+
+## Invocation
+
+`skill({name: "writing-plans-creation"})` — orchestrator dispatches pipeline steps to sub-agents via `task()`.
+
+**DISPATCH GATE — Pipeline steps dispatch to sub-agents.** The orchestrator routes each step to a clean-room sub-agent via `task()`. The orchestrator reads each step procedure from its task file and dispatches it. When external skills are needed (e.g., audit for fidelity/concern audits), invoke them via `skill({name: "..."})` with the appropriate task, dispatched to a sub-agent.
+
+| Task | Canonical Dispatch String |
+|------|--------------------------|
+| `verify-spec-approved` | `task(..., prompt: "execute verify-spec-approved from writing-plans-creation. Read \`writing-plans-creation/tasks/pre-plan-readiness.md\` first")` |
+| `research` | `task(..., prompt: "execute research from writing-plans-creation. Read \`writing-plans-creation/tasks/research.md\` first")` |
+| `artifact-validation` | `task(..., prompt: "execute artifact-validation from writing-plans-creation. Read \`writing-plans-creation/tasks/artifact-validation.md\` first")` |
+| `readiness` | `task(..., prompt: "execute readiness from writing-plans-creation. Read \`writing-plans-creation/tasks/readiness.md\` first")` |
+| `structure` | `task(..., prompt: "execute structure from writing-plans-creation. Read \`writing-plans-creation/tasks/structure.md\` first")` |
+| `solve` | `task(..., prompt: "execute solve from writing-plans-creation. Read \`writing-plans-creation/tasks/solve.md\` first")` |
+| `write` | `task(..., prompt: "execute write from writing-plans-creation. Read \`writing-plans-creation/tasks/write.md\` first")` |
+| `revisit` | `task(..., prompt: "execute revisit from writing-plans-creation. Read \`writing-plans-creation/tasks/revisit.md\` first")` |
+| `validate` | `task(..., prompt: "execute validate from writing-plans-creation. Read \`writing-plans-creation/tasks/validate.md\` first")` |
+| `audit-fidelity` | `task(..., prompt: "execute audit-fidelity from writing-plans-creation. Read \`writing-plans-creation/tasks/audit-fidelity.md\` first")` |
+| `audit-concern` | `task(..., prompt: "execute audit-concern from writing-plans-creation. Read \`writing-plans-creation/tasks/audit-concern.md\` first")` |
+| `completion` | `task(..., prompt: "execute completion from writing-plans-creation. Read \`writing-plans-creation/tasks/completion.md\` first")` |
+| `retroactive` | `task(..., prompt: "execute retroactive from writing-plans-creation. Read \`writing-plans-creation/tasks/retroactive.md\` first")` |
+| `clean-room` | `task(..., prompt: "execute clean-room from writing-plans-creation. Read \`writing-plans-creation/tasks/clean-room.md\` first")` |
+| `pre-plan-readiness` | `task(..., prompt: "execute pre-plan-readiness from writing-plans-creation. Read \`writing-plans-creation/tasks/pre-plan-readiness.md\` first")` |
+| `operating-protocol` | `task(..., prompt: "execute operating-protocol from writing-plans-creation. Read \`writing-plans-creation/tasks/operating-protocol.md\` first")` |
+| `update` | `task(..., prompt: "execute update from writing-plans-creation. Read \`writing-plans-creation/tasks/update.md\` first")` |
+| `holistic-self-check` | `task(..., prompt: "execute holistic-self-check from writing-plans-creation. Read \`writing-plans-holistic/tasks/holistic-self-check.md\` first")` |
+
+**CLI equivalent (for human TUI use):** `` `skill({name: "writing-plans-creation"})` ``

--- a/skills/writing-plans-creation/tasks/create.md
+++ b/skills/writing-plans-creation/tasks/create.md
@@ -121,6 +121,7 @@ The following steps are dispatched by the orchestrator from the SKILL.md Trigger
 | readiness | `{ spec_issue_number, research_output }` | status PASS |
 | structure | `{ spec_issue_number, readiness_output }` | phase definitions and dependency contract |
 | solve | `{ spec_issue_number, structure_output }` | SAT and SOLVED status |
+| plan-creation-pipeline | `{ spec_issue_number, structure_output }` | plan file path (dispatches to plan-creation-pipeline skill) |
 | write | `{ spec_issue_number, solve_output }` | plan file path |
 | revisit | `{ spec_issue_number, write_output }` | resolution_status |
 | validate | `{ spec_issue_number, plan_file_path }` | PASS status |
@@ -151,7 +152,7 @@ Each item is tagged with dispatch scope and chain dependency.
   - Chain: `step_1`
   - Expected: evidence_artifacts in research output
 
-- [ ] 3. (**inline**) Z3 check — `solve check` verify research output contains evidence_artifacts per `.opencode/skills/writing-plans/contracts/create-output-template.yaml:research`
+- [ ] 3. (**inline**) Z3 check — `solve check` verify research output contains evidence_artifacts per `.opencode/skills/writing-plans-creation/contracts/create-output-template.yaml:research`
   - Chain: `step_2`
 
 - [ ] 4. (**orchestrator**) Readiness — orchestrator dispatches via SKILL.md Trigger Dispatch Table. The readiness gate MUST read `sc-pipeline-readiness.yaml` created by an independent sub-agent (pipeline-readiness-gate task), NOT by the orchestrator. If the file was created by the orchestrator (same session, no sub-agent dispatch), the gate MUST return BLOCKED.
@@ -162,25 +163,31 @@ Each item is tagged with dispatch scope and chain dependency.
   - Chain: `step_4`
   - Expected: PASS in artifact-validation output; if BLOCKED, pipeline halts with `MISSING_SPEC_ARTIFACT`
 
-- [ ] 5. (**inline**) Z3 check — `solve check` verify readiness output has status PASS per `.opencode/skills/writing-plans/contracts/create-output-template.yaml:readiness`
+- [ ] 5. (**inline**) Z3 check — `solve check` verify readiness output has status PASS per `.opencode/skills/writing-plans-creation/contracts/create-output-template.yaml:readiness`
   - Chain: `step_4a`
 
 - [ ] 6. (**orchestrator**) Structure — orchestrator dispatches via SKILL.md Trigger Dispatch Table
   - Chain: `step_5`
   - Expected: phase definitions and dependency contract in structure output
 
-- [ ] 7. (**inline**) Z3 check — `solve check` verify structure output has phase definitions and dependency contract per `.opencode/skills/writing-plans/contracts/create-output-template.yaml:structure`
+- [ ] 7. (**inline**) Z3 check — `solve check` verify structure output has phase definitions and dependency contract per `.opencode/skills/writing-plans-creation/contracts/create-output-template.yaml:structure`
   - Chain: `step_6`
 
 - [ ] 8. (**orchestrator**) Solve — orchestrator dispatches via SKILL.md Trigger Dispatch Table
   - Chain: `step_7`
   - Expected: SAT and SOLVED status in solve output
 
-- [ ] 9. (**inline**) Z3 check — `solve check` verify solve output has SAT and SOLVED status per `.opencode/skills/writing-plans/contracts/create-output-template.yaml:solve`
+- [ ] 9. (**inline**) Z3 check — `solve check` verify solve output has SAT and SOLVED status per `.opencode/skills/writing-plans-creation/contracts/create-output-template.yaml:solve`
   - Chain: `step_8`
 
-- [ ] 10. (**orchestrator**) Write — orchestrator dispatches via SKILL.md Trigger Dispatch Table. **Post-dispatch file verification:** After the sub-agent returns DONE with a file path, run `ls` or `file-exists` to confirm the file exists on disk. If the file does not exist, re-task clean-room (do not accept the empty result).
+- [ ] 9a. (**orchestrator**) Plan creation pipeline — orchestrator dispatches to `plan-creation-pipeline` skill via SKILL.md Trigger Dispatch Table. This step replaces the bare inspection with a Z3-verified 6-step pipeline (spec-to-plan-handoff, plan-create, solve-model, solve-check, plan-plan, plan-completion).
   - Chain: `step_9`
+  - Context passed: `{ spec_issue_number, structure_output }`
+  - Expected: plan file path in pipeline output
+  - **Solve gate:** The pipeline includes Z3 verification at each transition (solve-model, solve-check, plan-plan) per `plan-creation-pipeline` SKILL.md
+
+- [ ] 10. (**orchestrator**) Write — orchestrator dispatches via SKILL.md Trigger Dispatch Table. **Post-dispatch file verification:** After the sub-agent returns DONE with a file path, run `ls` or `file-exists` to confirm the file exists on disk. If the file does not exist, re-task clean-room (do not accept the empty result).
+  - Chain: `step_9a`
   - Expected: plan file path in write output
   - **Behavioral SC requirement:** The write sub-agent MUST generate phase exit criteria for behavioral SCs that include both `behavior_run` artifact generation AND `behavioral-test-evaluation` clean-room dispatch steps. Each SC in the exit criteria MUST carry an `evidence_type` metadata annotation (e.g., `evidence_type: behavioral`). The VbC section for behavioral SCs MUST include a mandatory gate: after artifact generation, dispatch `behavioral-test-evaluation` before allowing PASS verdict.
 
@@ -188,35 +195,35 @@ Each item is tagged with dispatch scope and chain dependency.
   - Chain: `step_10`
   - Expected: clean_room_plan in output
 
-- [ ] 12. (**inline**) Z3 check — `solve check` verify clean-room plan output contains clean_room_plan per `.opencode/skills/writing-plans/contracts/create-output-template.yaml:write`
+- [ ] 12. (**inline**) Z3 check — `solve check` verify clean-room plan output contains clean_room_plan per `.opencode/skills/writing-plans-creation/contracts/create-output-template.yaml:write`
   - Chain: `step_11`
 
 - [ ] 13. (**orchestrator**) Revisit — orchestrator dispatches via SKILL.md Trigger Dispatch Table
   - Chain: `step_12`
   - Expected: resolution_status in revisit output
 
-- [ ] 14. (**inline**) Z3 check — `solve check` verify revisit output has resolution_status per `.opencode/skills/writing-plans/contracts/create-output-template.yaml:revisit`
+- [ ] 14. (**inline**) Z3 check — `solve check` verify revisit output has resolution_status per `.opencode/skills/writing-plans-creation/contracts/create-output-template.yaml:revisit`
   - Chain: `step_13`
 
 - [ ] 15. (**orchestrator**) Validate — orchestrator dispatches via SKILL.md Trigger Dispatch Table
   - Chain: `step_14`
   - Expected: PASS status in validate output
 
-- [ ] 16. (**inline**) Z3 check — `solve check` verify validate output has PASS status per `.opencode/skills/writing-plans/contracts/create-output-template.yaml:validate`
+- [ ] 16. (**inline**) Z3 check — `solve check` verify validate output has PASS status per `.opencode/skills/writing-plans-creation/contracts/create-output-template.yaml:validate`
   - Chain: `step_15`
 
 - [ ] 17. (**orchestrator**) Audit fidelity — orchestrator dispatches via SKILL.md Trigger Dispatch Table
   - Chain: `step_16`
   - Expected: PASS in audit-fidelity output
 
-- [ ] 18. (**inline**) Z3 check — `solve check` verify audit-fidelity output has PASS AND `all_criteria_pass == true` per `.opencode/skills/writing-plans/contracts/create-output-template.yaml:audit-fidelity`. If `all_criteria_pass` is `false` or missing, treat as FAIL — orchestrator MUST halt and require remediation before proceeding.
+- [ ] 18. (**inline**) Z3 check — `solve check` verify audit-fidelity output has PASS AND `all_criteria_pass == true` per `.opencode/skills/writing-plans-creation/contracts/create-output-template.yaml:audit-fidelity`. If `all_criteria_pass` is `false` or missing, treat as FAIL — orchestrator MUST halt and require remediation before proceeding.
   - Chain: `step_17`
 
 - [ ] 19. (**orchestrator**) Audit concern — orchestrator dispatches via SKILL.md Trigger Dispatch Table
   - Chain: `step_18`
   - Expected: PASS in audit-concern output
 
-- [ ] 20. (**inline**) Z3 check — `solve check` verify audit-concern output has PASS AND `all_criteria_pass == true` per `.opencode/skills/writing-plans/contracts/create-output-template.yaml:audit-concern`. If `all_criteria_pass` is `false` or missing, treat as FAIL — orchestrator MUST halt and require remediation before proceeding.
+- [ ] 20. (**inline**) Z3 check — `solve check` verify audit-concern output has PASS AND `all_criteria_pass == true` per `.opencode/skills/writing-plans-creation/contracts/create-output-template.yaml:audit-concern`. If `all_criteria_pass` is `false` or missing, treat as FAIL — orchestrator MUST halt and require remediation before proceeding.
   - Chain: `step_19`
 
 - [ ] 21. (**orchestrator**) Completion — orchestrator dispatches via SKILL.md Trigger Dispatch Table

--- a/skills/writing-plans-creation/tasks/pre-plan-readiness.md
+++ b/skills/writing-plans-creation/tasks/pre-plan-readiness.md
@@ -17,7 +17,8 @@ Verify that the local spec file and feature branch exist before allowing plan cr
 - BLOCKED if feature branch is missing
 - BLOCKED if `local-issues sync` has not been run
 - BLOCKED if any analytical artifact is missing (returns `MISSING_SPEC_ARTIFACT`)
-- PASS if all prerequisites are met
+- BLOCKED if `solve check` fails on readiness contract
+- PASS if all prerequisites are met and Z3 verification passes
 
 ## Procedure
 
@@ -36,4 +37,6 @@ Verify that the local spec file and feature branch exist before allowing plan cr
    - `state-analysis.yaml`
    - `testability-assessment.yaml`
    - If any missing: return `status: BLOCKED` with `reason: MISSING_SPEC_ARTIFACT` and list the missing artifacts
-5. Return `status: PASS` with `finding_summary: "All prerequisites met"`
+5. Run `solve check` on readiness output contract `.opencode/skills/writing-plans-creation/contracts/readiness-output-template.yaml`
+   - If Z3 returns UNSAT: return `status: BLOCKED` with `reason: READINESS_CONTRACT_UNSAT`
+6. Return `status: PASS` with `finding_summary: "All prerequisites met"`

--- a/skills/writing-plans-creation/tasks/write.md
+++ b/skills/writing-plans-creation/tasks/write.md
@@ -131,6 +131,35 @@ Every step MUST use one of three dispatch indicators:
 | `(**sub-agent**)` | Dispatch via `task()` with phase file + orchestrator-provided context | Phase file + orchestrator-provided context | `- [ ] 3. **RED (**sub-agent**).**` |
 | `(**clean-room**)` | Dispatch via `task()` with phase file only (routing metadata) | Phase file only (routing metadata) | `- [ ] 1. **Coherence gate (**clean-room**).**` |
 
+### Mandatory Pipeline Steps
+
+Every plan MUST include the full implementation pipeline. Plans missing any of these stages are structurally defective and MUST be rejected by plan-fidelity audit.
+
+**Pre-RED common steps (before any RED/GREEN cycle):**
+1. `assemble-work` — read plan, verify dispatch indicators, create work state
+2. `sc-coherence-gate` — dispatch audit coherence-extraction
+3. `pre-red-baseline` — dispatch pre-red-baseline, init solve state
+
+**RED/GREEN chained pipeline per item (repeat for each implementation item):**
+4. `red-phase` — write failing behavioral test
+5. `z3-check-red` — solve check verify RED test fails
+6. `red-doublecheck` — verification-before-completion verify RED
+7. `green-phase` — implement the change
+8. `z3-check-green` — solve check verify GREEN test passes
+9. `green-doublecheck` — verification-before-completion verify GREEN
+10. `checkpoint-tag-create` — create checkpoint tag
+11. `checkpoint-commit` — save checkpoint
+
+**Post-GREEN common steps (after all RED/GREEN cycles):**
+12. `green-vbc` — verification-before-completion for all SCs
+13. `sc-count-gate` — verify all SCs have verdicts
+14. `pre-pr-gate` — verify no FAIL verdicts
+15. `audit` — dispatch verification-audit + cross-validate
+16. `regression-check` — run regression tests
+17. `review-prep` — prepare for review
+18. `create-pr` — create pull request
+19. `exec-summary` — report final status
+
 ### Prohibited Patterns
 
 - **No dispatch tables** — do not include implementation-pipeline dispatch tables in plan files. The plan defines WHAT to do; the orchestrator determines HOW to dispatch.

--- a/skills/writing-plans/SKILL.md
+++ b/skills/writing-plans/SKILL.md
@@ -34,8 +34,9 @@ This skill operates in the main repo directory (direct-branch mode). When `WORKT
 
 | User says / Context | Task | Dispatch | Context passed |
 |---------------------|------|----------|----------------|
-| "create plan" / "implementation plan" / "write plan" / "plan" / "draft plan" / "auto-create plan" / "gap-fill plan" / "retroactive" / "retroactive plan" / "backfill plan" | `create` | `sub-task` | {spec_issue_number, spec_body} |
+| "create plan" / "implementation plan" / "write plan" / "plan" / "draft plan" / "auto-create plan" / "gap-fill plan" | `create` | `sub-task` | {spec_issue_number, spec_body} |
 | "update plan" / "plan update" / "auto-update plan" / "revise plan" | `update` | `sub-task` | {spec_issue_number, plan_issue_number} |
+| "retroactive plan" / "retroactive" / "backfill plan" | `retroactive` | `sub-task` | {spec_issue_number, spec_body} |
 | "holistic check" / "self-check" / "pre-completion check" | `holistic-self-check` | `sub-task` | {plan_context} |
 
 ## Persona
@@ -72,6 +73,7 @@ This skill produces plans by dispatching pipeline steps to sub-agents. The orche
 |------|--------------------------|
 | `create` | `task(..., prompt: "execute create from writing-plans-creation. Read \`writing-plans-creation/tasks/create.md\` first")` |
 | `update` | `task(..., prompt: "execute update from writing-plans-creation. Read \`writing-plans-creation/tasks/update.md\` first")` |
+| `retroactive` | `task(..., prompt: "execute retroactive from writing-plans-creation. Read \`writing-plans-creation/tasks/retroactive.md\` first")` |
 | `holistic-self-check` | `task(..., prompt: "execute holistic-self-check from writing-plans. Read \`writing-plans-holistic/tasks/holistic-self-check.md\` first")` |
 
 **CLI equivalent (for human TUI use):** `` `skill({name: "writing-plans"})` ``
@@ -81,7 +83,7 @@ This skill produces plans by dispatching pipeline steps to sub-agents. The orche
 ### Workflow 1: `create` — Full pipeline (17 steps)
 
 ```
- 1. [inline]  Verify spec approved (check `approved-for-*` label)
+ 1. [sub-task] Verify spec approved (pre-plan-readiness)
  2. [sub-task] Research
  3. [inline]  Z3 check — solve check verify research output
  4. [sub-task] Readiness
@@ -112,7 +114,13 @@ This skill produces plans by dispatching pipeline steps to sub-agents. The orche
  1. [sub-task] Update
 ```
 
-### Workflow 3: `holistic-self-check` — Quality gate (delegates to writing-plans-holistic)
+### Workflow 3: `retroactive` — Retroactive plan creation (delegates to writing-plans-creation retroactive task)
+
+```
+ 1. [sub-task] Retroactive
+```
+
+### Workflow 4: `holistic-self-check` — Quality gate (delegates to writing-plans-holistic)
 
 ```
  1. [sub-task] Holistic self-check

--- a/skills/writing-plans/SKILL.md
+++ b/skills/writing-plans/SKILL.md
@@ -37,6 +37,20 @@ This skill operates in the main repo directory (direct-branch mode). When `WORKT
 | "create plan" / "implementation plan" / "write plan" / "plan" / "draft plan" / "auto-create plan" / "gap-fill plan" / "retroactive" / "retroactive plan" / "backfill plan" | `create` | `sub-task` | {spec_issue_number, spec_body} |
 | "update plan" / "plan update" / "auto-update plan" / "revise plan" | `update` | `sub-task` | {spec_issue_number, plan_issue_number} |
 | "holistic check" / "self-check" / "pre-completion check" | `holistic-self-check` | `sub-task` | {plan_context} |
+| "verify spec approved" / "check spec approval" | `verify-spec-approved` | `sub-task` | {spec_issue_number} |
+| "research evidence" / "gather evidence" | `research` | `sub-task` | {spec_issue_number, spec_body} |
+| "artifact validation" / "validate artifacts" | `artifact-validation` | `sub-task` | {spec_issue_number, project_root, path} |
+| "readiness gate" / "check readiness" | `readiness` | `sub-task` | {spec_issue_number, research_output} |
+| "structure phases" / "define phases" | `structure` | `sub-task` | {spec_issue_number, readiness_output} |
+| "solve constraints" / "z3 solve" | `solve` | `sub-task` | {spec_issue_number, structure_output} |
+| "write plan" / "generate plan" | `write` | `sub-task` | {spec_issue_number, solve_output} |
+| "revisit plan" / "resolve conflicts" | `revisit` | `sub-task` | {spec_issue_number, write_output} |
+| "validate plan" / "check plan" | `validate` | `sub-task` | {spec_issue_number, plan_file_path} |
+| "audit fidelity" / "fidelity audit" | `audit-fidelity` | `sub-task` | {spec_issue_number, plan_file_path, audit_phase} |
+| "audit concern" / "concern audit" | `audit-concern` | `sub-task` | {spec_issue_number, plan_file_path, audit_phase} |
+| "complete plan" / "finish plan" | `completion` | `sub-task` | {workflow_state} |
+| "retroactive plan" / "retroactive" | `retroactive` | `sub-task` | {spec_issue_number} |
+| "clean-room plan" / "independent plan" | `clean-room` | `sub-task` | {problem_statement} |
 
 ## Persona
 
@@ -46,7 +60,7 @@ This skill produces plans by dispatching pipeline steps to sub-agents. The orche
 
 ## Tasks
 
-| `create` | `update` | `holistic-self-check` |
+| `create` | `update` | `holistic-self-check` | `verify-spec-approved` | `research` | `artifact-validation` | `readiness` | `structure` | `solve` | `write` | `revisit` | `validate` | `audit-fidelity` | `audit-concern` | `completion` | `retroactive` | `clean-room` |
 
 ## Plan Model
 
@@ -70,10 +84,23 @@ This skill produces plans by dispatching pipeline steps to sub-agents. The orche
 
 | Task | Execution |
 |------|-----------|
-| `create` | Sub-agent via `task(..., prompt: "execute create task from writing-plans")` |
-| `update` | Sub-agent via `task(..., prompt: "execute update task from writing-plans")` |
-| `holistic-self-check` | Sub-agent via `task(..., prompt: "execute holistic-self-check task from writing-plans")` |
-| `completion` | Sub-agent via `task(..., prompt: "execute completion task from writing-plans")` |
+| `create` | Sub-agent via `task(..., prompt: "execute create from writing-plans. Read \`writing-plans-creation/tasks/create.md\` first")` |
+| `update` | Sub-agent via `task(..., prompt: "execute update from writing-plans. Read \`writing-plans-creation/tasks/update.md\` first")` |
+| `holistic-self-check` | Sub-agent via `task(..., prompt: "execute holistic-self-check from writing-plans. Read \`writing-plans-holistic/tasks/holistic-self-check.md\` first")` |
+| `verify-spec-approved` | Sub-agent via `task(..., prompt: "execute verify-spec-approved from writing-plans-creation. Read \`writing-plans-creation/tasks/pre-plan-readiness.md\` first")` |
+| `research` | Sub-agent via `task(..., prompt: "execute research from writing-plans-creation. Read \`writing-plans-creation/tasks/research.md\` first")` |
+| `artifact-validation` | Sub-agent via `task(..., prompt: "execute artifact-validation from writing-plans-creation. Read \`writing-plans-creation/tasks/artifact-validation.md\` first")` |
+| `readiness` | Sub-agent via `task(..., prompt: "execute readiness from writing-plans-creation. Read \`writing-plans-creation/tasks/readiness.md\` first")` |
+| `structure` | Sub-agent via `task(..., prompt: "execute structure from writing-plans-creation. Read \`writing-plans-creation/tasks/structure.md\` first")` |
+| `solve` | Sub-agent via `task(..., prompt: "execute solve from writing-plans-creation. Read \`writing-plans-creation/tasks/solve.md\` first")` |
+| `write` | Sub-agent via `task(..., prompt: "execute write from writing-plans-creation. Read \`writing-plans-creation/tasks/write.md\` first")` |
+| `revisit` | Sub-agent via `task(..., prompt: "execute revisit from writing-plans-creation. Read \`writing-plans-creation/tasks/revisit.md\` first")` |
+| `validate` | Sub-agent via `task(..., prompt: "execute validate from writing-plans-creation. Read \`writing-plans-creation/tasks/validate.md\` first")` |
+| `audit-fidelity` | Sub-agent via `task(..., prompt: "execute audit-fidelity from writing-plans-creation. Read \`writing-plans-creation/tasks/audit-fidelity.md\` first")` |
+| `audit-concern` | Sub-agent via `task(..., prompt: "execute audit-concern from writing-plans-creation. Read \`writing-plans-creation/tasks/audit-concern.md\` first")` |
+| `completion` | Sub-agent via `task(..., prompt: "execute completion from writing-plans-creation. Read \`writing-plans-creation/tasks/completion.md\` first")` |
+| `retroactive` | Sub-agent via `task(..., prompt: "execute retroactive from writing-plans-creation. Read \`writing-plans-creation/tasks/retroactive.md\` first")` |
+| `clean-room` | Sub-agent via `task(..., prompt: "execute clean-room from writing-plans-creation. Read \`writing-plans-creation/tasks/clean-room.md\` first")` |
 
 **CLI equivalent (for human TUI use):** `` `skill({name: "writing-plans"})` ``
 

--- a/skills/writing-plans/SKILL.md
+++ b/skills/writing-plans/SKILL.md
@@ -37,20 +37,6 @@ This skill operates in the main repo directory (direct-branch mode). When `WORKT
 | "create plan" / "implementation plan" / "write plan" / "plan" / "draft plan" / "auto-create plan" / "gap-fill plan" / "retroactive" / "retroactive plan" / "backfill plan" | `create` | `sub-task` | {spec_issue_number, spec_body} |
 | "update plan" / "plan update" / "auto-update plan" / "revise plan" | `update` | `sub-task` | {spec_issue_number, plan_issue_number} |
 | "holistic check" / "self-check" / "pre-completion check" | `holistic-self-check` | `sub-task` | {plan_context} |
-| "verify spec approved" / "check spec approval" | `verify-spec-approved` | `sub-task` | {spec_issue_number} |
-| "research evidence" / "gather evidence" | `research` | `sub-task` | {spec_issue_number, spec_body} |
-| "artifact validation" / "validate artifacts" | `artifact-validation` | `sub-task` | {spec_issue_number, project_root, path} |
-| "readiness gate" / "check readiness" | `readiness` | `sub-task` | {spec_issue_number, research_output} |
-| "structure phases" / "define phases" | `structure` | `sub-task` | {spec_issue_number, readiness_output} |
-| "solve constraints" / "z3 solve" | `solve` | `sub-task` | {spec_issue_number, structure_output} |
-| "write plan" / "generate plan" | `write` | `sub-task` | {spec_issue_number, solve_output} |
-| "revisit plan" / "resolve conflicts" | `revisit` | `sub-task` | {spec_issue_number, write_output} |
-| "validate plan" / "check plan" | `validate` | `sub-task` | {spec_issue_number, plan_file_path} |
-| "audit fidelity" / "fidelity audit" | `audit-fidelity` | `sub-task` | {spec_issue_number, plan_file_path, audit_phase} |
-| "audit concern" / "concern audit" | `audit-concern` | `sub-task` | {spec_issue_number, plan_file_path, audit_phase} |
-| "complete plan" / "finish plan" | `completion` | `sub-task` | {workflow_state} |
-| "retroactive plan" / "retroactive" | `retroactive` | `sub-task` | {spec_issue_number} |
-| "clean-room plan" / "independent plan" | `clean-room` | `sub-task` | {problem_statement} |
 
 ## Persona
 
@@ -60,7 +46,7 @@ This skill produces plans by dispatching pipeline steps to sub-agents. The orche
 
 ## Tasks
 
-| `create` | `update` | `holistic-self-check` | `verify-spec-approved` | `research` | `artifact-validation` | `readiness` | `structure` | `solve` | `write` | `revisit` | `validate` | `audit-fidelity` | `audit-concern` | `completion` | `retroactive` | `clean-room` |
+| `create` | `update` | `holistic-self-check` |
 
 ## Plan Model
 
@@ -82,31 +68,98 @@ This skill produces plans by dispatching pipeline steps to sub-agents. The orche
 
 **DISPATCH GATE — Pipeline steps dispatch to sub-agents.** The orchestrator routes each step to a clean-room sub-agent via `task()`. The orchestrator reads each step procedure from its task file and dispatches it. When external skills are needed (e.g., audit for fidelity/concern audits), invoke them via `skill({name: "..."})` with the appropriate task, dispatched to a sub-agent.
 
-| Task | Execution |
-|------|-----------|
-| `create` | Sub-agent via `task(..., prompt: "execute create from writing-plans. Read \`writing-plans-creation/tasks/create.md\` first")` |
-| `update` | Sub-agent via `task(..., prompt: "execute update from writing-plans. Read \`writing-plans-creation/tasks/update.md\` first")` |
-| `holistic-self-check` | Sub-agent via `task(..., prompt: "execute holistic-self-check from writing-plans. Read \`writing-plans-holistic/tasks/holistic-self-check.md\` first")` |
-| `verify-spec-approved` | Sub-agent via `task(..., prompt: "execute verify-spec-approved from writing-plans-creation. Read \`writing-plans-creation/tasks/pre-plan-readiness.md\` first")` |
-| `research` | Sub-agent via `task(..., prompt: "execute research from writing-plans-creation. Read \`writing-plans-creation/tasks/research.md\` first")` |
-| `artifact-validation` | Sub-agent via `task(..., prompt: "execute artifact-validation from writing-plans-creation. Read \`writing-plans-creation/tasks/artifact-validation.md\` first")` |
-| `readiness` | Sub-agent via `task(..., prompt: "execute readiness from writing-plans-creation. Read \`writing-plans-creation/tasks/readiness.md\` first")` |
-| `structure` | Sub-agent via `task(..., prompt: "execute structure from writing-plans-creation. Read \`writing-plans-creation/tasks/structure.md\` first")` |
-| `solve` | Sub-agent via `task(..., prompt: "execute solve from writing-plans-creation. Read \`writing-plans-creation/tasks/solve.md\` first")` |
-| `write` | Sub-agent via `task(..., prompt: "execute write from writing-plans-creation. Read \`writing-plans-creation/tasks/write.md\` first")` |
-| `revisit` | Sub-agent via `task(..., prompt: "execute revisit from writing-plans-creation. Read \`writing-plans-creation/tasks/revisit.md\` first")` |
-| `validate` | Sub-agent via `task(..., prompt: "execute validate from writing-plans-creation. Read \`writing-plans-creation/tasks/validate.md\` first")` |
-| `audit-fidelity` | Sub-agent via `task(..., prompt: "execute audit-fidelity from writing-plans-creation. Read \`writing-plans-creation/tasks/audit-fidelity.md\` first")` |
-| `audit-concern` | Sub-agent via `task(..., prompt: "execute audit-concern from writing-plans-creation. Read \`writing-plans-creation/tasks/audit-concern.md\` first")` |
-| `completion` | Sub-agent via `task(..., prompt: "execute completion from writing-plans-creation. Read \`writing-plans-creation/tasks/completion.md\` first")` |
-| `retroactive` | Sub-agent via `task(..., prompt: "execute retroactive from writing-plans-creation. Read \`writing-plans-creation/tasks/retroactive.md\` first")` |
-| `clean-room` | Sub-agent via `task(..., prompt: "execute clean-room from writing-plans-creation. Read \`writing-plans-creation/tasks/clean-room.md\` first")` |
+| Task | Canonical Dispatch String |
+|------|--------------------------|
+| `create` | `task(..., prompt: "execute create from writing-plans-creation. Read \`writing-plans-creation/tasks/create.md\` first")` |
+| `update` | `task(..., prompt: "execute update from writing-plans-creation. Read \`writing-plans-creation/tasks/update.md\` first")` |
+| `holistic-self-check` | `task(..., prompt: "execute holistic-self-check from writing-plans. Read \`writing-plans-holistic/tasks/holistic-self-check.md\` first")` |
 
 **CLI equivalent (for human TUI use):** `` `skill({name: "writing-plans"})` ``
 
 ## Pipeline
 
-The pipeline is defined in `writing-plans-creation/tasks/create.md`. It consists of sequential steps dispatched by the orchestrator via the Trigger Dispatch Table, with Z3 contract verification between each step. See `create.md` for the full step list, dispatch modes, and contract table.
+### Workflow 1: `create` — Full pipeline (17 steps)
+
+```
+ 1. [inline]  Verify spec approved (check `approved-for-*` label)
+ 2. [sub-task] Research
+ 3. [inline]  Z3 check — solve check verify research output
+ 4. [sub-task] Readiness
+ 5. [sub-task] Artifact validation
+ 6. [inline]  Z3 check — solve check verify readiness output
+ 7. [sub-task] Structure
+ 8. [inline]  Z3 check — solve check verify structure output
+ 9. [sub-task] Solve
+10. [inline]  Z3 check — solve check verify solve output
+11. [sub-task] Plan creation pipeline (dispatches to plan-creation-pipeline skill)
+12. [sub-task] Write
+13. [inline]  Z3 check — solve check verify write output
+14. [sub-task] Revisit
+15. [inline]  Z3 check — solve check verify revisit output
+16. [sub-task] Validate
+17. [inline]  Z3 check — solve check verify validate output
+18. [sub-task] Audit fidelity
+19. [inline]  Z3 check — solve check verify audit-fidelity output
+20. [sub-task] Audit concern
+21. [inline]  Z3 check — solve check verify audit-concern output
+22. [sub-task] Completion
+23. [inline]  Z3 check — solve check verify completion output
+```
+
+### Workflow 2: `update` — Plan revision (delegates to writing-plans-creation update task)
+
+```
+ 1. [sub-task] Update
+```
+
+### Workflow 3: `holistic-self-check` — Quality gate (delegates to writing-plans-holistic)
+
+```
+ 1. [sub-task] Holistic self-check
+```
+
+### Sub-task Step Contract
+
+Every sub-task step follows the frugal contract pattern. The orchestrator passes only `{spec_issue_number, spec_body}` — no preloaded context, no file paths, no expected outcomes. The sub-agent reads its input from disk, writes its output to disk, and returns a frugal result contract.
+
+**Dispatch contract:**
+
+```
+Orchestrator                          Sub-agent
+    │                                      │
+    │  task(..., {spec_issue_number, spec_body})
+    │─────────────────────────────────────>│
+    │                                      │
+    │                         Reads input from .issues/{N}/spec.md
+    │                         Reads prior artifacts from .issues/{N}/artifacts/
+    │                         Writes output to .issues/{N}/artifacts/{name}.yaml
+    │                                      │
+    │  Result contract:                     │
+    │    status: DONE | BLOCKED            │
+    │    finding_summary: "<1-3 sentences>"│
+    │    artifact_path: .issues/{N}/artifacts/{name}.yaml
+    │    blocker_reason: ""               │
+    │<─────────────────────────────────────│
+    │                                      │
+    │  Reads artifact file ONLY if         │
+    │  routing-significant data needed     │
+```
+
+**Rules:**
+1. Orchestrator passes ONLY `{spec_issue_number, spec_body}` — no preloaded context, no file paths, no expected outcomes, no orchestrator reasoning
+2. Sub-agent reads from disk — `.issues/{N}/spec.md` for the spec body, `.issues/{N}/artifacts/` for prior step outputs
+3. Sub-agent writes to disk — `.issues/{N}/artifacts/{name}.yaml` for its output
+4. Sub-agent returns frugal result contract — `{status, finding_summary, artifact_path, blocker_reason}`
+5. Orchestrator reads artifact files ONLY for routing-significant data — never for full content
+6. No contract YAML files at `{project_root}/tmp/{N}/contracts/` — those are phantom infrastructure, stripped
+
+### Inline Steps (orchestrator executes directly)
+
+| Step | What the Orchestrator Does |
+|------|---------------------------|
+| Verify spec approved | Run `github_issue_read(method=get_labels, issue_number={N})` |
+| Z3 check | Run `.opencode/tools/solve check` with contract |
+| Plan creation pipeline | Dispatch to `plan-creation-pipeline` skill via SKILL.md Trigger Dispatch Table |
 
 ## Sub-Agent Routing
 

--- a/tests-v2/behaviors/beh-ev-classification-gate.sh
+++ b/tests-v2/behaviors/beh-ev-classification-gate.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# Behavioral test: beh-ev-classification-gate
+# See .opencode/tests-v2/AGENTS.md for the test harness specification and paradigm.
+# This script is an artifact-only generator — it does NOT evaluate model output.
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/helpers.sh"
+
+SCENARIO_NAME="beh-ev-classification-gate"
+SCENARIO_PROMPT="Create a spec for adding a new guideline that enforces mandatory code review for all PRs. The spec should include success criteria with evidence types. Follow the spec-creation workflow."
+
+behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT"
+exit 0

--- a/tests-v2/behaviors/behavioral-sc-evaluator-reads-artifacts.sh
+++ b/tests-v2/behaviors/behavioral-sc-evaluator-reads-artifacts.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# Behavioral test: behavioral-sc-evaluator-reads-artifacts
+# See .opencode/tests-v2/AGENTS.md for the test harness specification and paradigm.
+# This script is an artifact-only generator — it does NOT evaluate model output.
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/helpers.sh"
+
+SCENARIO_NAME="behavioral-sc-evaluator-reads-artifacts"
+SCENARIO_PROMPT="Read .opencode/skills/audit/tasks/behavioral-sc-evaluator.md and verify it requires reading stdout.log and stderr.log to render binary PASS/FAIL. Write your findings to tmp/audit-findings.md."
+
+behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT"
+exit 0

--- a/tests-v2/behaviors/behavioral-sc-evaluator-reads-artifacts.sh
+++ b/tests-v2/behaviors/behavioral-sc-evaluator-reads-artifacts.sh
@@ -8,7 +8,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/helpers.sh"
 
 SCENARIO_NAME="behavioral-sc-evaluator-reads-artifacts"
-SCENARIO_PROMPT="Read .opencode/skills/audit/tasks/behavioral-sc-evaluator.md and verify it requires reading stdout.log and stderr.log to render binary PASS/FAIL. Write your findings to tmp/audit-findings.md."
+SCENARIO_PROMPT="Read .opencode/skills/audit/tasks/behavioral-sc-evaluator.md. Then dispatch a clean-room sub-agent via task() to evaluate the behavioral test artifacts at tmp/behavioral-evidence-fixture/ against the SC: 'The agent must read stdout.log and stderr.log and render a binary PASS/FAIL verdict.' The sub-agent must read stdout.log and stderr.log from the artifact directory."
 
 behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT"
 exit 0

--- a/tests-v2/behaviors/clean-room-evaluator-dispatch.sh
+++ b/tests-v2/behaviors/clean-room-evaluator-dispatch.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# Behavioral test: clean-room-evaluator-dispatch
+# See .opencode/tests-v2/AGENTS.md for the test harness specification and paradigm.
+# This script is an artifact-only generator — it does NOT evaluate model output.
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/helpers.sh"
+
+SCENARIO_NAME="clean-room-evaluator-dispatch"
+SCENARIO_PROMPT="Read .opencode/skills/audit/tasks/verification-audit-evaluator.md and dispatch a clean-room sub-agent to evaluate behavioral SCs from the file. Use task() to dispatch the behavioral-sc-evaluator."
+
+behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT"
+exit 0

--- a/tests-v2/behaviors/cross-validate-evidence-type-mismatch.sh
+++ b/tests-v2/behaviors/cross-validate-evidence-type-mismatch.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# Behavioral test: cross-validate-evidence-type-mismatch
+# See .opencode/tests-v2/AGENTS.md for the test harness specification and paradigm.
+# This script is an artifact-only generator — it does NOT evaluate model output.
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/helpers.sh"
+
+SCENARIO_NAME="cross-validate-evidence-type-mismatch"
+SCENARIO_PROMPT="Read .opencode/skills/audit/tasks/cross-validate.md and verify it has EVIDENCE_TYPE_MISMATCH detection for behavioral SCs that cite only file paths. Write your findings to tmp/audit-findings.md."
+
+behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT"
+exit 0

--- a/tests-v2/behaviors/fixtures/code/login-bug/src/auth.py
+++ b/tests-v2/behaviors/fixtures/code/login-bug/src/auth.py
@@ -1,0 +1,16 @@
+"""Authentication module."""
+
+import hashlib
+
+USERS = {
+    "admin": hashlib.sha256(b"secret123").hexdigest(),
+    "user1": hashlib.sha256(b"password456").hexdigest(),
+}
+
+
+def authenticate(username: str, password: str) -> bool:
+    if username not in USERS:
+        return False
+    expected = USERS.get(password)
+    actual = hashlib.sha256(password.encode()).hexdigest()
+    return actual == expected

--- a/tests-v2/behaviors/fixtures/issues/2009/plan.md
+++ b/tests-v2/behaviors/fixtures/issues/2009/plan.md
@@ -1,0 +1,15 @@
+# Plan: Add Pipeline Completeness Check
+
+## Phase 1: Add pipeline completeness check to evaluator
+
+### Step 1: Add PF-PIPELINE-COMPLETENESS criterion to evaluation table
+- **Dispatch:** (**clean-room**)
+- **SC:** SC-1, SC-2, SC-3
+- **Action:** Add a new criterion PF-PIPELINE-COMPLETENESS to the evaluation table in Step 3 of plan-fidelity-evaluator.md
+- **Verification:** grep for PF-PIPELINE-COMPLETENESS in the evaluator file
+
+### Step 2: Add pipeline completeness check procedure
+- **Dispatch:** (**clean-room**)
+- **SC:** SC-1, SC-2
+- **Action:** Add a new step between Step 1 (Pre-Flight Validation Gate) and Step 2 (Read Upstream Artifacts) that checks the plan against the mandatory pipeline stages from implementation-pipeline SKILL.md
+- **Verification:** grep for the new step in the evaluator file

--- a/tests-v2/behaviors/fixtures/issues/2009/spec.md
+++ b/tests-v2/behaviors/fixtures/issues/2009/spec.md
@@ -1,0 +1,11 @@
+# Spec: Add Pipeline Completeness Check to Plan-Fidelity Evaluator
+
+## Problem
+The plan-fidelity evaluator (`audit/tasks/plan-fidelity-evaluator.md`) evaluates plan fidelity against spec but has no check for whether the plan includes all mandatory implementation pipeline stages. A plan that omits critical pipeline steps (assemble-work, sc-coherence-gate, pre-red-baseline, RED/GREEN per item, VbC, sc-count-gate, pre-pr-gate, audit, cross-validate, regression-check, review-prep, create-pr, exec-summary) passes the evaluator without detection.
+
+## Success Criteria
+| ID | Criterion | Evidence Type |
+|----|-----------|---------------|
+| SC-1 | Plan-fidelity evaluator checks for mandatory pipeline stages | behavioral |
+| SC-2 | Plan missing pipeline stages produces FAIL verdict | behavioral |
+| SC-3 | All mandatory stages from implementation-pipeline SKILL.md are enumerated | string |

--- a/tests-v2/behaviors/fixtures/setup-code-fixtures.sh
+++ b/tests-v2/behaviors/fixtures/setup-code-fixtures.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# setup-code-fixtures.sh — Inject code fixtures into behavioral test repos.
+#
+# Called by behavior_run() in helpers.sh after the isolated test repo is created.
+# Copies code fixtures (source files with known bugs) for tests that need
+# real codebases to investigate.
+#
+# Co-authored with AI: OpenCode (ollama-cloud/deepseek-v4-flash)
+
+set -euo pipefail
+
+CODE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/code"
+
+setup_code_fixtures() {
+    local workdir="$1"
+
+    if [ ! -d "$CODE_DIR" ]; then
+        echo "WARNING: code fixtures directory not found: $CODE_DIR" >&2
+        return 0
+    fi
+
+    # Copy all code fixture directories
+    for fixture_dir in "$CODE_DIR"/*/; do
+        if [ ! -d "$fixture_dir" ]; then
+            continue
+        fi
+        local fixture_name
+        fixture_name=$(basename "$fixture_dir")
+        mkdir -p "$workdir/src/$fixture_name"
+        cp -r "$fixture_dir"/* "$workdir/src/$fixture_name/" 2>/dev/null || true
+    done
+
+    local count
+    count=$(find "$workdir/src" -name '*.py' 2>/dev/null | wc -l)
+    echo "  injected $count code fixture files into test repo"
+
+    # Stage the src directory
+    git -C "$workdir" add src/ 2>/dev/null || true
+}
+
+# If called directly (not sourced), run setup
+if [ "${BASH_SOURCE[0]}" = "$0" ]; then
+    setup_code_fixtures "$@"
+fi

--- a/tests-v2/behaviors/helpers.sh
+++ b/tests-v2/behaviors/helpers.sh
@@ -294,7 +294,7 @@ behavior_run() {
 
     local test_home=""
     local setup_output
-    setup_output=$(bash "$PARENT_REPO_DIR/$BEHAVIOR_TEST_HOME" --setup)
+    setup_output=$(BEHAVIOR_SUBMODULE_COMMIT="$submodule_commit" bash "$PARENT_REPO_DIR/$BEHAVIOR_TEST_HOME" --setup)
     test_home=$(echo "$setup_output" | grep '^TEST_HOME=' | cut -d= -f2-)
     if [ -z "$test_home" ]; then
         echo "HARNESS_FAILURE: --setup failed to produce TEST_HOME" >&2
@@ -306,6 +306,7 @@ behavior_run() {
         echo "  [attempt $attempt/$BEHAVIOR_MAX_RETRIES]"
 
         TEST_WORKDIR="$workdir" \
+        BEHAVIOR_SUBMODULE_COMMIT="$submodule_commit" \
         bash "$PARENT_REPO_DIR/$BEHAVIOR_TEST_HOME" "${OPENCODE_CMD[@]}" run "$message" --model "$model" --log-level INFO --print-logs ${agent:+--agent "$agent"} \
             > "$output_file" 2> "$err_file" \
             || true

--- a/tests-v2/behaviors/helpers.sh
+++ b/tests-v2/behaviors/helpers.sh
@@ -301,6 +301,14 @@ behavior_run() {
         return 1
     fi
 
+    # Copy fixture evidence from workdir into test project so the agent can find it.
+    local test_project
+    test_project=$(echo "$setup_output" | grep '^TEST_PROJECT=' | cut -d= -f2-)
+    if [ -n "$test_project" ] && [ -d "$workdir/tmp/behavioral-evidence-fixture" ]; then
+        mkdir -p "$test_project/tmp"
+        cp -r "$workdir/tmp/behavioral-evidence-fixture" "$test_project/tmp/behavioral-evidence-fixture" 2>/dev/null || true
+    fi
+
     while [ "$attempt" -lt "$BEHAVIOR_MAX_RETRIES" ]; do
         attempt=$((attempt + 1))
         echo "  [attempt $attempt/$BEHAVIOR_MAX_RETRIES]"

--- a/tests-v2/behaviors/helpers.sh
+++ b/tests-v2/behaviors/helpers.sh
@@ -265,6 +265,12 @@ behavior_run() {
         setup_story_fixtures "$workdir"
     fi
 
+    CODE_SETUP="$(dirname "${BASH_SOURCE[0]}")/fixtures/setup-code-fixtures.sh"
+    if [ -f "$CODE_SETUP" ]; then
+        source "$CODE_SETUP"
+        setup_code_fixtures "$workdir"
+    fi
+
     LOCK_FILE="$PARENT_REPO_DIR/tmp/.behavior-run.lock"
     mkdir -p "$(dirname "$LOCK_FILE")"
     exec 200>"$LOCK_FILE"

--- a/tests-v2/behaviors/plan-fidelity-pipeline-completeness.sh
+++ b/tests-v2/behaviors/plan-fidelity-pipeline-completeness.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+# Behavioral test: plan-fidelity-pipeline-completeness
+# See .opencode/tests-v2/AGENTS.md for the test harness specification and paradigm.
+# This script is an artifact-only generator — it does NOT evaluate model output.
+#
+# SC-4: Plan-fidelity audit checks for mandatory pipeline steps and FAILs if missing
+#
+# RED phase: Must fail because plan-fidelity-evaluator.md has no pipeline
+# completeness check yet. The agent receives a plan that is missing mandatory
+# pipeline stages and is asked to run a plan-fidelity audit. Without the
+# pipeline completeness check in the evaluator, the audit will not detect the
+# missing stages — the test FAILs because the evaluator does not enforce
+# pipeline completeness.
+#
+# PROMPT CONSTRUCTION GUIDANCE:
+# Real-domain task: agent must run a plan-fidelity audit on a plan that is
+# structurally defective (missing pipeline steps). The plan-fidelity evaluator
+# has no pipeline completeness check, so the audit will not FAIL for missing
+# pipeline steps. This triggers natural agent behavior — not prose recall.
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/helpers.sh"
+
+SCENARIO_NAME="plan-fidelity-pipeline-completeness"
+SCENARIO_PROMPT="Run a plan-fidelity audit on the following plan against the following spec. The plan is missing mandatory implementation pipeline stages (assemble-work, sc-coherence-gate, pre-red-baseline, RED/GREEN per item with Z3 checks, VbC, sc-count-gate, pre-pr-gate, audit, cross-validate, regression-check, review-prep, create-pr, exec-summary). The plan-fidelity audit MUST FAIL because the plan is missing these mandatory pipeline steps.
+
+SPEC:
+# Spec: Add Pipeline Completeness Check to Plan-Fidelity Evaluator
+## Problem
+The plan-fidelity evaluator has no check for whether the plan includes all mandatory implementation pipeline stages.
+## Success Criteria
+| ID | Criterion | Evidence Type |
+| SC-1 | Plan-fidelity evaluator checks for mandatory pipeline stages | behavioral |
+| SC-2 | Plan missing pipeline stages produces FAIL verdict | behavioral |
+| SC-3 | All mandatory stages from implementation-pipeline SKILL.md are enumerated | string |
+
+PLAN:
+# Plan: Add Pipeline Completeness Check
+## Phase 1: Add pipeline completeness check to evaluator
+### Step 1: Add PF-PIPELINE-COMPLETENESS criterion to evaluation table
+- **Dispatch:** (**clean-room**)
+- **SC:** SC-1, SC-2, SC-3
+- **Action:** Add a new criterion PF-PIPELINE-COMPLETENESS to the evaluation table
+- **Verification:** grep for PF-PIPELINE-COMPLETENESS in the evaluator file
+### Step 2: Add pipeline completeness check procedure
+- **Dispatch:** (**clean-room**)
+- **SC:** SC-1, SC-2
+- **Action:** Add a new step that checks the plan against mandatory pipeline stages
+- **Verification:** grep for the new step in the evaluator file"
+
+behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT"
+exit 0

--- a/tests-v2/behaviors/plan-fidelity-pipeline-steps.sh
+++ b/tests-v2/behaviors/plan-fidelity-pipeline-steps.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# Behavioral test: plan-fidelity-pipeline-steps
+# See .opencode/tests-v2/AGENTS.md for the test harness specification and paradigm.
+# This script is an artifact-only generator — it does NOT evaluate model output.
+#
+# SC-3: write.md plan template includes mandatory Pipeline Steps section with all 15 stages
+# SC-4: Plan-fidelity audit checks for mandatory pipeline steps and FAILs if missing
+#
+# RED phase: Must fail because write.md has no Pipeline Steps section yet.
+# The agent receives a real-domain plan-creation prompt. Without the Pipeline Steps
+# section in write.md, the plan it produces will lack mandatory pipeline stages.
+# The plan-fidelity audit will FAIL because the plan is missing pipeline steps.
+#
+# PROMPT CONSTRUCTION GUIDANCE:
+# Real-domain task: agent must create a plan from a spec. The plan will be
+# structurally defective (missing pipeline steps) because write.md has no
+# Pipeline Steps section. This triggers natural agent behavior — not prose recall.
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/helpers.sh"
+
+SCENARIO_NAME="plan-fidelity-pipeline-steps"
+SCENARIO_PROMPT="Create a plan for issue #2009. The spec is at .opencode/.issues/2009/spec.md. Write the plan following the writing-plans-creation workflow."
+
+behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT"
+exit 0

--- a/tests-v2/behaviors/spec-creation-pipeline-routing.sh
+++ b/tests-v2/behaviors/spec-creation-pipeline-routing.sh
@@ -18,7 +18,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/helpers.sh"
 
 SCENARIO_NAME="spec-creation-pipeline-routing"
-SCENARIO_PROMPT="Create a spec for issue #42. I need a specification document for the new feature."
+SCENARIO_PROMPT="Users with valid credentials are getting 401 Unauthorized errors. The auth code is at src/login-bug/src/auth.py. Investigate the bug and create a spec for the fix."
 
 echo "=== Behavioral Test: $SCENARIO_NAME ==="
 

--- a/tests-v2/behaviors/spec-creation-pipeline-routing.sh
+++ b/tests-v2/behaviors/spec-creation-pipeline-routing.sh
@@ -18,7 +18,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/helpers.sh"
 
 SCENARIO_NAME="spec-creation-pipeline-routing"
-SCENARIO_PROMPT="Users with valid credentials are getting 401 Unauthorized errors. The auth code is at src/login-bug/src/auth.py. Investigate the bug and create a spec for the fix."
+SCENARIO_PROMPT="Users with valid credentials are getting 401 Unauthorized errors."
 
 echo "=== Behavioral Test: $SCENARIO_NAME ==="
 

--- a/tests-v2/behaviors/spec-creation-pipeline-routing.sh
+++ b/tests-v2/behaviors/spec-creation-pipeline-routing.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Behavioral test: spec-creation-pipeline-routing
+# See .opencode/tests-v2/AGENTS.md for the test harness specification and paradigm.
+# This script is an artifact-only generator — it does NOT evaluate model output.
+#
+# SC-1: Agent dispatches to spec-creation pipeline (skill + task) instead of direct github_issue_write
+# RED phase: Agent uses direct github_issue_write (Tier 1 rule is never overridable)
+# GREEN phase: Agent calls skill({name: "spec-creation"}) and dispatches create task
+#
+# SC-2: Agent produces correct remote body format (blockquote links, exec summary, AI agent instructions)
+# RED phase: Agent produces remote body without blockquote format or uses direct github_issue_write
+# GREEN phase: Agent produces remote body with blockquote format:
+#   > **Full spec and artifacts: [`.issues/{N}/`](...)**
+#   followed by exec summary and AI agent instructions
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/helpers.sh"
+
+SCENARIO_NAME="spec-creation-pipeline-routing"
+SCENARIO_PROMPT="Create a spec for issue #42. I need a specification document for the new feature."
+
+echo "=== Behavioral Test: $SCENARIO_NAME ==="
+
+behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT"
+exit 0

--- a/tests-v2/with-test-home
+++ b/tests-v2/with-test-home
@@ -336,8 +336,23 @@ git clone -q "$SUBMODULE_REMOTE_URL" "$TEST_PROJECT/.opencode" 2>/dev/null || {
     exit 1
 }
 
+# If BEHAVIOR_SUBMODULE_COMMIT is set, fetch and checkout that commit so
+# feature-branch changes are visible in the test project's .opencode.
+if [ -n "${BEHAVIOR_SUBMODULE_COMMIT:-}" ]; then
+    git -C "$TEST_PROJECT/.opencode" fetch -q origin 2>/dev/null || true
+    git -C "$TEST_PROJECT/.opencode" checkout -q "$BEHAVIOR_SUBMODULE_COMMIT" 2>/dev/null || {
+        echo "WARNING: could not checkout BEHAVIOR_SUBMODULE_COMMIT=$BEHAVIOR_SUBMODULE_COMMIT" >&2
+    }
+fi
+
 git -C "$TEST_PROJECT" add -A 2>/dev/null || true
 git -C "$TEST_PROJECT" commit -q --allow-empty -m "init" 2>/dev/null || true
+
+# Copy fixture evidence from TEST_WORKDIR into test project so the agent can find it.
+if [ -n "${TEST_WORKDIR:-}" ] && [ -d "$TEST_WORKDIR/tmp/behavioral-evidence-fixture" ]; then
+    mkdir -p "$TEST_PROJECT/tmp"
+    cp -r "$TEST_WORKDIR/tmp/behavioral-evidence-fixture" "$TEST_PROJECT/tmp/behavioral-evidence-fixture" 2>/dev/null || true
+fi
 
 seed_model_config
 
@@ -371,6 +386,8 @@ env -i -C "$TEST_PROJECT" \
     LANG="${LANG:-C.UTF-8}" \
     TERM="${TERM:-xterm-256color}" \
     GB_TOKEN="${GB_TOKEN:-}" \
+    BEHAVIOR_SUBMODULE_COMMIT="${BEHAVIOR_SUBMODULE_COMMIT:-}" \
+    TEST_WORKDIR="${TEST_WORKDIR:-}" \
     sh -c '
 echo "  [test-env] HOME=$HOME"
 echo "  [test-env] PATH=$PATH"

--- a/tests-v2/with-test-home
+++ b/tests-v2/with-test-home
@@ -237,17 +237,29 @@ do_setup() {
         exit 1
     fi
 
-    # Verify production DB was not modified by the test setup.
-    if [ -n "$prod_db_before" ]; then
-        local prod_db_after
-        prod_db_after=$(sha256sum "$prod_db" 2>/dev/null | cut -d' ' -f1)
-        if [ "$prod_db_before" != "$prod_db_after" ]; then
-            echo "  [isolation] FAIL: production DB was modified during test setup!" >&2
-            exit 1
+    # Verify test DB is isolated: the project.worktree field MUST point to the test project,
+    # NOT the production project. This is more reliable than sha256 comparison of the
+    # production DB, which can be legitimately modified by concurrent processes (desktop app,
+    # other CLI sessions) during test setup.
+    if [ -f "$test_db" ]; then
+        local test_worktree
+        test_worktree=$(sqlite3 "$test_db" "SELECT worktree FROM project;" 2>/dev/null || true)
+        if [ -n "$test_worktree" ]; then
+            case "$test_worktree" in
+                "$test_project"|"$test_project"/*)
+                    echo "  [isolation] PASS: test DB points to test project ($test_worktree)"
+                    ;;
+                *)
+                    echo "  [isolation] FAIL: test DB points to non-test path: $test_worktree" >&2
+                    echo "  [isolation]   expected prefix: $test_project" >&2
+                    exit 1
+                    ;;
+            esac
+        else
+            echo "  [isolation] WARNING: test DB exists but has no project.worktree entry" >&2
         fi
-        echo "  [isolation] PASS: production DB unchanged (sha256 match)"
     else
-        echo "  [isolation] PASS: no production DB found (local-only environment)"
+        echo "  [isolation] PASS: no test DB found (fresh setup)"
     fi
 
     echo "TEST_HOME=$test_home"

--- a/tests-v2/with-test-home
+++ b/tests-v2/with-test-home
@@ -221,16 +221,16 @@ do_setup() {
     while IFS= read -r -d '' f; do
         local rel="${f#$test_home/}"
         case "$rel" in
-            .config/opencode/*|.local/share/opencode/*|.cache/opencode/*|.runtime/*|.local/state/opencode/*|snap/opencode/*|project/*|.git/*)
+            "")
                 ;;
-            .gitignore|.gitattributes)
+.config*|.local*|.cache*|.runtime*|snap*|project*|.git*|.gitignore|.gitattributes)
                 ;;
             *)
                 echo "  [isolation] WARNING: unexpected file in test home: $rel" >&2
                 leak_found=1
                 ;;
         esac
-    done < <(find "$test_home" -not -path '*/project/.opencode/*' -not -path '*/.git/objects/*' -not -path '*/.git/refs/*' -print0 2>/dev/null || true)
+    done < <(find "$test_home" -mindepth 1 -not -path '*/project/.opencode/*' -not -path '*/.git/objects/*' -not -path '*/.git/refs/*' -print0 2>/dev/null || true)
 
     if [ "$leak_found" -eq 1 ]; then
         echo "  [isolation] FAIL: test home contains unexpected files" >&2

--- a/tests-v2/with-test-home
+++ b/tests-v2/with-test-home
@@ -151,6 +151,14 @@ do_setup() {
         exit 1
     }
 
+    # If BEHAVIOR_SUBMODULE_COMMIT is set, checkout that commit so feature-branch
+    # changes are visible in the test project's .opencode.
+    if [ -n "${BEHAVIOR_SUBMODULE_COMMIT:-}" ]; then
+        git -C "$test_project/.opencode" checkout -q "$BEHAVIOR_SUBMODULE_COMMIT" 2>/dev/null || {
+            echo "WARNING: could not checkout BEHAVIOR_SUBMODULE_COMMIT=$BEHAVIOR_SUBMODULE_COMMIT" >&2
+        }
+    fi
+
     git -C "$test_project" add -A 2>/dev/null || true
     git -C "$test_project" commit -q --allow-empty -m "init" 2>/dev/null || true
 

--- a/tests-v2/with-test-home
+++ b/tests-v2/with-test-home
@@ -151,9 +151,10 @@ do_setup() {
         exit 1
     }
 
-    # If BEHAVIOR_SUBMODULE_COMMIT is set, checkout that commit so feature-branch
-    # changes are visible in the test project's .opencode.
+    # If BEHAVIOR_SUBMODULE_COMMIT is set, fetch and checkout that commit so
+    # feature-branch changes are visible in the test project's .opencode.
     if [ -n "${BEHAVIOR_SUBMODULE_COMMIT:-}" ]; then
+        git -C "$test_project/.opencode" fetch -q origin 2>/dev/null || true
         git -C "$test_project/.opencode" checkout -q "$BEHAVIOR_SUBMODULE_COMMIT" 2>/dev/null || {
             echo "WARNING: could not checkout BEHAVIOR_SUBMODULE_COMMIT=$BEHAVIOR_SUBMODULE_COMMIT" >&2
         }


### PR DESCRIPTION
## Summary

Stacked PR for specs #1962 and #2009. Fixes writing-plans skill card architecture, enforces spec-creation pipeline as sole spec creation path, and mandates full implementation pipeline in plan template.

## #1962 — writing-plans workflow defects

- **writing-plans/SKILL.md**: TDT with 3 user-facing entries (create, update, holistic-self-check). Pipeline section with 3 workflows and step-level dispatch classification. Invocation with 3 canonical dispatch strings.
- **writing-plans-creation/SKILL.md**: Converted from skill card to task card — no YAML frontmatter, no "Skill:" header, no TDT, no Invocation. Plain task list.
- **writing-plans-creation/tasks/create.md**: Fixed 11 contract paths from `writing-plans/contracts/` to `writing-plans-creation/contracts/`. Added plan-creation-pipeline dispatch step.
- **writing-plans-creation/tasks/update.md**: Fixed contract paths.
- **writing-plans-creation/tasks/retroactive.md**: Fixed contract paths.
- **writing-plans-creation/tasks/pre-plan-readiness.md**: Added solve readiness gate.

## #2009 — Plan template pipeline mandate + spec-creation pipeline enforcement

- **000-critical-rules.md**: Added Tier 1 CRITICAL VIOLATION — direct `github_issue_write` for spec content bypasses the mandatory spec-creation pipeline. Never overridable, never waivable.
- **tests-v2/behaviors/spec-creation-pipeline-routing.sh**: Behavioral enforcement test verifying agent routes spec creation through spec-creation pipeline.
- **tests-v2/behaviors/plan-fidelity-pipeline-steps.sh**: Behavioral test for plan template pipeline steps.
- **tests-v2/behaviors/plan-fidelity-pipeline-completeness.sh**: Behavioral test for plan-fidelity pipeline completeness check.
- **writing-plans-creation/tasks/write.md**: Added mandatory Pipeline Steps section to plan template with all 19 implementation pipeline stages.
- **audit/tasks/plan-fidelity-evaluator.md**: Added PF-PIPELINE-COMPLETENESS criterion — FAILs if any mandatory pipeline stage is missing from a plan.

## Fixes

#1962, #2009