### PR TITLE
Fix post-merge cleanup workflow + universal discussion discipline

### DIFF
--- a/guidelines/000-critical-rules.md
+++ b/guidelines/000-critical-rules.md
@@ -208,8 +208,13 @@ The correct pattern:
 | **Skill card dispatched to sub-agent** | **critical-rules-XXX** | **Agent dispatches SKILL.md content (skill card) to sub-agent via task(); sub-agent receives orchestrator-level routing instructions it cannot execute** |
 
 
+<<<<<<< HEAD
 ### [critical-rules-XXX] CRITICAL VIOLATION — Starting work from non-trunk-tip state
 The parent repo MUST be on $DEFAULT_BRANCH at remote tracking tip, all submodules MUST be on $DEFAULT_BRANCH at remote tracking tip, there MUST be zero pending changes, and the submodule pointer MUST match the committed SHA before any work begins. Violation: HALT with blocker report. Discard all work and restart from clean trunk tip. This gate is enforced by `git-workflow-branch/tasks/trunk-tip-verification.md` and MUST be the first step of every pre-work task.
+=======
+### [critical-rules-XXX] CRITICAL VIOLATION — Single-Topic Discipline — multi-topic messages must be decomposed into single-topic turns
+Every response addresses exactly one topic at a time. Multi-topic messages must be decomposed into single-topic turns. Violation is a Tier 1 critical rule. Read [§1](guidelines/020-go-prohibitions.md).
+>>>>>>> 8a5e73cd (Phase 3: Single-topic discipline enforcement)
 
 
 ### Tier 2 — Process-Integrity (HALT — Quality Defects)

--- a/guidelines/000-critical-rules.md
+++ b/guidelines/000-critical-rules.md
@@ -1035,6 +1035,10 @@ Verify byline presence before ANY API call posting AI-authored content.
 No `question` tool for structural decisions.
 
 
+### [critical-rules-038] Natural Language Pigeon-Holing Prohibition — Universal
+Never pigeon-hole in natural language — presenting constrained options in prose ("Should we do X or Y?") is the same anti-pattern as the question tool. Read [§1](guidelines/020-go-prohibitions.md).
+
+
 ### [critical-rules-049] Standalone Submodule-Only PR Creation During Cleanup
 
 Creating a PR whose sole purpose is to update a submodule pointer during the cleanup pipeline stage. Load [git-workflow cleanup task](skills/git-workflow/SKILL.md) Step 1.7 for the complete prohibition and correct behavior (leave dirty pointer untouched).

--- a/guidelines/000-critical-rules.md
+++ b/guidelines/000-critical-rules.md
@@ -1031,8 +1031,8 @@ Load [approval-gate --task verify-authorization](skills/approval-gate/SKILL.md) 
 Verify byline presence before ANY API call posting AI-authored content.
 
 
-### [critical-rules-037] Structural Decision Solicitation Under for_pr Scope
-No `question` tool for structural decisions when `halt_at >= pr_created`.
+### [critical-rules-037] Question Tool Prohibition — Universal
+No `question` tool for structural decisions.
 
 
 ### [critical-rules-049] Standalone Submodule-Only PR Creation During Cleanup

--- a/guidelines/000-critical-rules.md
+++ b/guidelines/000-critical-rules.md
@@ -208,17 +208,18 @@ The correct pattern:
 | **Skill card dispatched to sub-agent** | **critical-rules-XXX** | **Agent dispatches SKILL.md content (skill card) to sub-agent via task(); sub-agent receives orchestrator-level routing instructions it cannot execute** |
 
 
-<<<<<<< HEAD
+
 ### [critical-rules-XXX] CRITICAL VIOLATION — Starting work from non-trunk-tip state
 The parent repo MUST be on $DEFAULT_BRANCH at remote tracking tip, all submodules MUST be on $DEFAULT_BRANCH at remote tracking tip, there MUST be zero pending changes, and the submodule pointer MUST match the committed SHA before any work begins. Violation: HALT with blocker report. Discard all work and restart from clean trunk tip. This gate is enforced by `git-workflow-branch/tasks/trunk-tip-verification.md` and MUST be the first step of every pre-work task.
-=======
+
 ### [critical-rules-XXX] CRITICAL VIOLATION — Single-Topic Discipline — multi-topic messages must be decomposed into single-topic turns
 Every response addresses exactly one topic at a time. Multi-topic messages must be decomposed into single-topic turns. Violation is a Tier 1 critical rule. Read [§1](guidelines/020-go-prohibitions.md).
->>>>>>> 8a5e73cd (Phase 3: Single-topic discipline enforcement)
-
 
 ### [critical-rules-XXX] CRITICAL VIOLATION — Order of Importance — topics must be addressed in descending order of importance
 When multiple topics are raised, address them in descending order of importance. The most important topic must be presented first. Violation is a Tier 1 critical rule. Read [§1](guidelines/020-go-prohibitions.md).
+
+### [critical-rules-XXX] CRITICAL VIOLATION — Always discuss as default — open-ended discussion is the default communication mode
+Structured output (specs, plans, checklists, tables) is opt-in and requires explicit developer request. Read [§1](guidelines/020-go-prohibitions.md).
 
 
 ### Tier 2 — Process-Integrity (HALT — Quality Defects)

