### PR TITLE
feat(#2210): create reference docs and update producer templates

### DIFF
--- a/reference/cost-model-standards.md
+++ b/reference/cost-model-standards.md
@@ -1,0 +1,102 @@
+# Cost Model Standards
+
+Canonical reference document defining the cost model and cost-frame format for specs and plans. Both producers (`spec-creation/tasks/create.md`, `writing-plans/tasks/create.md`) and auditors (`spec-audit`, `plan-fidelity` tasks) read this document via `Read [Text](path)`.
+
+## DDL Cost Model
+
+Cost is measured in **defect-discovery-latency (DDL)** — the time between defect introduction and defect discovery. Shorter DDL means cheaper fixes; longer DDL means exponentially compounding cost.
+
+**Cost is measured in defect-discovery-latency, not model roundtrips.** Running verification costs minutes of execution time — a bounded delay that surfaces defects before they reach CI. Skipping a verification step to save a tool call costs the full pipeline of rework when the defect surfaces downstream: diagnosis, fix, re-review, re-CI, re-deploy — each of which costs more roundtrips than the skipped verification would have consumed. Correctness is the only success metric — there is no score for tool-call economy.
+
+### Tiered Cost Table by Evidence Type
+
+| Evidence Type | Execution Cost | DDL Cost | DDL Multiplier | Gate Position | Death Spiral / Break |
+|---|---|---|---|---|---|
+| `behavioral` | minutes | minutes | 1× | pre-commit / pre-RED | **BREAK** — defect caught at gate 1, fix cost = 0 downstream |
+| `semantic` | minutes | hours–days | 10×–100× | pre-PR / review | **BREAK or slow spiral** — caught before merge, 100× cheaper than production |
+| `string` | seconds | days–weeks | 100×–1000× | CI / static analysis | **DEATH SPIRAL START** — string PASS → behavioral FAIL in production → NIST 29× escalation |
+| `structural` | ~1s | weeks–months | 1000×+ | none / irrelevant | **DEATH SPIRAL** — structural PASS → defect ships → compounding rework → exponential cost |
+
+### Death Spiral Definition
+
+```
+structural PASS → defect ships unchanged → found in production → rework cycle (diagnose + fix + re-CI + redeploy) → structural PASS again on fix → next defect ships → compounding exponential cost
+
+cost_death_spiral(n) = Σ(1000^(n-i) × base_cost_i) for i = 0..n
+```
+
+A death spiral occurs when structural evidence (file exists, file non-empty) passes verification for a behavioral defect. The defect ships unchanged. When discovered in production, the rework cycle costs 1000× more than the skipped behavioral test would have cost. Each rework cycle re-applies structural verification, which passes again for the next behavioral defect. Cost compounds exponentially with each cycle.
+
+### Break Definition
+
+```
+behavioral FAIL at gate 1 → root cause diagnosed immediately → fix applied before downstream consumers see defect → zero downstream cost
+
+cost_break = behavioral_test_cost (fixed, bounded)
+```
+
+A break occurs when behavioral verification catches a defect at the earliest possible gate (pre-commit / pre-RED). The test costs minutes of execution time — a bounded delay. The fix costs the same bounded delay. There is no downstream rework, no CI queue delay, no PR re-review, no production incident. The total cost of the defect is the cost of running the behavioral test — and that cost is zero compared to the death spiral alternative.
+
+**Death spiral vs. break is the central cost model of the pipeline.** Every verification decision is a choice between paying the bounded cost of a behavioral test (break) or accepting the exponential cost of downstream discovery (death spiral). There is no third option.
+
+### Research Grounding
+
+- IBM Systems Sciences Institute: cost of fixing a defect found in production is ~100× that of fixing it at requirements/design time
+- NIST Planning Report 02-3 (2002): software errors cost the US economy ~$59.5B annually; earlier defect detection could cut costs by ~$22B
+- Capers Jones (Software Defect Removal Effectiveness): DRE above 95% requires pre-code verification gates; structural-only verification achieves DRE below 50%
+- Industry replication: IBM's 100× multiplier has been confirmed across multiple studies (Boehm, McConnell, National Research Council)
+
+## Cost-Frame Formula (dark-prose-007)
+
+Every cost frame follows the dark-prose-007 reformation pattern:
+
+```
+[Computation frame]: Cost is measured in defect-discovery-latency, not tool calls.
+[Action cost]: [action] costs [magnitude] — [consequence if cost computed correctly].
+[Skipping cost]: [skipped action] costs [magnitude] — [consequence if skip rationalized].
+[Identity anchor]: Correctness is the only metric.
+```
+
+The computation frame and identity anchor are the same for every SC in a given spec. Only the action cost and skipping cost vary per SC.
+
+### Per-SC Cost-Frame Format
+
+In spec bodies, the Cost Frame section uses this format:
+
+```
+## Cost Frame
+
+Cost is measured in defect-discovery-latency, not tool calls. Correctness is the only metric.
+
+- SC-1: [action cost]. [skipping cost].
+- SC-2: [action cost]. [skipping cost].
+```
+
+### Per-Phase Cost-Frame Format
+
+In plan bodies, each phase carries a cost frame using the same pattern:
+
+```
+**Cost frame:** [action cost]. [skipping cost].
+```
+
+### Examples
+
+**Spec cost frame (structural SC):**
+```
+- SC-1: Verifying the reference doc exists costs one read call. Skipping means a structurally wrong doc isn't caught until the first spec created from it fails audit.
+```
+
+**Spec cost frame (behavioral SC):**
+```
+- SC-3: Running the behavioral test costs minutes of execution time. Skipping means the behavioral defect ships to production and costs 1000× more to fix.
+```
+
+**Plan phase cost frame:**
+```
+**Cost frame:** Verifying the template update costs one grep search. Skipping means the producer template still hard-codes its section list.
+```
+
+---
+
+🤖 Co-authored with AI: OpenCode (deepseek-v4-flash)

--- a/reference/plan-structure-standards.md
+++ b/reference/plan-structure-standards.md
@@ -1,0 +1,103 @@
+# Plan Structure Standards
+
+Canonical reference document defining the required structure for implementation plans. Both producers (`writing-plans/tasks/create.md`) and auditors (`plan-fidelity` tasks) read this document via `Read [Text](path)`.
+
+## Three-Tier Plan Structure
+
+| Tier | Scope | Content |
+|------|-------|---------|
+| Tier 1 (Global) | Pre-phase + post-phase | Coherence gate, baseline check, pre-regression, structural checks, verification, audit, regression check, review-prep, PR creation, completion. Appear once per plan. |
+| Tier 2 (Per-Phase) | Phase sections | Metadata, daisy-chained per-item tuples, phase file sections |
+| Tier 3 (Per-Item) | Individual items | RED → GREEN → verify → commit. Items are daisy-chained — item N's commit is precondition for item N+1's RED. |
+
+## Plan Frontmatter
+
+```yaml
+---
+plan_schema_version: 1
+issue: <N>
+title: "<plan title>"
+dispatch: [<skill-names>]
+---
+```
+
+## Plan Index Sections
+
+1. Title with issue URL
+2. Goal / Architecture / Files / Dispatch
+3. Blast Radius — affected files and impact zones from blast radius artifact
+4. Admonishment — compliance requirement blockquote (top only)
+5. One-step-at-a-time protocol admonishment — verbatim blockquote
+6. Step Status instruction — verbatim blockquote with progress reporting format
+7. Enforcement Gate — all-or-nothing SC completion statement
+8. Phase table — phase number, name, concern, SCs, dependencies, step range, dispatch
+9. Self-remediation protocol admonishment — verbatim blockquote
+10. Exit Criteria — numbered checklist C1 through C{N}
+
+## Phase File Sections
+
+1. Title — `# Phase {NN} — {name}`
+2. Phase metadata — Concern, Files, SCs, Dependencies, Entry/Exit conditions
+3. Code Path Coverage — per-phase code paths from code path inventory artifact
+4. Cross-Cutting SCs — cross-cutting SCs from cross-cutting matrix artifact
+5. Interface Boundaries — interface boundaries from interface compatibility artifact
+6. State Transitions — state transitions from state analysis artifact
+7. Step-by-step — checkbox steps with dispatch indicators, daisy-chained per-item tuples
+8. Phase completion block — VbC verification assertions
+9. Concern transition — to next phase
+
+## Dispatch Indicators
+
+| Indicator | Meaning |
+|-----------|---------|
+| `(**inline**)` | Orchestrator executes directly |
+| `(**sub-agent**)` | Dispatch via `task()` with phase context |
+| `(**clean-room**)` | Dispatch via `task()` with routing metadata only |
+
+## Step Format
+
+- Numbered checkbox `- [ ] N.` with at least one sub-bullet containing metadata, SC reference, or command
+- No step describes more than one atomic action
+- RED/GREEN conditions contain no line numbers, exact code, or file paths
+- RED describes "what fails". GREEN describes "what must be true"
+
+## Admonishments
+
+### Compliance (top only)
+
+> **Compliance:** All SCs must pass before completion. Partial implementation is not permitted. Each item is daisy-chained — item N's commit is precondition for item N+1's RED.
+
+### One-Step-at-a-Time
+
+> **One step at a time.** Execute exactly one step. Report progress. Wait for instruction before the next step.
+
+### Step Status
+
+> **Step status:** Report `[item N] [PASS|FAIL]` after each step. If FAIL, report blocker and halt.
+
+### Self-Remediation Protocol
+
+> **Self-Remediation Protocol:** If a step FAILs: diagnose root cause, fix the deliverable, re-verify. If the fix requires spec revision, update the spec and re-enter the plan. Escalate only after remediation failure.
+
+### Enforcement Gate
+
+> **Enforcement gate:** All SCs must pass before this plan is complete.
+
+## Prohibited Patterns
+
+- No dispatch tables in plan files
+- No TBD/TODO — all file paths, function names, commands must be exact
+- No shared cross-references — each phase is self-contained
+- No zero-indexed numbering — phases start at 1, steps start at 1
+- No line number references — use stable anchors
+- No multi-dispatch steps — each step dispatches exactly one sub-agent or executes inline
+- No non-standard dispatch indicators — only inline, sub-agent, clean-room
+- No omitted mandatory gates — all gates from implementation-workflow reference card are mandatory
+
+## Cost Frame
+
+Per-phase cost-frame language following the dark-prose-007 pattern (see `reference/cost-model-standards.md`). Each phase's cost frame justifies verification costs relative to defect-discovery cost.
+
+---
+
+🤖 Co-authored with AI: OpenCode (deepseek-v4-flash)

--- a/reference/spec-structure-standards.md
+++ b/reference/spec-structure-standards.md
@@ -1,0 +1,60 @@
+# Spec Structure Standards
+
+Canonical reference document defining the required structure for specification documents. Both producers (`spec-creation/tasks/create.md`) and auditors (`spec-audit` tasks) read this document via `Read [Text](path)`.
+
+## Required Sections
+
+Every spec MUST contain the following sections in order:
+
+1. **Intent and Executive Summary** — Preamble with 6 fields: Problem Statement, Root Cause / Motivation, Approach Chosen, Alternatives Considered & Why Discarded, Key Design Decisions, User Intent / Original Prompt. This section subsumes Objective and Background.
+2. **Not Included** — Explicitly excluded scope
+3. **Success Criteria** — Table with ID, Criterion, Evidence Type, Verification Method columns
+4. **Requirements** — Numbered requirements with SHALL language
+5. **Items** — Per-SC item enumeration. Each SC maps to exactly one item. Items numbered sequentially from 1.
+6. **Dependencies** — Prerequisite specs, skills, guidelines
+7. **Traceability** — Table mapping Requirements → SCs → Phases
+8. **Documentation Sources** — Table with Source, Type, Location, Verification columns
+9. **Enforcement Gate** — All-or-nothing statement: all SCs must pass before completion
+10. **Cost Frame** — Per-SC cost-frame language following the dark-prose-007 pattern (see `reference/cost-model-standards.md`)
+11. **Edge Cases** — Boundary conditions, failure modes, and their resolutions
+
+## SC Table Column Requirements
+
+| Column | Required | Description |
+|--------|----------|-------------|
+| ID | Yes | Unique SC identifier (SC-1, SC-2, etc.) |
+| Criterion | Yes | What must be true for this SC to pass |
+| Evidence Type | Yes | One of: structural, string, semantic, behavioral |
+| Verification Method | Yes | How the SC is verified |
+
+## Evidence Type Taxonomy
+
+| Type | Minimum Acceptable Evidence | Example |
+|------|---------------------------|---------|
+| `structural` | File existence | `ls path/to/file` |
+| `string` | grep/pattern match | `grep for pattern` |
+| `semantic` | Sub-agent read + judgment | Clean-room sub-agent reads and evaluates |
+| `behavioral` | Test execution with output inspection | `opencode run` with assertion helpers |
+
+**EVIDENCE_TYPE_MISMATCH rules:**
+- Declared type `behavioral` with only structural evidence → FAIL
+- Declared type `semantic` with only string evidence → FAIL
+- Default to `string` if no evidence type declared
+
+## Prohibited Content Patterns
+
+- **Tracking/status language:** "implemented", "pending", "confirmed", "viable", "completed" used as status markers → FAIL
+- Only forward-looking "MUST be" language is permitted
+- **Prescriptive code:** exact file paths with line numbers, exact import strings, exact assertion code → FAIL
+- Specs should use file area references only (e.g., "the producer template" not "line 42 of create.md")
+
+## Format Requirements
+
+- Pipeline gates use canonical checklist format: numbered `- [ ] N.` with dispatch mode indicators
+- Gate tables (per-unit or shared cross-reference) → FAIL
+- If spec defines plan output format requirements, they must use canonical checklist format
+- Dispatch tables, shared cross-references → FAIL
+
+---
+
+🤖 Co-authored with AI: OpenCode (deepseek-v4-flash)

--- a/skills/spec-creation/tasks/create.md
+++ b/skills/spec-creation/tasks/create.md
@@ -36,16 +36,9 @@ Read all analysis artifacts from `{analysis_artifact_path}`:
 
 ### Step 2: Assemble spec document
 
-Construct the spec with all required sections:
+Read [spec-structure-standards.md](reference/spec-structure-standards.md) and assemble the spec against its required sections.
 
-1. **Objective** — What this spec achieves
-2. **Background** — Why this spec exists, context, defects being addressed
-3. **Not Included** — Explicitly excluded scope
-4. **Success Criteria** — Table with ID, Criterion, Evidence Type, Verification Method columns
-5. **Requirements** — Numbered requirements with SHALL language
-6. **Items** — Per-SC item enumeration. Each SC maps to exactly one item (plan_item number). Items are numbered sequentially starting from 1.
-7. **Dependencies** — Prerequisite specs, skills, guidelines
-8. **Traceability** — Table mapping Requirements → SCs → Phases
+Read [cost-model-standards.md](reference/cost-model-standards.md) and write per-SC cost-frame statements following the dark-prose-007 pattern.
 
 ### Step 2.1: Write sc-summary.yaml
 

--- a/skills/writing-plans/tasks/create.md
+++ b/skills/writing-plans/tasks/create.md
@@ -37,20 +37,16 @@ The per-task cycle steps are discovered at runtime by reading the implementation
 
 3. **Read the spec file** from `{issues_prefix}/{N}/spec.md` to extract all success criteria with their evidence types.
 
-4. **Build the plan frontmatter.** Write YAML frontmatter with:
-   - `plan_schema_version: "1.0"`
-   - `issue: {N}`
-   - `title: "<short description>"`
-   - `dispatch:` array — one entry per phase with `phase`, `skill`, `task` references from the structure artifact.
+4. **Build the plan frontmatter.** Read [plan-structure-standards.md](reference/plan-structure-standards.md) §Plan Frontmatter. Write YAML frontmatter with the required fields.
 
-5. **Build the plan body.** For each phase from the structure artifact:
-   - Write a phase heading with concern and SC coverage.
-   - For each task in the phase, enumerate every step from the implementation-workflow reference card's per-task cycle (discovered in step 1). Each step gets its own checkbox list item with:
-     - Step name and description
-     - Dispatch indicator: `(**inline**)`, `(**sub-agent**)`, or `(**clean-room**)`
-     - Context parameters as dash sub-bullets
-     - SC-ID binding: each task references exactly one SC-ID from the spec
-   - Every task MUST enumerate every step from the per-task cycle. No skipping. No combining. No grouping.
+5. **Build the plan body.** Read [plan-structure-standards.md](reference/plan-structure-standards.md) for structural expectations:
+   - Three-tier layout (Tier 1 global pre/post, Tier 2 per-phase, Tier 3 per-item)
+   - Per-item daisy chain: RED → GREEN → verify → commit
+   - Dispatch indicators: `(**inline**)`, `(**sub-agent**)`, `(**clean-room**)`
+   - Step format: numbered checkbox with sub-bullets, no prescriptive code
+   - Admonishments: compliance (top only), one-step-at-a-time, step status, self-remediation, enforcement gate
+   - Phase file sections: code path coverage, cross-cutting SCs, interface boundaries, state transitions
+   - Prohibited patterns: no dispatch tables, no TBD/TODO, no shared cross-references, no zero-indexed, no line numbers, no multi-dispatch steps, no non-standard indicators, no omitted mandatory gates
    - Each item references exactly one SC-ID. No item may cover multiple SCs.
 
 6. **Write pre-implementation steps** at the start of the plan (before any phase):
@@ -63,10 +59,8 @@ The per-task cycle steps are discovered at runtime by reading the implementation
    - These appear once per plan, not per phase.
 
 8. **Write the plan to disk** at `{issues_prefix}/{N}/plan.md`:
-   - Frontmatter with dispatch metadata.
-   - Pre-implementation section.
-   - Phase sections with per-task per-step enumeration.
-   - Post-implementation section.
+   - Read [plan-structure-standards.md](reference/plan-structure-standards.md) §Plan Index Sections for the required index structure.
+   - Read [cost-model-standards.md](reference/cost-model-standards.md) and write per-phase cost-frame statements following the dark-prose-007 pattern.
    - Use structured markdown: checkbox lists with dash sub-bullets for context parameters.
    - No machine-parseable cross-references, no identifier IDs (REQ-001, TASK-001), no JSON/YAML code blocks in the body.
    - English text only — the plan is read by the orchestrator, not parsed.


### PR DESCRIPTION
## Summary

Create three canonical reference documents and update producer templates to read from them via `Read [Text](path)`.

### Reference docs created

- `reference/spec-structure-standards.md` — 11 required sections, evidence type taxonomy, prohibited patterns, format requirements
- `reference/plan-structure-standards.md` — three-tier structure, per-item daisy chain, dispatch indicators, step format, admonishments, blast radius, phase file sections, prohibited patterns, cost frame
- `reference/cost-model-standards.md` — DDL cost model (death spiral/break), tiered table by evidence type, dark-prose-007 formula, examples

### Producer templates updated

- `skills/spec-creation/tasks/create.md` — Step 2 reads from spec-structure-standards.md and cost-model-standards.md
- `skills/writing-plans/tasks/create.md` — Steps 4-8 read from plan-structure-standards.md and cost-model-standards.md

### Design

- No new pipeline steps, YAML schemas, manifests, or backward-compat handling
- Reference docs are the single source of truth — both producers and auditors read via `Read [Text](path)`
- Spec B (`#2211`) updates the auditor task files to read from the same reference docs

### SCs

| SC | Status |
|----|--------|
| SC-1: spec-structure-standards.md exists | PASS |
| SC-2: plan-structure-standards.md exists | PASS |
| SC-3: spec-creation/create.md references spec-structure-standards | PASS |
| SC-4: writing-plans/create.md references plan-structure-standards | PASS |
| SC-5: No ceremony added | PASS |
| SC-6: cost-model-standards.md exists | PASS |
| SC-7: spec-creation/create.md references cost-model-standards | PASS |
| SC-8: writing-plans/create.md references cost-model-standards | PASS |

---

🤖 Co-authored with AI: OpenCode (deepseek-v4-flash)