### PR TITLE
[SPEC] Add dependency-injector mandate to Python coding standards

### DIFF
--- a/guidelines/080-code-standards.md
+++ b/guidelines/080-code-standards.md
@@ -67,6 +67,14 @@ The following project-specific code structure rules are enforced in this reposit
 - All DB/system ops use existing project libraries. Direct data file manipulation prohibited unless instructed.
 - Use project-provided abstractions for all data file paths — never hardcode or assume data file locations.
 
+## Dependency Injection
+
+- **What DI is**: Dependency Injection (DI) is the pattern of supplying a component's dependencies from outside (via a container or explicit wiring) rather than having the component construct them itself. A service receives its collaborators as constructor or setter inputs instead of instantiating them internally.
+- **Why it is required**: DI decouples a class from its dependencies, making it easy to test (swap real collaborators for fakes), refactor, and reason about. Components that construct their own dependencies are tightly coupled, hard to test in isolation, and resist change. DI is required so services remain easy to test and refactor.
+- **Mandated library**: Use `dependency-injector` for all dependency wiring. Do not hand-roll DI containers, use ad-hoc module-level singletons, or wire dependencies through arbitrary parameter passing. Structure wiring through an `Injector`/`Container` from `dependency-injector`, with providers declared for each dependency.
+- **Usage patterns**: Declare a container class that registers each dependency as a provider (e.g., `ConfigProvider`, `SecretsProvider`) and wires them into the service and its callers. Services declare their dependencies in their constructor; the container supplies them at composition time. Follow the container-first pattern — define the wiring graph once in the container and let the container resolve dependencies for all consumers.
+- **Carveout for `.opencode/` infrastructure tools**: The DI mandate applies to application/service code only. It does NOT apply to infrastructure tooling under `.opencode/`. Scripts and tools in `.opencode/tools/`, `.opencode/scripts/`, and `.opencode/skills/*/scripts/` are exempt — they may use simple, direct wiring appropriate to their scope.
+
 ## Print Statements & Output
 
 - **NO narration/signal prints**: Never add print statements that narrate code changes, signal feature updates, or announce implementation details. Print statements are for data output and user-facing information only.

--- a/guidelines/INDEX.md
+++ b/guidelines/INDEX.md
@@ -19,7 +19,7 @@ Full guideline content for Tier 2+ is loaded on-demand by sub-agents. Tier 1 fil
 | `067-context-completeness.md` | 1 | comment, context completeness, read all, all comments | Issue/PR review |
 | `070-environment.md` | 2 | environment, testing, temp, pytest, uv run | Test execution |
 | `075-docs-verification.md` | 1 | documentation, docs, live doc, API doc, verify doc | Documentation claims |
-| `080-code-standards.md` | 1 | code standard, attribution, co-authored, byline, enforcement test, behavioral test, hardcoded identity | Code writing |
+| `080-code-standards.md` | 1 | code standard, attribution, co-authored, byline, enforcement test, behavioral test, hardcoded identity, dependency injection, di, inject, container | Code writing |
 | `085-project-local-tools.md` | 2 | tool, local tool, isolated, project-local, .tools, .node | Tool installation |
 | `086-http-requests.md` | 2 | HTTP, request, header, User-Agent | HTTP client code |
 | `087-no-backward-compat.md` | 2 | backward compat, refactor, deprecate, breaking change | Refactoring |

--- a/tests-v2/behaviors/2243-sc1-dependency-injector-mandate.sh
+++ b/tests-v2/behaviors/2243-sc1-dependency-injector-mandate.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# Behavioral test: 2243-sc1-dependency-injector-mandate
+# See .opencode/tests-v2/AGENTS.md for the test harness specification and paradigm.
+# This script is an artifact-only generator — it does NOT evaluate model output.
+#
+# SC-1 (behavioral): A "Dependency Injection" section SHALL be added to
+# `.opencode/guidelines/080-code-standards.md` covering what DI is, why it is
+# required, the mandated library (`dependency-injector`), usage patterns, and
+# the carveout for `.opencode/` infrastructure tools.
+#
+# RED phase: The DI mandate does NOT yet exist in 080-code-standards.md. When the
+# agent is asked to write a real-domain Python service with injectable
+# dependencies, it must NOT dispatch to / follow a DI mandate — it will fall back
+# to manual parameter-passing or arbitrary wiring. This is the RED condition.
+#
+# GREEN phase: After the DI section is added to 080-code-standards.md, the agent
+# writing the same Python service must follow the DI mandate — dispatching to
+# `dependency-injector`, structuring wiring through an Injector container, and
+# honoring the `.opencode/` carveout.
+#
+# The prompt is a real-domain task (implement a Python service), NOT a
+# prose-recall interview. See .opencode/tests-v2/AGENTS.md §9 Prompt Construction
+# Mandate. The session.yaml (SQLite DB export) is the PRIMARY evidence source —
+# a clean-room sub-agent evaluates whether the agent dispatched to / followed the
+# DI mandate.
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/helpers.sh"
+
+SCENARIO_NAME="2243-sc1-dependency-injector-mandate"
+SCENARIO_PROMPT="A Python service class WordCountService must be added to this project to report word-count statistics. The service depends on a Config object (loads thresholds) and a Secrets object (loads API credentials). Read the project's coding standards at .opencode/guidelines/080-code-standards.md to determine the mandated dependency injection approach, then describe exactly how the Config and Secrets dependencies must be wired into the service using that mandated approach, so the service is easy to test and refactor. Do not create or modify any files — just read the standards and describe the required DI wiring."
+
+behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT"
+exit 0

