### PR TITLE
fix: resolve .issues/ paths from session-init repo prefix in spec-creation pipeline

### DIFF
--- a/skills/spec-creation-decomposition/tasks/analytical-artifacts.md
+++ b/skills/spec-creation-decomposition/tasks/analytical-artifacts.md
@@ -2,21 +2,21 @@
 
 ## Purpose
 
-Generate 7 analytical artifacts from a completed spec body. Each artifact is a YAML file stored at `.issues/{N}/artifacts/{name}.yaml`.
+Generate 7 analytical artifacts from a completed spec body. Each artifact is a YAML file stored at `{project_root}/{path}/.issues/{N}/artifacts/{name}.yaml`.
 
 ## Entry Criteria
 
-- Completed spec body at `.issues/{N}/spec.md`
+- Completed spec body at `{project_root}/{path}/.issues/{N}/spec.md`
 - Spec body includes all required sections (SC table, preamble, compliance blocks)
 - All Step 1 sub-artifacts exist (sc-summary.yaml, verification-consistency-contract.yaml, lifecycle.yaml, spec-to-plan-handoff.yaml, revision-re-entry-contract.yaml)
 
 ## Input Artifacts
 
-This sub-agent reads from `.issues/{N}/spec.md` and prior artifacts in `.issues/{N}/artifacts/`.
+This sub-agent reads from `{project_root}/{path}/.issues/{N}/spec.md` and prior artifacts in `{project_root}/{path}/.issues/{N}/artifacts/`.
 
 ## Procedure
 
-Generate all 7 artifacts sequentially — each artifact may inform the next. Write each to `.issues/{N}/artifacts/{name}.yaml`.
+Generate all 7 artifacts sequentially — each artifact may inform the next. Write each to `{project_root}/{path}/.issues/{N}/artifacts/{name}.yaml`.
 
 - [ ] 1. Generate `blast-radius.yaml` — Analyze the spec body and identify affected components and ripple effects per phase. Schema:
 
@@ -144,5 +144,5 @@ Generate all 7 artifacts sequentially — each artifact may inform the next. Wri
 |-------|-------|
 | `status` | `DONE` \| `BLOCKED` |
 | `finding_summary` | `"Generated 7 analytical artifacts for spec #N"` |
-| `artifact_path` | `.issues/{N}/artifacts/` |
+| `artifact_path` | `{project_root}/{path}/.issues/{N}/artifacts/` |
 | `blocker_reason` | `<why if BLOCKED>` |

--- a/skills/spec-creation-requirements/tasks/requirements.md
+++ b/skills/spec-creation-requirements/tasks/requirements.md
@@ -101,7 +101,7 @@ Action: [auto-fix|FAIL]
 
 ## Structured Output Format
 
-Requirements analysis MUST be written to a structured artifact at `.issues/{issue-N}/requirements.yaml` with the following schema:
+Requirements analysis MUST be written to a structured artifact at `{project_root}/{path}/.issues/{issue-N}/requirements.yaml` with the following schema:
 
 ```yaml
 requirements:

--- a/skills/spec-creation-validation/tasks/completion.md
+++ b/skills/spec-creation-validation/tasks/completion.md
@@ -29,7 +29,7 @@ Idempotent completion subtask for spec-creation. Ensures mandatory steps ran reg
    - If missing: perform self-review (placeholder scan, consistency check)
 
 - [ ] 3b. **Holistic self-check** (MANDATORY before finalization):
-   - Read `.issues/{N}/artifacts/holistic-self-check.yaml` to verify all 11 dimensions PASS
+   - Read `{project_root}/{path}/.issues/{N}/artifacts/holistic-self-check.yaml` to verify all 11 dimensions PASS
    - If the file does not exist or any dimension FAIL: return spec to create task for revision. Do NOT finalize.
 
 - [ ] 4. **Chat executive summary** (if not already produced):
@@ -38,7 +38,7 @@ Idempotent completion subtask for spec-creation. Ensures mandatory steps ran reg
 
 - [ ] 5. **Spec folder URL blockquote** (if not already present in issue body):
    - Generate the spec folder URL: `{html_url}/{owner}/{repo}/tree/issues-data/{N}/`
-   - Check if the issue body already contains the `.issues/{N}/` blockquote
+   - Check if the issue body already contains the `{path}/.issues/{N}/` blockquote
    - If missing: prepend the blockquote (per Step 6.8 of Load [write.md](skills/spec-creation-validation/tasks/create.md)) and update the issue body
 
 - [ ] 6. **Push artifacts to issues-data** (after spec issue exists):
@@ -100,5 +100,5 @@ HALT
 |-------|-------|
 | `status` | `DONE` \| `BLOCKED` |
 | `finding_summary` | `"Completion check for spec #N: all mandatory steps verified"` |
-| `artifact_path` | `.issues/{N}/lifecycle.yaml` |
+| `artifact_path` | `{project_root}/{path}/.issues/{N}/lifecycle.yaml` |
 | `blocker_reason` | `<why if BLOCKED>` |

--- a/skills/spec-creation-validation/tasks/create-remote-stub.md
+++ b/skills/spec-creation-validation/tasks/create-remote-stub.md
@@ -12,8 +12,8 @@ Obtain a spec issue number and create a stub file. Handles both remote (GitHub/G
 ## Procedure
 
 - [ ] 1. **Check platform** — Read `github.platform` from session-init. If `local`, proceed with local mode. If `github.com` or `gitbucket`, proceed with remote mode.
-- [ ] 2. **Remote mode:** Create a minimal issue via the platform API with title and `needs-approval` label. Save the returned issue number as `N`. Write stub to `.issues/{N}/remote.md` with the issue URL and number.
-- [ ] 3. **Local mode:** List existing `.issues/` directories, find the max number, increment by 1. Create `.issues/{N}/remote.md` with a stub noting local-only mode.
+- [ ] 2. **Remote mode:** Create a minimal issue via the platform API with title and `needs-approval` label. Save the returned issue number as `N`. Write stub to `{project_root}/{path}/.issues/{N}/remote.md` with the issue URL and number.
+- [ ] 3. **Local mode:** List existing `{project_root}/{path}/.issues/` directories, find the max number, increment by 1. Create `{project_root}/{path}/.issues/{N}/remote.md` with a stub noting local-only mode.
 - [ ] 4. **Return spec_number** — The spec number `N` is used by all subsequent pipeline steps for artifact paths.
 
 ## Result Contract
@@ -22,5 +22,5 @@ Obtain a spec issue number and create a stub file. Handles both remote (GitHub/G
 |-------|-------|
 | `status` | `DONE` |
 | `finding_summary` | `"Issue #N created via <platform>"` |
-| `artifact_path` | `.issues/{N}/remote.md` |
+| `artifact_path` | `{project_root}/{path}/.issues/{N}/remote.md` |
 | `spec_number` | `N` |

--- a/skills/spec-creation-validation/tasks/create.md
+++ b/skills/spec-creation-validation/tasks/create.md
@@ -19,16 +19,16 @@ Assemble the final spec with acceptance criteria, ambiguity elimination, and del
 - Chat output is ONLY: `<exec summary>` + `<issue URL>` + `<byline>` (no full spec dump)
 - User reviews spec ON THE ISSUE (not in chat)
 - Ready for spec-auditor and approval-gate
-- `.issues/{N}/spec-to-plan-handoff.yaml` generated with artifact manifest (SC-27)
-- `.issues/{N}/sc-summary.yaml` includes flat `scs` list with `id`, `description`, `evidence_type`, `verification_gate`, `plan_phase` per SC (SC-28)
-- `.issues/{N}/spec.md` saved with full spec content (SC-29)
-- `.opencode/tools/local-issues sync` run after all `.issues/{N}/` file changes (SC-33)
+- `{project_root}/{path}/.issues/{N}/spec-to-plan-handoff.yaml` generated with artifact manifest (SC-27)
+- `{project_root}/{path}/.issues/{N}/sc-summary.yaml` includes flat `scs` list with `id`, `description`, `evidence_type`, `verification_gate`, `plan_phase` per SC (SC-28)
+- `{project_root}/{path}/.issues/{N}/spec.md` saved with full spec content (SC-29)
+- `.opencode/tools/local-issues sync` run after all `{project_root}/{path}/.issues/{N}/` file changes (SC-33)
 
 ## Procedure
 
 - [ ] 1. **Step 1: Verification Gate (MANDATORY FIRST)** — Before assembling the spec, collect evidence artifacts for the factual claims the spec will make — file references, API signatures, configuration fields, code behavior, and environment details. Evidence artifacts collected here ensure that the spec's claims are grounded in live sources. Claims that cannot be verified at this stage are marked with `⚠️ UNVERIFIED` for resolution in the post-generation revisit pass. (The SKILL.md pipeline handles verification-enforcement dispatch as an inline orchestrator step — this sub-agent does not call it.)
 
-- [ ] 2. **Step 2: Stub Creation (SC-22 — behavioral)** — The SKILL.md pipeline handles create-remote-stub as a separate sub-task step before this sub-agent runs. This sub-agent reads the spec number from `.issues/{N}/remote.md` and uses it for all subsequent artifact paths. The full spec body will be populated in Step 7.
+- [ ] 2. **Step 2: Stub Creation (SC-22 — behavioral)** — The SKILL.md pipeline handles create-remote-stub as a separate sub-task step before this sub-agent runs. This sub-agent reads the spec number from `{project_root}/{path}/.issues/{N}/remote.md` and uses it for all subsequent artifact paths. The full spec body will be populated in Step 7.
 
 - [ ] 3. **Step 3: Behavioral Test Mandate in Success Criteria (MANDATORY)** — Behavioral enforcement tests are NOT written during spec creation. They are written during implementation, per the post-approval spec mandate. However, the spec MUST include a Success Criterion mandating behavioral test creation before implementation.
 
@@ -48,7 +48,7 @@ Assemble the final spec with acceptance criteria, ambiguity elimination, and del
 
     When creating the behavioral test success criterion, ensure it mandates real-domain prompts and stderr-based assertions, not prose-recall prompts.
 
-- [ ] 5. **Step 5: Assemble Spec** — The generated spec body MUST include YAML frontmatter at the top of the LOCAL `.issues/{N}/spec.md` file. The remote issue body remains markdown-only (no frontmatter).
+- [ ] 5. **Step 5: Assemble Spec** — The generated spec body MUST include YAML frontmatter at the top of the LOCAL `{project_root}/{path}/.issues/{N}/spec.md` file. The remote issue body remains markdown-only (no frontmatter).
 
     The local `spec.md` MUST begin with YAML frontmatter:
 
@@ -65,9 +65,9 @@ Assemble the final spec with acceptance criteria, ambiguity elimination, and del
     ---
     ```
 