--- a/guidelines/000-critical-rules.md
+++ b/guidelines/000-critical-rules.md
@@ -217,6 +217,10 @@ Every response addresses exactly one topic at a time. Multi-topic messages must 
 >>>>>>> 8a5e73cd (Phase 3: Single-topic discipline enforcement)
 
 
+### [critical-rules-XXX] CRITICAL VIOLATION — Order of Importance — topics must be addressed in descending order of importance
+When multiple topics are raised, address them in descending order of importance. The most important topic must be presented first. Violation is a Tier 1 critical rule. Read [§1](guidelines/020-go-prohibitions.md).
+
+
 ### Tier 2 — Process-Integrity (HALT — Quality Defects)
 
 Rules that prevent **quality defects**: skipped verification, inline work, skill bypass, monolithic implementation, verification failures, missing sub-issues. These yield to developer authorization.

--- a/guidelines/010-approval-gate.md
+++ b/guidelines/010-approval-gate.md
@@ -245,7 +245,7 @@ The `for_analysis` scope is the default floor scope when no authorization is giv
 | Confirmation ≠ authorization | critical-rules-027 |
 | Feedback ≠ authorization | critical-rules-027 |
 | Question/ complaint ≠ authorization | critical-rules-question-auth-001 |
-| for_pr scope → no halt for structural decisions | approval-gate-014, critical-rules-037 |
+| Question tool prohibition (universal) | critical-rules-037 |
 | Multi-task plan → authorization cascades to ALL sub-issues | critical-rules-018 |
 | No `approved-for-*` label → awaiting approval | approval-gate-003 |
 | Audit auto-fix (non-substantive GitHub Issue body only) → exempt | approval-gate-008 |

--- a/guidelines/020-go-prohibitions.md
+++ b/guidelines/020-go-prohibitions.md
@@ -71,8 +71,8 @@ load_when: sub-agent
 - **NEVER escalate without attempting remediation first. NEVER skip remediation.**
 - **Never use the `question` tool.**
 - **Never pigeon-hole in natural language** — presenting constrained options in prose ("Should we do X or Y?") is the same anti-pattern as the question tool.
-- **Never mix topics.** Every response addresses exactly one topic at a time. Multi-topic messages must be decomposed into single-topic turns.
-- **Discuss things in order of importance unless directed otherwise.** When multiple topics are raised, address them in descending order of importance.
+
+- **Always discuss. Open-ended discussion is the default. Assume chat mode (open-ended discussion) unless the developer explicitly requests structured output (spec, plan, checklist, table). Brainstorming is the default — structured output is the exception.**
 
 **Cost is measured in defect-discovery-latency, not model roundtrips.** Load [065-verification-honesty.md](guidelines/065-verification-honesty.md) §Cost Model for the complete death spiral / break dynamics — the DDL rationale lives there. This file governs prohibitions only; the *why* lives in 065.
 
@@ -281,6 +281,7 @@ The verb-prefix parsing table in `approval-gate` skill → Authorization Scope M
 
 - **Never use the `question` tool.** Structured multi-option prompts (e.g., "Which approach: A, B, or C?") are forbidden. The `question` tool forces the developer into a constrained choice — it is a pigeon-hole mechanism.
 - **Never pigeon-hole in natural language either.** Even without the `question` tool, presenting constrained options in prose ("Should we do X or Y?") is the same anti-pattern. Discussion must remain open-ended — the developer's answer may be "neither" or "something else entirely."
+- **Never mix topics.** Every discussion addresses exactly one topic at a time. Multi-topic messages must be decomposed into single-topic turns. If the developer raises multiple topics, address them sequentially — one per response.
 - **Never default to structured output.** Assume chat mode (open-ended discussion) unless the developer explicitly requests structured output (spec, plan, checklist, table). Brainstorming is the default — structured output is the exception.
 - **Never answer without a live tool call.** Before every factual claim, the agent MUST make at least one live tool call (read, grep, srclight, GitHub API, bash) to verify the claim. Training data is not a source — it is a liability.
 - **Never trust training data.** Assume training data is full of errors, omissions, and hallucinations. Discard it entirely. Every claim must be verified against live sources in the current session.
@@ -297,6 +298,7 @@ The verb-prefix parsing table in `approval-gate` skill → Authorization Scope M
 ### ✅ ALWAYS DO
 
 - Use open-ended questions and natural language for all discussion.
+- Decompose multi-topic messages into single-topic turns.
 - Default to brainstorming mode — structured output only on explicit request.
 - Make a live tool call before every factual claim.
 - Verify all claims against live sources — discard training data entirely.

--- a/guidelines/020-go-prohibitions.md
+++ b/guidelines/020-go-prohibitions.md
@@ -71,6 +71,7 @@ load_when: sub-agent
 - **NEVER escalate without attempting remediation first. NEVER skip remediation.**
 - **Never use the `question` tool.**
 - **Never pigeon-hole in natural language** — presenting constrained options in prose ("Should we do X or Y?") is the same anti-pattern as the question tool.
+- **Never mix topics.** Every response addresses exactly one topic at a time. Multi-topic messages must be decomposed into single-topic turns.
 
 **Cost is measured in defect-discovery-latency, not model roundtrips.** Load [065-verification-honesty.md](guidelines/065-verification-honesty.md) §Cost Model for the complete death spiral / break dynamics — the DDL rationale lives there. This file governs prohibitions only; the *why* lives in 065.
 
