### PR TITLE
fix(#2090): move submodule-content tests from parent repo to submodule tests-v2/behaviors/

### DIFF
--- a/tests-v2/behaviors/rationalization-check-pipeline.sh
+++ b/tests-v2/behaviors/rationalization-check-pipeline.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: 2026 Michael Conrad
+# SPDX-License-Identifier: MIT
+# Provenance: AI-generated
+# GREEN phase test: rationalization-check-pipeline
+# Verifies that implementation-pipeline SKILL.md has the rationalization-check TDT entry
+
+set -euo pipefail
+
+echo "=== GREEN Test: rationalization-check-pipeline ==="
+echo "Checking implementation-pipeline SKILL.md for rationalization-check TDT entry..."
+
+SKILL_MD=".opencode/skills/implementation-pipeline/SKILL.md"
+ALL_PASS=true
+
+if [ ! -f "$SKILL_MD" ]; then
+    echo "  [MISSING] $SKILL_MD does not exist"
+    ALL_PASS=false
+else
+    if grep -q "rationalization.check\|REMEDIATION_MANDATORY" "$SKILL_MD" 2>/dev/null; then
+        echo "  [FOUND] rationalization-check TDT entry present"
+    else
+        echo "  [MISSING] rationalization-check TDT entry"
+        ALL_PASS=false
+    fi
+
+    if grep -q "rationalization-check" "$SKILL_MD" 2>/dev/null; then
+        echo "  [FOUND] rationalization-check in step labels"
+    else
+        echo "  [MISSING] rationalization-check in step labels"
+        ALL_PASS=false
+    fi
+fi
+
+echo ""
+if [ "$ALL_PASS" = true ]; then
+    echo "PASS: rationalization-check-pipeline"
+    exit 0
+else
+    echo "FAIL: rationalization-check-pipeline"
+    exit 1
+fi

--- a/tests-v2/behaviors/rationalization-check-remediation.sh
+++ b/tests-v2/behaviors/rationalization-check-remediation.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: 2026 Michael Conrad
+# SPDX-License-Identifier: MIT
+# Provenance: AI-generated
+# GREEN phase test: rationalization-check-remediation
+# Verifies that behavioral-test-remediation.md has the rationalization-check gate
+
+set -euo pipefail
+
+echo "=== GREEN Test: rationalization-check-remediation ==="
+echo "Checking behavioral-test-remediation.md for rationalization-check gate..."
+
+REMED_MD=".opencode/skills/implementation-pipeline/tasks/behavioral-test-remediation.md"
+ALL_PASS=true
+
+if [ ! -f "$REMED_MD" ]; then
+    echo "  [MISSING] $REMED_MD does not exist"
+    ALL_PASS=false
+else
+    if grep -q "rationalization.check\|REMEDIATION_MANDATORY" "$REMED_MD" 2>/dev/null; then
+        echo "  [FOUND] rationalization-check gate present"
+    else
+        echo "  [MISSING] rationalization-check gate"
+        ALL_PASS=false
+    fi
+
+    if grep -q "clean.room.*rationalization\|rationalization.check.*sub.agent" "$REMED_MD" 2>/dev/null; then
+        echo "  [FOUND] clean-room sub-agent dispatch for rationalization check"
+    else
+        echo "  [MISSING] clean-room sub-agent dispatch for rationalization check"
+        ALL_PASS=false
+    fi
+
+    if grep -q "REMEDIATION_MANDATORY" "$REMED_MD" 2>/dev/null; then
+        echo "  [FOUND] REMEDIATION_MANDATORY verdict code"
+    else
+        echo "  [MISSING] REMEDIATION_MANDATORY verdict code"
+        ALL_PASS=false
+    fi
+fi
+
+echo ""
+if [ "$ALL_PASS" = true ]; then
+    echo "PASS: rationalization-check-remediation"
+    exit 0
+else
+    echo "FAIL: rationalization-check-remediation"
+    exit 1
+fi

--- a/tests-v2/behaviors/rationalization-check-verify.sh
+++ b/tests-v2/behaviors/rationalization-check-verify.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: 2026 Michael Conrad
+# SPDX-License-Identifier: MIT
+# Provenance: AI-generated
+# GREEN phase test: rationalization-check-verify
+# Verifies that verify.md has the rationalization-check gate
+
+set -euo pipefail
+
+echo "=== GREEN Test: rationalization-check-verify ==="
+echo "Checking verify.md for rationalization-check gate..."
+
+VERIFY_MD=".opencode/skills/verification-before-completion/tasks/verify.md"
+
+ALL_PASS=true
+
+if [ ! -f "$VERIFY_MD" ]; then
+    echo "  [MISSING] $VERIFY_MD does not exist"
+    ALL_PASS=false
+else
+    if grep -q "rationalization.check\|REMEDIATION_MANDATORY" "$VERIFY_MD" 2>/dev/null; then
+        echo "  [FOUND] rationalization-check gate present"
+    else
+        echo "  [MISSING] rationalization-check gate"
+        ALL_PASS=false
+    fi
+
+    if grep -q "clean.room.*rationalization\|rationalization.check.*sub.agent" "$VERIFY_MD" 2>/dev/null; then
+        echo "  [FOUND] clean-room sub-agent dispatch for rationalization check"
+    else
+        echo "  [MISSING] clean-room sub-agent dispatch for rationalization check"
+        ALL_PASS=false
+    fi
+
+    if grep -q "REMEDIATION_MANDATORY" "$VERIFY_MD" 2>/dev/null; then
+        echo "  [FOUND] REMEDIATION_MANDATORY verdict code"
+    else
+        echo "  [MISSING] REMEDIATION_MANDATORY verdict code"
+        ALL_PASS=false
+    fi
+fi
+
+echo ""
+if [ "$ALL_PASS" = true ]; then
+    echo "PASS: rationalization-check-verify"
+    exit 0
+else
+    echo "FAIL: rationalization-check-verify"
+    exit 1
+fi

--- a/tests-v2/behaviors/verify-auth-step5d.sh
+++ b/tests-v2/behaviors/verify-auth-step5d.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+# Behavioral test: verify-auth-step5d
+# See .opencode/tests/AGENTS.md for the test harness specification and paradigm.
+# This script is an artifact-only generator — it does NOT evaluate model output.
+# Behavioral Enforcement Test: Step 5d readiness checks in verify-authorization chain
+#
+# SC-9: Agent approves an already-completed issue (merged PR exists) → agent auto-closes
+#        instead of proceeding to implementation
+# SC-10: Agent approves a stale spec (superseded by later issue) → agent halts with
+#        superseding report
+# SC-11: Agent approves an issue with blocking dependencies → agent halts with blocker
+#        report
+#
+# Issue #1187: Restore pre-implementation readiness checks to verify-authorization chain
+#
+# Co-authored with AI: OpenCode (deepseek-v4-flash)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/helpers.sh"
+
+OVERALL_RESULT=0
+
+# ============================================================
+# SC-9: Already-completed issue → auto-close
+# ============================================================
+SCENARIO_9="verify-auth-step5d-sc9"
+PROMPT_9="approved #999 for implementation — the spec for adding a 'version' field to config schema. The issue has label 'spec' and a merged PR #42 already implements it."
+
+echo "=== SC-9: Already-completed issue → auto-close ==="
+behavior_run "$SCENARIO_9" "$PROMPT_9"
+
+assert_semantic "SC-9" \
+  "Agent recognizes that issue #999 is already implemented (merged PR #42 exists) and auto-closes the issue instead of proceeding to implementation. The agent must NOT create a branch, write code, or dispatch implementation-pipeline. The agent must close the issue with state_reason 'completed' and post a comment referencing the merged PR." \
+  "required" || OVERALL_RESULT=1
+
+assert_forbidden_pattern_absent \
+  "git checkout -b\|git switch -c\|implementation-pipeline\|executing-plans\|writing-plans" \
+  "agent did not create branch or dispatch implementation" || OVERALL_RESULT=1
+
+# ============================================================
+# SC-10: Stale spec → halt with superseding report
+# ============================================================
+SCENARIO_10="verify-auth-step5d-sc10"
+PROMPT_10="approved #999 for implementation — the spec for adding a 'version' field to config schema. Issue #1001 is a later spec that supersedes #999 with a different approach."
+
+echo "=== SC-10: Stale spec → halt with superseding report ==="
+behavior_run "$SCENARIO_10" "$PROMPT_10"
+
+assert_semantic "SC-10" \
+  "Agent detects that issue #999 is superseded by a later issue (#1001) and halts with a superseding report. The agent must NOT proceed to implementation. The agent must report the superseding issue URL and explain that the spec is stale." \
+  "required" || OVERALL_RESULT=1
+
+assert_forbidden_pattern_absent \
+  "git checkout -b\|git switch -c\|implementation-pipeline\|executing-plans" \
+  "agent did not proceed to implementation despite superseding issue" || OVERALL_RESULT=1
+
+assert_required_pattern_present \
+  "supersed\|#1001\|stale\|later issue\|newer spec" \
+  "agent references superseding issue" || OVERALL_RESULT=1
+
+# ============================================================
+# SC-11: Blocking dependencies → halt with blocker report
+# ============================================================
+SCENARIO_11="verify-auth-step5d-sc11"
+PROMPT_11="approved #999 for implementation — the spec for adding a 'version' field to config schema. Issue #1002 is a blocking dependency that is still open."
+
+echo "=== SC-11: Blocking dependencies → halt with blocker report ==="
+behavior_run "$SCENARIO_11" "$PROMPT_11"
+
+assert_semantic "SC-11" \
+  "Agent detects that issue #999 has a blocking dependency (#1002 still open) and halts with a blocker report. The agent must NOT proceed to implementation. The agent must report the blocking issue and explain that implementation cannot proceed until the dependency is resolved." \
+  "required" || OVERALL_RESULT=1
+
+assert_forbidden_pattern_absent \
+  "git checkout -b\|git switch -c\|implementation-pipeline\|executing-plans" \
+  "agent did not proceed to implementation despite blocking dependency" || OVERALL_RESULT=1
+
+assert_required_pattern_present \
+  "block\|#1002\|dependenc\|cannot proceed\|waiting on" \
+  "agent references blocking dependency" || OVERALL_RESULT=1
+
+# ============================================================
+# Summary
+# ============================================================
+echo ""
+if [ "$OVERALL_RESULT" -eq 0 ]; then
+    echo "PASS: verify-auth-step5d — all scenarios passed"
+else
+    echo "FAIL: verify-auth-step5d — one or more scenarios failed"
+fi
+
+exit $OVERALL_RESULT

--- a/tests-v2/behaviors/writing-plans-analyze.sh
+++ b/tests-v2/behaviors/writing-plans-analyze.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: 2026 Michael Conrad
+# SPDX-License-Identifier: MIT
+# Provenance: AI-generated
+# Content-Verification Test: Writing-Plans Analyze Task Card
+#
+# Verifies that skills/writing-plans/tasks/analyze.md has explicit entry
+# criteria gates for SPEC_NOT_FOUND (missing spec) and SPEC_NOT_APPROVED
+# (missing approval in frontmatter), matching the spec's requirement that
+# these be Entry Criteria gates, not just Procedure steps.
+#
+# RED phase: analyze.md has SPEC_NOT_FOUND/SPEC_NOT_APPROVED in Procedure
+# but NOT as explicit Entry Criteria gates. Expected to FAIL (non-zero exit).
+#
+# Co-authored with AI: OpenCode (deepseek-v4-flash)
+
+set -euo pipefail
+
+ANALYZE_MD=".opencode/skills/writing-plans/tasks/analyze.md"
+
+echo "=== RED Test: writing-plans-analyze ==="
+echo "Checking $ANALYZE_MD for entry criteria gates..."
+echo ""
+
+HAS_ENTRY_SPEC_NOT_FOUND=false
+HAS_ENTRY_SPEC_NOT_APPROVED=false
+HAS_PROCEDURE_SPEC_NOT_FOUND=false
+HAS_PROCEDURE_SPEC_NOT_APPROVED=false
+
+# Check 1: Entry Criteria must explicitly mention SPEC_NOT_FOUND
+if grep -q 'SPEC_NOT_FOUND' "$ANALYZE_MD" 2>/dev/null; then
+    # Check if SPEC_NOT_FOUND appears in Entry Criteria section
+    if sed -n '/^## Entry Criteria/,/^## /p' "$ANALYZE_MD" | grep -q 'SPEC_NOT_FOUND' 2>/dev/null; then
+        HAS_ENTRY_SPEC_NOT_FOUND=true
+        echo "  [FOUND] SPEC_NOT_FOUND in Entry Criteria"
+    else
+        echo "  [MISSING] SPEC_NOT_FOUND in Entry Criteria (expected RED)"
+    fi
+else
+    echo "  [MISSING] SPEC_NOT_FOUND not found anywhere (expected RED)"
+fi
+
+# Check 2: Entry Criteria must explicitly mention SPEC_NOT_APPROVED
+if grep -q 'SPEC_NOT_APPROVED' "$ANALYZE_MD" 2>/dev/null; then
+    # Check if SPEC_NOT_APPROVED appears in Entry Criteria section
+    if sed -n '/^## Entry Criteria/,/^## /p' "$ANALYZE_MD" | grep -q 'SPEC_NOT_APPROVED' 2>/dev/null; then
+        HAS_ENTRY_SPEC_NOT_APPROVED=true
+        echo "  [FOUND] SPEC_NOT_APPROVED in Entry Criteria"
+    else
+        echo "  [MISSING] SPEC_NOT_APPROVED in Entry Criteria (expected RED)"
+    fi
+else
+    echo "  [MISSING] SPEC_NOT_APPROVED not found anywhere (expected RED)"
+fi
+
+# Check 3: Procedure must have SPEC_NOT_FOUND (should already pass)
+if grep -q 'SPEC_NOT_FOUND' "$ANALYZE_MD" 2>/dev/null; then
+    HAS_PROCEDURE_SPEC_NOT_FOUND=true
+    echo "  [FOUND] SPEC_NOT_FOUND in file"
+fi
+
+# Check 4: Procedure must have SPEC_NOT_APPROVED (should already pass)
+if grep -q 'SPEC_NOT_APPROVED' "$ANALYZE_MD" 2>/dev/null; then
+    HAS_PROCEDURE_SPEC_NOT_APPROVED=true
+    echo "  [FOUND] SPEC_NOT_APPROVED in file"
+fi
+
+echo ""
+if $HAS_ENTRY_SPEC_NOT_FOUND && $HAS_ENTRY_SPEC_NOT_APPROVED; then
+    echo "UNEXPECTED PASS: analyze.md has both SPEC_NOT_FOUND and SPEC_NOT_APPROVED in Entry Criteria"
+    exit 0
+else
+    echo "EXPECTED FAIL: analyze.md missing entry criteria gates (RED phase confirmed)"
+    echo "  Procedure has SPEC_NOT_FOUND=$HAS_PROCEDURE_SPEC_NOT_FOUND, SPEC_NOT_APPROVED=$HAS_PROCEDURE_SPEC_NOT_APPROVED"
+    echo "  But Entry Criteria needs explicit gates per spec §Task Cards → analyze.md"
+    exit 1
+fi

--- a/tests-v2/behaviors/writing-plans-backfill.sh
+++ b/tests-v2/behaviors/writing-plans-backfill.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: 2026 Michael Conrad
+# SPDX-License-Identifier: MIT
+# Provenance: AI-generated
+# Content-Verification Test: Writing-Plans Backfill Task Card
+#
+# Verifies that skills/writing-plans/tasks/backfill.md exists and
+# blocks on missing spec (entry criteria requiring spec presence).
+#
+# RED phase: backfill.md does NOT exist yet.
+# Expected to FAIL (non-zero exit).
+#
+# Co-authored with AI: OpenCode (deepseek-v4-flash)
+
+set -euo pipefail
+
+BACKFILL_MD=".opencode/skills/writing-plans/tasks/backfill.md"
+
+echo "=== RED Test: writing-plans-backfill ==="
+echo "Checking $BACKFILL_MD exists and blocks on missing spec..."
+echo ""
+
+EXISTS=false
+BLOCKS_ON_MISSING=false
+
+# Check 1: backfill.md must exist
+if [ -f "$BACKFILL_MD" ]; then
+    EXISTS=true
+    echo "  [FOUND] $BACKFILL_MD exists"
+
+    # Check 2: Must have entry criteria requiring spec presence
+    if grep -qi 'spec.*required\|missing.*spec\|spec.*not.*found\|no.*spec\|spec.*must\|entry.*criterion.*spec' "$BACKFILL_MD" 2>/dev/null; then
+        BLOCKS_ON_MISSING=true
+        echo "  [FOUND] Entry criteria blocks on missing spec"
+    else
+        echo "  [MISSING] No spec-required entry criteria (expected RED)"
+    fi
+else
+    echo "  [MISSING] $BACKFILL_MD does not exist (expected RED)"
+fi
+
+echo ""
+if $EXISTS && $BLOCKS_ON_MISSING; then
+    echo "UNEXPECTED PASS: backfill.md exists with spec-required entry criteria"
+    exit 0
+else
+    echo "EXPECTED FAIL: backfill.md not found or missing spec-required entry criteria (RED phase confirmed)"
+    exit 1
+fi

--- a/tests-v2/behaviors/writing-plans-cleanup.sh
+++ b/tests-v2/behaviors/writing-plans-cleanup.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: 2026 Michael Conrad
+# SPDX-License-Identifier: MIT
+# Provenance: AI-generated
+# Content-Verification Test: Writing-Plans Cleanup
+#
+# Verifies that old task files (retroactive.md, explore.md) are removed
+# and exactly 18 contract templates exist in contracts/.
+#
+# RED phase: retroactive.md still exists, contracts incomplete.
+# Expected to FAIL (non-zero exit).
+#
+# Co-authored with AI: OpenCode (deepseek-v4-flash)
+
+set -euo pipefail
+
+TASKS_DIR=".opencode/skills/writing-plans/tasks"
+CONTRACTS_DIR=".opencode/skills/writing-plans/contracts"
+
+echo "=== RED Test: writing-plans-cleanup ==="
+echo "Checking old files removed and 18 contract templates exist..."
+echo ""
+
+OLD_FILES_REMOVED=true
+CONTRACT_COUNT_OK=true
+
+# Check 1: retroactive.md must NOT exist
+if [ -f "$TASKS_DIR/retroactive.md" ]; then
+    OLD_FILES_REMOVED=false
+    echo "  [STILL EXISTS] $TASKS_DIR/retroactive.md (expected REMOVED)"
+else
+    echo "  [REMOVED] $TASKS_DIR/retroactive.md"
+fi
+
+# Check 2: explore.md must NOT exist
+if [ -f "$TASKS_DIR/explore.md" ]; then
+    OLD_FILES_REMOVED=false
+    echo "  [STILL EXISTS] $TASKS_DIR/explore.md (expected REMOVED)"
+else
+    echo "  [REMOVED] $TASKS_DIR/explore.md"
+fi
+
+# Check 3: Exactly 18 contract templates must exist
+CONTRACT_COUNT=0
+if [ -d "$CONTRACTS_DIR" ]; then
+    CONTRACT_COUNT=$(ls -1 "$CONTRACTS_DIR"/*.yaml 2>/dev/null | wc -l)
+fi
+echo "  Contract templates found: $CONTRACT_COUNT (expected 18)"
+if [ "$CONTRACT_COUNT" -ne 18 ]; then
+    CONTRACT_COUNT_OK=false
+fi
+
+echo ""
+if $OLD_FILES_REMOVED && $CONTRACT_COUNT_OK; then
+    echo "UNEXPECTED PASS: All old files removed and 18 contract templates exist"
+    exit 0
+else
+    echo "EXPECTED FAIL: Old files still exist or contract count != 18 (RED phase confirmed)"
+    exit 1
+fi

--- a/tests-v2/behaviors/writing-plans-create.sh
+++ b/tests-v2/behaviors/writing-plans-create.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: 2026 Michael Conrad
+# SPDX-License-Identifier: MIT
+# Provenance: AI-generated
+# Content-Verification Test: Writing-Plans Create Task Card
+#
+# Verifies that skills/writing-plans/tasks/create.md produces plans with
+# the full per-task cycle from the implementation-pipeline TDT.
+# Every task in every phase must enumerate every step from the
+# implementation-pipeline's per-task cycle (RED, Z3 check RED, RED doublecheck,
+# Z3 check RED doublecheck, Post-RED enforcement, Z3 check post-RED, GREEN,
+# Z3 check GREEN, Post-GREEN enforcement, Z3 check post-GREEN, Checkpoint tag,
+# Checkpoint commit).
+#
+# RED phase: current create.md does NOT enumerate the full per-task cycle.
+# Expected to FAIL (non-zero exit).
+#
+# Co-authored with AI: OpenCode (deepseek-v4-flash)
+
+set -euo pipefail
+
+CREATE_MD=".opencode/skills/writing-plans/tasks/create.md"
+
+echo "=== RED Test: writing-plans-create ==="
+echo "Checking $CREATE_MD produces plans with full per-task cycle..."
+echo ""
+
+EXISTS=false
+LOADS_TDT=false
+ENUMERATES_CYCLE=false
+
+# Check 1: create.md must exist
+if [ -f "$CREATE_MD" ]; then
+    EXISTS=true
+    echo "  [FOUND] $CREATE_MD exists"
+else
+    echo "  [MISSING] $CREATE_MD does not exist (expected RED)"
+fi
+
+# Check 2: Must reference loading the implementation-pipeline TDT at runtime
+if grep -qi 'implementation-pipeline.*TDT\|load.*implementation-pipeline\|read.*implementation-pipeline.*trigger\|skill.*implementation-pipeline' "$CREATE_MD" 2>/dev/null; then
+    LOADS_TDT=true
+    echo "  [FOUND] References loading implementation-pipeline TDT"
+else
+    echo "  [MISSING] No reference to loading implementation-pipeline TDT (expected RED)"
+fi
+
+# Check 3: Must enumerate the full per-task cycle steps
+# The per-task cycle includes: RED, Z3 check RED, RED doublecheck, Z3 check RED doublecheck,
+# Post-RED enforcement, Z3 check post-RED, GREEN, Z3 check GREEN, Post-GREEN enforcement,
+# Z3 check post-GREEN, Checkpoint tag, Checkpoint commit
+CYCLE_STEPS=("red" "z3 check red" "red doublecheck" "z3 check red doublecheck"
+             "post-red enforcement" "z3 check post-red" "green"
+             "z3 check green" "post-green enforcement" "z3 check post-green"
+             "checkpoint tag" "checkpoint commit")
+
+MATCH_COUNT=0
+for step in "${CYCLE_STEPS[@]}"; do
+    if grep -qi "$step" "$CREATE_MD" 2>/dev/null; then
+        MATCH_COUNT=$((MATCH_COUNT + 1))
+    fi
+done
+
+if [ "$MATCH_COUNT" -ge 10 ]; then
+    ENUMERATES_CYCLE=true
+    echo "  [FOUND] Enumerates $MATCH_COUNT/12 per-task cycle steps"
+else
+    echo "  [MISSING] Only $MATCH_COUNT/12 per-task cycle steps found (expected RED)"
+fi
+
+echo ""
+if $EXISTS && $LOADS_TDT && $ENUMERATES_CYCLE; then
+    echo "UNEXPECTED PASS: create.md already produces plans with full per-task cycle"
+    exit 0
+else
+    echo "EXPECTED FAIL: create.md does not produce plans with full per-task cycle (RED phase confirmed)"
+    exit 1
+fi

--- a/tests-v2/behaviors/writing-plans-self-review.sh
+++ b/tests-v2/behaviors/writing-plans-self-review.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: 2026 Michael Conrad
+# SPDX-License-Identifier: MIT
+# Provenance: AI-generated
+# Content-Verification Test: Writing-Plans Self-Review Task Card
+#
+# Verifies that skills/writing-plans/tasks/self-review.md detects missing
+# steps, placeholder patterns, SC coverage gaps, and type/name inconsistencies
+# in plans, and verifies every task follows every step from the Per-Task Cycle.
+#
+# RED phase: self-review.md does NOT exist yet.
+# Expected to FAIL (non-zero exit).
+#
+# Co-authored with AI: OpenCode (deepseek-v4-flash)
+
+set -euo pipefail
+
+SELF_REVIEW_MD=".opencode/skills/writing-plans/tasks/self-review.md"
+
+echo "=== RED Test: writing-plans-self-review ==="
+echo "Checking $SELF_REVIEW_MD for plan review capabilities..."
+echo ""
+
+EXISTS=false
+DETECTS_MISSING_STEPS=false
+DETECTS_PLACEHOLDERS=false
+DETECTS_SC_GAPS=false
+DETECTS_INCONSISTENCIES=false
+VERIFIES_PER_TASK_CYCLE=false
+
+# Check 1: self-review.md must exist
+if [ -f "$SELF_REVIEW_MD" ]; then
+    EXISTS=true
+    echo "  [FOUND] $SELF_REVIEW_MD exists"
+else
+    echo "  [MISSING] $SELF_REVIEW_MD does not exist (expected RED)"
+fi
+
+# Check 2: Must detect missing steps in plans
+if $EXISTS && grep -qi 'missing.*step\|step.*missing\|step.*gap\|incomplete.*step\|step.*absent\|step.*not.*found\|missing.*task' "$SELF_REVIEW_MD" 2>/dev/null; then
+    DETECTS_MISSING_STEPS=true
+    echo "  [FOUND] Missing step detection"
+else
+    echo "  [MISSING] Missing step detection (expected RED)"
+fi
+
+# Check 3: Must detect placeholder patterns
+if $EXISTS && grep -qi 'placeholder\|TODO\|FIXME\|TBD\|to.*do\|to.*be.*determined\|not.*implemented\|stub' "$SELF_REVIEW_MD" 2>/dev/null; then
+    DETECTS_PLACEHOLDERS=true
+    echo "  [FOUND] Placeholder pattern detection"
+else
+    echo "  [MISSING] Placeholder pattern detection (expected RED)"
+fi
+
+# Check 4: Must detect SC coverage gaps
+if $EXISTS && grep -qi 'SC.*coverage\|coverage.*gap\|SC.*gap\|success.*criterion.*missing\|SC.*missing\|SC.*not.*covered\|SC.*uncovered\|SC.*absent' "$SELF_REVIEW_MD" 2>/dev/null; then
+    DETECTS_SC_GAPS=true
+    echo "  [FOUND] SC coverage gap detection"
+else
+    echo "  [MISSING] SC coverage gap detection (expected RED)"
+fi
+
+# Check 5: Must detect type/name inconsistencies
+if $EXISTS && grep -qi 'type.*inconsist\|name.*inconsist\|inconsist.*type\|inconsist.*name\|mismatch\|type.*mismatch\|name.*mismatch\|inconsistent.*naming' "$SELF_REVIEW_MD" 2>/dev/null; then
+    DETECTS_INCONSISTENCIES=true
+    echo "  [FOUND] Type/name inconsistency detection"
+else
+    echo "  [MISSING] Type/name inconsistency detection (expected RED)"
+fi
+
+# Check 6: Must verify every task follows every step from Per-Task Cycle
+if $EXISTS && grep -qi 'per-task.*cycle\|task.*cycle\|every.*step\|each.*step\|full.*cycle\|cycle.*step\|step.*enumeration\|all.*steps.*present\|verify.*cycle' "$SELF_REVIEW_MD" 2>/dev/null; then
+    VERIFIES_PER_TASK_CYCLE=true
+    echo "  [FOUND] Per-task cycle verification"
+else
+    echo "  [MISSING] Per-task cycle verification (expected RED)"
+fi
+
+echo ""
+if $EXISTS && $DETECTS_MISSING_STEPS && $DETECTS_PLACEHOLDERS && $DETECTS_SC_GAPS && $DETECTS_INCONSISTENCIES && $VERIFIES_PER_TASK_CYCLE; then
+    echo "UNEXPECTED PASS: self-review.md already has all required plan review capabilities"
+    exit 0
+else
+    echo "EXPECTED FAIL: self-review.md missing required capabilities (RED phase confirmed)"
+    echo "  EXISTS=$EXISTS MISSING_STEPS=$DETECTS_MISSING_STEPS PLACEHOLDERS=$DETECTS_PLACEHOLDERS"
+    echo "  SC_GAPS=$DETECTS_SC_GAPS INCONSISTENCIES=$DETECTS_INCONSISTENCIES PER_TASK_CYCLE=$VERIFIES_PER_TASK_CYCLE"
+    exit 1
+fi

--- a/tests-v2/behaviors/writing-plans-structure.sh
+++ b/tests-v2/behaviors/writing-plans-structure.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: 2026 Michael Conrad
+# SPDX-License-Identifier: MIT
+# Provenance: AI-generated
+# Content-Verification Test: Writing-Plans Structure Task Card
+#
+# Verifies that skills/writing-plans/tasks/structure.md produces phase
+# decomposition, builds a dependency DAG, and selects skill+task from
+# the implementation-pipeline Trigger Dispatch Table.
+#
+# RED phase: structure.md does NOT exist yet.
+# Expected to FAIL (non-zero exit).
+#
+# Co-authored with AI: OpenCode (deepseek-v4-flash)
+
+set -euo pipefail
+
+STRUCTURE_MD=".opencode/skills/writing-plans/tasks/structure.md"
+
+echo "=== RED Test: writing-plans-structure ==="
+echo "Checking $STRUCTURE_MD for phase decomposition, DAG, and TDT selection..."
+echo ""
+
+EXISTS=false
+HAS_PHASE_DECOMP=false
+HAS_DAG=false
+HAS_TDT_SELECT=false
+
+# Check 1: structure.md must exist
+if [ -f "$STRUCTURE_MD" ]; then
+    EXISTS=true
+    echo "  [FOUND] $STRUCTURE_MD exists"
+else
+    echo "  [MISSING] $STRUCTURE_MD does not exist (expected RED)"
+fi
+
+# Check 2: Must produce phase decomposition
+if $EXISTS && grep -qi 'phase.*decomp\|decompose.*phase\|phase.*structur\|phase.*plan\|phase.*step\|phase.*concern' "$STRUCTURE_MD" 2>/dev/null; then
+    HAS_PHASE_DECOMP=true
+    echo "  [FOUND] Phase decomposition logic"
+else
+    echo "  [MISSING] Phase decomposition (expected RED)"
+fi
+
+# Check 3: Must build a dependency DAG
+if $EXISTS && grep -qi 'dag\|dependency.*graph\|dependency.*dag\|depends.*on\|dependency.*order\|dependency.*chain' "$STRUCTURE_MD" 2>/dev/null; then
+    HAS_DAG=true
+    echo "  [FOUND] Dependency DAG logic"
+else
+    echo "  [MISSING] Dependency DAG (expected RED)"
+fi
+
+# Check 4: Must select skill+task from implementation-pipeline TDT
+if $EXISTS && grep -qi 'implementation-pipeline\|trigger.*dispatch.*table\|tdt\|skill.*task.*select\|dispatch.*table\|pipeline.*tdt' "$STRUCTURE_MD" 2>/dev/null; then
+    HAS_TDT_SELECT=true
+    echo "  [FOUND] Implementation-pipeline TDT selection"
+else
+    echo "  [MISSING] Implementation-pipeline TDT selection (expected RED)"
+fi
+
+echo ""
+if $EXISTS && $HAS_PHASE_DECOMP && $HAS_DAG && $HAS_TDT_SELECT; then
+    echo "UNEXPECTED PASS: structure.md has phase decomposition, DAG, and TDT selection"
+    exit 0
+else
+    echo "EXPECTED FAIL: structure.md missing required capabilities (RED phase confirmed)"
+    echo "  EXISTS=$EXISTS PHASE_DECOMP=$HAS_PHASE_DECOMP DAG=$HAS_DAG TDT_SELECT=$HAS_TDT_SELECT"
+    exit 1
+fi

--- a/tests-v2/behaviors/writing-plans-workflows.sh
+++ b/tests-v2/behaviors/writing-plans-workflows.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: 2026 Michael Conrad
+# SPDX-License-Identifier: MIT
+# Provenance: AI-generated
+# Content-Verification Test: Writing-Plans Workflows
+#
+# Verifies the writing-plans SKILL.md has 3 self-contained workflow tables
+# (Create, Revise, Retroactive) with no cross-references between them.
+#
+# RED phase: SKILL.md currently has prose workflows, not tables.
+# Expected to FAIL (non-zero exit).
+#
+# Co-authored with AI: OpenCode (deepseek-v4-flash)
+
+set -euo pipefail
+
+SKILL_MD=".opencode/skills/writing-plans/SKILL.md"
+
+echo "=== RED Test: writing-plans-workflows ==="
+echo "Checking $SKILL_MD for 3 self-contained workflow tables..."
+echo ""
+
+HAS_CREATE=false
+HAS_REVISE=false
+HAS_RETROACTIVE=false
+HAS_CROSS_REF=false
+
+# Check 1: SKILL.md must have a markdown table row containing "Create"
+if grep -q '|.*Create.*|' "$SKILL_MD" 2>/dev/null; then
+    HAS_CREATE=true
+    echo "  [FOUND] Create workflow table row"
+else
+    echo "  [MISSING] Create workflow table row (expected RED)"
+fi
+
+# Check 2: Must have a table row containing "Revise"
+if grep -q '|.*Revise.*|' "$SKILL_MD" 2>/dev/null; then
+    HAS_REVISE=true
+    echo "  [FOUND] Revise workflow table row"
+else
+    echo "  [MISSING] Revise workflow table row (expected RED)"
+fi
+
+# Check 3: Must have a table row containing "Retroactive"
+if grep -q '|.*Retroactive.*|' "$SKILL_MD" 2>/dev/null; then
+    HAS_RETROACTIVE=true
+    echo "  [FOUND] Retroactive workflow table row"
+else
+    echo "  [MISSING] Retroactive workflow table row (expected RED)"
+fi
+
+# Check 4: Tables must be self-contained (no cross-references)
+if grep -qi 'same as\|see.*workflow\|as step\|as above\|see above' "$SKILL_MD" 2>/dev/null; then
+    HAS_CROSS_REF=true
+    echo "  [FOUND] Cross-references between workflows (expected RED)"
+else
+    echo "  [CLEAN] No cross-references between workflows"
+fi
+
+echo ""
+if $HAS_CREATE && $HAS_REVISE && $HAS_RETROACTIVE && ! $HAS_CROSS_REF; then
+    echo "UNEXPECTED PASS: All 3 workflow tables already exist with no cross-references"
+    exit 0
+else
+    echo "EXPECTED FAIL: SKILL.md missing workflow tables (RED phase confirmed)"
+    exit 1
+fi

--- a/tests-v2/behaviors/writing-plans.sh
+++ b/tests-v2/behaviors/writing-plans.sh
@@ -1,0 +1,236 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: 2026 Michael Conrad
+# SPDX-License-Identifier: MIT
+# Provenance: AI-generated
+# Content-Verification Test: Writing-Plans Comprehensive
+#
+# Verifies the new writing-plans structure:
+# 1. SKILL.md has 3 self-contained workflow tables (Create, Revise, Retroactive)
+# 2. 9 task cards exist (analyze, backfill, structure, create, self-review,
+#    solve, validate, revise, completion)
+# 3. Plan artifact uses structured markdown format with dispatch frontmatter,
+#    per-task checkbox lists, and dash sub-bullets
+#
+# GREEN phase: implementation is already in place from Phase 1.
+# Expected to PASS (exit 0).
+#
+# Co-authored with AI: OpenCode (deepseek-v4-flash)
+
+set -euo pipefail
+
+SKILL_MD=".opencode/skills/writing-plans/SKILL.md"
+TASKS_DIR=".opencode/skills/writing-plans/tasks"
+PLAN_FILE=".opencode/.issues/2085/plan.md"
+
+echo "=== GREEN Test: writing-plans ==="
+echo "Checking SKILL.md workflows, task cards, and plan format..."
+echo ""
+
+ALL_PASS=true
+
+# ============================================================
+# CHECK 1: SKILL.md has 3 self-contained workflow tables
+# ============================================================
+echo "--- Check 1: SKILL.md workflow tables ---"
+
+HAS_CREATE=false
+HAS_REVISE=false
+HAS_RETROACTIVE=false
+HAS_CROSS_REF=false
+
+# Check 1a: Create workflow section heading + table
+if grep -q '^### Create a plan from an approved spec' "$SKILL_MD" 2>/dev/null; then
+    HAS_CREATE=true
+    echo "  [FOUND] Create workflow section"
+else
+    echo "  [MISSING] Create workflow section"
+fi
+
+# Check 1b: Revise workflow section heading + table
+if grep -q '^### Revise an existing plan' "$SKILL_MD" 2>/dev/null; then
+    HAS_REVISE=true
+    echo "  [FOUND] Revise workflow section"
+else
+    echo "  [MISSING] Revise workflow section"
+fi
+
+# Check 1c: Retroactive workflow section heading + table
+if grep -q '^### Retroactive plan' "$SKILL_MD" 2>/dev/null; then
+    HAS_RETROACTIVE=true
+    echo "  [FOUND] Retroactive workflow section"
+else
+    echo "  [MISSING] Retroactive workflow section"
+fi
+
+# Check 1d: No cross-references between workflow tables
+# Scope the check to lines between first workflow heading and last workflow table end
+WORKFLOW_START=$(grep -n '^### Create a plan' "$SKILL_MD" | head -1 | cut -d: -f1)
+WORKFLOW_END=$(grep -n '^## Task Cards' "$SKILL_MD" | head -1 | cut -d: -f1)
+if [ -n "$WORKFLOW_START" ] && [ -n "$WORKFLOW_END" ]; then
+    if sed -n "${WORKFLOW_START},${WORKFLOW_END}p" "$SKILL_MD" | grep -qi 'same as\|see.*workflow\|as step\|as above\|see above'; then
+        HAS_CROSS_REF=true
+        echo "  [CROSS-REF] Cross-references detected between workflows"
+    else
+        echo "  [CLEAN] No cross-references between workflows"
+    fi
+else
+    echo "  [SKIP] Could not determine workflow boundaries"
+fi
+
+if $HAS_CREATE && $HAS_REVISE && $HAS_RETROACTIVE && ! $HAS_CROSS_REF; then
+    echo "  >> PASS: 3 workflow tables, no cross-references"
+else
+    echo "  >> FAIL: workflow table check"
+    ALL_PASS=false
+fi
+echo ""
+
+# ============================================================
+# CHECK 2: 9 task cards exist
+# ============================================================
+echo "--- Check 2: Task cards ---"
+
+REQUIRED_TASKS=("analyze" "backfill" "structure" "create" "self-review" "solve" "validate" "revise" "completion")
+MISSING_TASKS=()
+
+for task in "${REQUIRED_TASKS[@]}"; do
+    if [ -f "$TASKS_DIR/$task.md" ]; then
+        echo "  [FOUND] tasks/$task.md"
+    else
+        echo "  [MISSING] tasks/$task.md"
+        MISSING_TASKS+=("$task")
+    fi
+done
+
+if [ ${#MISSING_TASKS[@]} -eq 0 ]; then
+    echo "  >> PASS: All 9 task cards present"
+else
+    echo "  >> FAIL: Missing ${#MISSING_TASKS[@]} task card(s): ${MISSING_TASKS[*]}"
+    ALL_PASS=false
+fi
+echo ""
+
+# ============================================================
+# CHECK 3: Plan artifact uses structured markdown format
+# ============================================================
+echo "--- Check 3: Plan structured markdown format ---"
+
+HAS_FRONTMATTER=false
+HAS_DISPATCH=false
+HAS_TITLE=false
+HAS_GOAL=false
+HAS_ARCHITECTURE=false
+HAS_TECH_STACK=false
+HAS_PRE_IMPL=false
+HAS_PHASE=false
+HAS_TASK=false
+HAS_CHECKBOX=false
+HAS_DASH_BULLET=false
+
+# Check 3a: YAML frontmatter with plan_schema_version
+if grep -q 'plan_schema_version:' "$PLAN_FILE" 2>/dev/null; then
+    HAS_FRONTMATTER=true
+    echo "  [FOUND] YAML frontmatter with plan_schema_version"
+else
+    echo "  [MISSING] YAML frontmatter with plan_schema_version"
+fi
+
+# Check 3b: Dispatch section in frontmatter
+if grep -q 'dispatch:' "$PLAN_FILE" 2>/dev/null; then
+    HAS_DISPATCH=true
+    echo "  [FOUND] Dispatch section in frontmatter"
+else
+    echo "  [MISSING] Dispatch section in frontmatter"
+fi
+
+# Check 3c: Title section
+if grep -q '^# Implementation Plan' "$PLAN_FILE" 2>/dev/null; then
+    HAS_TITLE=true
+    echo "  [FOUND] Title section"
+else
+    echo "  [MISSING] Title section"
+fi
+
+# Check 3d: Goal section
+if grep -q '^\*\*Goal:\*\*' "$PLAN_FILE" 2>/dev/null; then
+    HAS_GOAL=true
+    echo "  [FOUND] Goal section"
+else
+    echo "  [MISSING] Goal section"
+fi
+
+# Check 3e: Architecture section
+if grep -q '^\*\*Architecture:\*\*' "$PLAN_FILE" 2>/dev/null; then
+    HAS_ARCHITECTURE=true
+    echo "  [FOUND] Architecture section"
+else
+    echo "  [MISSING] Architecture section"
+fi
+
+# Check 3f: Tech Stack section
+if grep -q '^\*\*Tech Stack:\*\*' "$PLAN_FILE" 2>/dev/null; then
+    HAS_TECH_STACK=true
+    echo "  [FOUND] Tech Stack section"
+else
+    echo "  [MISSING] Tech Stack section"
+fi
+
+# Check 3g: Pre-Implementation section
+if grep -q '^## Pre-Implementation' "$PLAN_FILE" 2>/dev/null; then
+    HAS_PRE_IMPL=true
+    echo "  [FOUND] Pre-Implementation section"
+else
+    echo "  [MISSING] Pre-Implementation section"
+fi
+
+# Check 3h: Phase sections
+if grep -q '^## Phase' "$PLAN_FILE" 2>/dev/null; then
+    HAS_PHASE=true
+    echo "  [FOUND] Phase sections"
+else
+    echo "  [MISSING] Phase sections"
+fi
+
+# Check 3i: Task subsections
+if grep -q '^### Task' "$PLAN_FILE" 2>/dev/null; then
+    HAS_TASK=true
+    echo "  [FOUND] Task subsections"
+else
+    echo "  [MISSING] Task subsections"
+fi
+
+# Check 3j: Checkbox lists
+if grep -q '\- \[ \]' "$PLAN_FILE" 2>/dev/null; then
+    HAS_CHECKBOX=true
+    echo "  [FOUND] Checkbox lists"
+else
+    echo "  [MISSING] Checkbox lists"
+fi
+
+# Check 3k: Dash sub-bullets (Dispatch/Context lines)
+if grep -q '^  - Dispatch:\|^  - Context:' "$PLAN_FILE" 2>/dev/null; then
+    HAS_DASH_BULLET=true
+    echo "  [FOUND] Dash sub-bullets (Dispatch/Context)"
+else
+    echo "  [MISSING] Dash sub-bullets (Dispatch/Context)"
+fi
+
+if $HAS_FRONTMATTER && $HAS_DISPATCH && $HAS_TITLE && $HAS_GOAL && $HAS_ARCHITECTURE && $HAS_TECH_STACK && $HAS_PRE_IMPL && $HAS_PHASE && $HAS_TASK && $HAS_CHECKBOX && $HAS_DASH_BULLET; then
+    echo "  >> PASS: Plan follows structured markdown format"
+else
+    echo "  >> FAIL: Plan missing required sections"
+    ALL_PASS=false
+fi
+echo ""
+
+# ============================================================
+# RESULT
+# ============================================================
+echo "=== RESULT ==="
+if $ALL_PASS; then
+    echo "PASS: All 3 checks pass (writing-plans satisfies new behavior)"
+    exit 0
+else
+    echo "FAIL: writing-plans does not fully satisfy new behavior checks"
+    exit 1
+fi


### PR DESCRIPTION
## Summary

Move 12 test files from the parent repo (`opencode-config/tests/behaviors/`) into the submodule's test infrastructure (`tests-v2/behaviors/`). These tests verify submodule content (writing-plans skill, rationalization-check gates) and belong here.

## Changes
- Move 12 test files from parent repo to `tests-v2/behaviors/`
- Tests: writing-plans-*.sh, rationalization-check-*.sh, verify-auth-step5d.sh

Fixes #2090