-    This frontmatter is for the LOCAL `.issues/{N}/spec.md` file ONLY. The remote issue body (GitHub Issue) uses markdown-only format without frontmatter.
+    This frontmatter is for the LOCAL `{project_root}/{path}/.issues/{N}/spec.md` file ONLY. The remote issue body (GitHub Issue) uses markdown-only format without frontmatter.
 
-    The local `.issues/{N}/spec.md` file also includes a STATUS/CREATED preamble header and compliance statement blockquotes at the top and bottom. These are for the LOCAL spec file ONLY — the remote issue body does NOT use this format.
+    The local `{project_root}/{path}/.issues/{N}/spec.md` file also includes a STATUS/CREATED preamble header and compliance statement blockquotes at the top and bottom. These are for the LOCAL spec file ONLY — the remote issue body does NOT use this format.
 
     **Template — STATUS/CREATED header (top of local spec.md, after YAML frontmatter):**
 
@@ -207,22 +207,22 @@ Assemble the final spec with acceptance criteria, ambiguity elimination, and del
 
 - [ ] 6. **Step 6: Generate Spec Artifacts (MANDATORY)** — Generate the following permanent artifacts:
 
-    - [ ] **SC coverage summary YAML** — Create `.issues/{issue-N}/sc-summary.yaml` with machine-parseable coverage data including SC IDs, evidence types, phase bindings, and verification gates.
-    - [ ] **Verification consistency contract** — Create `.issues/{issue-N}/verification-consistency-contract.yaml` as a solve contract with compliance matrix variables.
-    - [ ] **Lifecycle manifest** — Create `.issues/{N}/lifecycle.yaml` with initial `spec_created` event. Append-only format; never overwrite.
-    - [ ] **Revision re-entry protocol contract** — Create `.issues/{issue-N}/revision-re-entry-contract.yaml` as a solve contract with cascade variables for each revision scope.
+    - [ ] **SC coverage summary YAML** — Create `{project_root}/{path}/.issues/{issue-N}/sc-summary.yaml` with machine-parseable coverage data including SC IDs, evidence types, phase bindings, and verification gates.
+    - [ ] **Verification consistency contract** — Create `{project_root}/{path}/.issues/{issue-N}/verification-consistency-contract.yaml` as a solve contract with compliance matrix variables.
+    - [ ] **Lifecycle manifest** — Create `{project_root}/{path}/.issues/{N}/lifecycle.yaml` with initial `spec_created` event. Append-only format; never overwrite.
+    - [ ] **Revision re-entry protocol contract** — Create `{project_root}/{path}/.issues/{issue-N}/revision-re-entry-contract.yaml` as a solve contract with cascade variables for each revision scope.
 
     Artifact generation occurs during Step 1 assembly. Self-review (Step 6) validates YAML-vs-prose consistency.
 
 - [ ] 7. **Step 7: Plan Creation Mandate in Spec Body (MANDATORY)** — The generated spec body MUST include a paragraph in the preamble or before the Success Criteria section that mandates plan creation via `writing-plans`:
 
     ```markdown
-    After this spec is approved, invoke `writing-plans` to create `.issues/{N}/plan.md` before implementation begins.
+    After this spec is approved, invoke `writing-plans` to create `{project_root}/{path}/.issues/{N}/plan.md` before implementation begins.
     ```
 
     Where `{N}` is the actual issue number, substituted at generation time. This mandate is in the spec content (what the writer generates), not just the task procedure.
 
-- [ ] 8. **Step 8: SC Coverage YAML Generation (SC-4, SC-28)** — After assembling the spec content, generate a machine-parseable SC coverage summary at `.issues/{issue-N}/sc-summary.yaml`:
+- [ ] 8. **Step 8: SC Coverage YAML Generation (SC-4, SC-28)** — After assembling the spec content, generate a machine-parseable SC coverage summary at `{project_root}/{path}/.issues/{issue-N}/sc-summary.yaml`:
 
     ```yaml
     sc_coverage:
@@ -253,7 +253,7 @@ Assemble the final spec with acceptance criteria, ambiguity elimination, and del
 
     Required validation: cross-reference `sc_coverage.total` against the prose SC table row count. Mismatch MUST be flagged as a STRUCTURE-VIOLATION.
 
-- [ ] 9. **Step 9: Verification Consistency Contract Generation (SC-8)** — Generate a verification consistency solve contract at `.issues/{issue-N}/verification-consistency-contract.yaml` with a compliance matrix as solve variables:
+- [ ] 9. **Step 9: Verification Consistency Contract Generation (SC-8)** — Generate a verification consistency solve contract at `{project_root}/{path}/.issues/{issue-N}/verification-consistency-contract.yaml` with a compliance matrix as solve variables:
 
     ```yaml
     spec: {browser_url}/{owner}/{repo}/issues/{N}