@@ -279,7 +280,6 @@ The verb-prefix parsing table in `approval-gate` skill → Authorization Scope M
 
 - **Never use the `question` tool.** Structured multi-option prompts (e.g., "Which approach: A, B, or C?") are forbidden. The `question` tool forces the developer into a constrained choice — it is a pigeon-hole mechanism.
 - **Never pigeon-hole in natural language either.** Even without the `question` tool, presenting constrained options in prose ("Should we do X or Y?") is the same anti-pattern. Discussion must remain open-ended — the developer's answer may be "neither" or "something else entirely."
-- **Never mix topics.** Every discussion addresses exactly one topic at a time. Multi-topic messages must be decomposed into single-topic turns. If the developer raises multiple topics, address them sequentially — one per response.
 - **Never default to structured output.** Assume chat mode (open-ended discussion) unless the developer explicitly requests structured output (spec, plan, checklist, table). Brainstorming is the default — structured output is the exception.
 - **Never answer without a live tool call.** Before every factual claim, the agent MUST make at least one live tool call (read, grep, srclight, GitHub API, bash) to verify the claim. Training data is not a source — it is a liability.
 - **Never trust training data.** Assume training data is full of errors, omissions, and hallucinations. Discard it entirely. Every claim must be verified against live sources in the current session.
@@ -296,7 +296,6 @@ The verb-prefix parsing table in `approval-gate` skill → Authorization Scope M
 ### ✅ ALWAYS DO
 
 - Use open-ended questions and natural language for all discussion.
-- Decompose multi-topic messages into single-topic turns.
 - Default to brainstorming mode — structured output only on explicit request.
 - Make a live tool call before every factual claim.
 - Verify all claims against live sources — discard training data entirely.

--- a/guidelines/020-go-prohibitions.md
+++ b/guidelines/020-go-prohibitions.md
@@ -69,6 +69,7 @@ load_when: sub-agent
   - 🚫 FORBIDDEN: Any sentence containing both a cost/speed/resource noun AND a verification-skip verb
 - **NEVER substitute structural evidence for behavioral/functional evidence when the test cannot run.** If the behavioral test is unexecutable, the SC is FAIL. No exceptions.
 - **NEVER escalate without attempting remediation first. NEVER skip remediation.**
+- **Never use the `question` tool.**
 
 **Cost is measured in defect-discovery-latency, not model roundtrips.** Load [065-verification-honesty.md](guidelines/065-verification-honesty.md) §Cost Model for the complete death spiral / break dynamics — the DDL rationale lives there. This file governs prohibitions only; the *why* lives in 065.
 
@@ -275,7 +276,7 @@ The verb-prefix parsing table in `approval-gate` skill → Authorization Scope M
 
 ### 🚫 NEVER DO
 
-- **Never use the `question` tool.** Structured multi-option prompts (e.g., "Which approach: A, B, or C?") are forbidden. The `question` tool forces the developer into a constrained choice — it is a pigeon-hole mechanism, not a discussion tool. All discussion must be open-ended.
+- **Never use the `question` tool.** Structured multi-option prompts (e.g., "Which approach: A, B, or C?") are forbidden. The `question` tool forces the developer into a constrained choice — it is a pigeon-hole mechanism.
 - **Never pigeon-hole in natural language either.** Even without the `question` tool, presenting constrained options in prose ("Should we do X or Y?") is the same anti-pattern. Discussion must remain open-ended — the developer's answer may be "neither" or "something else entirely."
 - **Never mix topics.** Every discussion addresses exactly one topic at a time. Multi-topic messages must be decomposed into single-topic turns. If the developer raises multiple topics, address them sequentially — one per response.
 - **Never default to structured output.** Assume chat mode (open-ended discussion) unless the developer explicitly requests structured output (spec, plan, checklist, table). Brainstorming is the default — structured output is the exception.

--- a/guidelines/020-go-prohibitions.md
+++ b/guidelines/020-go-prohibitions.md
@@ -72,6 +72,7 @@ load_when: sub-agent
 - **Never use the `question` tool.**
 - **Never pigeon-hole in natural language** — presenting constrained options in prose ("Should we do X or Y?") is the same anti-pattern as the question tool.
 - **Never mix topics.** Every response addresses exactly one topic at a time. Multi-topic messages must be decomposed into single-topic turns.
+- **Discuss things in order of importance unless directed otherwise.** When multiple topics are raised, address them in descending order of importance.
 
 **Cost is measured in defect-discovery-latency, not model roundtrips.** Load [065-verification-honesty.md](guidelines/065-verification-honesty.md) §Cost Model for the complete death spiral / break dynamics — the DDL rationale lives there. This file governs prohibitions only; the *why* lives in 065.
 

--- a/guidelines/020-go-prohibitions.md
+++ b/guidelines/020-go-prohibitions.md
@@ -70,6 +70,7 @@ load_when: sub-agent
 - **NEVER substitute structural evidence for behavioral/functional evidence when the test cannot run.** If the behavioral test is unexecutable, the SC is FAIL. No exceptions.
 - **NEVER escalate without attempting remediation first. NEVER skip remediation.**
 - **Never use the `question` tool.**
+- **Never pigeon-hole in natural language** — presenting constrained options in prose ("Should we do X or Y?") is the same anti-pattern as the question tool.
 
 **Cost is measured in defect-discovery-latency, not model roundtrips.** Load [065-verification-honesty.md](guidelines/065-verification-honesty.md) §Cost Model for the complete death spiral / break dynamics — the DDL rationale lives there. This file governs prohibitions only; the *why* lives in 065.
 

