### PR TITLE
Per-SC decomposition, stop-command halt, connectivity verification gate

### DIFF
--- a/guidelines/000-critical-rules.md
+++ b/guidelines/000-critical-rules.md
@@ -280,6 +280,22 @@ Using `github_issue_write` to create or update spec issue content (issue body, t
 - `github_issue_write` for labels, assignees, comments, and status markers only
 
 
+### [critical-rules-stop] CRITICAL VIOLATION — "stop" command triggers terminal halt — zero output, zero tool calls, zero proposals
+When the user says "stop" (or unambiguous equivalent), the agent MUST immediately cease all operations: no further output, no tool calls, no proposals, no follow-up questions. "stop" is a hard state transition — there is no recovery from "stop" within the same session. The user must explicitly restart with a new message. This is a Tier 1 safety-critical rule — it NEVER yields to developer authorization.
+
+#### 🚫 FORBIDDEN
+- Producing any output after "stop" (including "okay, stopping now", "understood", or any acknowledgment)
+- Making any tool call after "stop" (including cleanup, save, or status checks)
+- Proposing alternatives, asking for clarification, or suggesting next steps
+- Treating "stop" as "stop and try something else" — it is terminal, not conditional
+- Any form of acknowledgment, confirmation, or farewell
+
+#### ✅ REQUIRED
+- On detecting "stop": immediately cease all operations
+- Zero output, zero tool calls, zero proposals
+- The user must explicitly restart with a new message to resume interaction
+- "stop" is a hard state transition — no recovery within the same session
+
 ### Tier 2 — Process-Integrity (HALT — Quality Defects)
 
 Rules that prevent **quality defects**: skipped verification, inline work, skill bypass, monolithic implementation, verification failures, missing sub-issues. These yield to developer authorization.
@@ -1174,22 +1190,6 @@ All failures are agent-owned. Remediation is the default action. Escalation is o
 ### [critical-rules-066] Terminology Standardization — all context references must use standardized vocabulary
 All references to "context budget", "context cost", and "context awareness" must use the standardized vocabulary: "orchestrator context", "sub-agent context", and "orchestrator context discipline". These terms describe operational bookkeeping for context management — they are NOT implementation complexity measures. Read [§1.1 Terminology Standardization](guidelines/020-go-prohibitions.md). CHANGELOG entries and historical references are exempt.
 
-
-### [critical-rules-stop] CRITICAL VIOLATION — "stop" command triggers terminal halt — zero output, zero tool calls, zero proposals
-When the user says "stop" (or unambiguous equivalent), the agent MUST immediately cease all operations: no further output, no tool calls, no proposals, no follow-up questions. "stop" is a hard state transition — there is no recovery from "stop" within the same session. The user must explicitly restart with a new message. This is a Tier 1 safety-critical rule — it NEVER yields to developer authorization.
-
-#### 🚫 FORBIDDEN
-- Producing any output after "stop" (including "okay, stopping now", "understood", or any acknowledgment)
-- Making any tool call after "stop" (including cleanup, save, or status checks)
-- Proposing alternatives, asking for clarification, or suggesting next steps
-- Treating "stop" as "stop and try something else" — it is terminal, not conditional
-- Any form of acknowledgment, confirmation, or farewell
-
-#### ✅ REQUIRED
-- On detecting "stop": immediately cease all operations
-- Zero output, zero tool calls, zero proposals
-- The user must explicitly restart with a new message to resume interaction
-- "stop" is a hard state transition — no recovery within the same session
 
 ### Channel-Routing Table — Issue Comments vs. Chat Output
 

--- a/skills/spec-creation/tasks/create.md
+++ b/skills/spec-creation/tasks/create.md
@@ -43,7 +43,7 @@ Construct the spec with all required sections:
 3. **Not Included** — Explicitly excluded scope
 4. **Success Criteria** — Table with ID, Criterion, Evidence Type, Verification Method columns
 5. **Requirements** — Numbered requirements with SHALL language
-6. **Phases** — Implementation phases with REQ references
+6. **Items** — Per-SC item enumeration. Each SC maps to exactly one item (plan_item number). Items are numbered sequentially starting from 1.
 7. **Dependencies** — Prerequisite specs, skills, guidelines
 8. **Traceability** — Table mapping Requirements → SCs → Phases
 


### PR DESCRIPTION
## Summary

Implements three issues in a stacked PR:

### .opencode#2104 — Per-SC RED/GREEN Decomposition
- Updated spec-creation create.md Step 6: 'Phases' → 'Items' with per-SC enumeration
- All other affected files already had per-SC content (pipeline-executor, tdd-chaining-gate, red.md, green.md, AGENTS.md, 091-incremental-build.md)

### .opencode#2108 — Connectivity Verification Gate
- Added Connectivity Verification Gate section to .opencode/AGENTS.md
- Behavioral test exists at tests-v2/behaviors/connectivity-verification.sh

### .opencode#2109 — Stop-Command Terminal Halt
- Added [critical-rules-stop] Tier 1 section to 000-critical-rules.md
- Removed duplicate from Tier 3 section
- Behavioral tests exist: stop-command.sh, discuss-boundary.sh, solicitation-gate.sh

## Files Changed
- `guidelines/000-critical-rules.md` — Added stop-command section, removed duplicate
- `skills/spec-creation/tasks/create.md` — Step 6: Phases → Items

## Fixes
Closes .opencode#2104, .opencode#2108, .opencode#2109