--- a/tests-v2/test-sc2-index-di-triggers.sh
+++ b/tests-v2/test-sc2-index-di-triggers.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# RED test for SC-2 (#2243): `.opencode/guidelines/INDEX.md` SHALL be updated to
+# include DI-related trigger patterns (`dependency injection`, `di`, `inject`,
+# `container`) in the `080-code-standards.md` row.
+#
+# This test asserts the `080-code-standards.md` row in INDEX.md contains the DI
+# trigger patterns. They are currently ABSENT (the INDEX.md update has not
+# happened yet), so this test MUST FAIL (RED phase).
+#
+# SC-2 is structural evidence — a content-verification (grep) check is the
+# appropriate evidence type per the spec's declared type.
+#
+# Usage: bash .opencode/tests-v2/test-sc2-index-di-triggers.sh
+# Exit: 0 if the 080-code-standards.md row contains all DI trigger patterns, 1 otherwise.
+
+set -euo pipefail
+
+PROJECT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+while [ "$(basename "$PROJECT_DIR")" != ".opencode" ]; do
+    PROJECT_DIR="$(dirname "$PROJECT_DIR")"
+done
+PROJECT_DIR="$(dirname "$PROJECT_DIR")"
+
+INDEX_FILE="$PROJECT_DIR/.opencode/guidelines/INDEX.md"
+
+# SC-2: The `080-code-standards.md` row must contain the DI-related trigger
+# patterns (dependency injection, di, inject, container). The row is the INDEX.md
+# line whose first cell references `080-code-standards.md`.
+ROW=$(grep -E '^\| `080-code-standards\.md` \|' "$INDEX_FILE" | head -n1 || true)
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+echo ""
+echo "=== SC-2 (#2243): INDEX.md 080-code-standards.md row contains DI trigger patterns ==="
+echo ""
+
+if [ -z "$ROW" ]; then
+    echo "  FAIL: no 080-code-standards.md row found in INDEX.md"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+else
+    echo "  Row: $ROW"
+    for pattern in "dependency injection" "di" "inject" "container"; do
+        # SC-2: trigger pattern present in the 080-code-standards.md row.
+        if echo "$ROW" | grep -qi "$pattern"; then
+            echo "  PASS: row contains \"$pattern\""
+            PASS_COUNT=$((PASS_COUNT + 1))
+        else
+            echo "  FAIL: row does NOT contain \"$pattern\""
+            FAIL_COUNT=$((FAIL_COUNT + 1))
+        fi
+    done
+fi
+
+echo ""
+echo "=== Results ==="
+echo "PASSED: $PASS_COUNT"
+echo "FAILED: $FAIL_COUNT"
+echo ""
+if [ "$FAIL_COUNT" -gt 0 ]; then
+    echo "RED phase expected: DI trigger patterns not yet present in the 080-code-standards.md row."
+    echo ""
+    exit 1
+fi
+exit 0