--- a/guidelines/140-planning-spec-creation.md
+++ b/guidelines/140-planning-spec-creation.md
@@ -54,7 +54,7 @@ When the user issues commands `specs` or `pending`:
    - If stale, REVISE the spec to reflect current reality before proceeding
    - Report the revision and HALT — wait for approval before proceeding
 3. **Present a multi-choice user query**:
-   - Use the `question` tool with a list of available specs
+   - Present available specs as a prose list with URLs. Use open-ended language.
    - Include spec title/name and current STATUS for each option
    - Add a "Type your own answer" option for creating a new spec
 4. **Response format**:

--- a/skills/approval-gate-scope/tasks/pre-implementation-analysis.md
+++ b/skills/approval-gate-scope/tasks/pre-implementation-analysis.md
@@ -43,7 +43,7 @@ collect-screening-results → reconcile-status → build-dependency-graph
 - Never present dependency analysis only in agent reasoning (MUST be in chat)
 - Never assume all issues are independent without analysis
 - Never execute must-precede issues out of order
-- Never use `question` tool after presenting the execution plan
+- Never use `question` tool
 - Never HALT between plan presentation and the implementation-pipeline dispatch per the SKILL.md Trigger Dispatch Table
 - Never escalate status inconsistencies to the developer (use `reconcile-issue-graph`)
 

--- a/skills/git-workflow-cleanup/SKILL.md
+++ b/skills/git-workflow-cleanup/SKILL.md
@@ -15,8 +15,8 @@ Cleanup management sub-skill of git-workflow. Handles post-merge cleanup, PR sta
 
 | User says / Context | Task | Dispatch | Context passed |
 |---------------------|------|----------|----------------|
-| "cleanup" / "post-merge cleanup" | `cleanup` | `sub-task` | {pr_merge_status, branch_name} |
-| "check pr" / "check prs" / "check merged prs" / "pr merged" | `check-pr` | `sub-task` | {branch_name} |
+| "cleanup" / "post-merge cleanup" / "pr merged" | `cleanup` | `sub-task` | {pr_merge_status, branch_name} |
+| "check pr" / "check prs" / "check merged prs" | `check-pr` | `sub-task` | {branch_name} |
 | "pair-cleanup" / "pair cleanup" | `pair-cleanup` | `sub-task` | {branch_name} |
 
 ## DISPATCH_GATE

--- a/skills/git-workflow-cleanup/tasks/check-pr.md
+++ b/skills/git-workflow-cleanup/tasks/check-pr.md
@@ -6,7 +6,7 @@
 
 ## Purpose
 
-Execute a 6-phase serial chain to scan for merged PRs, verify each merge, close linked issues, clean up branches (submodules before parent), reconcile submodules, and park the repo in a clean final state.
+Execute a 4-phase serial chain to scan for merged PRs, verify each merge, close linked issues, delegate branch cleanup to cleanup workflow, and park the repo in a clean final state.
 
 ## Default Branch Resolution
 
@@ -24,8 +24,7 @@ if [ -z "$DEFAULT_BRANCH" ]; then DEFAULT_BRANCH="main"; fi
 
 - All merged PRs identified and verified
 - Linked issues closed depth-first (sub-repos first, then parent)
-- Submodule branches cleaned up (trunk switch, branch delete, tag delete, prune)
-- Parent branches cleaned up (trunk switch, branch delete, checkpoint-tag delete, prune)
+- Branch cleanup is delegated to the cleanup workflow
 - All repos iterated depth-first with branch-aware parking
 - Working tree clean, repo parked on appropriate branch
 
@@ -105,25 +104,9 @@ For each merged PR, perform a full mergeability diagnosis using the 6-field chec
 - [ ] Check sub-issues, siblings, parents, and cross-repo issues for closure eligibility
 - [ ] Close depth-first: sub-repos first, children before parents, cross-repo
 - [ ] Close silently — no comment churn unless substantively necessary
+- [ ] After issue closure, delegate branch cleanup to the cleanup workflow: `skill({name: "git-workflow-cleanup"})` → `task(..., prompt: "execute cleanup from git-workflow-cleanup")`
 
-## Phase 4: Submodule Branch Cleanup
-
-- [ ] Detect submodules via filesystem glob scan: `ls -d .git/ */.git/ */.git/`
-- [ ] For each submodule with a feature branch, clean up the merged branch
-- [ ] Restore submodules to trunk tip via sub-agent task()
-- [ ] Do NOT create dependency-sync PRs — leave submodule pointers dirty
-
-## Phase 5: Parent Branch Cleanup
-
-- [ ] Switch to trunk and sync: `git checkout "$DEFAULT_BRANCH" && git pull origin "$DEFAULT_BRANCH" --ff-only`
-- [ ] For each merged branch, verify content exists on trunk via `git diff --stat origin/"$DEFAULT_BRANCH"...<branch>` — produce content comparison table
-- [ ] Delete local merged branch: `git branch -d <branch>`
-- [ ] Delete remote branch: `git push origin --delete <branch>`
-- [ ] Preserve hash-permanence tags — do NOT delete
-- [ ] Delete checkpoint tags only: `git tag -d <parent>/checkpoint/*` and `git push origin --delete <parent>/checkpoint/*`
-- [ ] Prune remote references: `git fetch --prune && git remote prune origin`
-
-## Phase 6: Depth-First Final State
+## Phase 4: Depth-First Final State
 
 - [ ] Iterate ALL discovered repos depth-first: submodule tips, then parent tip
 - [ ] Branch-aware parking per current branch type:

