### PR TITLE
Fix writing-plans behavioral test: trunk tip default, fixture, valid prompt

### DIFF
--- a/tests-v2/behaviors/fixtures/issues/2081-writing-plans/spec.md
+++ b/tests-v2/behaviors/fixtures/issues/2081-writing-plans/spec.md
@@ -1,0 +1,26 @@
+---
+number: 2081
+title: "[SPEC] Replace writing-plans skill with flat architecture (routing-table plan artifact)"
+status: approved
+labels:
+  - SPEC
+  - approved-for-pr
+---
+
+# [SPEC] Replace writing-plans skill with flat architecture
+
+## Problem Statement
+
+The current writing-plans skill has 3 SKILL.md files, 19 task files, 22 contract templates.
+
+## Success Criteria
+
+| ID | Criterion | Evidence Type |
+|----|-----------|---------------|
+| SC-1 | Flat SKILL.md with Workflows section | structural |
+| SC-2 | 7 task files | structural |
+| SC-4 | Plan artifact uses routing-table format | behavioral |
+| SC-7 | analyze checks local spec.md exists | behavioral |
+| SC-8 | analyze checks spec approval from local frontmatter | behavioral |
+| SC-9 | solve runs tools/solve and tools/plan | behavioral |
+| SC-14 | External callers updated to new dispatch strings | structural |

--- a/tests-v2/behaviors/helpers.sh
+++ b/tests-v2/behaviors/helpers.sh
@@ -204,8 +204,11 @@ behavior_run() {
     submodule_remote_url=$(echo "$submodule_remote_url" | sed 's|^git@github.com:|https://github.com/|' | sed 's|\.git$||')
 
     local submodule_commit="${BEHAVIOR_SUBMODULE_COMMIT:-}"
+    # Default to trunk tip (remote default branch). Only pin to a specific commit
+    # when BEHAVIOR_SUBMODULE_COMMIT is explicitly set. Using local HEAD is wrong —
+    # it may be a feature branch or uncommitted state not yet pushed to remote.
     if [ -z "$submodule_commit" ]; then
-        submodule_commit=$(git -C "$BEHAVIOR_HELPERS_DIR/../.." rev-parse HEAD 2>/dev/null || true)
+        submodule_commit=""  # let clone use remote default branch
     fi
 
     local attempt=0

--- a/tests-v2/behaviors/writing-plans-flat-pipeline.sh
+++ b/tests-v2/behaviors/writing-plans-flat-pipeline.sh
@@ -8,7 +8,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/helpers.sh"
 
 SCENARIO_NAME="writing-plans-flat-pipeline"
-SCENARIO_PROMPT="Load the writing-plans skill and describe what it does"
+SCENARIO_PROMPT="Create an implementation plan for issue #2081 using the writing-plans skill"
 
 behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT"
 exit 0

--- a/tests-v2/behaviors/writing-plans-flat-pipeline.sh
+++ b/tests-v2/behaviors/writing-plans-flat-pipeline.sh
@@ -8,7 +8,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/helpers.sh"
 
 SCENARIO_NAME="writing-plans-flat-pipeline"
-SCENARIO_PROMPT="Load the writing-plans skill and create a plan for issue .opencode#2081"
+SCENARIO_PROMPT="Load the writing-plans skill and describe what it does"
 
 behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT"
 exit 0


### PR DESCRIPTION
Fixes the writing-plans behavioral test to work correctly with the test framework.

- behavior_run defaults to trunk tip (remote default branch), not local HEAD
- Added fixture issue 2081-writing-plans with approved spec for test use
- Test prompt uses real-domain task with fixture issue
- Removed interview-style 'describe what it does' prompt