### PR TITLE
docs(#2189): add submodule-only push bypass and wrong-repo lessons to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -149,6 +149,10 @@ Guidelines are pruned to the absolute minimum. See `.opencode/guidelines/` for:
 
 **Post-timeout recovery:** SQLite DB in the test home survives bash tool kills. Export manually via the procedure in `.opencode/tests-v2/AGENTS.md §10.5`.
 
+**Submodule-only push bypass — CRITICAL VIOLATION:** Using `--no-verify` to bypass the pre-push hook on a submodule-only push is never correct. The hook exists because submodule-only PRs create review overhead with zero functional change. If the submodule PR is already merged, the work is done — no pointer-only PR is needed. The pointer updates naturally alongside the next real parent-repo change. A blocked push means the hook is working correctly — investigate why, don't bypass it. See `.opencode/AGENTS.md §Submodule Pointer Updates`.
+
+**Wrong repo for spec creation:** When creating a spec to track changes, the agent MUST file the issue against the repo where the change lives — not the root repo by default. Check `## Repo Information` from session-init to determine the correct owner/repo. Changes to `.opencode/` files belong in the `.opencode` repo. Changes to root repo files belong in the root repo. Defaulting to the root repo produces issues in the wrong repository.
+
 ---
 
 ## `gb` CLI Tool — GitBucket Operations


### PR DESCRIPTION
## Summary

Adds two new lessons to the Testing Lessons Learned section in `.opencode/AGENTS.md`:

1. **Submodule-only push bypass — CRITICAL VIOLATION:** Documents that using `--no-verify` to bypass the pre-push hook on a submodule-only push is never correct. The hook was working correctly — the work was already done, no PR was needed.

2. **Wrong repo for spec creation:** Documents that specs must be filed against the repo where the change lives, not the root repo by default. Agents must check `## Repo Information` from session-init to determine the correct owner/repo.

## Success Criteria

| ID | Criterion | Evidence Type |
|----|-----------|---------------|
| SC-1 | AGENTS.md contains a "Submodule-only push bypass — CRITICAL VIOLATION" lesson under Testing Lessons Learned | `string` |
| SC-2 | Lesson states that `--no-verify` to bypass the pre-push hook on a submodule-only push is a CRITICAL VIOLATION | `string` |
| SC-3 | Lesson cross-references the Submodule Pointer Updates section and critical-rules-049 | `string` |
| SC-4 | Lesson explains the correct response to a blocked submodule-only push: the work is done, no PR needed | `string` |
| SC-5 | AGENTS.md contains a "Wrong repo for spec creation" lesson under Testing Lessons Learned | `string` |
| SC-6 | Lesson states that specs must be filed against the repo where the change lives, not the root repo by default | `string` |
| SC-7 | Lesson instructs agents to check `## Repo Information` from session-init to determine the correct repo before creating issues | `string` |
| SC-8 | Pre-push hook and critical-rules-049 remain untouched (no modification to enforcement mechanisms) | `structural` |

## Related

- Closes #2189