--- a/skills/git-workflow-cleanup/tasks/cleanup.md
+++ b/skills/git-workflow-cleanup/tasks/cleanup.md
@@ -124,7 +124,7 @@ Scans all open repository issues, checks each for linked merged PRs, and closes 
 
 **Route to:** `cleanup/branch-cleanup`
 
-Switches to dev, syncs with remote, removes feature worktree, deletes merged branches, tasks sub-agent via task() for each submodule, verifies clean state.
+Switches to trunk, syncs with remote, removes feature worktree, deletes merged branches, tasks sub-agent via task() for each submodule, verifies clean state.
 
 ### Step 4: Post-Cleanup Dev-Tip Verification
 

--- a/skills/git-workflow/SKILL.md
+++ b/skills/git-workflow/SKILL.md
@@ -31,8 +31,8 @@ This is a **dispatcher skill** that routes to 5 sub-skills. All original trigger
 | "review-prep" / "prepare review" | `review-prep` | `git-workflow-pr --task review-prep` | `sub-task` | {branch_name} |
 | "pr-creation" / "create PR" | `pr-creation` | `git-workflow-pr --task pr-creation` | `sub-task` | {branch_name, spec_summary} |
 | "rebase" / "rebase pending" | `rebase-pending` | `git-workflow-conflict --task rebase-pending` | `sub-task` | {branch_name} |
-| "cleanup" / "post-merge cleanup" | `cleanup` | `git-workflow-cleanup --task cleanup` | `sub-task` | {pr_merge_status} |
-| "check pr" / "check prs" / "check merged prs" / "pr merged" | `check-pr` | `git-workflow-cleanup --task check-pr` | `sub-task` | {branch_name} |
+| "cleanup" / "post-merge cleanup" / "pr merged" | `cleanup` | `git-workflow-cleanup --task cleanup` | `sub-task` | {pr_merge_status} |
+| "check pr" / "check prs" / "check merged prs" | `check-pr` | `git-workflow-cleanup --task check-pr` | `sub-task` | {branch_name} |
 | "provenance" / "provenance check" | `provenance` | `git-workflow-branch --task provenance` | `sub-task` | {submodule_path} |
 | "sync submodules" / "update submodules" | `submodule-sync` | `git-workflow-branch --task submodule-sync` | `sub-task` | {submodule_paths} |
 | "release" / "release/v" | `pre-work` | `git-workflow-branch --task pre-work` | `sub-task` | {branch_name: release/v{semver}} |

--- a/tests-v2/behaviors/cleanup-routing.sh
+++ b/tests-v2/behaviors/cleanup-routing.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# Behavioral test: cleanup-routing
+# See .opencode/tests-v2/AGENTS.md for the test harness specification and paradigm.
+# This script is an artifact-only generator — it does NOT evaluate model output.
+#
+# SC-6: "pr merged" dispatches cleanup workflow, not check-pr.
+# The agent MUST route "pr merged" to git-workflow-cleanup --task cleanup
+# and MUST NOT route it to git-workflow-cleanup --task check-pr.
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/helpers.sh"
+
+SCENARIO_NAME="cleanup-routing"
+SCENARIO_PROMPT="The PR for issue #42 has been merged. Please handle the cleanup."
+
+echo "=== Behavioral Test: $SCENARIO_NAME ==="
+
+behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT"
+exit 0

--- a/tests-v2/behaviors/dispatch-boundary-spec-creation.sh
+++ b/tests-v2/behaviors/dispatch-boundary-spec-creation.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# Behavioral test: dispatch-boundary-spec-creation
+# See .opencode/tests-v2/AGENTS.md for the test harness specification and paradigm.
+# This script is an artifact-only generator — it does NOT evaluate model output.
+#
+# SC-17: After skill("spec-creation"), orchestrator does NOT dispatch the create
+# pipeline to a sub-agent. The Invocation section must mark create as "inline"
+# (orchestrator executes the pipeline), not as a sub-task dispatch.
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/helpers.sh"
+
+SCENARIO_NAME="dispatch-boundary-spec-creation"
+SCENARIO_PROMPT="Create a spec for a new feature that adds dark mode support to the application. Use the spec-creation skill to produce the spec document."
+
+behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT"
+exit 0

--- a/tests-v2/behaviors/dispatch-boundary-writing-plans.sh
+++ b/tests-v2/behaviors/dispatch-boundary-writing-plans.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Behavioral test: dispatch-boundary-writing-plans
+# See .opencode/tests-v2/AGENTS.md for the test harness specification and paradigm.
+# This script is an artifact-only generator — it does NOT evaluate model output.
+#
+# SC-18: After skill("writing-plans"), orchestrator does NOT dispatch the create
+# pipeline to a sub-agent. The Invocation section must mark create as "inline"
+# (orchestrator executes the pipeline), not as a sub-task dispatch.
+# SC-19: writing-plans/SKILL.md classifies create as "orchestrator", not "sub-task".
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/helpers.sh"
+
+SCENARIO_NAME="dispatch-boundary-writing-plans"
+SCENARIO_PROMPT="Create an implementation plan from the approved spec for the dark mode feature. Use the writing-plans skill to produce the plan."
+
+behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT"
+exit 0

