### PR TITLE
[SPEC-FIX] Prefer built-ins/libraries/add-ons over bespoke code

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -148,6 +148,25 @@ The snap binary at `/snap/bin/opencode` hardcodes `SNAP_USER_DATA=~/snap/opencod
 
 ---
 
+## Prefer Built-ins Over Bespoke Code
+
+**Global mandate:** ALL agent work MUST prefer opencode built-in tools, MCP servers, standard libraries, or existing add-ons over writing bespoke code (custom scripts, inline shell commands, ad-hoc Python, one-off utilities).
+
+**Preferred alternatives (non-exhaustive):**
+- opencode built-in tools: `read`, `write`, `edit`, `glob`, `grep`
+- MCP servers: `srclight` (code search), `editor` (file editing), `the-notebook-mcp` (notebooks), GitHub MCP (API operations)
+- `vibeguard` plugin for guardrail enforcement
+- Standard shell commands (`ls`, `git`, `uv`, `bash`)
+- Python standard library (`pathlib`, `shutil`, `json`, `csv`, `re`)
+- Published packages via `pip`, `npm`, `cargo`, `go install`
+- Existing `.opencode/tools/` scripts
+
+**Feasibility justification required:** Any spec or plan that proposes new bespoke code MUST include a justification explaining why none of the existing alternatives suffice. A one-sentence rationale is sufficient.
+
+**Scope:** Forward-looking — this mandate applies to new work only. Existing bespoke code is grandfathered and does not need to be replaced.
+
+---
+
 ## `gb` CLI Tool — GitBucket Operations
 
 This repo uses the [`gb` CLI](https://github.com/Masahiro-Obuchi/gitbucket-cli-rs) (v0.6.1) for all GitBucket API operations. The `gb` tool replaces the previous bespoke `gitbucket-api` Python tool.

--- a/guidelines/060-tool-usage.md
+++ b/guidelines/060-tool-usage.md
@@ -34,6 +34,16 @@ TIER 5 — LAST RESORT: Direct CLI (bash)
 ABSOLUTE EXCEPTION: .ipynb files → the-notebook-mcp MANDATORY (zero tolerance, no fallback)
 ```
 
+### Prefer Built-ins Over Bespoke Code
+
+**Global mandate:** ALL agent work MUST prefer opencode built-in tools, MCP servers, standard libraries, or existing add-ons over writing bespoke code (custom scripts, inline shell commands, ad-hoc Python, one-off utilities). Load [the full mandate in AGENTS.md](AGENTS.md) and [080-code-standards.md](guidelines/080-code-standards.md).
+
+The five-tier hierarchy above defines the preferred tool chain. Bespoke code (custom scripts, inline shell commands, ad-hoc Python) is implicitly demoted below Tier 3 — it should only be used when no existing tool in Tiers 1-3 suffices.
+
+**Feasibility justification required:** Any spec or plan that proposes new bespoke code MUST include a justification explaining why none of the existing alternatives suffice. A one-sentence rationale is sufficient.
+
+**Scope:** Forward-looking — this mandate applies to new work only. Existing bespoke code is grandfathered and does not need to be replaced.
+
 ### 🚫 PROHIBITED (Hard stop violation)
 
 - ANY direct access to `.ipynb` files (use `the-notebook-mcp` exclusively)

--- a/guidelines/080-code-standards.md
+++ b/guidelines/080-code-standards.md
@@ -819,3 +819,20 @@ Session-init and env-loader are two independent pipelines with separate naming c
 `GIT_OWNER`, `GIT_REPO`, `GIT_PLATFORM`, `GITHUB_HTML_URL`, `GITBUCKET_HTML_URL`, `GITBUCKET_SSH_URL`, `GITBUCKET_HAS_CREDENTIALS`, `DEV_NAME`, `DEV_EMAIL`, `BRANCH_NAME`, `WORKTREE_PATH`, `WORKTREE_FATAL`
 
 These pipelines are independent. Changing session-init output names does NOT require changes to env-loader, and vice versa.
+
+## Prefer Built-ins Over Bespoke Code
+
+**Global mandate:** ALL agent work MUST prefer opencode built-in tools, MCP servers, standard libraries, or existing add-ons over writing bespoke code (custom scripts, inline shell commands, ad-hoc Python, one-off utilities).
+
+**Preferred alternatives (non-exhaustive):**
+- opencode built-in tools: `read`, `write`, `edit`, `glob`, `grep`
+- MCP servers: `srclight` (code search), `editor` (file editing), `the-notebook-mcp` (notebooks), GitHub MCP (API operations)
+- `vibeguard` plugin for guardrail enforcement
+- Standard shell commands (`ls`, `git`, `uv`, `bash`)
+- Python standard library (`pathlib`, `shutil`, `json`, `csv`, `re`)
+- Published packages via `pip`, `npm`, `cargo`, `go install`
+- Existing `.opencode/tools/` scripts
+
+**Feasibility justification required:** Any spec or plan that proposes new bespoke code MUST include a justification explaining why none of the existing alternatives suffice. A one-sentence rationale is sufficient.
+
+**Scope:** Forward-looking — this mandate applies to new work only. Existing bespoke code is grandfathered and does not need to be replaced.


### PR DESCRIPTION
## Summary

Adds a **Prefer Built-ins Over Bespoke Code** mandate to three agent-facing files:

- **`.opencode/AGENTS.md`** — Standing mandate section with global scope
- **`.opencode/guidelines/080-code-standards.md`** — New top-level section
- **`.opencode/guidelines/060-tool-usage.md`** — Subsection under Tool Priority Hierarchy

## Changes

All agent work MUST prefer opencode built-in tools, MCP servers, standard libraries, or existing add-ons over writing bespoke code (custom scripts, inline shell commands, ad-hoc Python, one-off utilities). New bespoke code requires a feasibility justification. Existing bespoke code is grandfathered.

## Fixes

Closes #2035

🤖 Co-authored with AI: OpenCode (deepseek-v4-flash)