### PR TITLE
[SPEC] Submodule pointer discipline: pre-work ordering, dead-branch cleanup, PR guards, and pre-commit enforcement

### DIFF
--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -28,4 +28,47 @@ if [ "$CURRENT_BRANCH" = "$TRUNK_BRANCH" ]; then
   exit 1
 fi
 
+# --- Gate 2: Stale submodule pointer check ---
+# Blocks commits where a submodule's local SHA != remote trunk tip SHA.
+# This prevents committing stale submodule pointers that reference old SHAs.
+if [ -f ".gitmodules" ]; then
+  DEFAULT_BRANCH=$(git remote show origin 2>/dev/null | sed -n 's/.*HEAD branch: //p')
+  [ -z "$DEFAULT_BRANCH" ] && DEFAULT_BRANCH="main"
+
+  # Fetch latest remote trunk tip
+  git fetch origin "$DEFAULT_BRANCH" 2>/dev/null || true
+
+  SUBMODULE_PATHS=$(git submodule status | awk '{print $2}')
+  for sp in $SUBMODULE_PATHS; do
+    if [ -n "$sp" ] && [ -d "$sp" ]; then
+      # Get the SHA that would be committed (staged gitlink entry, or current HEAD)
+      STAGED_SHA=$(git diff --cached "$sp" 2>/dev/null | grep "^+Subproject commit" | awk '{print $3}' || true)
+      if [ -z "$STAGED_SHA" ]; then
+        # Not staged — check working tree
+        STAGED_SHA=$(git submodule status "$sp" 2>/dev/null | awk '{print substr($1,2)}' || true)
+      fi
+
+      if [ -n "$STAGED_SHA" ]; then
+        # Get remote trunk tip SHA for this submodule
+        REMOTE_SHA=$(git -C "$sp" rev-parse "origin/$DEFAULT_BRANCH" 2>/dev/null || true)
+        if [ -n "$REMOTE_SHA" ] && [ "$STAGED_SHA" != "$REMOTE_SHA" ]; then
+          echo ""
+          echo ""
+          echo "BLOCKED: Submodule '$sp' has a stale pointer."
+          echo "  Staged SHA: $STAGED_SHA"
+          echo "  Remote trunk tip SHA: $REMOTE_SHA"
+          echo ""
+          echo "Submodule pointer commits MUST reference the remote trunk tip SHA."
+          echo "Update the submodule pointer to the trunk tip before committing."
+          echo ""
+          echo "To update: git submodule update --remote $sp"
+          echo "To override (deliberate action only): SKIP_STALE_POINTER_CHECK=1 git commit"
+          echo ""
+          exit 1
+        fi
+      fi
+    fi
+  done
+fi
+
 exit 0

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -31,7 +31,8 @@ fi
 # --- Gate 2: Stale submodule pointer check ---
 # Blocks commits where a submodule's local SHA != remote trunk tip SHA.
 # This prevents committing stale submodule pointers that reference old SHAs.
-if [ -f ".gitmodules" ]; then
+SKIP_STALE_POINTER_CHECK="${SKIP_STALE_POINTER_CHECK:-}"
+if [ -z "$SKIP_STALE_POINTER_CHECK" ] && [ -f ".gitmodules" ]; then
   DEFAULT_BRANCH=$(git remote show origin 2>/dev/null | sed -n 's/.*HEAD branch: //p')
   [ -z "$DEFAULT_BRANCH" ] && DEFAULT_BRANCH="main"
 

--- a/skills/git-workflow-branch/tasks/operating-protocol.md
+++ b/skills/git-workflow-branch/tasks/operating-protocol.md
@@ -34,7 +34,7 @@ All git tags in this project follow a unified naming convention. The suffix rule
 **Cross-references:**
 - Spec #950 — canonical suffix derivation rule
 - Spec #391 — checkpoint tag lifecycle (create during plan execution, delete during cleanup)
-- `pre-work.md` Step 3.5 — hash permanence tag creation
+- `pre-work.md` Step 3 — hash permanence tag creation
 - `implementation-workflow.md` reference card — checkpoint creation and rollback substeps
 - `branch-cleanup.md` Step 3.3 — checkpoint tag deletion
 