@@ -274,7 +274,7 @@ Assemble the final spec with acceptance criteria, ambiguity elimination, and del
 
     The pre-approval gate validates every SC's Verification Gate against its Evidence Type. SAT for compliant specs, UNSAT with unsat_core for non-compliant.
 
-- [ ] 10. **Step 10: Lifecycle Manifest Initialization (SC-6)** — Initialize the append-only lifecycle manifest at `.issues/{N}/lifecycle.yaml` with a `spec_created` event:
+- [ ] 10. **Step 10: Lifecycle Manifest Initialization (SC-6)** — Initialize the append-only lifecycle manifest at `{project_root}/{path}/.issues/{N}/lifecycle.yaml` with a `spec_created` event:
 
     ```yaml
     events:
@@ -287,7 +287,7 @@ Assemble the final spec with acceptance criteria, ambiguity elimination, and del
 
     Each pipeline stage appends its event. Blocker events appended on FAIL with severity, reason, and resolution fields.
 
-- [ ] 11. **Step 11: Spec-to-Plan Handoff Manifest Generation (SC-27)** — Generate a spec-to-plan handoff manifest at `.issues/{issue-N}/spec-to-plan-handoff.yaml` that the plan writer and pre-flight handoff use to verify artifact completeness:
+- [ ] 11. **Step 11: Spec-to-Plan Handoff Manifest Generation (SC-27)** — Generate a spec-to-plan handoff manifest at `{project_root}/{path}/.issues/{issue-N}/spec-to-plan-handoff.yaml` that the plan writer and pre-flight handoff use to verify artifact completeness:
 
     ```yaml
     spec: {browser_url}/{owner}/{repo}/issues/{N}
@@ -297,21 +297,21 @@ Assemble the final spec with acceptance criteria, ambiguity elimination, and del
     phase_count: <integer>
     status: <complete | partial>
     artifacts:
-      - path: .issues/{N}/spec.md
+      - path: {project_root}/{path}/.issues/{N}/spec.md
         required: true
-      - path: .issues/{N}/sc-summary.yaml
+      - path: {project_root}/{path}/.issues/{N}/sc-summary.yaml
         required: true
-      - path: .issues/{N}/verification-consistency-contract.yaml
+      - path: {project_root}/{path}/.issues/{N}/verification-consistency-contract.yaml
         required: true
-      - path: .issues/{N}/revision-re-entry-contract.yaml
+      - path: {project_root}/{path}/.issues/{N}/revision-re-entry-contract.yaml
         required: true
-      - path: .issues/{N}/spec-to-plan-handoff.yaml
+      - path: {project_root}/{path}/.issues/{N}/spec-to-plan-handoff.yaml
         required: true
     ```
 
     The handoff manifest is consumed by Load [pre-flight-handoff.md](implementation-pipeline/tasks/pre-flight-handoff.md) which validates that all required artifacts exist before the pipeline proceeds. If any required artifact is missing, pre-flight returns BLOCKED.
 
-- [ ] 12. **Step 12: Revision Re-Entry Protocol Contract Generation (SC-5)** — Generate a revision re-entry solve contract at `.issues/{issue-N}/revision-re-entry-contract.yaml` with cascade variables for each revision scope:
+- [ ] 12. **Step 12: Revision Re-Entry Protocol Contract Generation (SC-5)** — Generate a revision re-entry solve contract at `{project_root}/{path}/.issues/{issue-N}/revision-re-entry-contract.yaml` with cascade variables for each revision scope:
 
     ```yaml
     spec: {browser_url}/{owner}/{repo}/issues/{N}
@@ -495,7 +495,7 @@ Assemble the final spec with acceptance criteria, ambiguity elimination, and del
     | Missing expected values | "returns the correct result", "validates input" | No concrete expected value to compare against |
     | Implicit behavior | "should not crash", "works normally" | No negative criterion — what constitutes "not crashing" is undefined |
 
-    **Verification:** For each SC, attempt to write an executable verification command (`uv run pytest test_X.py::test_Y`, `bash verify.sh arg`, `read(filePath=.issues/{N}/spec.md)` with specific field check). If no executable command can be written, the SC is not deterministic.
+    **Verification:** For each SC, attempt to write an executable verification command (`uv run pytest test_X.py::test_Y`, `bash verify.sh arg`, `read(filePath={project_root}/{path}/.issues/{N}/spec.md)` with specific field check). If no executable command can be written, the SC is not deterministic.
 
     ✅ **Gate presence verification:** Verify the all-or-nothing gate statement is present in the assembled spec body. If absent → `STRUCTURE-VIOLATION` requiring rewrite before submission.
 
@@ -521,11 +521,11 @@ Assemble the final spec with acceptance criteria, ambiguity elimination, and del
 
     ```bash
     ./.opencode/tools/solve model \
-      --contract-path .issues/{issue-N}/pre-approval-gate-contract.yaml \
-      --output .issues/{N}/artifacts/constraints-contract.yaml
+      --contract-path {project_root}/{path}/.issues/{issue-N}/pre-approval-gate-contract.yaml \
+      --output {project_root}/{path}/.issues/{N}/artifacts/constraints-contract.yaml
     ```
 
-    On success: constraints contract written to `.issues/{N}/artifacts/constraints-contract.yaml`.
+    On success: constraints contract written to `{project_root}/{path}/.issues/{N}/artifacts/constraints-contract.yaml`.
     On UNSAT: **HALT** with blocker report — do NOT proceed with manual fallback.
     On utility unavailable: **HALT** with blocker report — do NOT proceed without solve verification.
 
@@ -533,8 +533,8 @@ Assemble the final spec with acceptance criteria, ambiguity elimination, and del
 
     ```bash
     ./.opencode/tools/solve check \
-      --state-path .issues/{N}/artifacts/constraints-contract.yaml \
-      --contract-path .issues/{issue-N}/pre-approval-gate-contract.yaml
+      --state-path {project_root}/{path}/.issues/{N}/artifacts/constraints-contract.yaml \
+      --contract-path {project_root}/{path}/.issues/{issue-N}/pre-approval-gate-contract.yaml
     ```
 
     MUST return SAT. UNSAT → HALT with blocker report. No fallback paths.
@@ -545,8 +545,8 @@ Assemble the final spec with acceptance criteria, ambiguity elimination, and del
 
     ```bash
     ./.opencode/tools/plan plan \
-      --problem .issues/{N}/artifacts/phase-plan-problem.yaml \
-      --output .issues/{N}/artifacts/phase-plan-validated.yaml
+      --problem {project_root}/{path}/.issues/{N}/artifacts/phase-plan-problem.yaml \
+      --output {project_root}/{path}/.issues/{N}/artifacts/phase-plan-validated.yaml
     ```
 
     On success: planner returns SOLVED_SATISFICING or SOLVED_OPTIMALLY per `plan` skill → `plan.md` task.
@@ -592,16 +592,16 @@ Assemble the final spec with acceptance criteria, ambiguity elimination, and del
        - `structural` → `behavioral`: Must add a real test execution command (e.g., `opencode run`, `pytest`, `bash test.sh`)
        - `string` → `behavioral`: Must replace grep assertion with test execution + semantic inspection
     5. **Re-check**: After remediation, re-run the classification check. Confirm no remaining misclassifications.
