### PR TITLE
feat(#2066): BEH-EV classification gate + evaluator clean-room dispatch

### DIFF
--- a/skills/audit/tasks/behavioral-sc-evaluator.md
+++ b/skills/audit/tasks/behavioral-sc-evaluator.md
@@ -4,6 +4,14 @@
 
 Clean-room evaluation of behavioral test artifacts. Reads behavioral test execution output and renders binary PASS/FAIL verdicts per success criterion. This is a clean-room sub-agent — it receives ONLY the artifact directory path and evaluates the output cold, without any orchestrator context or preloaded expectations.
 
+## Orchestrator Dispatch Entry
+
+This task is dispatched by the orchestrator when an evaluator result contract contains
+a non-empty `needs_clean_room` list. The orchestrator dispatches this task once per
+SC in the list, passing only the artifact directory path.
+
+**Dispatch context:** `{artifact_evidence_dir, sc_id}`
+
 ## Entry Criteria
 
 - Artifact directory path is provided (containing `stdout.log` and `stderr.log`)

--- a/skills/audit/tasks/coherence-maintenance-evaluator.md
+++ b/skills/audit/tasks/coherence-maintenance-evaluator.md
@@ -383,6 +383,12 @@ failing_criterion_ids: ["<criterion-id>", ...]
 executive_summary: "Coherence maintenance evaluation: <N>/5 criteria PASS. <C> controlled changes, <U> uncontrolled changes. Verdict: <PASS|FAIL>."
 ```
 
+### Step 11.5: Identify Behavioral SCs for Clean-Room Evaluation
+
+- [ ] 11.5. From the evaluated criteria, collect SC IDs whose evidence type is `behavioral` (either declared or uplifted)
+  - Add `needs_clean_room: [SC-IDs]` to the result contract
+  - If no behavioral SCs, set `needs_clean_room: []`
+
 ### Step 12: Return Frugal Result Contract
 
 ```yaml
@@ -391,6 +397,7 @@ artifact_path: "{artifact_evidence_dir}/verdict.yaml"
 summary: "Coherence maintenance evaluated: <N>/5 criteria PASS. <C> controlled, <U> uncontrolled changes. Verdict: <PASS|FAIL>."
 all_criteria_pass: true | false
 remediation_required: true | false
+needs_clean_room: [SC-IDs]
 ```
 
 ## Completion Dependency Chain
@@ -409,6 +416,7 @@ Every step in this task is a mandatory dependency. Skipping any step produces an
 - [ ] 9. Compute Overall Verdict → INVALID if skipped
 - [ ] 10. Apply Self-Consistency Gate → INVALID if skipped
 - [ ] 11. Write verdict.yaml → INVALID if skipped
+- [ ] 11.5. Identify Behavioral SCs for Clean-Room Evaluation → INVALID if skipped
 - [ ] 12. Return Frugal Result Contract → INVALID if skipped
 
 ## Error Handling

--- a/skills/audit/tasks/concern-separation-evaluator.md
+++ b/skills/audit/tasks/concern-separation-evaluator.md
@@ -425,6 +425,12 @@ remediation_required: <true|false>
 exec_summary: "Concern separation: <X>/<Y> criteria PASS. <N> phases need review."
 ```
 
+### Step 16.5: Identify Behavioral SCs for Clean-Room Evaluation
+
+- [ ] 16.5. From the evaluated criteria, collect SC IDs whose evidence type is `behavioral` (either declared or uplifted)
+  - Add `needs_clean_room: [SC-IDs]` to the result contract
+  - If no behavioral SCs, set `needs_clean_room: []`
+
 ### Step 17: Return Frugal Result Contract
 
 ```yaml
@@ -433,6 +439,7 @@ artifact_path: "{project_root}/tmp/{issue-N}/artifacts/concern-separation/verdic
 summary: "Concern separation evaluated: {N} criteria, {X} PASS, {Y} FAIL. Verdict: {PASS|FAIL}."
 all_criteria_pass: <true|false>
 remediation_required: <true|false>
+needs_clean_room: [SC-IDs]
 ```
 
 ## Edge Cases

--- a/skills/audit/tasks/content-audit-evaluator.md
+++ b/skills/audit/tasks/content-audit-evaluator.md
@@ -485,6 +485,12 @@ self_consistency_downgrades:
 - [ ] 2. Write `verdict.yaml` with the complete verdict structure
 - [ ] 3. Verify the file was written and is non-empty
 
+### Step 14.5: Identify Behavioral SCs for Clean-Room Evaluation
+
+- [ ] 14.5. From the evaluated criteria, collect SC IDs whose evidence type is `behavioral` (either declared or uplifted)
+  - Add `needs_clean_room: [SC-IDs]` to the result contract
+  - If no behavioral SCs, set `needs_clean_room: []`
+
 ### Step 15: Return Frugal Result Contract
 
 ```yaml
@@ -493,6 +499,7 @@ artifact_path: "{artifact_evidence_dir}/verdict.yaml"
 summary: "<N> claims evaluated. <X> PASS, <Y> FAIL, <Z> FABRICATED."
 all_claims_pass: true | false
 remediation_required: true | false
+needs_clean_room: [SC-IDs]
 ```
 
 ## Result Contract
@@ -503,6 +510,7 @@ artifact_path: "{artifact_evidence_dir}/verdict.yaml"
 summary: "<N> claims evaluated. <X> PASS, <Y> FAIL, <Z> FABRICATED."
 all_claims_pass: true | false
 remediation_required: true | false
+needs_clean_room: [SC-IDs]
 ```
 
 ## Clean-Room Protocol
@@ -531,6 +539,7 @@ Every step in this task is a mandatory dependency. Skipping any step produces an
 - [ ] 12. Process Verdicts → INVALID if skipped
 - [ ] 13. Apply Self-Consistency Gate → INVALID if skipped
 - [ ] 14. Write verdict.yaml → INVALID if skipped
+- [ ] 14.5. Identify Behavioral SCs for Clean-Room Evaluation → INVALID if skipped
 - [ ] 15. Return Frugal Result Contract → INVALID if skipped
 
 ## Error Handling

--- a/skills/audit/tasks/cross-validate.md
+++ b/skills/audit/tasks/cross-validate.md
@@ -183,6 +183,27 @@ If an auditor's YAML artifact has extra criterion ids not in `evaluation_criteri
 
 If an auditor's YAML artifact is missing a criterion id from `evaluation_criteria`: treat that criterion as `FAIL` for that auditor with explanation `"MISSING_VERDICT"`.
 
+### Step 4: Load and Compare Clean-Room Evaluation Results
+
+- [ ] 4. Read `behavioral-sc-evaluation.yaml` from `{artifact_evidence_dir}/behavioral-sc-evaluation.yaml`
+  - If file exists: extract per-SC verdicts from the clean-room evaluation
+  - If file does not exist: all behavioral SCs default to FAIL with `MISSING_CLEAN_ROOM_EVIDENCE`
+
+- [ ] 4a. For each SC in the evaluator's `needs_clean_room` list, compare evaluator verdict vs. clean-room verdict:
+  - If evaluator verdict == clean-room verdict → report CONSENSUS (use that verdict)
+  - If evaluator verdict != clean-room verdict → report CONFLICT, use FAIL as the safe default
+  - If clean-room verdict is MISSING (file absent or SC not evaluated) → use evaluator verdict with `NO_CLEAN_ROOM` flag
+
+- [ ] 4b. Record clean-room comparison results in the cross-validate output:
+  ```yaml
+  clean_room_comparison:
+    sc_id: "SC-N"
+    evaluator_verdict: "PASS|FAIL"
+    clean_room_verdict: "PASS|FAIL|MISSING"
+    comparison: "CONSENSUS|CONFLICT|NO_CLEAN_ROOM"
+    final_verdict: "PASS|FAIL"
+  ```
+
 ### Step 5: Cross-Reference Verdicts — Monotonic Non-Increasing Invariant
 
 **Cross-validate verdicts are monotonic non-increasing in PASSness.** Verdicts must never increase in PASSness at the cross-validate stage. Cross-validate is a rejection filter, not a remediation gate.

--- a/skills/audit/tasks/drift-detection-evaluator.md
+++ b/skills/audit/tasks/drift-detection-evaluator.md
@@ -442,6 +442,12 @@ bidirectional_findings:
 - [ ] 2. Write `verdict.yaml` with the complete verdict structure
 - [ ] 3. Verify the file was written and is non-empty
 
+### Step 15.5: Identify Behavioral SCs for Clean-Room Evaluation
+
+- [ ] 15.5. From the evaluated criteria, collect SC IDs whose evidence type is `behavioral` (either declared or uplifted)
+  - Add `needs_clean_room: [SC-IDs]` to the result contract
+  - If no behavioral SCs, set `needs_clean_room: []`
+
 ### Step 16: Return Frugal Result Contract
 
 Return only routing-significant data:
@@ -452,6 +458,7 @@ artifact_path: "{artifact_evidence_dir}/verdict.yaml"
 summary: "Drift detection: {spec_drift_count} spec drift, {code_drift_count} code drift, {sync_count} sync. Verdict: {overall}."
 all_criteria_pass: true | false
 remediation_required: true | false
+needs_clean_room: [SC-IDs]
 ```
 
 ## Result Contract
@@ -462,6 +469,7 @@ artifact_path: "{artifact_evidence_dir}/verdict.yaml"
 summary: "Drift detection: {spec_drift_count} spec drift, {code_drift_count} code drift, {sync_count} sync. Verdict: {overall}."
 all_criteria_pass: true | false
 remediation_required: true  # When status is FAIL: full mandatory re-audit required
+needs_clean_room: [SC-IDs]
 ```
 
 ## Completion Dependency Chain
@@ -484,6 +492,7 @@ Every step in this task is a mandatory dependency. Skipping any step produces an
 - [ ] 13. Process Verdicts → INVALID if skipped
 - [ ] 14. Apply Self-Consistency Gate → INVALID if skipped
 - [ ] 15. Write verdict.yaml → INVALID if skipped
+- [ ] 15.5. Identify Behavioral SCs for Clean-Room Evaluation → INVALID if skipped
 - [ ] 16. Return Frugal Result Contract → INVALID if skipped
 
 ## Error Handling

--- a/skills/audit/tasks/guideline-audit-evaluator.md
+++ b/skills/audit/tasks/guideline-audit-evaluator.md
@@ -487,6 +487,12 @@ bidirectional_findings:
     revision_option: "<guidance>"
 ```
 
+### Step 12.5: Identify Behavioral SCs for Clean-Room Evaluation
+
+- [ ] 12.5. From the evaluated criteria, collect SC IDs whose evidence type is `behavioral` (either declared or uplifted)
+  - Add `needs_clean_room: [SC-IDs]` to the result contract
+  - If no behavioral SCs, set `needs_clean_room: []`
+
 ### Step 13: Return Frugal Result Contract
 
 ```yaml
@@ -495,6 +501,7 @@ artifact_path: "{artifact_evidence_dir}/verdict.yaml"
 summary: "<N> criteria evaluated. <X> PASS, <Y> FAIL."
 all_criteria_pass: true | false
 remediation_required: true | false
+needs_clean_room: [SC-IDs]
 ```
 
 ## Completion Dependency Chain
@@ -514,6 +521,7 @@ Every step in this task is a mandatory dependency. Skipping any step produces an
 - [ ] 10. Apply Self-Consistency Gate → INVALID if skipped
 - [ ] 11. Generate Bidirectional Findings → INVALID if skipped
 - [ ] 12. Write verdict.yaml → INVALID if skipped
+- [ ] 12.5. Identify Behavioral SCs for Clean-Room Evaluation → INVALID if skipped
 - [ ] 13. Return Frugal Result Contract → INVALID if skipped
 
 ## Error Handling

--- a/skills/audit/tasks/plan-fidelity-evaluator.md
+++ b/skills/audit/tasks/plan-fidelity-evaluator.md
@@ -323,6 +323,12 @@ auto_fixes_applied: []
 exec_summary: "Plan fidelity: X/Y criteria PASS. N discrepancies found."
 ```
 
+### Step 13.5: Identify Behavioral SCs for Clean-Room Evaluation
+
+- [ ] 13.5. From the evaluated criteria, collect SC IDs whose evidence type is `behavioral` (either declared or uplifted)
+  - Add `needs_clean_room: [SC-IDs]` to the result contract
+  - If no behavioral SCs, set `needs_clean_room: []`
+
 ### Step 14: Return Frugal Result Contract
 
 ```yaml
@@ -331,6 +337,7 @@ artifact_path: "{project_root}/tmp/{issue-N}/artifacts/plan-fidelity/verdict.yam
 summary: "N criteria evaluated. X PASS, Y FAIL. Z discrepancies found."
 all_criteria_pass: true | false
 remediation_required: true | false
+needs_clean_room: [SC-IDs]
 ```
 
 ## Error Handling

--- a/skills/audit/tasks/spec-audit-evaluator.md
+++ b/skills/audit/tasks/spec-audit-evaluator.md
@@ -667,6 +667,12 @@ bidirectional_findings:
     revision_option: "<guidance>"
 ```
 
+### Step 19.5: Identify Behavioral SCs for Clean-Room Evaluation
+
+- [ ] 19.5. From the evaluated criteria, collect SC IDs whose evidence type is `behavioral` (either declared or uplifted)
+  - Add `needs_clean_room: [SC-IDs]` to the result contract
+  - If no behavioral SCs, set `needs_clean_room: []`
+
 ### Step 20: Return Frugal Result Contract
 
 ```yaml
@@ -676,6 +682,7 @@ summary: "<N> criteria evaluated. <X> PASS, <Y> FAIL."
 all_criteria_pass: true | false
 remediation_required: true | false
 holistic_status: "PASS|DRAFT"
+needs_clean_room: [SC-IDs]
 ```
 
 ## Completion Dependency Chain
@@ -702,6 +709,7 @@ Every step in this task is a mandatory dependency. Skipping any step produces an
 - [ ] 17. Apply Self-Consistency Gate → INVALID if skipped
 - [ ] 18. Generate Bidirectional Findings → INVALID if skipped
 - [ ] 19. Write verdict.yaml → INVALID if skipped
+- [ ] 19.5. Identify Behavioral SCs for Clean-Room Evaluation → INVALID if skipped
 - [ ] 20. Return Frugal Result Contract → INVALID if skipped
 
 ## Error Handling

--- a/skills/audit/tasks/test-quality-audit-evaluator.md
+++ b/skills/audit/tasks/test-quality-audit-evaluator.md
@@ -391,6 +391,12 @@ self_consistency_downgrades:
     hedging_phrase: "<matched phrase>"
 ```
 
+### Step 13.5: Identify Behavioral SCs for Clean-Room Evaluation
+
+- [ ] 13.5. From the evaluated criteria, collect SC IDs whose evidence type is `behavioral` (either declared or uplifted)
+  - Add `needs_clean_room: [SC-IDs]` to the result contract
+  - If no behavioral SCs, set `needs_clean_room: []`
+
 ### Step 14: Return Frugal Result Contract
 
 ```yaml
@@ -399,6 +405,7 @@ artifact_path: "{artifact_evidence_dir}/verdict.yaml"
 summary: "<N> criteria evaluated. <X> PASS, <Y> FAIL."
 all_criteria_pass: true | false
 remediation_required: true | false
+needs_clean_room: [SC-IDs]
 ```
 
 ## Completion Dependency Chain
@@ -419,6 +426,7 @@ Every step in this task is a mandatory dependency. Skipping any step produces an
 - [ ] 11. Process Verdicts → INVALID if skipped
 - [ ] 12. Apply Self-Consistency Gate → INVALID if skipped
 - [ ] 13. Write verdict.yaml → INVALID if skipped
+- [ ] 13.5. Identify Behavioral SCs for Clean-Room Evaluation → INVALID if skipped
 - [ ] 14. Return Frugal Result Contract → INVALID if skipped
 
 ## Error Handling

--- a/skills/audit/tasks/verification-audit-evaluator.md
+++ b/skills/audit/tasks/verification-audit-evaluator.md
@@ -255,6 +255,12 @@ self_consistency_downgrades:
 
 - [ ] 5. Re-write `verdict.yaml` with the corrected verdicts
 
+### Step 9.5: Identify Behavioral SCs for Clean-Room Evaluation
+
+- [ ] 9.5. From the evaluated criteria, collect SC IDs whose evidence type is `behavioral` (either declared or uplifted)
+  - Add `needs_clean_room: [SC-IDs]` to the result contract
+  - If no behavioral SCs, set `needs_clean_room: []`
+
 ### Step 10: Return Frugal Result Contract
 
 Return only routing-significant data:
@@ -265,6 +271,7 @@ artifact_path: "{project_root}/tmp/{issue-N}/artifacts/verification-audit/verdic
 summary: "{total_criteria} criteria evaluated. {pass} PASS, {fail} FAIL."
 all_criteria_pass: false | true
 remediation_required: false | true
+needs_clean_room: [SC-IDs]
 ```
 
 ## Result Contract
@@ -275,6 +282,7 @@ artifact_path: "{project_root}/tmp/{issue-N}/artifacts/verification-audit/verdic
 summary: "{total_criteria} criteria evaluated. {pass} PASS, {fail} FAIL."
 all_criteria_pass: false | true
 remediation_required: false | true
+needs_clean_room: [SC-IDs]
 ```
 
 ## Error Handling
@@ -309,6 +317,7 @@ Every step in this task is a mandatory dependency. Skipping any step produces an
 - [ ] 7. Generate Per-Criterion Findings → INVALID if skipped
 - [ ] 8. Write verdict.yaml → INVALID if skipped
 - [ ] 9. Self-Consistency Gate → INVALID if skipped
+- [ ] 9.5. Identify Behavioral SCs for Clean-Room Evaluation → INVALID if skipped
 - [ ] 10. Return Frugal Result Contract → INVALID if skipped
 
 ## Cross-References

--- a/skills/spec-creation-validation/tasks/decompose.md
+++ b/skills/spec-creation-validation/tasks/decompose.md
@@ -14,6 +14,18 @@ Decompose the problem into success criteria for the spec.
 - [ ] 1. Read concern analysis from `concern_artifact_path`
 - [ ] 2. Decompose each concern into specific, testable success criteria
 - [ ] 3. Assign evidence types to each SC
+      - [ ] 3a. For each SC, ask: "Does this change affect runtime behavior?"
+            (Runtime behavior includes: agent dispatch decisions, enforcement gate outcomes,
+            tool selection, pipeline routing, conditional branching, test execution results,
+            and any observable system output. This question is substrate-determined —
+            it applies to ALL SCs in ALL specs, regardless of language or domain.)
+      - [ ] 3b. Presumptive YES for file types: SKILL.md, tasks/*.md, guidelines/*.md,
+            enforcement/*.md — these files control agent behavior at runtime.
+            Any SC modifying them is automatically behavioral.
+      - [ ] 3c. If YES → evidence type MUST be `behavioral` (automatic uplift per
+            critical-rules-BEH-EV in 000-critical-rules.md)
+      - [ ] 3d. If NO → choose from: `behavioral`, `semantic`, `string`, `structural`
+      - [ ] 3e. Record classification in decomposition artifact
 - [ ] 4. Write decomposition artifact to `./tmp/{issue-N}/artifacts/decomposition.yaml`
 
 ## Exit Criteria


### PR DESCRIPTION
## Summary

Fixes #2066 — supersedes #2011 (SC-1 and SC-2 failed audit).

### Phase 1: BEH-EV classification gate
Extended `spec-creation-validation/tasks/decompose.md` step 3 with mandatory BEH-EV classification sub-steps (3a-3e). Every SC must answer the substrate-determined question: "Does this change affect runtime behavior?" Presumptive YES for SKILL.md, tasks/*.md, guidelines/*.md, enforcement/*.md.

### Phase 2: Evaluator clean-room dispatch
- All 9 evaluator result contracts carry `needs_clean_room: [SC-IDs]` field
- `behavioral-sc-evaluator.md` has orchestrator dispatch entry point
- `cross-validate.md` compares evaluator verdict vs clean-room results (CONSENSUS/CONFLICT)

## SCs
- SC-1: BEH-EV classification gate in decompose.md
- SC-2: Evaluator result contracts carry needs_clean_room
- SC-3: Orchestrator dispatches behavioral-sc-evaluator
- SC-4: Arbiter receives both verdicts and compares