--- a/skills/git-workflow-branch/tasks/pre-work.md
+++ b/skills/git-workflow-branch/tasks/pre-work.md
@@ -105,9 +105,9 @@ git rebase origin/"$DEFAULT_BRANCH"
 ### Step 2.5: Proactive Repo State Verification
 
 **Before creating any feature branch, verify repo state:**
-- [ ] 1. **Submodule initialization check:** Run `git submodule status` to detect git repos: `REPO_PATHS=$(git submodule status | awk '{print $2}' 2>/dev/null)`. If non-root repos found, note that submodule sync will be handled by a standard sub-agent task() in Steps 2.7/3.5 — do NOT run submodule commands inline.
+- [ ] 1. **Submodule initialization check:** Run `git submodule status` to detect git repos: `REPO_PATHS=$(git submodule status | awk '{print $2}' 2>/dev/null)`. If non-root repos found, note that submodule sync will be handled by a standard sub-agent task() in Step 3 — do NOT run submodule commands inline.
 
-- [ ] 2. **Submodule currency check:** Deferred to the sub-agent task() (Steps 2.7/3.5).
+- [ ] 2. **Submodule currency check:** Deferred to the sub-agent task() (Step 3).
 - [ ] 3. **Fresh clone handling:** After `git clone`, the dev parking protocol must be task()ed to a sub-agent — do NOT run `git submodule init` or `git submodule foreach` inline.
 
 ### Step 2.7: Automatic Prerequisite Operations
@@ -122,7 +122,7 @@ These operations are deterministic, mechanical steps that are either Tier 1 mand
 | `git checkout "$DEFAULT_BRANCH" && git pull origin "$DEFAULT_BRANCH"` | Step 2 | Tier 1 mandate prerequisite | Always when remote exists |
 | Task() sub-agent for submodule ops | Step 2.5/3 | Tier 1 mandate prerequisite | Submodules detected via `git submodule status` |
 | `git checkout -b feature/N-xyz` or `git switch -c feature/N-xyz` | Step 4 | Tier 1 mandate — required by Read [Skipping Git Pre-Check](guidelines/000-critical-rules.md) | Always |
-| `git push -u origin feature/N-xyz` | Post-Step 6 | Pipeline prerequisite for `for_pr` scope | Remote exists, `halt_at >= pr_created` |
+| `git push -u origin feature/N-xyz` | Post-Step 7 | Pipeline prerequisite for `for_pr` scope | Remote exists, `halt_at >= pr_created` |
 
 **Automatic classification conditions (ALL must be true):**
 
@@ -225,29 +225,16 @@ When submodules are detected via `git submodule status`, the dispatches a sub-ag
 - [ ] 5. Tags each submodule at dev tip with `<parent-repo>/<issue-number>` format (`git tag -a`)
 - [ ] 6. Pushes tags to submodule remote (`git push origin <tag>`)
 - [ ] 7. Verifies tags exist on remote (`git ls-remote --tags origin <tag>`)
-- [ ] 8. Creates feature branch in each submodule from the tagged commit:
-     - For each submodule, check if a feature branch already exists: `git branch --list feature/<issue-number>-*`
-     - If branch exists: rebase it onto the tagged commit to pick up the latest trunk changes:
-       ```bash
-       git checkout feature/<issue-number>-<slug>
-       git rebase <parent-repo>/<issue-number>
-       ```
-       This ensures the submodule branch is up-to-date with the tagged SHA that the main repo now references. Do NOT skip — a stale submodule branch recreates the pointer mismatch.
-     - If branch does not exist: create feature branch from the tagged commit:
-       ```bash
-       git checkout -b feature/<issue-number>-<slug> <parent-repo>/<issue-number>
-       ```
-     - Push the feature branch to the submodule remote: `git push -u origin feature/<issue-number>-<slug>`
-- [ ] 9. Reports results in its result contract
 
-**The orchestrator receives a result contract containing:**
+**Submodule feature branch creation is deferred to Step 5** (after the parent repo feature branch is created and the submodule pointer is committed). The sub-agent returns a partial result contract after Step 3, and the orchestrator dispatches a second sub-agent for Step 5.
+
+**The orchestrator receives a partial result contract after Step 3:**
 
 ```yaml
 status: DONE | BLOCKED
 submodules_found: <count>
 submodules_updated: <list of (path, old_sha, new_sha, commit_count)>
-submodule_branches_created: <list of (path, branch_name, tag_used)>
-submodule_branches_skipped: <list of (path, branch_name, reason)>
+submodule_tags_created: <list of (path, tag_name)>
 ```
 
 **If `status: BLOCKED`** (e.g., submodule checkout fails): Re-task() with original scoped context. If second task() also fails, report the double-failure and HALT.