-    6. **Evidence artifact**: Write findings to `.issues/{N}/post-sc-uplift-check.yaml`
+    6. **Evidence artifact**: Write findings to `{project_root}/{path}/.issues/{N}/post-sc-uplift-check.yaml`
 
 - [ ] 35. **Step 35: Evidence Artifact Verification (MANDATORY)** — **🚫 CRITICAL: Each self-review checkpoint MUST produce a tool-call artifact demonstrating the verification was performed. Assertions without tool-call evidence are VERIFICATION-GAP findings per Load [065-verification-honesty.md](guidelines/065-verification-honesty.md).**
 
     | Checkpoint | Verification Action | Tool Call | Problem Class |
     | ---------- | ---------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- | ------------------- |
-    | No placeholders remain | Verify spec body contains no "TBD", "TODO", "FIXME", or incomplete section markers | `read(filePath=.issues/{N}/spec.md)` → search body for `/TBD\|TODO\|FIXME/` | STRUCTURE-VIOLATION |
-    | Internal consistency | Cross-reference requirement IDs between sections; verify no contradictions | `read(filePath=.issues/{N}/spec.md)` → parse section anchors vs referenced IDs | CONFLICTING |
-    | Scope check evidence | Verify scope is appropriate for single plan or flagged for decomposition | `read(filePath=.issues/{N}/spec.md)` → count affected files, check for phase markers | VERIFICATION-GAP |
-    | Ambiguity resolved | Verify no requirement can be interpreted two ways | `read(filePath=.issues/{N}/spec.md)` → scan for "should", "etc.", vague terms | STRUCTURE-VIOLATION |
+    | No placeholders remain | Verify spec body contains no "TBD", "TODO", "FIXME", or incomplete section markers | `read(filePath={project_root}/{path}/.issues/{N}/spec.md)` → search body for `/TBD\|TODO\|FIXME/` | STRUCTURE-VIOLATION |
+    | Internal consistency | Cross-reference requirement IDs between sections; verify no contradictions | `read(filePath={project_root}/{path}/.issues/{N}/spec.md)` → parse section anchors vs referenced IDs | CONFLICTING |
+    | Scope check evidence | Verify scope is appropriate for single plan or flagged for decomposition | `read(filePath={project_root}/{path}/.issues/{N}/spec.md)` → count affected files, check for phase markers | VERIFICATION-GAP |
+    | Ambiguity resolved | Verify no requirement can be interpreted two ways | `read(filePath={project_root}/{path}/.issues/{N}/spec.md)` → scan for "should", "etc.", vague terms | STRUCTURE-VIOLATION |
 
     **Evidence format:**
 
@@ -629,28 +629,28 @@ Assemble the final spec with acceptance criteria, ambiguity elimination, and del
 - [ ] 37. **Step 37: Generate Spec Folder URL (SC-6)** — Generate the spec folder URL and prepare the blockquote for embedding at the top of the issue body. Follow the pattern from Load [AGENTS.md](.issues/AGENTS.md):
 
     ```
-    > **Full spec and artifacts: [`.issues/{N}/`]({html_url}/{owner}/{repo}/tree/issues-data/{N})** — this issue is a condensed exec summary; the authoritative spec lives in the `issues-data` branch.
+    > **Full spec and artifacts: [`{path}/.issues/{N}/`]({html_url}/{owner}/{repo}/tree/issues-data/{path}/.issues/{N})** — this issue is a condensed exec summary; the authoritative spec lives in the `issues-data` branch.
     >
-    > **Local artifacts:** `.issues/{N}/` — implementation plan, card catalogue, dependency contracts, research, designs, audit findings
+    > **Local artifacts:** `{path}/.issues/{N}/` — implementation plan, card catalogue, dependency contracts, research, designs, audit findings
     ```
 
     The URL follows the pattern: `{html_url}/{owner}/{repo}/tree/issues-data/{N}` where `{html_url}`, `{owner}`, and `{repo}` are resolved from the session-init repo entry whose `path` matches the issue's repo. Load [AGENTS.md](.issues/AGENTS.md) for the canonical URL convention.
 
     Embed this blockquote at the TOP of the issue body (before the spec content), prepended when creating the issue body or updated after creation.
 
-- [ ] 38. **Step 38: Local Spec Assembly (SC-29)** — After creating the remote issue, save the full spec content to the local `.issues/{N}/spec.md` file:
+- [ ] 38. **Step 38: Local Spec Assembly (SC-29)** — After creating the remote issue, save the full spec content to the local `{project_root}/{path}/.issues/{N}/spec.md` file:
 
-    - [ ] Write the complete spec body (including all sections, SC table, compliance blocks, preamble, byline, and YAML frontmatter) to `.issues/{N}/spec.md`
+    - [ ] Write the complete spec body (including all sections, SC table, compliance blocks, preamble, byline, and YAML frontmatter) to `{project_root}/{path}/.issues/{N}/spec.md`
     - [ ] The local spec.md is the authoritative spec — the remote issue body is a condensed exec summary
-    - [ ] The plan writer reads from `.issues/{N}/spec.md`, not from the remote issue body
-    - [ ] Verify the file was written: `ls .issues/{N}/spec.md`
+    - [ ] The plan writer reads from `{project_root}/{path}/.issues/{N}/spec.md`, not from the remote issue body
+    - [ ] Verify the file was written: `ls {project_root}/{path}/.issues/{N}/spec.md`
 
-- [ ] 39. **Step 39: Post-Creation Sync (SC-33)** — After creating or modifying any files in `.issues/{N}/`, run `local-issues sync` to commit and push the local artifacts to the `issues-data` branch:
+- [ ] 39. **Step 39: Post-Creation Sync (SC-33)** — After creating or modifying any files in `{project_root}/{path}/.issues/{N}/`, run `local-issues sync` to commit and push the local artifacts to the `issues-data` branch:
 
-    - [ ] Run `.opencode/tools/local-issues sync` to commit all local `.issues/{N}/` files and push to the `issues-data` branch
-    - [ ] This ensures links in the remote issue body that refer to the spec folder (`.issues/{N}/`) resolve correctly
+    - [ ] Run `.opencode/tools/local-issues sync` to commit all local `{project_root}/{path}/.issues/{N}/` files and push to the `issues-data` branch
+    - [ ] This ensures links in the remote issue body that refer to the spec folder (`{path}/.issues/{N}/`) resolve correctly
     - [ ] The `issues-data` branch is the canonical store for all spec artifacts — without sync, downstream consumers (plan writer, auditors) cannot access the local files
-    - [ ] Run `local-issues sync` after EVERY change to files in `.issues/{N}/` — not just at creation time
+    - [ ] Run `local-issues sync` after EVERY change to files in `{project_root}/{path}/.issues/{N}/` — not just at creation time
 
 - [ ] 41. **Step 41: User Review on Issue** — The user reviews the spec ON THE GITHUB ISSUE, not in chat.
 
@@ -664,30 +664,30 @@ Assemble the final spec with acceptance criteria, ambiguity elimination, and del
 
 - Preceded by: `requirements` (mandatory), `decompose`, `traceability`, `risk` (or explicitly skipped)
 - Extends: brainstorming Steps 7-9 (adapted, not verbatim move)
-- Calls: `.opencode/tools/local-issues sync` (after all `.issues/{N}/` file changes)
+- Calls: `.opencode/tools/local-issues sync` (after all `{project_root}/{path}/.issues/{N}/` file changes)
 - Followed by: `spec-auditor`, then user review on the issue
 
 ## Input Artifacts
 
