### PR TITLE
fix(#2232): writing-plans task cards - frontmatter fix, dep contract, audit

### DIFF
--- a/skills/writing-plans/SKILL.md
+++ b/skills/writing-plans/SKILL.md
@@ -54,7 +54,7 @@ Generate and validate implementation plans from approved specs. Flat architectur
 
 | File | Purpose |
 |------|---------|
-| `tasks/analyze.md` | Verify spec exists locally, check approval from frontmatter, validate analytical artifacts exist |
+| `tasks/analyze.md` | Verify spec exists locally, check approval from issue.yaml labels, validate analytical artifacts exist |
 | `tasks/backfill.md` | Generate missing analytical artifacts from spec body when spec-creation did not produce them |
 | `tasks/research.md` | Decompose SCs into phases, build dependency DAG, select skill+task from implementation-workflow reference card Trigger Dispatch Table, run Z3 constraint solving |
 | `tasks/create.md` | Write self-contained plan with full implementation-workflow reference card per-task cycle. Plan is structured markdown with English instructions. Every task enumerates every step from the implementation-workflow reference card's per-task cycle. No skipping, no combining, no grouping |

--- a/skills/writing-plans/tasks/analyze.md
+++ b/skills/writing-plans/tasks/analyze.md
@@ -6,7 +6,7 @@
 
 ## Purpose
 
-Verify spec exists locally, check approval from frontmatter, validate analytical artifacts exist.
+Verify spec exists locally, check approval from issue.yaml labels, validate analytical artifacts exist.
 
 ## Task Discipline
 
@@ -19,8 +19,8 @@ Verify spec exists locally, check approval from frontmatter, validate analytical
 
 - `{issues_prefix}/{N}/spec.md` must exist
   - If missing: return BLOCKED with `SPEC_NOT_FOUND` and the resolved path
-- The spec frontmatter `approved` field must be present and truthy
-  - If not approved: return BLOCKED with `SPEC_NOT_APPROVED`
+- `{issues_prefix}/{N}/issue.yaml` must exist and contain an `approved-for-*` label
+  - If missing or no `approved-for-*` label: return BLOCKED with `SPEC_NOT_APPROVED`
 - The issue number `{N}` must be provided
 - The project root and issues prefix must be set
 
@@ -28,9 +28,9 @@ Verify spec exists locally, check approval from frontmatter, validate analytical
 
 1. Verify the spec file exists at `{issues_prefix}/{N}/spec.md`.
    - If missing: return BLOCKED with `SPEC_NOT_FOUND` and the resolved path.
-2. Read the spec file and extract the frontmatter.
-   - Verify the `approved` field is present and truthy.
-   - If not approved: return BLOCKED with `SPEC_NOT_APPROVED`.
+2. Read `{issues_prefix}/{N}/issue.yaml` and check the `labels` field.
+   - Verify at least one label matches `approved-for-*`.
+   - If no `approved-for-*` label: return BLOCKED with `SPEC_NOT_APPROVED`.
 3. Read the spec body and extract the success criteria table.
    - Verify at least one SC is defined.
    - If no SCs: return BLOCKED with `NO_SUCCESS_CRITERIA`.
@@ -41,7 +41,7 @@ Verify spec exists locally, check approval from frontmatter, validate analytical
    - Verify all referenced files exist in the codebase.
    - If any file is missing: record as a finding.
 6. Write the analysis summary to `{issues_prefix}/{N}/artifacts/analysis-summary.yaml`.
-   - Include: spec path, approval status, SC count, artifact presence per artifact, scope boundary findings.
+   - Include: spec path, approval status (from issue.yaml labels), SC count, artifact presence per artifact, scope boundary findings.
 7. Return the result contract.
 
 ## Exit Criteria

--- a/skills/writing-plans/tasks/research.md
+++ b/skills/writing-plans/tasks/research.md
@@ -42,8 +42,11 @@ Decompose success criteria into implementation phases, build a dependency DAG be
    - Phase list with SC assignments
    - Dependency DAG edges
    - Skill+task selection per phase
-9. Read the dependency contract from `{issues_prefix}/{N}/dependency-contract.yaml`.
-   - If missing: return BLOCKED with `DEPENDENCY_CONTRACT_NOT_FOUND`.
+9. Generate the dependency contract from the interface-compatibility artifact:
+   - Read `{issues_prefix}/{N}/artifacts/interface-compatibility.yaml`.
+   - Extract the `dependency_contract` section.
+   - Write the extracted contract to `{issues_prefix}/{N}/dependency-contract.yaml`.
+   - If `interface-compatibility.yaml` is missing or has no `dependency_contract` section: return BLOCKED with `DEPENDENCY_CONTRACT_NOT_FOUND`.
 10. Run `./.opencode/tools/solve model --contract-path {issues_prefix}/{N}/dependency-contract.yaml --query sat`.
     - If UNSAT: return BLOCKED with `UNSAT` and the solver output.
 11. Run `./.opencode/tools/solve check --contract-path {issues_prefix}/{N}/dependency-contract.yaml --state-path {issues_prefix}/{N}/artifacts/state-analysis.yaml`.

--- a/tests-v2/behaviors/2232-analyze-frontmatter-fix.sh
+++ b/tests-v2/behaviors/2232-analyze-frontmatter-fix.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# RED test for #2232 Phase 1: SC-1, SC-4
+# Verify analyze.md checks issue.yaml labels for approved-for-* instead of spec frontmatter approved field
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/helpers.sh"
+
+OVERALL_RESULT=0
+TARGET=".opencode/skills/writing-plans/tasks/analyze.md"
+
+echo "=== RED: SC-1 — analyze.md checks issue.yaml labels for approved-for-* ==="
+
+# SC-1: grep for issue.yaml and approved-for in analyze.md
+if grep -q 'issue.yaml' "$TARGET" 2>/dev/null && grep -q 'approved-for' "$TARGET" 2>/dev/null; then
+  echo "PASS: analyze.md references issue.yaml and approved-for-*"
+else
+  echo "FAIL: analyze.md does not reference issue.yaml and approved-for-*"
+  OVERALL_RESULT=1
+fi
+
+# SC-1: grep for frontmatter.*approved returns zero matches
+if grep -q 'frontmatter.*approved' "$TARGET" 2>/dev/null; then
+  echo "FAIL: analyze.md still references frontmatter approved field"
+  OVERALL_RESULT=1
+else
+  echo "PASS: analyze.md has no frontmatter approved references"
+fi
+
+echo ""
+echo "=== RED: SC-4 — analyze.md Entry Criteria and Procedure no longer reference spec frontmatter approved field ==="
+
+# SC-4: grep for 'frontmatter' in analyze.md returns zero matches
+if grep -q 'frontmatter' "$TARGET" 2>/dev/null; then
+  echo "FAIL: analyze.md still contains 'frontmatter' references"
+  OVERALL_RESULT=1
+else
+  echo "PASS: analyze.md has no 'frontmatter' references"
+fi
+
+# SC-4: verify Entry Criteria uses issue.yaml labels, not frontmatter
+if grep -q 'issue.yaml.*approved' "$TARGET" 2>/dev/null; then
+  echo "PASS: Entry Criteria references issue.yaml for approval check"
+else
+  echo "FAIL: Entry Criteria does not reference issue.yaml for approval check"
+  OVERALL_RESULT=1
+fi
+
+echo ""
+echo "=== Result ==="
+if [ "$OVERALL_RESULT" -eq 0 ]; then
+  echo "ALL PASS"
+else
+  echo "SOME FAIL"
+fi
+exit $OVERALL_RESULT

--- a/tests-v2/behaviors/fixtures/issues/2081-writing-plans/spec.md
+++ b/tests-v2/behaviors/fixtures/issues/2081-writing-plans/spec.md
@@ -21,6 +21,6 @@ The current writing-plans skill has 3 SKILL.md files, 19 task files, 22 contract
 | SC-2 | 7 task files | structural |
 | SC-4 | Plan artifact uses routing-table format | behavioral |
 | SC-7 | analyze checks local spec.md exists | behavioral |
-| SC-8 | analyze checks spec approval from local frontmatter | behavioral |
+| SC-8 | analyze checks spec approval from issue.yaml labels | behavioral |
 | SC-9 | solve runs tools/solve and tools/plan | behavioral |
 | SC-14 | External callers updated to new dispatch strings | structural |

--- a/tests-v2/behaviors/writing-plans-analyze.sh
+++ b/tests-v2/behaviors/writing-plans-analyze.sh
@@ -4,13 +4,16 @@
 # Provenance: AI-generated
 # Content-Verification Test: Writing-Plans Analyze Task Card
 #
-# Verifies that skills/writing-plans/tasks/analyze.md has explicit entry
-# criteria gates for SPEC_NOT_FOUND (missing spec) and SPEC_NOT_APPROVED
-# (missing approval in frontmatter), matching the spec's requirement that
-# these be Entry Criteria gates, not just Procedure steps.
+# Verifies that skills/writing-plans/tasks/analyze.md checks issue.yaml
+# labels for approved-for-* instead of spec frontmatter approved field.
 #
-# RED phase: analyze.md has SPEC_NOT_FOUND/SPEC_NOT_APPROVED in Procedure
-# but NOT as explicit Entry Criteria gates. Expected to FAIL (non-zero exit).
+# SC-1: analyze.md checks issue.yaml labels for approved-for-* instead of
+#        spec frontmatter approved field
+# SC-4: analyze.md Entry Criteria and Procedure no longer reference spec
+#        frontmatter approved field
+#
+# GREEN phase: analyze.md uses issue.yaml label-based check.
+# Expected to PASS (exit 0).
 #
 # Co-authored with AI: OpenCode (deepseek-v4-flash)
 
@@ -19,59 +22,50 @@ set -euo pipefail
 ANALYZE_MD=".opencode/skills/writing-plans/tasks/analyze.md"
 
 echo "=== RED Test: writing-plans-analyze ==="
-echo "Checking $ANALYZE_MD for entry criteria gates..."
+echo "Checking $ANALYZE_MD for label-based approval check..."
 echo ""
 
-HAS_ENTRY_SPEC_NOT_FOUND=false
-HAS_ENTRY_SPEC_NOT_APPROVED=false
-HAS_PROCEDURE_SPEC_NOT_FOUND=false
-HAS_PROCEDURE_SPEC_NOT_APPROVED=false
+HAS_OLD_FRONTMATTER_ENTRY=false
+HAS_OLD_FRONTMATTER_PROCEDURE=false
+HAS_LABEL_CHECK=false
 
-# Check 1: Entry Criteria must explicitly mention SPEC_NOT_FOUND
-if grep -q 'SPEC_NOT_FOUND' "$ANALYZE_MD" 2>/dev/null; then
-    # Check if SPEC_NOT_FOUND appears in Entry Criteria section
-    if sed -n '/^## Entry Criteria/,/^## /p' "$ANALYZE_MD" | grep -q 'SPEC_NOT_FOUND' 2>/dev/null; then
-        HAS_ENTRY_SPEC_NOT_FOUND=true
-        echo "  [FOUND] SPEC_NOT_FOUND in Entry Criteria"
-    else
-        echo "  [MISSING] SPEC_NOT_FOUND in Entry Criteria (expected RED)"
-    fi
+# Check 1 (SC-4): Entry Criteria must NOT reference spec frontmatter approved field
+# Use specific pattern to distinguish from approved-for-* label references
+if sed -n '/^## Entry Criteria/,/^## /p' "$ANALYZE_MD" | grep -qE 'frontmatter.*approved|approved.*(field|truthy)' 2>/dev/null; then
+    HAS_OLD_FRONTMATTER_ENTRY=true
+    echo "  [FOUND] frontmatter approved field in Entry Criteria (old check - expected RED)"
 else
-    echo "  [MISSING] SPEC_NOT_FOUND not found anywhere (expected RED)"
+    echo "  [OK] No frontmatter approved field in Entry Criteria"
 fi
 
-# Check 2: Entry Criteria must explicitly mention SPEC_NOT_APPROVED
-if grep -q 'SPEC_NOT_APPROVED' "$ANALYZE_MD" 2>/dev/null; then
-    # Check if SPEC_NOT_APPROVED appears in Entry Criteria section
-    if sed -n '/^## Entry Criteria/,/^## /p' "$ANALYZE_MD" | grep -q 'SPEC_NOT_APPROVED' 2>/dev/null; then
-        HAS_ENTRY_SPEC_NOT_APPROVED=true
-        echo "  [FOUND] SPEC_NOT_APPROVED in Entry Criteria"
-    else
-        echo "  [MISSING] SPEC_NOT_APPROVED in Entry Criteria (expected RED)"
-    fi
+# Check 2 (SC-4): Procedure must NOT reference spec frontmatter approved field
+# Use specific pattern to distinguish from approved-for-* label references
+if sed -n '/^## Procedure/,/^## /p' "$ANALYZE_MD" | grep -qE 'frontmatter.*approved|approved.*(field|truthy)' 2>/dev/null; then
+    HAS_OLD_FRONTMATTER_PROCEDURE=true
+    echo "  [FOUND] frontmatter approved field in Procedure (old check - expected RED)"
 else
-    echo "  [MISSING] SPEC_NOT_APPROVED not found anywhere (expected RED)"
+    echo "  [OK] No frontmatter approved field in Procedure"
 fi
 
-# Check 3: Procedure must have SPEC_NOT_FOUND (should already pass)
-if grep -q 'SPEC_NOT_FOUND' "$ANALYZE_MD" 2>/dev/null; then
-    HAS_PROCEDURE_SPEC_NOT_FOUND=true
-    echo "  [FOUND] SPEC_NOT_FOUND in file"
-fi
-
-# Check 4: Procedure must have SPEC_NOT_APPROVED (should already pass)
-if grep -q 'SPEC_NOT_APPROVED' "$ANALYZE_MD" 2>/dev/null; then
-    HAS_PROCEDURE_SPEC_NOT_APPROVED=true
-    echo "  [FOUND] SPEC_NOT_APPROVED in file"
+# Check 3 (SC-1): Must reference issue.yaml labels for approved-for-*
+if grep -q 'issue\.yaml' "$ANALYZE_MD" 2>/dev/null && grep -q 'approved-for-' "$ANALYZE_MD" 2>/dev/null; then
+    HAS_LABEL_CHECK=true
+    echo "  [FOUND] issue.yaml approved-for-* label check"
+else
+    echo "  [MISSING] issue.yaml approved-for-* label check (expected RED)"
 fi
 
 echo ""
-if $HAS_ENTRY_SPEC_NOT_FOUND && $HAS_ENTRY_SPEC_NOT_APPROVED; then
-    echo "UNEXPECTED PASS: analyze.md has both SPEC_NOT_FOUND and SPEC_NOT_APPROVED in Entry Criteria"
-    exit 0
-else
-    echo "EXPECTED FAIL: analyze.md missing entry criteria gates (RED phase confirmed)"
-    echo "  Procedure has SPEC_NOT_FOUND=$HAS_PROCEDURE_SPEC_NOT_FOUND, SPEC_NOT_APPROVED=$HAS_PROCEDURE_SPEC_NOT_APPROVED"
-    echo "  But Entry Criteria needs explicit gates per spec §Task Cards → analyze.md"
+if $HAS_OLD_FRONTMATTER_ENTRY || $HAS_OLD_FRONTMATTER_PROCEDURE; then
+    echo "EXPECTED FAIL: analyze.md still uses old spec frontmatter approved field check"
+    echo "  Entry Criteria has old check: $HAS_OLD_FRONTMATTER_ENTRY"
+    echo "  Procedure has old check: $HAS_OLD_FRONTMATTER_PROCEDURE"
+    echo "  Has new label check: $HAS_LABEL_CHECK"
     exit 1
+elif ! $HAS_LABEL_CHECK; then
+    echo "EXPECTED FAIL: analyze.md missing issue.yaml approved-for-* label check"
+    exit 1
+else
+    echo "PASS: analyze.md uses label-based check, no frontmatter approved field"
+    exit 0
 fi


### PR DESCRIPTION
## Summary

Fixes #2232 — three changes to writing-plans task cards:

1. **Phase 1 (SC-1, SC-4):** `analyze.md` now checks `issue.yaml` labels for `approved-for-*` instead of spec frontmatter `approved` field
2. **Phase 2 (SC-2):** `research.md` generates `dependency-contract.yaml` from `interface-compatibility.yaml` `dependency_contract` section instead of BLOCKing if missing
3. **Phase 3 (SC-3):** Cross-skill audit of all `.opencode/skills/*/tasks/*.md` — zero tracking-state-in-spec violations found

## Changes

- `skills/writing-plans/tasks/analyze.md`: Replaced spec frontmatter `approved` check with `issue.yaml` label check
- `skills/writing-plans/tasks/research.md`: Step 9 now generates `dependency-contract.yaml` from `interface-compatibility.yaml`
- `skills/writing-plans/SKILL.md`: Updated cross-references
- `tests-v2/behaviors/writing-plans-analyze.sh`: Updated behavioral test for new label-based check
- `tests-v2/behaviors/2232-analyze-frontmatter-fix.sh`: New behavioral enforcement test
- `tests-v2/behaviors/fixtures/issues/2081-writing-plans/spec.md`: Updated test fixture

## Audit

Cross-skill audit of all `.opencode/skills/*/tasks/*.md` for tracking-state-in-spec violations: **PASS — zero violations found.**

## Related

- Issue: #2232