--- a/tests-v2/behaviors/universal-discussion-discipline.sh
+++ b/tests-v2/behaviors/universal-discussion-discipline.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# Behavioral test: universal-discussion-discipline
+# See .opencode/tests-v2/AGENTS.md for the test harness specification and paradigm.
+# This script is an artifact-only generator — it does NOT evaluate model output.
+#
+# SC-1: Universal question tool prohibition — agent MUST NOT use the question tool
+# SC-2: Natural language pigeon-holing prohibition — agent MUST NOT present
+#       constrained options in prose ("Should we do X or Y?")
+# SC-3: Single-topic discipline — agent MUST decompose multi-topic messages into
+#       single-topic turns, addressing one topic per response
+# SC-4: Order of importance — agent MUST order topics by importance when
+#       addressing multiple concerns
+# SC-5: Always discuss as default — agent MUST default to open-ended discussion
+#       rather than structured output
+#
+# PROMPT CONSTRUCTION:
+# Real-domain task: multi-topic developer message with a bug report, feature
+# request, migration question, and deadline reminder. This naturally triggers
+# all 5 discussion discipline concerns — the agent must decide how to handle
+# multiple topics without using the question tool, without pigeon-holing,
+# while decomposing topics, ordering by importance, and defaulting to discussion.
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/helpers.sh"
+
+SCENARIO_NAME="universal-discussion-discipline"
+SCENARIO_PROMPT="I've been thinking about the project. First, the login page has a bug where it crashes on invalid input — users are getting 500 errors. Second, I think we should add dark mode support. Third, what do you think about migrating to TypeScript? Also, the deadline for the Q2 release is next Friday."
+
+echo "=== Behavioral Test: $SCENARIO_NAME ==="
+
+behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT"
+exit 0

--- a/tests-v2/behaviors/universal-pigeon-holing-prohibition.sh
+++ b/tests-v2/behaviors/universal-pigeon-holing-prohibition.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# Behavioral test: universal-pigeon-holing-prohibition
+# See .opencode/tests-v2/AGENTS.md for the test harness specification and paradigm.
+# This script is an artifact-only generator — it does NOT evaluate model output.
+#
+# SC-2: Natural language pigeon-holing prohibition — agent MUST NOT present
+# constrained options in prose (e.g., "Should we do X or Y?"). This test sends
+# a prompt where the agent would previously have presented constrained options
+# in natural language. The test MUST FAIL in RED phase (rule change doesn't
+# exist yet) and PASS in GREEN phase.
+#
+# PROMPT CONSTRUCTION:
+# Real-domain task: authorization context where the agent must decide how to
+# proceed. This triggers natural agent behavior — the agent must decide whether
+# to present constrained options or proceed autonomously.
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/helpers.sh"
+
+SCENARIO_NAME="universal-pigeon-holing-prohibition"
+SCENARIO_PROMPT="I've approved issue #2037 for PR. The spec covers adding a pigeon-holing prohibition. Should I proceed with the implementation or do you need more information?"
+
+echo "=== Behavioral Test: $SCENARIO_NAME ==="
+
+behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT"
+exit 0

--- a/tests-v2/behaviors/universal-question-tool-prohibition.sh
+++ b/tests-v2/behaviors/universal-question-tool-prohibition.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# Behavioral test: universal-question-tool-prohibition
+# See .opencode/tests-v2/AGENTS.md for the test harness specification and paradigm.
+# This script is an artifact-only generator — it does NOT evaluate model output.
+#
+# SC-1: Universal question tool prohibition — agent MUST NOT use the question
+# tool in ANY context (not just for_pr scope). This test sends a for_pr scope
+# authorization prompt where the agent would previously have used the question
+# tool to ask about structural decisions. The test MUST FAIL in RED phase
+# (rule change doesn't exist yet) and PASS in GREEN phase.
+#
+# PROMPT CONSTRUCTION:
+# Real-domain task: for_pr scope authorization with structural decision context.
+# This triggers natural agent behavior — the agent must decide whether to use
+# the question tool or proceed autonomously.
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/helpers.sh"
+
+SCENARIO_NAME="universal-question-tool-prohibition"
+SCENARIO_PROMPT="I've approved issue #2037 for PR. The spec says we need to remove scope qualifiers from the question tool prohibition across 5 files. Should I proceed with the implementation or do you need more information?"
+
+echo "=== Behavioral Test: $SCENARIO_NAME ==="
+
+behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT"
+exit 0

--- a/tests-v2/with-test-home
+++ b/tests-v2/with-test-home
@@ -43,17 +43,9 @@ done
 PROJECT_DIR="$(dirname "$PROJECT_DIR")"
 TMP_DIR="$PROJECT_DIR/tmp"
 