-This sub-agent reads prior artifacts from the following paths under `.issues/{N}/artifacts/`:
+This sub-agent reads prior artifacts from the following paths under `{project_root}/{path}/.issues/{N}/artifacts/`:
 
 | # | Artifact | Path |
 |---|----------|------|
-| 1 | Pre-spec inspection | `.issues/{N}/artifacts/pre-spec-inspection.yaml` |
-| 2 | Research cards consulted | `.issues/{N}/artifacts/research-cards-consulted.yaml` |
-| 3 | Requirements | `.issues/{N}/artifacts/requirements.yaml` |
-| 4 | Concern map | `.issues/{N}/artifacts/concern-map.yaml` |
-| 5 | Decomposition | `.issues/{N}/artifacts/decomposition.yaml` |
-| 6 | Blast radius | `.issues/{N}/artifacts/blast-radius.yaml` |
-| 7 | Cross-cutting matrix | `.issues/{N}/artifacts/cross-cutting-matrix.yaml` |
-| 8 | Traceability | `.issues/{N}/artifacts/traceability.yaml` |
-| 9 | Code path inventory | `.issues/{N}/artifacts/code-path-inventory.yaml` |
-| 10 | Interface compatibility | `.issues/{N}/artifacts/interface-compatibility.yaml` |
-| 11 | State analysis | `.issues/{N}/artifacts/state-analysis.yaml` |
-| 12 | SC pipeline readiness | `.issues/{N}/artifacts/sc-pipeline-readiness.yaml` |
-| 13 | Testability assessment | `.issues/{N}/artifacts/testability-assessment.yaml` |
-| 14 | Risk | `.issues/{N}/artifacts/risk.yaml` |
-| 15 | Interdependency check | `.issues/{N}/artifacts/interdependency-check.yaml` |
+| 1 | Pre-spec inspection | `{project_root}/{path}/.issues/{N}/artifacts/pre-spec-inspection.yaml` |
+| 2 | Research cards consulted | `{project_root}/{path}/.issues/{N}/artifacts/research-cards-consulted.yaml` |
+| 3 | Requirements | `{project_root}/{path}/.issues/{N}/artifacts/requirements.yaml` |
+| 4 | Concern map | `{project_root}/{path}/.issues/{N}/artifacts/concern-map.yaml` |
+| 5 | Decomposition | `{project_root}/{path}/.issues/{N}/artifacts/decomposition.yaml` |
+| 6 | Blast radius | `{project_root}/{path}/.issues/{N}/artifacts/blast-radius.yaml` |
+| 7 | Cross-cutting matrix | `{project_root}/{path}/.issues/{N}/artifacts/cross-cutting-matrix.yaml` |
+| 8 | Traceability | `{project_root}/{path}/.issues/{N}/artifacts/traceability.yaml` |
+| 9 | Code path inventory | `{project_root}/{path}/.issues/{N}/artifacts/code-path-inventory.yaml` |
+| 10 | Interface compatibility | `{project_root}/{path}/.issues/{N}/artifacts/interface-compatibility.yaml` |
+| 11 | State analysis | `{project_root}/{path}/.issues/{N}/artifacts/state-analysis.yaml` |
+| 12 | SC pipeline readiness | `{project_root}/{path}/.issues/{N}/artifacts/sc-pipeline-readiness.yaml` |
+| 13 | Testability assessment | `{project_root}/{path}/.issues/{N}/artifacts/testability-assessment.yaml` |
+| 14 | Risk | `{project_root}/{path}/.issues/{N}/artifacts/risk.yaml` |
+| 15 | Interdependency check | `{project_root}/{path}/.issues/{N}/artifacts/interdependency-check.yaml` |
 
 ## Result Contract
 
@@ -695,5 +695,5 @@ This sub-agent reads prior artifacts from the following paths under `.issues/{N}
 |-------|-------|
 | `status` | `DONE` \| `BLOCKED` |
 | `finding_summary` | `"Spec #N written with M SCs"` |
-| `artifact_path` | `.issues/{N}/spec.md` |
+| `artifact_path` | `{project_root}/{path}/.issues/{N}/spec.md` |
 | `blocker_reason` | `<why if BLOCKED>` |

--- a/skills/spec-creation-validation/tasks/holistic-self-check.md
+++ b/skills/spec-creation-validation/tasks/holistic-self-check.md
@@ -23,7 +23,7 @@ Evaluate a spec against the 11-dimension holistic semantic gate before finalizat
 
 - [ ] 1. **Load dimension definitions** — Read `.opencode/reference/holistic-dimensions.yaml` to load the canonical 11 spec dimensions with their questions and checks.
 
-- [ ] 2. **Read the spec** — Read the full spec body from the local `.issues/{N}/spec.md` file. Read all sections: preamble, problem statement, root cause analysis, alternatives considered, safety considerations, success criteria, traceability table, feasibility assessment, constraints, dependencies, and any other content.
+- [ ] 2. **Read the spec** — Read the full spec body from the local `{project_root}/{path}/.issues/{N}/spec.md` file. Read all sections: preamble, problem statement, root cause analysis, alternatives considered, safety considerations, success criteria, traceability table, feasibility assessment, constraints, dependencies, and any other content.
 
 - [ ] 3. **Evaluate each dimension** — For each of the 11 dimensions, produce a single PASS/FAIL verdict. The sub-agent reads the full spec and judges independently — no grep, no pattern matching, no checklist. Each dimension is a semantic question:
 
@@ -61,7 +61,7 @@ Evaluate a spec against the 11-dimension holistic semantic gate before finalizat
           name: "<dimension name>"
           finding: "<what failed>"
           resolution: "<what needs to be fixed>"
-      artifact_path: ".issues/{N}/artifacts/holistic-self-check.yaml"
+      artifact_path: "{project_root}/{path}/.issues/{N}/artifacts/holistic-self-check.yaml"
     ```
 
 - [ ] 5. **If all PASS** — Return `status: DONE` with the verdict artifact. Spec is ready for finalization.
@@ -79,6 +79,6 @@ Evaluate a spec against the 11-dimension holistic semantic gate before finalizat
 ```yaml
 status: DONE | BLOCKED
 finding_summary: "Holistic self-check: <N>/11 PASS, <M>/11 FAIL. Failed: <dimension names>"
-artifact_path: ".issues/{N}/artifacts/holistic-self-check.yaml"
+artifact_path: "{project_root}/{path}/.issues/{N}/artifacts/holistic-self-check.yaml"
 blocker_reason: "HOLISTIC_GATE_FAILED: <dimension names> failed. See artifact for details."  # if BLOCKED
 ```

--- a/skills/spec-creation-validation/tasks/pipeline-readiness-gate.md
+++ b/skills/spec-creation-validation/tasks/pipeline-readiness-gate.md
@@ -23,7 +23,7 @@ Validate that spec success criteria are structurally fit for the implementation 
 - PR-3 (single concern): PASS — every SC targets one file category and one verification domain
 - PR-4 (phase dependency): PASS — `solve prove` confirms phase dependency graph is acyclic
 - PR-5 (three-tier structure): PASS — multi-phase specs have three-tier phase structure (SC-31)
-- Artifact `.issues/{issue-N}/sc-pipeline-readiness.yaml` written with status PASS/FAIL
+- Artifact `{project_root}/{path}/.issues/{issue-N}/sc-pipeline-readiness.yaml` written with status PASS/FAIL
 
 ## Procedure
 
