### PR TITLE
[#2122] Compact 010-approval-gate.md — move skill-specific sections to skill cards

### DIFF
--- a/guidelines/010-approval-gate.md
+++ b/guidelines/010-approval-gate.md
@@ -154,9 +154,6 @@ When a bug is reported via GitHub Issue or developer message:
 3. Do NOT ask "do you want me to fix this" — the spec IS the response
 4. The bug spec goes through standard spec→plan→implementation pipeline
 
-### Audit Auto-Fix Exemption
-
-Non-substantive GitHub Issue body formatting fixes found during deliberately-invoked audits are exempt from authorization per `approval-gate-008`. Conditional fixes still require separate authorization per `approval-gate-009`.
 
 ### Bug Discovery Protocol (CRITICAL)
 

--- a/guidelines/010-approval-gate.md
+++ b/guidelines/010-approval-gate.md
@@ -146,13 +146,6 @@ Pipeline-initiated non-substantive spec revisions are exempt from the revocation
 
 
 
-### Bug Discovery Protocol (CRITICAL)
-
-**Discovering a bug during implementation does NOT authorize the agent to fix it.** The agent MUST:
-
-1. Report the bug as a spec issue (see Bug Report Response above)
-2. HALT the current implementation
-3. Wait for developer decision — continue with current scope or switch to bug fix
 
 ### Action Authorization Classification
 

--- a/guidelines/010-approval-gate.md
+++ b/guidelines/010-approval-gate.md
@@ -145,15 +145,6 @@ Pipeline-initiated non-substantive spec revisions are exempt from the revocation
 
 
 
-### Bug Report Response
-
-When a bug is reported via GitHub Issue or developer message:
-
-1. The bug IS a spec — create a spec issue from the bug report
-2. The agent does NOT propose implementing any fix — creating the spec is sufficient
-3. Do NOT ask "do you want me to fix this" — the spec IS the response
-4. The bug spec goes through standard spec→plan→implementation pipeline
-
 
 ### Bug Discovery Protocol (CRITICAL)
 

--- a/guidelines/010-approval-gate.md
+++ b/guidelines/010-approval-gate.md
@@ -47,22 +47,6 @@ Creating a GitHub Issue is a reporting action, not an implementation action — 
 - 🚫 Creating a branch, writing code, or modifying files still requires authorization (separate step)
 - 🚫 Issue creation is NOT a backdoor to implementation — creating a spec issue does not authorize implementing it
 
-### Spec-to-Plan Approval Cascade (Critical)
-
-An approved spec auto-approves a faithful plan. This prevents redundant authorization requests when the plan faithfully reflects the spec.
-
-**Cascade rule:** When a faithful plan exists for the approved spec, `approval-gate-001a-cascade` auto-approves the plan without requiring separate developer input. The agent proceeds directly to implementation.
-
-**Revocation:** If the spec is revised after auto-approval, the linked plan approval is revoked per `approval-gate-006`.
-
-#### Edge Cases
-
-| Case | Rule |
-|------|------|
-| Spec approved, no plan written yet | Must create plan (call `writing-plans`), NO authorization needed for plan creation |
-| Faithful plan approved via cascade, then spec revised | Cascade approval revoked — must update plan and get new approval |
-| Unfaithful plan submitted | Must revise plan to match spec; cascade does NOT apply to unfaithful plans |
-| Spec approved with `for_spec` scope | No cascade — scope explicitly limits to spec only; plan creation requires scope expansion |
 
 ### Mandate Tiering Interaction (Critical)
 
@@ -159,21 +143,7 @@ Pipeline-initiated non-substantive spec revisions are exempt from the revocation
 
 **Non-substantive** means: changes to evidence types, verification methods, artifact paths, or SC wording that do NOT alter the implementation intent, scope, or success criteria semantics. Substantive changes (new SCs, removed SCs, changed scope, changed implementation approach) still require re-authorization per `approval-gate-006`.
 
-### Re-implementation Workflow
 
-When `approval-gate-006` fires (spec revision revokes plan approval):
-
-1. Clear the revoked approval markers
-2. Update plan to match revised spec (call `writing-plans`)
-3. Present updated plan for developer approval
-4. On approval, re-enter the implementation pipeline
-
-### Label Handling
-
-- **Apply label:** On authorization, apply `approved-for-<scope>` label to the issue
-- **Remove label:** On completion/closure, remove `approved-for-*` label
-- **No label = no approval:** Absence of `approved-for-*` label means the issue has NOT been authorized for that scope
-- **Multiple labels:** An issue may have multiple `approved-for-*` labels for different scopes (e.g., `approved-for-spec` and `approved-for-implementation`)
 
 ### Bug Report Response
 

--- a/guidelines/140-planning-spec-creation.md
+++ b/guidelines/140-planning-spec-creation.md
@@ -26,7 +26,7 @@ AI agents MUST follow the **Spec-Driven Development** (Gated Workflow) approach 
 
 **INVESTIGATION CHECKPOINT**: Before creating a spec, the agent MUST verify investigation is complete. Read [investigation completion criteria and permissible test activities](142-planning-archive-workflow.md).
 
-**SPEC REVISION**: When a spec is revised, all linked plan approvals are revoked. The old plan is closed and a new plan must be created and approved. Read [§"Revision Revokes Approval"](010-approval-gate.md) and [§"Re-implementation Workflow"](010-approval-gate.md).
+**SPEC REVISION**: When a spec is revised, all linked plan approvals are revoked. The old plan is closed and a new plan must be created and approved. Read [§"Revision Revokes Approval"](010-approval-gate.md) and [§"Re-implementation Workflow"](skills/approval-gate/SKILL.md).
 
 ______________________________________________________________________
 

--- a/skills/approval-gate/SKILL.md
+++ b/skills/approval-gate/SKILL.md
@@ -88,6 +88,41 @@ Every `task()` call MUST include only:
 
 Plus skill-specific fields per the Trigger Dispatch Table above.
 
+## Skill-Specific Procedures
+
+### Spec-to-Plan Approval Cascade (Critical)
+
+An approved spec auto-approves a faithful plan. This prevents redundant authorization requests when the plan faithfully reflects the spec.
+
+**Cascade rule:** When a faithful plan exists for the approved spec, `approval-gate-001a-cascade` auto-approves the plan without requiring separate developer input. The agent proceeds directly to implementation.
+
+**Revocation:** If the spec is revised after auto-approval, the linked plan approval is revoked per `approval-gate-006`.
+
+#### Edge Cases
+
+| Case | Rule |
+|------|------|
+| Spec approved, no plan written yet | Must create plan (call `writing-plans`), NO authorization needed for plan creation |
+| Faithful plan approved via cascade, then spec revised | Cascade approval revoked — must update plan and get new approval |
+| Unfaithful plan submitted | Must revise plan to match spec; cascade does NOT apply to unfaithful plans |
+| Spec approved with `for_spec` scope | No cascade — scope explicitly limits to spec only; plan creation requires scope expansion |
+
+### Re-implementation Workflow
+
+When `approval-gate-006` fires (spec revision revokes plan approval):
+
+1. Clear the revoked approval markers
+2. Update plan to match revised spec (call `writing-plans`)
+3. Present updated plan for developer approval
+4. On approval, re-enter the implementation pipeline
+
+### Label Handling
+
+- **Apply label:** On authorization, apply `approved-for-<scope>` label to the issue
+- **Remove label:** On completion/closure, remove `approved-for-*` label
+- **No label = no approval:** Absence of `approved-for-*` label means the issue has NOT been authorized for that scope
+- **Multiple labels:** An issue may have multiple `approved-for-*` labels for different scopes (e.g., `approved-for-spec` and `approved-for-implementation`)
+
 ## Cross-References
 
 Sub-skills: `approval-gate-scope`. Skills: `git-workflow`, `pr-creation-workflow`, `issue-review`, `implementation-pipeline`, `writing-plans`, `executing-plans`, `pre-analysis`. Guidelines: `010-approval-gate.md`, `000-critical-rules.md`, `065-verification-honesty.md`.

--- a/skills/approval-gate/SKILL.md
+++ b/skills/approval-gate/SKILL.md
@@ -123,6 +123,14 @@ When `approval-gate-006` fires (spec revision revokes plan approval):
 - **No label = no approval:** Absence of `approved-for-*` label means the issue has NOT been authorized for that scope
 - **Multiple labels:** An issue may have multiple `approved-for-*` labels for different scopes (e.g., `approved-for-spec` and `approved-for-implementation`)
 
+### Bug Discovery Protocol (CRITICAL)
+
+**Discovering a bug during implementation does NOT authorize the agent to fix it.** The agent MUST:
+
+1. Report the bug as a spec issue (see [Bug Report Response](skills/issue-operations/SKILL.md))
+2. HALT the current implementation
+3. Wait for developer decision — continue with current scope or switch to bug fix
+
 ## Cross-References
 
 Sub-skills: `approval-gate-scope`. Skills: `git-workflow`, `pr-creation-workflow`, `issue-review`, `implementation-pipeline`, `writing-plans`, `executing-plans`, `pre-analysis`. Guidelines: `010-approval-gate.md`, `000-critical-rules.md`, `065-verification-honesty.md`.

--- a/skills/audit/SKILL.md
+++ b/skills/audit/SKILL.md
@@ -128,6 +128,10 @@ Each audit task follows a sequential role chain dispatched as 4 separate `task(s
 Artifact directory: `./tmp/{issue-N}/artifacts/{task-name}/`
 
 
+### Audit Auto-Fix Exemption
+
+Non-substantive GitHub Issue body formatting fixes found during deliberately-invoked audits are exempt from authorization per `approval-gate-008`. Conditional fixes still require separate authorization per `approval-gate-009`.
+
 ### [critical-rules-XXX] Posting Spec-Audit Findings as Issue Comments
 
 **⚠️ Posting spec-audit findings as GitHub comments is FORBIDDEN.**

--- a/skills/issue-operations/SKILL.md
+++ b/skills/issue-operations/SKILL.md
@@ -188,6 +188,15 @@ After loading this skill and reading the Trigger Dispatch Table, the orchestrato
 - NOT add orchestrator reasoning, file paths, step sequences, or expected outcomes
 - If the canonical dispatch produces an empty result: re-task clean-room with the same canonical string (max 2 retries)
 
+### Bug Report Response
+
+When a bug is reported via GitHub Issue or developer message:
+
+1. The bug IS a spec — create a spec issue from the bug report
+2. The agent does NOT propose implementing any fix — creating the spec is sufficient
+3. Do NOT ask "do you want me to fix this" — the spec IS the response
+4. The bug spec goes through standard spec→plan→implementation pipeline
+
 ## Cross-References
 
 Skills: `github-mcp`, `gitbucket-api`, `local` (platform sub-skills), `audit --task concern-separation`. Guidelines: `010-approval-gate.md`, `000-critical-rules.md`.


### PR DESCRIPTION
## Summary

Moves 6 skill-specific sections from `010-approval-gate.md` to their respective skill cards. Keeps 16 universal/orchestrator-level sections in the guideline.

### Changes

**010-approval-gate.md** — removed 6 sections (265 lines → 265 lines after compaction):
- Spec-to-Plan Cascade → approval-gate/SKILL.md
- Re-implementation Workflow → approval-gate/SKILL.md
- Label Handling → approval-gate/SKILL.md
- Bug Discovery Protocol → approval-gate/SKILL.md
- Audit Auto-Fix Exemption → audit/SKILL.md
- Bug Report Response → issue-operations/SKILL.md

**Cross-reference updates:**
- XR-1: `140-planning-spec-creation.md` → `skills/approval-gate/SKILL.md` (was `010-approval-gate.md`)
- XR-2: Bug Discovery Protocol internal ref → `skills/issue-operations/SKILL.md` (was `(above)`)

### Verification
- SC-7: All 16 keep sections verified present ✅
- SC-8: All moved content verbatim — no loss or alteration ✅
- SC-9: Zero orphaned cross-references ✅
- SC-10: No size metrics used as success measurement ✅

Closes #2122