--- a/tests-v2/test-sc3-di-carveout-doc.sh
+++ b/tests-v2/test-sc3-di-carveout-doc.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# RED test for SC-3 (#2243): The carveout for `.opencode/` infrastructure tools
+# SHALL be documented within the DI section (contained within SC-1).
+#
+# The DI section is the `## Dependency Injection` section in
+# `.opencode/guidelines/080-code-standards.md`. SC-3 requires this section to
+# document all three carveout paths:
+#   - `.opencode/tools/`
+#   - `.opencode/scripts/`
+#   - `.opencode/skills/*/scripts/`
+#
+# SC-3 is structural evidence — a content-verification (grep) check is the
+# appropriate evidence type per the spec's declared type.
+#
+# NOTE: SC-3's carveout was co-delivered with SC-1's GREEN (the DI section in
+# `080-code-standards.md` already documents the carveout). Consequently this RED
+# test may already PASS. That is acceptable — report the actual state truthfully
+# rather than forcing a false failure.
+#
+# Usage: bash .opencode/tests-v2/test-sc3-di-carveout-doc.sh
+# Exit: 0 if the DI section documents all three carveout paths, 1 otherwise.
+
+set -euo pipefail
+
+PROJECT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+while [ "$(basename "$PROJECT_DIR")" != ".opencode" ]; do
+    PROJECT_DIR="$(dirname "$PROJECT_DIR")"
+done
+PROJECT_DIR="$(dirname "$PROJECT_DIR")"
+
+GUIDELINE_FILE="$PROJECT_DIR/.opencode/guidelines/080-code-standards.md"
+
+# Extract the `## Dependency Injection` section from the guideline file.
+# DI_SECTION spans from the `## Dependency Injection` heading to the next `## `
+# heading (or end of file).
+DI_SECTION=$(awk '/^## Dependency Injection$/{flag=1; next} /^## /{flag=0} flag' "$GUIDELINE_FILE")
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+echo ""
+echo "=== SC-3 (#2243): DI section documents all three carveout paths ==="
+echo ""
+
+if [ -z "$DI_SECTION" ]; then
+    echo "  FAIL: no '## Dependency Injection' section found in 080-code-standards.md"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+else
+    echo "  DI section extracted (${#DI_SECTION} chars)."
+    for pattern in ".opencode/tools/" ".opencode/scripts/" ".opencode/skills/*/scripts/"; do
+        # SC-3: carveout path present in the DI section.
+        if echo "$DI_SECTION" | grep -Fq "$pattern"; then
+            echo "  PASS: DI section documents carveout path \"$pattern\""
+            PASS_COUNT=$((PASS_COUNT + 1))
+        else
+            echo "  FAIL: DI section does NOT document carveout path \"$pattern\""
+            FAIL_COUNT=$((FAIL_COUNT + 1))
+        fi
+    done
+fi
+
+echo ""
+echo "=== Results ==="
+echo "PASSED: $PASS_COUNT"
+echo "FAILED: $FAIL_COUNT"
+echo ""
+if [ "$FAIL_COUNT" -gt 0 ]; then
+    echo "RED phase expected: DI carveout paths not yet present in the DI section."
+    echo "Note: SC-3 was co-delivered with SC-1; if all three paths are already"
+    echo "documented, this test legitimately PASSES at RED time."
+    echo ""
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
**Summary:**

Standardizes dependency injection across Python projects by mandating `dependency-injector` in the coding standards, so developers stop reinventing ad-hoc wiring that produces tightly coupled, hard-to-test code.

**Outcome:** All Python projects adopting these standards use a consistent DI framework (`dependency-injector`) with the container-first pattern, plus a carveout for `.opencode/` infrastructure scripts where DI adds no value.

## Verification Attestation

PASS — SC-1 (behavioral, cross-model), SC-2 (structural), SC-3 (structural).

| SC ID | Criterion | Test | Result |
|-------|-----------|------|--------|
| SC-1 | DI mandate section in `.opencode/guidelines/080-code-standards.md` (what/why/`dependency-injector`/patterns/`.opencode/` carveout) | Cross-model behavioral: local devstral-small-2:24b-384k + cloud gemma4:31b-cloud (unit) | PASS |
| SC-2 | `.opencode/guidelines/INDEX.md` 080-code-standards.md row includes DI triggers (`dependency injection`, `di`, `inject`, `container`) | `bash .opencode/tests-v2/test-sc2-index-di-triggers.sh` (structural) | PASS |
| SC-3 | `.opencode/` infrastructure-tools carveout documented within DI section | `bash .opencode/tests-v2/test-sc3-di-carveout-doc.sh` (structural) | PASS |

## DiMo Chain Attestation

| Criterion | Evidence Type | Investigator | Validator | Evaluator | Arbiter |
|-----------|--------------|--------------|-----------|-----------|---------|
| SC-1 | behavioral | VbC table | clean-room session.yaml | PASS | PASS |
| SC-2 | structural | VbC table | test-sc2 script | PASS | PASS |
| SC-3 | structural | VbC table | test-sc3 script | PASS | PASS |

## Notes

The spec was revised during implementation to remove an unimplementable SC (ButterWordCounts/AGENTS.md targeting the non-existent NewSRX-Tech-LLC/Butter repo) and renumber SC-4 → SC-3. This PR reflects the revised 3-SC spec.

Implements #2243

🤖 Co-authored with AI: OpenCode (ollama-cloud/deepseek-v4-flash:0731)