@@ -44,7 +44,7 @@ Extract the SC dependency graph from `depends_on` fields:
 
 - [ ] 1. Collect all SC-ID → `depends_on: [SC-IDs]` mappings
 - [ ] 1. Verify every referenced SC-ID in `depends_on` is defined in the SC table
-- [ ] 1. Generate a Z3 ordering contract at `.issues/{issue-N}/sc-dependency-contract.yaml`
+- [ ] 1. Generate a Z3 ordering contract at `{project_root}/{path}/.issues/{issue-N}/sc-dependency-contract.yaml`
 
    Contract schema (SC DAG ordering):
 
@@ -63,7 +63,7 @@ Extract the SC dependency graph from `depends_on` fields:
 
    The theorem `sc_dag_is_valid` is a Z3 assertion that the conjunction of all implication invariants is SAT (the dependency graph has no contradictions). If Z3 returns UNSAT, the dependency graph is invalid.
 
-- [ ] 1. Run `solve prove --contract-path .issues/{issue-N}/sc-dependency-contract.yaml --theorem "sc_dag_is_valid"` to validate the DAG
+- [ ] 1. Run `solve prove --contract-path {project_root}/{path}/.issues/{issue-N}/sc-dependency-contract.yaml --theorem "sc_dag_is_valid"` to validate the DAG
 - [ ] 1. If any cycle or missing dependency is found: PR-2 = FAIL
 
 ### Step 3: Validate Single Concern (PR-3)
@@ -106,7 +106,7 @@ Record each SC as `decomposition_depth_valid: true | false`. Any SC failing this
 Extract the phase dependency graph:
 
 - [ ] 1. Collect all phase → `depends_on: [phase-names]` mappings
-- [ ] 1. Generate a Z3 ordering contract at `.issues/{issue-N}/dependency-ordering-verification/ordering.yaml`
+- [ ] 1. Generate a Z3 ordering contract at `{project_root}/{path}/.issues/{issue-N}/dependency-ordering-verification/ordering.yaml`
 
    Contract schema (phase DAG ordering) — same structure as Step 2:
 
@@ -122,7 +122,7 @@ Extract the phase dependency graph:
      - "phase_dag_is_acyclic"
    ```
 
-- [ ] 1. Run `solve prove --contract-path .issues/{issue-N}/dependency-ordering-verification/ordering.yaml --theorem "phase_dag_is_acyclic"` to validate
+- [ ] 1. Run `solve prove --contract-path {project_root}/{path}/.issues/{issue-N}/dependency-ordering-verification/ordering.yaml --theorem "phase_dag_is_acyclic"` to validate
 - [ ] 1. If any cycle is found: PR-4 = FAIL
 
 ### Step 4.5: Validate Three-Tier Phase Structure (PR-5 — SC-31)
@@ -147,7 +147,7 @@ For multi-phase specs (2+ phases), validate that the phase structure follows the
 
 Generate timestamp via `.opencode/tools/schema-version`. Store result in `$TIMESTAMP`.
 
-Write `.issues/{issue-N}/sc-pipeline-readiness.yaml`:
+Write `{project_root}/{path}/.issues/{issue-N}/sc-pipeline-readiness.yaml`:
 
 ```yaml
 schema_version: "1.0"
@@ -159,7 +159,7 @@ checks:
     detail: "..."
   - check_id: PR-2
     result: PASS | FAIL
-    solve_contract_path: ".issues/{issue-N}/sc-dependency-contract.yaml"
+    solve_contract_path: "{project_root}/{path}/.issues/{issue-N}/sc-dependency-contract.yaml"
     prove_results:
       - theorem: "sc_dag_is_valid"
         result: VALID | INVALID
@@ -168,7 +168,7 @@ checks:
     detail: "..."
   - check_id: PR-4
     result: PASS | FAIL
-    solve_contract_path: ".issues/{issue-N}/dependency-ordering-verification/ordering.yaml"
+    solve_contract_path: "{project_root}/{path}/.issues/{issue-N}/dependency-ordering-verification/ordering.yaml"
     prove_results:
       - theorem: "phase_dag_is_acyclic"
         result: VALID | INVALID

--- a/skills/spec-creation-validation/tasks/pre-spec-inspection.md
+++ b/skills/spec-creation-validation/tasks/pre-spec-inspection.md
@@ -19,7 +19,7 @@ Check for superseding issues, overlapping specs, and codebase conflicts before s
      - **PARTIAL-OVERLAP:** Specs share files/symbols but have different core concerns → Surface to developer
      - **CONFLICT-RISK:** Same files modified with conflicting intent → BLOCKED
      - **INDEPENDENT:** No meaningful overlap → Proceed
-- [ ] 5. **Write findings** — Save to `.issues/{N}/artifacts/pre-spec-inspection.yaml` with classification and evidence.
+- [ ] 5. **Write findings** — Save to `{project_root}/{path}/.issues/{N}/artifacts/pre-spec-inspection.yaml` with classification and evidence.
 
 ## Result Contract
 
@@ -27,5 +27,5 @@ Check for superseding issues, overlapping specs, and codebase conflicts before s
 |-------|-------|
 | `status` | `DONE` \| `BLOCKED` |
 | `finding_summary` | `"Pre-spec inspection: <classification> — <summary>"` |
-| `artifact_path` | `.issues/{N}/artifacts/pre-spec-inspection.yaml` |
+| `artifact_path` | `{project_root}/{path}/.issues/{N}/artifacts/pre-spec-inspection.yaml` |
 | `blocker_reason` | `<why if BLOCKED>` |

--- a/skills/spec-creation-validation/tasks/revise-remote-body.md
+++ b/skills/spec-creation-validation/tasks/revise-remote-body.md
@@ -6,20 +6,20 @@ Update the remote issue body with correct folder links after the local spec work
 
 ## Entry Criteria
 
-- Spec body exists at `.issues/{N}/spec.md`
+- Spec body exists at `{project_root}/{path}/.issues/{N}/spec.md`
 - Session-init values are available for URL construction
 - Remote issue exists (for remote platforms)
 
 ## Procedure
 
 - [ ] 1. **Check platform** — Read `github.platform` from session-init. If `local`, return SKIPPED.
-- [ ] 2. **Read spec body** — Read `.issues/{N}/spec.md` to extract the exec summary content.
+- [ ] 2. **Read spec body** — Read `{project_root}/{path}/.issues/{N}/spec.md` to extract the exec summary content.
 - [ ] 3. **Construct folder URL** — Build the spec folder URL from session-init values: `{html_url}/{owner}/{repo}/tree/issues-data/{N}/`
 - [ ] 4. **Update remote issue body** — Prepend the spec reference blockquote to the existing issue body via the platform API. The blockquote format:
      ```
-     > **Full spec and artifacts: [`.issues/{N}/`]({html_url}/{owner}/{repo}/tree/issues-data/{N}/)** — this issue is a condensed exec summary; the authoritative spec lives in the `issues-data` branch.
+     > **Full spec and artifacts: [`{path}/.issues/{N}/`]({html_url}/{owner}/{repo}/tree/issues-data/{path}/.issues/{N}/)** — this issue is a condensed exec summary; the authoritative spec lives in the `issues-data` branch.
      >
-     > **Local artifacts:** `.issues/{N}/` — implementation plan, card catalogue, dependency contracts, research, designs, audit findings
+     > **Local artifacts:** `{path}/.issues/{N}/` — implementation plan, card catalogue, dependency contracts, research, designs, audit findings
      ```
 - [ ] 5. **Verify** — Confirm the remote body was updated with correct links.
 