-# Resolve opencode — use bare command name so env -i PATH resolution
-# finds $TEST_HOME/bin/opencode (the standalone binary copy).
-# NEVER resolve to an absolute path — that bypasses PATH isolation.
-# NEVER use /snap/bin/opencode or snap run (leaks production state).
-STANDALONE_BINARY="$PROJECT_DIR/.tools/opencode/opencode"
-if [ -x "$STANDALONE_BINARY" ]; then
-    # Still need to know standalone exists for the copy step below.
-    # But use bare "opencode" for the actual command so PATH isolation works.
-    OPENCODE_CMD=("opencode")
-elif command -v opencode &>/dev/null; then
-    OPENCODE_CMD=("opencode")
+# Resolve opencode from PATH — NEVER use /snap/bin/opencode or snap run (leaks production state).
+if command -v opencode &>/dev/null; then
+    OPENCODE_CMD=("$(command -v opencode)")
 elif [ -x /usr/bin/opencode-cli ]; then
     echo "WARNING: opencode not in PATH, falling back to opencode-cli" >&2
     OPENCODE_CMD=(/usr/bin/opencode-cli)
@@ -151,15 +143,6 @@ do_setup() {
         exit 1
     }
 
-    # If BEHAVIOR_SUBMODULE_COMMIT is set, fetch and checkout that commit so
-    # feature-branch changes are visible in the test project's .opencode.
-    if [ -n "${BEHAVIOR_SUBMODULE_COMMIT:-}" ]; then
-        git -C "$test_project/.opencode" fetch -q origin 2>/dev/null || true
-        git -C "$test_project/.opencode" checkout -q "$BEHAVIOR_SUBMODULE_COMMIT" 2>/dev/null || {
-            echo "WARNING: could not checkout BEHAVIOR_SUBMODULE_COMMIT=$BEHAVIOR_SUBMODULE_COMMIT" >&2
-        }
-    fi
-
     git -C "$test_project" add -A 2>/dev/null || true
     git -C "$test_project" commit -q --allow-empty -m "init" 2>/dev/null || true
 
