### PR TITLE
fix #2009 SC-3, #2020 SC-10: add pipeline stages, revise stale criterion

### DIFF
--- a/skills/writing-plans-creation/tasks/write.md
+++ b/skills/writing-plans-creation/tasks/write.md
@@ -204,7 +204,7 @@ Numbered checklist C1 through C{N} at the end of the plan, after the bottom admo
 
 ## Pipeline Steps
 
-Every plan references implementation pipeline stages by name. The following 15 stages from `implementation-pipeline/SKILL.md` Trigger Dispatch Table define the canonical gate sequence:
+Every plan references implementation pipeline stages by name. The following 18 stages from `implementation-pipeline/SKILL.md` Trigger Dispatch Table define the canonical gate sequence:
 
 | # | Stage | Description | Dispatch |
 |---|-------|-------------|----------|
@@ -222,4 +222,7 @@ Every plan references implementation pipeline stages by name. The following 15 s
 | 12 | `pre-pr-gate` | Verify all SCs PASS | `sub-task` |
 | 13 | `audit` | Adversarial audit | `orchestrator` |
 | 14 | `cross-validate` | Consensus check via `audit --task cross-validate` | `sub-task` |
-| 15 | `review-prep` | Prepare for PR review via `git-workflow --task review-prep` | `sub-task` |
+| 15 | `regression-check` | Run regression tests via `test-driven-development --task patterns` | `sub-task` |
+| 16 | `review-prep` | Prepare for PR review via `git-workflow --task review-prep` | `sub-task` |
+| 17 | `create-pr` | Create pull request via `pr-creation-workflow --task create` | `sub-task` |
+| 18 | `exec-summary` | Completion summary via `completion-core --task completion` | `sub-task` |


### PR DESCRIPTION
## Summary

DiMo implementation audit remediation for #2009 and #2020.

## Changes

- **write.md**: Pipeline Steps table expanded from 15 to 18 stages — added `regression-check`, `review-prep`, `create-pr`, `exec-summary`
- **2020/spec.md**: SC-10 criterion revised from "Pipeline sections unchanged" to "Pipeline sections removed"

## Fixes

- #2009 SC-3: Pipeline Steps table missing 3 required stages
- #2020 SC-10: Stale criterion (Pipeline sections were removed during restructuring)

🤖 Co-authored with AI: OpenCode (deepseek-v4-flash)