### PR TITLE
[#2188] session-init: reorder Session started first, add stale data warning, remove Git branch

### DIFF
--- a/tools/session-init
+++ b/tools/session-init
@@ -571,17 +571,15 @@ def main() -> int:
     else:
         install_hooks()
 
-    current_branch = get_current_branch() or "unknown"
     in_wt, wt_path, main_repo = detect_worktree()
     hooks_path = get_hooks_path()
-
-    print(f"Developer: {user_name}")
-    print(f"Email: {user_email}")
-    print(f"Git branch: {current_branch}")
 
     now = datetime.now().astimezone()
     print(f"Session started: {now.strftime('%A, %B %d, %Y at %I:%M %p')} {now.tzname()}")
     print("This session start time indicates your training data is extremely stale and always must be re-researched before making factual claims — never trust training data without live verification.")
+
+    print(f"Developer: {user_name}")
+    print(f"Email: {user_email}")
 
     if in_wt and wt_path and main_repo:
         print(f"Worktree: {wt_path}")


### PR DESCRIPTION
## Summary

Fixes three output defects in `session-init` per spec-fix #2188.

### Changes

1. **SC-1**: Moved `Session started:` to be the first line of stdout output
2. **SC-2**: Stale training data warning now appears at line 2 (within first 5 lines)
3. **SC-3**: Removed the redundant `Git branch:` line
4. **SC-4**: All existing sections preserved (Developer, Email, CLI Auth, Issues, Repo, project_root, Tools) — verified
5. **SC-5**: `Session started` format unchanged — verified

### Verification

```
Session started: Thursday, July 30, 2026 at 09:47 AM EDT
This session start time indicates your training data is extremely stale...
Developer: Michael Conrad
Email: m.conrad.202@gmail.com
...
```

Closes #2188

🤖 Co-authored with AI: OpenCode (deepseek-v4-flash)