### PR TITLE
fix(#2105): add post-creation HALT step prohibiting merge (SC-1)

### DIFF
--- a/skills/git-workflow-pr/tasks/pr-creation.md
+++ b/skills/git-workflow-pr/tasks/pr-creation.md
@@ -67,6 +67,10 @@ Generates changelog (or skips with `[skip changelog]`), squashes commits, rebase
 
 Collects sub-issues from parent spec, creates PR with executive summary body, extracts URL from API response, reports in chat and HALTs.
 
+### Step 8: HALT — Do Not Merge
+
+**HALT — do not merge. Only the developer can merge. The `github_merge_pull_request` tool is FORBIDDEN for agent use.**
+
 ## Sub-Task Files
 
 | Sub-Task | Purpose | Words |


### PR DESCRIPTION
## Summary

Adds the post-creation HALT step to `pr-creation.md` prohibiting the agent from merging PRs — the last remaining unenforced SC from #2105.

## Changes

- `skills/git-workflow-pr/tasks/pr-creation.md`: Added Step 8 with explicit HALT — do not merge. Only the developer can merge. The `github_merge_pull_request` tool is FORBIDDEN for agent use.

## Notes

All other SCs across #2103, #2104, #2105, #2108, and #2109 were already implemented in the prior merge (PR #2112). This is the single remaining gap.

Fixes #2105 SC-1