--- a/skills/spec-creation/SKILL.md
+++ b/skills/spec-creation/SKILL.md
@@ -73,7 +73,7 @@ This is a **dispatcher skill** that routes to 5 sub-skills. All original trigger
 19. [inline]  plan plan                                   # phase solvability validation
 20. [sub-task] interdependency-check                     # check for conflicting open specs
 21. [sub-task] create (local only)                        # write spec.md + sub-artifacts
-22. [sub-task] revise-remote-body                         # update links to .issues/{N}/ folder
+22. [sub-task] revise-remote-body                         # update links to {project_root}/{path}/.issues/{N}/ folder
 23. [inline]  local-issues sync                           # push artifacts so links resolve
 24. [sub-task] completion                                 # state check and report
 25. [inline]  spec-audit                                  # quality audit
@@ -108,14 +108,14 @@ Orchestrator                          Sub-agent
     │  task(..., {issue_number})            │
     │─────────────────────────────────────>│
     │                                      │
-    │                         Reads input from .issues/{N}/spec.md
-    │                         Reads prior artifacts from .issues/{N}/artifacts/
-    │                         Writes output to .issues/{N}/artifacts/{name}.yaml
+    │                         Reads input from {project_root}/{path}/.issues/{N}/spec.md
+    │                         Reads prior artifacts from {project_root}/{path}/.issues/{N}/artifacts/
+    │                         Writes output to {project_root}/{path}/.issues/{N}/artifacts/{name}.yaml
     │                                      │
     │  Result contract:                     │
     │    status: DONE | BLOCKED            │
     │    finding_summary: "<1-3 sentences>"│
-    │    artifact_path: .issues/{N}/artifacts/{name}.yaml
+    │    artifact_path: {project_root}/{path}/.issues/{N}/artifacts/{name}.yaml
     │    blocker_reason: ""               │
     │<─────────────────────────────────────│
     │                                      │
@@ -125,8 +125,8 @@ Orchestrator                          Sub-agent
 
 **Rules:**
 1. Orchestrator passes ONLY `{issue_number}` — no preloaded context, no file paths, no expected outcomes, no orchestrator reasoning
-2. Sub-agent reads from disk — `.issues/{N}/spec.md` for the spec body, `.issues/{N}/artifacts/` for prior step outputs
-3. Sub-agent writes to disk — `.issues/{N}/artifacts/{name}.yaml` for its output
+2. Sub-agent reads from disk — `{project_root}/{path}/.issues/{N}/spec.md` for the spec body, `{project_root}/{path}/.issues/{N}/artifacts/` for prior step outputs
+3. Sub-agent writes to disk — `{project_root}/{path}/.issues/{N}/artifacts/{name}.yaml` for its output
 4. Sub-agent returns frugal result contract — `{status, finding_summary, artifact_path, blocker_reason}`
 5. Orchestrator reads artifact files ONLY for routing-significant data — never for full content
 6. No contract YAML files at `{project_root}/tmp/{N}/contracts/` — those are phantom infrastructure, stripped
@@ -135,27 +135,27 @@ Orchestrator                          Sub-agent
 
 | Step | Sub-agent Reads | Sub-agent Writes | Result Contract |
 |------|----------------|-----------------|-----------------|