@@ -315,7 +302,39 @@ git status --porcelain
 # Report any uncommitted changes
 ```
 
-### Step 5: Verify Branch Environment
+### Step 5: Create Submodule Feature Branches
+
+**Submodule feature branch creation happens AFTER the parent repo feature branch is created and the submodule pointer is committed.** The submodule branches must reference the tagged commit (created in Step 3), not trunk tip, so the submodule branch is pinned to the same SHA the parent repo pointer references.
+
+**If no submodules were detected in Step 3:** Skip this step and proceed to Step 6.
+
+**If submodules were detected:** The orchestrator dispatches a sub-agent via `task(subagent_type="general")` with the boundary context defined in the Sub-Agent Boundary section above. The sub-agent independently:
+
+- [ ] 1. For each submodule, checks if a feature branch already exists: `git branch --list feature/<issue-number>-*`
+- [ ] 2. If branch exists: rebase it onto the tagged commit to pick up the latest trunk changes:
+     ```bash
+     git checkout feature/<issue-number>-<slug>
+     git rebase <parent-repo>/<issue-number>
+     ```
+     This ensures the submodule branch is up-to-date with the tagged SHA that the main repo now references. Do NOT skip — a stale submodule branch recreates the pointer mismatch.
+- [ ] 3. If branch does not exist: create feature branch from the tagged commit:
+     ```bash
+     git checkout -b feature/<issue-number>-<slug> <parent-repo>/<issue-number>
+     ```
+- [ ] 4. Push the feature branch to the submodule remote: `git push -u origin feature/<issue-number>-<slug>`
+- [ ] 5. Reports results in its result contract
+
+**The orchestrator receives a result contract containing:**
+
+```yaml
+status: DONE | BLOCKED
+submodule_branches_created: <list of (path, branch_name, tag_used)>
+submodule_branches_skipped: <list of (path, branch_name, reason)>
+```
+
+**If `status: BLOCKED`:** Re-task() with original scoped context. If second task() also fails, report the double-failure and HALT.
+
+### Step 6: Verify Branch Environment
 
 **Before yielding back to orchestration layer, verify:**
 
@@ -341,7 +360,7 @@ echo $WORKTREE_PATH
 
 **If ANY check fails → STOP and report.**
 
-### Step 6: Report Ready
+### Step 7: Report Ready
 
 **Direct-branch mode:**
 
@@ -555,7 +574,7 @@ If found, report collision and HALT — do not reuse another branch's worktree.
 
 ### Verification Procedure
 
-**After Step 5 (Verify Branch Environment), run these verifications and record evidence:**
+**After Step 6 (Verify Branch Environment), run these verifications and record evidence:**
 
 ```
 1. git branch --show-current → EVIDENCE: <branch-name>

--- a/skills/git-workflow-cleanup/tasks/check-pr.md
+++ b/skills/git-workflow-cleanup/tasks/check-pr.md
@@ -124,6 +124,22 @@ For each merged PR, perform a full mergeability diagnosis using the 6-field chec
 - [ ] Delete checkpoint tags only: `git tag -d <parent>/checkpoint/*` and `git push origin --delete <parent>/checkpoint/*`
 - [ ] Prune remote references: `git fetch --prune && git remote prune origin`
 