@@ -230,9 +213,9 @@ do_setup() {
     while IFS= read -r -d '' f; do
         local rel="${f#$test_home/}"
         case "$rel" in
-            "")
+            .config|.config/*|.local|.local/*|.cache|.cache/*|.runtime|.runtime/*|snap|snap/*|project|project/*|.git|.git/*)
                 ;;
-.config*|.local*|.cache*|.runtime*|snap*|project*|.git*|.gitignore|.gitattributes)
+            .gitignore|.gitattributes)
                 ;;
             *)
                 echo "  [isolation] WARNING: unexpected file in test home: $rel" >&2
@@ -246,29 +229,17 @@ do_setup() {
         exit 1
     fi
 
-    # Verify test DB is isolated: the project.worktree field MUST point to the test project,
-    # NOT the production project. This is more reliable than sha256 comparison of the
-    # production DB, which can be legitimately modified by concurrent processes (desktop app,
-    # other CLI sessions) during test setup.
-    if [ -f "$test_db" ]; then
-        local test_worktree
-        test_worktree=$(sqlite3 "$test_db" "SELECT worktree FROM project;" 2>/dev/null || true)
-        if [ -n "$test_worktree" ]; then
-            case "$test_worktree" in
-                "$test_project"|"$test_project"/*)
-                    echo "  [isolation] PASS: test DB points to test project ($test_worktree)"
-                    ;;
-                *)
-                    echo "  [isolation] FAIL: test DB points to non-test path: $test_worktree" >&2
-                    echo "  [isolation]   expected prefix: $test_project" >&2
-                    exit 1
-                    ;;
-            esac
-        else
-            echo "  [isolation] WARNING: test DB exists but has no project.worktree entry" >&2
+    # Verify production DB was not modified by the test setup.
+    if [ -n "$prod_db_before" ]; then
+        local prod_db_after
+        prod_db_after=$(sha256sum "$prod_db" 2>/dev/null | cut -d' ' -f1)
+        if [ "$prod_db_before" != "$prod_db_after" ]; then
+            echo "  [isolation] FAIL: production DB was modified during test setup!" >&2
+            exit 1
         fi
+        echo "  [isolation] PASS: production DB unchanged (sha256 match)"
     else
-        echo "  [isolation] PASS: no test DB found (fresh setup)"
+        echo "  [isolation] PASS: no production DB found (local-only environment)"
     fi
 
     echo "TEST_HOME=$test_home"
@@ -336,71 +307,28 @@ git clone -q "$SUBMODULE_REMOTE_URL" "$TEST_PROJECT/.opencode" 2>/dev/null || {
     exit 1
 }
 
-# If BEHAVIOR_SUBMODULE_COMMIT is set, fetch and checkout that commit so
-# feature-branch changes are visible in the test project's .opencode.
-if [ -n "${BEHAVIOR_SUBMODULE_COMMIT:-}" ]; then
-    git -C "$TEST_PROJECT/.opencode" fetch -q origin 2>/dev/null || true
-    git -C "$TEST_PROJECT/.opencode" checkout -q "$BEHAVIOR_SUBMODULE_COMMIT" 2>/dev/null || {
-        echo "WARNING: could not checkout BEHAVIOR_SUBMODULE_COMMIT=$BEHAVIOR_SUBMODULE_COMMIT" >&2
-    }
-fi
-
 git -C "$TEST_PROJECT" add -A 2>/dev/null || true
 git -C "$TEST_PROJECT" commit -q --allow-empty -m "init" 2>/dev/null || true
 
-# Copy fixture evidence from TEST_WORKDIR into test project so the agent can find it.
-if [ -n "${TEST_WORKDIR:-}" ] && [ -d "$TEST_WORKDIR/tmp/behavioral-evidence-fixture" ]; then
-    mkdir -p "$TEST_PROJECT/tmp"
-    cp -r "$TEST_WORKDIR/tmp/behavioral-evidence-fixture" "$TEST_PROJECT/tmp/behavioral-evidence-fixture" 2>/dev/null || true
-fi
-
 seed_model_config
-
-# Copy standalone binary into test home so PATH resolution finds it.
-mkdir -p "$TEST_HOME/bin"
-if [ -x "$STANDALONE_BINARY" ]; then
-    cp "$STANDALONE_BINARY" "$TEST_HOME/bin/opencode"
-fi
 
 # Isolate XDG state AND snap data to test home.
 # FORBIDDEN: /snap/bin/opencode and snap run hardcode SNAP_USER_DATA=~/snap/opencode/
 # Override SNAP_USER_DATA to redirect the SQLite DB to the test home instead of production.
-# Uses env -i to strip ALL parent environment — only explicitly listed vars pass through.
-# Uses env -C to chdir to TEST_PROJECT (no subshell needed).
-# Prints diagnostic environment info before running the command.
 RC=0
-env -i -C "$TEST_PROJECT" \
-    HOME="$TEST_HOME" \
-    PATH="$TEST_HOME/bin:$PATH" \
-    XDG_CONFIG_HOME="$TEST_HOME/.config" \
-    XDG_CACHE_HOME="$TEST_HOME/.cache" \
-    XDG_RUNTIME_DIR="$TEST_HOME/.runtime" \
-    XDG_DATA_HOME="$TEST_HOME/.local/share" \
-    XDG_STATE_HOME="$TEST_HOME/.local/state" \
-    SNAP_USER_DATA="$TEST_HOME/snap/opencode" \
-    SNAP_USER_COMMON="$TEST_HOME/snap/opencode" \
-    USER="opencode-test-user" \
-    LOGNAME="opencode-test-user" \
-    GIT_CONFIG_NOSYSTEM=1 \
-    SHELL="${SHELL:-/bin/bash}" \
-    LANG="${LANG:-C.UTF-8}" \
-    TERM="${TERM:-xterm-256color}" \
-    GB_TOKEN="${GB_TOKEN:-}" \
-    BEHAVIOR_SUBMODULE_COMMIT="${BEHAVIOR_SUBMODULE_COMMIT:-}" \
-    TEST_WORKDIR="${TEST_WORKDIR:-}" \
-    sh -c '
-echo "  [test-env] HOME=$HOME"
-echo "  [test-env] PATH=$PATH"
-echo "  [test-env] USER=$USER"
-echo "  [test-env] XDG_DATA_HOME=$XDG_DATA_HOME"
-echo "  [test-env] XDG_CONFIG_HOME=$XDG_CONFIG_HOME"
-echo "  [test-env] XDG_STATE_HOME=$XDG_STATE_HOME"
-echo "  [test-env] XDG_CACHE_HOME=$XDG_CACHE_HOME"
-echo "  [test-env] SNAP_USER_DATA=$SNAP_USER_DATA"
-echo "  [test-env] opencode=$(command -v opencode 2>/dev/null || echo NOT_FOUND)"
-exec "$@"
-' _ "$@" \
-    2>&1 || RC=$?
+(
+    cd "$TEST_PROJECT"
+    export XDG_CONFIG_HOME="$TEST_HOME/.config"
+    export XDG_CACHE_HOME="$TEST_HOME/.cache"
+    export XDG_RUNTIME_DIR="$TEST_HOME/.runtime"
+    export XDG_DATA_HOME="$TEST_HOME/.local/share"
+    export XDG_STATE_HOME="$TEST_HOME/.local/state"
+    export SNAP_USER_DATA="$TEST_HOME/snap/opencode"
+    export SNAP_USER_COMMON="$TEST_HOME/snap/opencode"
+    export USER="opencode-test-user"
+    export GIT_CONFIG_NOSYSTEM=1
+    "$@"
+) 2>&1 || RC=$?
 
 if [ "${KEEP_TEST_HOME:-0}" != "1" ]; then
     rm -rf "$TEST_HOME"


### PR DESCRIPTION
## Summary

Two specs implemented in a stacked PR:

### #2034 — Fix post-merge cleanup workflow
- Fix trigger routing: "pr merged" maps to `cleanup` (not `check-pr`) in both `git-workflow/SKILL.md` and `git-workflow-cleanup/SKILL.md`
- Fix `cleanup.md` Step 3 description (dev → trunk)
- Extract Phases 4-5 from `check-pr.md` — delegate branch cleanup to cleanup workflow
- Add behavioral enforcement test for cleanup routing

### #2037 — Universal discussion discipline
- Universal question tool prohibition (all scopes, all workflows)
- Pigeon-holing in natural language prohibition (Tier 1)
- Single-topic discipline enforcement (Tier 1)
- Order of importance rule (Tier 1)
- Always discuss as default (Tier 1)
- Remove contradictory question tool instruction from 140-planning-spec-creation.md
- Add behavioral enforcement test for all 5 rules

## Files Changed

12 commits across git-workflow, git-workflow-cleanup, guidelines (020-go-prohibitions.md, 000-critical-rules.md, 010-approval-gate.md, 140-planning-spec-creation.md), pre-implementation-analysis.md, and behavioral tests.

## Fixes

Closes #2034, Closes #2037