-| create-remote-stub | (none — platform check only) | `.issues/{N}/remote.md` | `{status: DONE, finding_summary: "Issue #N created via ", artifact_path: ".issues/{N}/remote.md", spec_number: N}` |
-| pre-spec-inspection | GitHub API for open specs, codebase | `.issues/{N}/artifacts/pre-spec-inspection.yaml` | `{status: DONE \| BLOCKED, finding_summary: "...", artifact_path: "...", blocker_reason: "..."}` |
-| research-card-consultation | `.opencode/.issues/research-cards/*.md` | `.issues/{N}/artifacts/research-cards-consulted.yaml` | `{status: DONE, finding_summary: "...", artifact_path: "...", blocker_reason: null}` |
-| requirements | brainstorming output | `.issues/{N}/artifacts/requirements.yaml` | same |
-| concern-analysis | `.issues/{N}/artifacts/requirements.yaml` | `.issues/{N}/artifacts/concern-map.yaml` | same |
-| decompose | `.issues/{N}/artifacts/requirements.yaml`, `.issues/{N}/artifacts/concern-map.yaml` | `.issues/{N}/artifacts/decomposition.yaml` | same |
-| blast-radius | `.issues/{N}/artifacts/decomposition.yaml` | `.issues/{N}/artifacts/blast-radius.yaml` | same |
-| cross-cutting | `.issues/{N}/artifacts/decomposition.yaml`, `.issues/{N}/artifacts/concern-map.yaml` | `.issues/{N}/artifacts/cross-cutting-matrix.yaml` | same |
-| traceability | `.issues/{N}/artifacts/requirements.yaml`, `.issues/{N}/artifacts/decomposition.yaml` | `.issues/{N}/artifacts/traceability.yaml` | same |
-| code-path-analysis | `.issues/{N}/artifacts/decomposition.yaml`, `.issues/{N}/artifacts/blast-radius.yaml` | `.issues/{N}/artifacts/code-path-inventory.yaml` | same |
-| interface-compatibility | `.issues/{N}/artifacts/decomposition.yaml`, `.issues/{N}/artifacts/concern-map.yaml` | `.issues/{N}/artifacts/interface-compatibility.yaml` | same |
-| state-analysis | `.issues/{N}/artifacts/decomposition.yaml`, `.issues/{N}/artifacts/interface-compatibility.yaml` | `.issues/{N}/artifacts/state-analysis.yaml` | same |
-| pipeline-readiness-gate | `.issues/{N}/spec.md` (SC table), `.issues/{N}/artifacts/*.yaml` | `.issues/{N}/artifacts/sc-pipeline-readiness.yaml` | same |
-| testability-assessment | `.issues/{N}/artifacts/requirements.yaml`, `.issues/{N}/artifacts/code-path-inventory.yaml` | `.issues/{N}/artifacts/testability-assessment.yaml` | same |
-| risk | `.issues/{N}/artifacts/requirements.yaml`, `.issues/{N}/artifacts/decomposition.yaml` | `.issues/{N}/artifacts/risk.yaml` | same |
-| interdependency-check | GitHub API for open specs | `.issues/{N}/artifacts/interdependency-check.yaml` | same |
-| create (local) | All prior artifacts in `.issues/{N}/artifacts/` | `.issues/{N}/spec.md`, `.issues/{N}/sc-summary.yaml`, `.issues/{N}/verification-consistency-contract.yaml`, `.issues/{N}/spec-to-plan-handoff.yaml`, `.issues/{N}/revision-re-entry-contract.yaml`, `.issues/{N}/lifecycle.yaml` | `{status: DONE \| BLOCKED, finding_summary: "Spec #N written with M SCs", artifact_path: ".issues/{N}/spec.md", blocker_reason: null}` |
-| revise-remote-body | `.issues/{N}/spec.md`, session-init values | (updates remote issue body) | `{status: DONE \| SKIPPED, finding_summary: "Remote body updated" \| "No remote API — skipped", artifact_path: null, blocker_reason: null}` |
-| completion | `.issues/{N}/spec.md`, `.issues/{N}/artifacts/` | State check report | same |
-| holistic-self-check | `.issues/{N}/spec.md` | `.issues/{N}/artifacts/holistic-self-check.yaml` | same |
-| change-control | `.issues/{N}/spec.md` (current and prior versions) | `.issues/{N}/artifacts/change-control.yaml` | same |
+| create-remote-stub | (none — platform check only) | `{project_root}/{path}/.issues/{N}/remote.md` | `{status: DONE, finding_summary: "Issue #N created via ", artifact_path: "{project_root}/{path}/.issues/{N}/remote.md", spec_number: N}` |
+| pre-spec-inspection | GitHub API for open specs, codebase | `{project_root}/{path}/.issues/{N}/artifacts/pre-spec-inspection.yaml` | `{status: DONE \| BLOCKED, finding_summary: "...", artifact_path: "...", blocker_reason: "..."}` |
+| research-card-consultation | `.opencode/.issues/research-cards/*.md` | `{project_root}/{path}/.issues/{N}/artifacts/research-cards-consulted.yaml` | `{status: DONE, finding_summary: "...", artifact_path: "...", blocker_reason: null}` |
+| requirements | brainstorming output | `{project_root}/{path}/.issues/{N}/artifacts/requirements.yaml` | same |
+| concern-analysis | `{project_root}/{path}/.issues/{N}/artifacts/requirements.yaml` | `{project_root}/{path}/.issues/{N}/artifacts/concern-map.yaml` | same |
+| decompose | `{project_root}/{path}/.issues/{N}/artifacts/requirements.yaml`, `{project_root}/{path}/.issues/{N}/artifacts/concern-map.yaml` | `{project_root}/{path}/.issues/{N}/artifacts/decomposition.yaml` | same |
+| blast-radius | `{project_root}/{path}/.issues/{N}/artifacts/decomposition.yaml` | `{project_root}/{path}/.issues/{N}/artifacts/blast-radius.yaml` | same |
+| cross-cutting | `{project_root}/{path}/.issues/{N}/artifacts/decomposition.yaml`, `{project_root}/{path}/.issues/{N}/artifacts/concern-map.yaml` | `{project_root}/{path}/.issues/{N}/artifacts/cross-cutting-matrix.yaml` | same |
+| traceability | `{project_root}/{path}/.issues/{N}/artifacts/requirements.yaml`, `{project_root}/{path}/.issues/{N}/artifacts/decomposition.yaml` | `{project_root}/{path}/.issues/{N}/artifacts/traceability.yaml` | same |
+| code-path-analysis | `{project_root}/{path}/.issues/{N}/artifacts/decomposition.yaml`, `{project_root}/{path}/.issues/{N}/artifacts/blast-radius.yaml` | `{project_root}/{path}/.issues/{N}/artifacts/code-path-inventory.yaml` | same |
+| interface-compatibility | `{project_root}/{path}/.issues/{N}/artifacts/decomposition.yaml`, `{project_root}/{path}/.issues/{N}/artifacts/concern-map.yaml` | `{project_root}/{path}/.issues/{N}/artifacts/interface-compatibility.yaml` | same |
+| state-analysis | `{project_root}/{path}/.issues/{N}/artifacts/decomposition.yaml`, `{project_root}/{path}/.issues/{N}/artifacts/interface-compatibility.yaml` | `{project_root}/{path}/.issues/{N}/artifacts/state-analysis.yaml` | same |
+| pipeline-readiness-gate | `{project_root}/{path}/.issues/{N}/spec.md` (SC table), `{project_root}/{path}/.issues/{N}/artifacts/*.yaml` | `{project_root}/{path}/.issues/{N}/artifacts/sc-pipeline-readiness.yaml` | same |
+| testability-assessment | `{project_root}/{path}/.issues/{N}/artifacts/requirements.yaml`, `{project_root}/{path}/.issues/{N}/artifacts/code-path-inventory.yaml` | `{project_root}/{path}/.issues/{N}/artifacts/testability-assessment.yaml` | same |
+| risk | `{project_root}/{path}/.issues/{N}/artifacts/requirements.yaml`, `{project_root}/{path}/.issues/{N}/artifacts/decomposition.yaml` | `{project_root}/{path}/.issues/{N}/artifacts/risk.yaml` | same |
+| interdependency-check | GitHub API for open specs | `{project_root}/{path}/.issues/{N}/artifacts/interdependency-check.yaml` | same |
+| create (local) | All prior artifacts in `{project_root}/{path}/.issues/{N}/artifacts/` | `{project_root}/{path}/.issues/{N}/spec.md`, `{project_root}/{path}/.issues/{N}/sc-summary.yaml`, `{project_root}/{path}/.issues/{N}/verification-consistency-contract.yaml`, `{project_root}/{path}/.issues/{N}/spec-to-plan-handoff.yaml`, `{project_root}/{path}/.issues/{N}/revision-re-entry-contract.yaml`, `{project_root}/{path}/.issues/{N}/lifecycle.yaml` | `{status: DONE \| BLOCKED, finding_summary: "Spec #N written with M SCs", artifact_path: "{project_root}/{path}/.issues/{N}/spec.md", blocker_reason: null}` |
+| revise-remote-body | `{project_root}/{path}/.issues/{N}/spec.md`, session-init values | (updates remote issue body) | `{status: DONE \| SKIPPED, finding_summary: "Remote body updated" \| "No remote API — skipped", artifact_path: null, blocker_reason: null}` |
+| completion | `{project_root}/{path}/.issues/{N}/spec.md`, `{project_root}/{path}/.issues/{N}/artifacts/` | State check report | same |
+| holistic-self-check | `{project_root}/{path}/.issues/{N}/spec.md` | `{project_root}/{path}/.issues/{N}/artifacts/holistic-self-check.yaml` | same |
+| change-control | `{project_root}/{path}/.issues/{N}/spec.md` (current and prior versions) | `{project_root}/{path}/.issues/{N}/artifacts/change-control.yaml` | same |
 
 ### Inline Steps (orchestrator executes directly)
 


### PR DESCRIPTION
## Summary

Replaces all hardwired `.issues/{N}/` paths in the spec-creation pipeline task files with resolved prefix patterns `{project_root}/{path}/.issues/{N}/` (for file paths) and `{path}/.issues/{N}/` (for URL/blockquote display text).

## Problem

The spec-creation pipeline hardwired `.issues/{N}/` paths throughout. When the issue belongs to a submodule repo (e.g., `.opencode`), the correct local path is `.opencode/.issues/{N}/`, not `.issues/{N}/`. This caused 404 links in remote issue bodies, sub-agent read failures, and artifact write failures.

## Changes

| File | Replacements |
|------|-------------|
| `spec-creation-validation/tasks/create.md` | ~68 |
| `spec-creation-validation/tasks/revise-remote-body.md` | 4 |
| `spec-creation-validation/tasks/completion.md` | 3 |
| `spec-creation-validation/tasks/pre-spec-inspection.md` | 2 |
| `spec-creation-validation/tasks/create-remote-stub.md` | 3 |
| `spec-creation-validation/tasks/pipeline-readiness-gate.md` | 8 |
| `spec-creation-validation/tasks/holistic-self-check.md` | 3 |
| `spec-creation/SKILL.md` | 28 |
| `spec-creation-decomposition/tasks/analytical-artifacts.md` | 5 |
| `spec-creation-requirements/tasks/requirements.md` | 1 |

## Verification

All 6 success criteria pass:
- SC-1: `revise-remote-body.md` blockquote uses `{path}/.issues/{N}/` pattern
- SC-2: `create.md` Step 37 blockquote uses `{path}/.issues/{N}/` pattern
- SC-3: No bare `.issues/` paths remain in `spec-creation-validation/tasks/`
- SC-4: No bare `.issues/` paths remain in `spec-creation/SKILL.md`
- SC-5: No bare `.issues/` paths remain in `spec-creation-decomposition/`
- SC-6: No bare `.issues/` paths remain in `spec-creation-requirements/`

Fixes #2031