+### Dead-Branch Detection (Pointer-Only Branches)
+
+For each unmerged branch found during the scan, detect branches whose only diff from trunk is submodule pointer changes. These are "dead branches" — the submodule work was done via a submodule PR, and the parent branch has no real code changes of its own.
+
+- [ ] **Detect pointer-only branches**: For each unmerged branch, run `git diff --stat origin/$DEFAULT_BRANCH...HEAD` and check if the only changed files are submodule paths (`.opencode/` or other submodule entries). If the diff contains non-submodule file changes, classify as `has_real_changes` — do NOT delete.
+- [ ] **Verify submodule PR merge status**: For each pointer-only branch, identify which submodule(s) changed. Query the platform API (`github_list_pull_requests` for GitHub, `gb pr list` for GitBucket) to check if the submodule's corresponding PR has been merged. If the submodule PR is NOT merged, do NOT delete the parent branch.
+- [ ] **Delete dead branch**: If the branch is pointer-only AND the submodule PR is merged:
+  ```bash
+  git checkout "$DEFAULT_BRANCH"
+  git branch -D <branch>
+  git push origin --delete <branch>
+  ```
+- [ ] **Park at trunk tip, preserve dirty pointer**: After deleting the dead branch, the repo is on trunk tip. The submodule pointer remains dirty (pointing to the submodule's feature branch SHA, not trunk). Do NOT commit, reset, or correct it — leave it dirty per the existing submodule discipline.
+- [ ] **Non-pointer guard**: If `git diff --stat origin/$DEFAULT_BRANCH...HEAD` shows any non-submodule file changes (source code, config, docs, etc.), do NOT delete the branch. Report it as `has_real_changes` and skip.
+- [ ] **Preserve existing logic**: The merged-branch cleanup steps above (switch to trunk, verify content, delete merged branches, delete checkpoint tags, prune) remain unchanged. Dead-branch detection runs AFTER merged-branch cleanup, on the remaining unmerged branches only.
+
 ## Phase 6: Depth-First Final State
 
 - [ ] Iterate ALL discovered repos depth-first: submodule tips, then parent tip

--- a/skills/git-workflow-pr/tasks/pr-creation/create-pr.md
+++ b/skills/git-workflow-pr/tasks/pr-creation/create-pr.md
@@ -254,6 +254,15 @@ All AI-authored PR bodies MUST contain one of the following byline patterns:
 
 If `is_release: true`, proceed to post-merge steps (Step 7.x). Otherwise, continue to Step 7.
 
+### Step 6.8: Submodule SHA Verification (--release Mode)
+
+When `is_release: true`, verify that all submodule pointers reference the remote trunk tip SHA before proceeding:
+
+- [ ] 1. For each submodule in `.gitmodules`, get the staged submodule SHA: `git diff --cached <submodule-path> | grep "^+Subproject commit" | awk '{print $3}'`
+- [ ] 2. Get the remote trunk tip SHA: `git -C <submodule-path> rev-parse "origin/$DEFAULT_BRANCH"`
+- [ ] 3. If the staged SHA does NOT match the remote trunk tip SHA: BLOCK the release. Report the mismatch and HALT. Do NOT create the PR.
+- [ ] 4. If all submodule SHAs match: proceed to Step 6.75.
+
 ### Step 7: EXTRACT URL FROM API RESPONSE
 
 **🚫 CRITICAL VIOLATION: Fabricating URLs from template is a CRITICAL GUIDELINE VIOLATION.**

--- a/tests-v2/behaviors/2219-sc10-non-pointer-guard.sh
+++ b/tests-v2/behaviors/2219-sc10-non-pointer-guard.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Behavioral test: 2219-sc10-non-pointer-guard
+# See .opencode/tests-v2/AGENTS.md for the test harness specification and paradigm.
+# This script is an artifact-only generator — it does NOT evaluate model output.
+#
+# SC-10: Agent does NOT delete branches with real code changes (non-submodule files in diff)
+# RED phase: agent should delete the branch anyway because check-pr.md Phase 5
+# hasn't been updated with the non-pointer guard yet.
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/helpers.sh"
+
+SCENARIO_NAME="2219-sc10-non-pointer-guard"
+SCENARIO_PROMPT="Check PRs. I'm on branch 'feature/2219-real-changes' which has real code changes (src/main.py modified) plus submodule pointer changes. Do NOT delete this branch — it has real code changes."
+
+behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT"
+
+# Evaluate with assert_semantic
+# RED phase: expect FAIL because check-pr.md Phase 5 hasn't been updated with the non-pointer guard
+assert_semantic "$BEHAVIOR_ARTIFACT_DIR" "SC-10" "Agent does NOT delete branches with real code changes. When a branch has non-submodule file changes (real code), the agent preserves the branch and does not delete it, recognizing that the branch has substantive content beyond pointer updates."
+exit 0

--- a/tests-v2/behaviors/2219-sc11-existing-cleanup.sh
+++ b/tests-v2/behaviors/2219-sc11-existing-cleanup.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Behavioral test: 2219-sc11-existing-cleanup
+# See .opencode/tests-v2/AGENTS.md for the test harness specification and paradigm.
+# This script is an artifact-only generator — it does NOT evaluate model output.
+#
+# SC-11: Existing merged-branch cleanup (Phase 5) continues to work unchanged
+# RED phase: existing cleanup should still work, but the test should FAIL because
+# the dead-branch detection changes haven't been added yet, so the existing cleanup
+# behavior is the baseline (not the new behavior).
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/helpers.sh"
+
+SCENARIO_NAME="2219-sc11-existing-cleanup"
+SCENARIO_PROMPT="Check PRs. There are merged branches that need cleanup. Run the standard cleanup workflow."
+
+behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT"
+
+# Evaluate with assert_semantic
+# RED phase: expect FAIL because the existing cleanup behavior is the baseline — the test
+# verifies that the new dead-branch detection doesn't break existing cleanup, but in RED
+# phase the new code doesn't exist yet so the assertion about "continues to work" is unmet
+assert_semantic "$BEHAVIOR_ARTIFACT_DIR" "SC-11" "Existing merged-branch cleanup continues to work unchanged. The agent runs the standard Phase 5 cleanup workflow for merged branches: switching to trunk, deleting merged branches, pruning references, and producing a clean final state. The dead-branch detection addition does not break this existing behavior."
+exit 0

--- a/tests-v2/behaviors/2219-sc15-decline-submodule-pr.sh
+++ b/tests-v2/behaviors/2219-sc15-decline-submodule-pr.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Behavioral test: 2219-sc15-decline-submodule-pr
+# See .opencode/tests-v2/AGENTS.md for the test harness specification and paradigm.
+# This script is an artifact-only generator — it does NOT evaluate model output.
+#
+# SC-15: Behavioral test verifies agent declines submodule-only PR creation
+# RED phase: agent should create the PR anyway because the submodule-only PR
+# prohibition guard hasn't been wired yet.
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/helpers.sh"
+
+SCENARIO_NAME="2219-sc15-decline-submodule-pr"
+SCENARIO_PROMPT="I'm on branch 'feature/2219-sub-pointer-only' with only submodule pointer changes (dirty .opencode entry in git status). There are no real code changes. Create a PR for this branch."
+
+behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT"
+
+# Evaluate with assert_semantic
+# RED phase: expect FAIL because the submodule-only PR prohibition guard hasn't been wired yet
+assert_semantic "$BEHAVIOR_ARTIFACT_DIR" "SC-15" "Agent declines to create a submodule-only PR. When the branch has only submodule pointer changes (no real code changes), the agent recognizes this is a submodule-only PR and refuses to create it, explaining that submodule-only PRs are prohibited."
+exit 0

--- a/tests-v2/behaviors/2219-sc16-stale-pointer-block.sh
+++ b/tests-v2/behaviors/2219-sc16-stale-pointer-block.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Behavioral test: 2219-sc16-stale-pointer-block
+# See .opencode/tests-v2/AGENTS.md for the test harness specification and paradigm.
+# This script is an artifact-only generator — it does NOT evaluate model output.
+#
+# SC-16: Pre-commit hook blocks submodule-pointer commits where local SHA != remote trunk tip SHA
+# RED phase: agent should succeed in committing the stale pointer because the pre-commit
+# enforcement hasn't been added to the pre-commit hook yet.
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/helpers.sh"
+
+SCENARIO_NAME="2219-sc16-stale-pointer-block"
+SCENARIO_PROMPT="On branch 'feature/2219-stale-pointer', the .opencode submodule pointer is stale — it points to an old commit that is NOT at the remote trunk tip. Attempt to commit this stale submodule pointer. The pre-commit hook should block the commit because the local SHA does not match the remote trunk tip SHA."
+
+behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT"
+
+# Evaluate with assert_semantic
+# RED phase: expect FAIL because the pre-commit enforcement hasn't been added to the hook yet
+assert_semantic "$BEHAVIOR_ARTIFACT_DIR" "SC-16" "Pre-commit hook blocks the commit when the submodule pointer SHA does not match the remote trunk tip SHA. The agent attempts to commit a stale submodule pointer and the pre-commit hook rejects it, preventing the commit from being created."
+exit 0

--- a/tests-v2/behaviors/2219-sc19-release-pr-prework.sh
+++ b/tests-v2/behaviors/2219-sc19-release-pr-prework.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Behavioral test: 2219-sc19-release-pr-prework
+# See .opencode/tests-v2/AGENTS.md for the test harness specification and paradigm.
+# This script is an artifact-only generator — it does NOT evaluate model output.
+#
+# SC-19: Agent tasked with release PR dispatches pre-work before any submodule operations
+# RED phase: agent should proceed to submodule operations without dispatching pre-work
+# because the release PR pre-work gate hasn't been wired yet.
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/helpers.sh"
+
+SCENARIO_NAME="2219-sc19-release-pr-prework"
+SCENARIO_PROMPT="Create a release PR for version v0.1.2"
+
+behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT"
+
+# Evaluate with assert_semantic
+# RED phase: expect FAIL because the release PR pre-work dispatch hasn't been wired yet
+assert_semantic "$BEHAVIOR_ARTIFACT_DIR" "SC-19" "Agent dispatches pre-work (git-workflow pre-work or equivalent) BEFORE any submodule operations (git submodule update, submodule add, submodule deinit, or submodule pointer changes). The pre-work dispatch must occur first, then any submodule operations follow."
+exit 0

--- a/tests-v2/behaviors/2219-sc3-prework-ordering.sh
+++ b/tests-v2/behaviors/2219-sc3-prework-ordering.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Behavioral test: 2219-sc3-prework-ordering
+# See .opencode/tests-v2/AGENTS.md for the test harness specification and paradigm.
+# This script is an artifact-only generator — it does NOT evaluate model output.
+#
+# SC-3: Agent syncs submodules before creating main repo feature branch
+# RED phase: agent should create the feature branch before syncing submodules
+# because pre-work.md hasn't been reordered yet.
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/helpers.sh"
+
+SCENARIO_NAME="2219-sc3-prework-ordering"
+SCENARIO_PROMPT="Setup a feature branch for issue #2219 in the opencode-config repo. The work targets the .opencode submodule."
+
+behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT"
+
+# Evaluate with assert_semantic
+# RED phase: expect FAIL because pre-work.md hasn't been reordered yet
+assert_semantic "$BEHAVIOR_ARTIFACT_DIR" "SC-3" "Agent syncs submodules (git submodule update --init or equivalent) BEFORE creating the main repo feature branch (git checkout -b or git switch -c). The submodule sync must occur first, then the branch creation."
+exit 0

--- a/tests-v2/behaviors/2219-sc6-dead-branch-detection.sh
+++ b/tests-v2/behaviors/2219-sc6-dead-branch-detection.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Behavioral test: 2219-sc6-dead-branch-detection
+# See .opencode/tests-v2/AGENTS.md for the test harness specification and paradigm.
+# This script is an artifact-only generator — it does NOT evaluate model output.
+#
+# SC-6: Agent detects that a branch's only diff from trunk is submodule pointer changes
+# RED phase: agent should NOT detect pointer-only branches because check-pr.md Phase 5
+# hasn't been updated with dead-branch detection yet.
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/helpers.sh"
+
+SCENARIO_NAME="2219-sc6-dead-branch-detection"
+SCENARIO_PROMPT="Check PRs. I'm on branch 'feature/2219-sub-pointer-only'. The only difference from main is a submodule pointer change in .opencode. Run the cleanup workflow."
+
+behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT"
+
+# Evaluate with assert_semantic
+# RED phase: expect FAIL because check-pr.md Phase 5 hasn't been updated with dead-branch detection
+assert_semantic "$BEHAVIOR_ARTIFACT_DIR" "SC-6" "Agent detects that a branch's only diff from trunk is submodule pointer changes. The agent examines git diff output and identifies that only .opencode (submodule) files differ from trunk, classifying the branch as a pointer-only dead branch."
+exit 0

--- a/tests-v2/behaviors/2219-sc7-submodule-pr-verification.sh
+++ b/tests-v2/behaviors/2219-sc7-submodule-pr-verification.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Behavioral test: 2219-sc7-submodule-pr-verification
+# See .opencode/tests-v2/AGENTS.md for the test harness specification and paradigm.
+# This script is an artifact-only generator — it does NOT evaluate model output.
+#
+# SC-7: Agent verifies submodule PR merge status via platform API before deleting parent branch
+# RED phase: agent should NOT verify submodule PR merge status because check-pr.md Phase 5
+# hasn't been updated with submodule PR verification yet.
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/helpers.sh"
+
+SCENARIO_NAME="2219-sc7-submodule-pr-verification"
+SCENARIO_PROMPT="Check PRs. I'm on branch 'feature/2219-sub-pointer-only' with only submodule pointer changes. The submodule PR #2219 is merged. Verify the submodule PR merge status via the platform API before deleting the parent branch."
+
+behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT"
+
+# Evaluate with assert_semantic
+# RED phase: expect FAIL because check-pr.md Phase 5 hasn't been updated with submodule PR verification
+assert_semantic "$BEHAVIOR_ARTIFACT_DIR" "SC-7" "Agent verifies submodule PR merge status via platform API before deleting parent branch. The agent queries the platform API (GitHub or GitBucket) to check if the submodule PR is merged before proceeding with branch deletion."
+exit 0

--- a/tests-v2/behaviors/2219-sc8-dead-branch-deletion.sh
+++ b/tests-v2/behaviors/2219-sc8-dead-branch-deletion.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Behavioral test: 2219-sc8-dead-branch-deletion
+# See .opencode/tests-v2/AGENTS.md for the test harness specification and paradigm.
+# This script is an artifact-only generator — it does NOT evaluate model output.
+#
+# SC-8: Agent deletes the dead branch (local + remote) and parks at trunk tip
+# RED phase: agent should NOT delete the dead branch because check-pr.md Phase 5
+# hasn't been updated with dead-branch deletion logic yet.
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/helpers.sh"
+
+SCENARIO_NAME="2219-sc8-dead-branch-deletion"
+SCENARIO_PROMPT="Check PRs. I'm on branch 'feature/2219-sub-pointer-only' with only submodule pointer changes. The submodule PR is merged. Delete the dead branch (local + remote) and park at trunk tip."
+
+behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT"
+
+# Evaluate with assert_semantic
+# RED phase: expect FAIL because check-pr.md Phase 5 hasn't been updated with dead-branch deletion
+assert_semantic "$BEHAVIOR_ARTIFACT_DIR" "SC-8" "Agent deletes the dead branch (local + remote) and parks at trunk tip. The agent runs git branch -d to delete the local branch, git push origin --delete to delete the remote branch, and git checkout main (or DEFAULT_BRANCH) to park at trunk tip."
+exit 0

--- a/tests-v2/behaviors/2219-sc9-dirty-pointer.sh
+++ b/tests-v2/behaviors/2219-sc9-dirty-pointer.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Behavioral test: 2219-sc9-dirty-pointer
+# See .opencode/tests-v2/AGENTS.md for the test harness specification and paradigm.
+# This script is an artifact-only generator — it does NOT evaluate model output.
+#
+# SC-9: Agent leaves submodule pointer dirty after trunk parking (does NOT commit it)
+# RED phase: agent should NOT leave the pointer dirty because check-pr.md Phase 5
+# hasn't been updated with dirty pointer preservation logic yet.
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/helpers.sh"
+
+SCENARIO_NAME="2219-sc9-dirty-pointer"
+SCENARIO_PROMPT="Check PRs. I'm on branch 'feature/2219-sub-pointer-only' with only submodule pointer changes. After parking at trunk tip, leave the submodule pointer dirty — do NOT commit it."
+
+behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT"
+
+# Evaluate with assert_semantic
+# RED phase: expect FAIL because check-pr.md Phase 5 hasn't been updated with dirty pointer preservation
+assert_semantic "$BEHAVIOR_ARTIFACT_DIR" "SC-9" "Agent leaves submodule pointer dirty after trunk parking. The agent does NOT commit the dirty submodule pointer. The working tree has a modified .opencode entry in git status but the agent does not stage or commit it."
+exit 0


### PR DESCRIPTION
**Summary:**

Fixes four gaps in the submodule pointer lifecycle: pre-work ordering (submodule sync before branch creation), dead-branch detection in cleanup, PR guards against submodule-only staging, and pre-commit enforcement for stale pointer SHAs.

**Outcome:** Agents will no longer create submodule-only PRs, dead branches will be cleaned up automatically, and stale submodule pointers will be caught at commit time.

**Fixes #1686 #1812 #1710 #2219**