### PR TITLE
fix: remove --no-interactive flag from gh auth status call

### DIFF
--- a/tools/session-init
+++ b/tools/session-init
@@ -201,7 +201,7 @@ def check_cli_auth_status() -> list[str]:
     if gh_path:
         try:
             result = subprocess.run(
-                ["gh", "auth", "status", "--no-interactive"],
+                ["gh", "auth", "status"],
                 capture_output=True,
                 text=True,
                 check=False,


### PR DESCRIPTION
## Summary

Remove the `--no-interactive` flag from the `gh auth status` call in `session-init`. This flag does not exist in gh v2.45.0, causing `session-init` to incorrectly report `gh: not_logged_in` even when gh is fully authenticated.

## Root Cause

`gh auth status --no-interactive` fails with exit code 1 because `--no-interactive` is not a valid flag. The script's fallback interprets any non-zero exit as `not_logged_in`.

## Fix

`gh auth status` is non-interactive by default when stdout is not a TTY (which `subprocess.run` with `capture_output=True` ensures). Removing the flag restores correct behavior.

## Verification

- SC-1: `--no-interactive` absent from `session-init` — confirmed via grep
- SC-2: `gh auth status` present without `--no-interactive` — confirmed
- SC-3: `session-init` reports `gh: ✓ Logged in` with authenticated gh — confirmed via execution

Fixes #2012

🤖 Co-authored with AI: OpenCode (deepseek-v4-flash)