### PR TITLE
fix(#2198): #2176 audit remediation — remove stale sc-count-gate and enforcement gate references

### DIFF
--- a/skills/implementation-pipeline/pipeline-state-machine.yaml
+++ b/skills/implementation-pipeline/pipeline-state-machine.yaml
@@ -20,7 +20,6 @@ variables:
       - audit
       - z3-check
       - structural-checks
-      - sc-count-gate
       - pre-pr-gate
       - rationalization-check
       - regression-check
@@ -41,7 +40,6 @@ variables:
       - audit
       - z3-check
       - structural-checks
-      - sc-count-gate
       - pre-pr-gate
       - rationalization-check
       - regression-check
@@ -62,8 +60,7 @@ preconditions:
   - "z3.Implies(previous_step == z3.StringVal('commit-inline'), current_step == z3.StringVal('audit'))"
   - "z3.Implies(previous_step == z3.StringVal('audit'), z3.Or(current_step == z3.StringVal('z3-check'), current_step == z3.StringVal('red')))"
   - "z3.Implies(previous_step == z3.StringVal('z3-check'), z3.Or(current_step == z3.StringVal('structural-checks'), current_step == z3.StringVal('red')))"
-  - "z3.Implies(previous_step == z3.StringVal('structural-checks'), z3.Or(current_step == z3.StringVal('sc-count-gate'), current_step == z3.StringVal('red')))"
-  - "z3.Implies(previous_step == z3.StringVal('sc-count-gate'), z3.Or(current_step == z3.StringVal('pre-pr-gate'), current_step == z3.StringVal('red')))"
+  - "z3.Implies(previous_step == z3.StringVal('structural-checks'), z3.Or(current_step == z3.StringVal('pre-pr-gate'), current_step == z3.StringVal('red')))"
   - "z3.Implies(previous_step == z3.StringVal('pre-pr-gate'), z3.Or(current_step == z3.StringVal('rationalization-check'), current_step == z3.StringVal('red')))"
   - "z3.Implies(previous_step == z3.StringVal('rationalization-check'), z3.Or(current_step == z3.StringVal('regression-check'), current_step == z3.StringVal('red')))"
   - "z3.Implies(previous_step == z3.StringVal('regression-check'), z3.Or(current_step == z3.StringVal('review-prep'), current_step == z3.StringVal('red')))"

--- a/skills/test-driven-development/tasks/green.md
+++ b/skills/test-driven-development/tasks/green.md
@@ -57,7 +57,4 @@ GREEN-phase sub-agents implement code only — they MUST NOT write or modify tes
 
 ### Violation Handling
 
-The `post-green-enforcement` gate runs
-`git diff --name-only -- test/ | wc -l` and FAILs if the count > 0. If this gate
-fires, the orchestrator re-dispatches the GREEN-phase from clean-room state — no
-inline fallback.
+The GREEN-phase sub-agent MUST NOT modify any file under `test/`. If `git diff --name-only -- test/` shows changes after GREEN, the orchestrator re-dispatches the GREEN-phase from clean-room state — no inline fallback.

--- a/skills/test-driven-development/tasks/operating-protocol.md
+++ b/skills/test-driven-development/tasks/operating-protocol.md
@@ -22,18 +22,18 @@ All TDD task headings in plan documents MUST use the SC-ID parenthetical format:
 **✅ CORRECT:**
 ```text
 ### TDD-1: Update sc-coherence-gate with evidence-type uplift scan (SC-6)
-### TDD-4: Add post-red-enforcement to routing table (SC-1, SC-5)
+### TDD-4: Add pre-regression-verify to routing table (SC-1, SC-5)
 ```
 
 **🚫 INCORRECT:**
 ```text
 ### TDD-1: Update sc-coherence-gate with evidence-type uplift scan  ← missing SC-ID
-### TDD-4: Add post-red-enforcement: SC-1, SC-5  ← wrong format
+### TDD-4: Add pre-regression-verify: SC-1, SC-5  ← wrong format
 ```
 
 ### Enforcement
 
-The `pre-red-baseline` sub-agent parses plan TDD headings, extracts SC-IDs, and cross-references against the spec SC table. If any TDD heading references an SC-ID that does not exist in the spec, the gate returns BLOCKED with `MISSING-TRACEABILITY`.
+The TDD heading validator parses plan TDD headings, extracts SC-IDs, and cross-references against the spec SC table. If any TDD heading references an SC-ID that does not exist in the spec, the validator returns BLOCKED with `MISSING-TRACEABILITY`.
 
 ### SC-ID Extraction Contract
 

--- a/skills/test-driven-development/tasks/red.md
+++ b/skills/test-driven-development/tasks/red.md
@@ -74,4 +74,4 @@ RED-phase sub-agents write tests only — they MUST NOT modify `src/` or any imp
 
 ### Violation Handling
 
-The `post-red-enforcement` gate executes `git diff --name-only -- src/ | wc -l` and FAILs if the count > 0. If this gate fires, the orchestrator re-dispatches the RED-phase from clean-room state — no inline fallback.
+The RED-phase sub-agent MUST NOT modify any file under `src/`. If `git diff --name-only -- src/` shows changes after RED, the orchestrator re-dispatches the RED-phase from clean-room state — no inline fallback.


### PR DESCRIPTION
## Summary

Remediation of 2 FAIL findings from the #2176 spec audit (DiMo chain). The implementation left stale references behind: `sc-count-gate` in the pipeline state machine, and `post-red-enforcement`/`post-green-enforcement`/`pre-red-baseline` in TDD task files.

## Changes

| File | Change |
|------|--------|
| `pipeline-state-machine.yaml` | Removed `sc-count-gate` from both domain lists and 2 Z3 preconditions; `structural-checks` → `pre-pr-gate` directly |
| `test-driven-development/tasks/red.md` | Replaced `post-red-enforcement` gate reference with RED-phase constraint description |
| `test-driven-development/tasks/green.md` | Replaced `post-green-enforcement` gate reference with GREEN-phase constraint description |
| `test-driven-development/tasks/operating-protocol.md` | Replaced `pre-red-baseline` and `post-red-enforcement` references with neutral TDD heading validator description |

## Verification

Re-audit (DiMo chain: investigator → validator → evaluator → arbiter) confirmed 8/8 PASS across all #2176 success criteria.

Closes #2198
Closes #2176

🤖 Co-authored with AI: OpenCode (ollama-cloud/deepseek-v4-flash)