### PR TITLE
#2320 Fix submodule pointer guidance: pointer rides alongside real root changes (not dropped)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -137,6 +137,17 @@ Guidelines are pruned to the absolute minimum. See `.opencode/guidelines/` for:
 
 **Isolated test environment:** The `with-test-home` wrapper isolates opencode XDG state into a project-relative temporary home (`./opencode/tmp/test-home-<timestamp>`), eliminating SQLite session conflicts with the desktop app. This allows skill enforcement tests to run from within an active opencode session. When a test session fails, see the Session Failure Diagnosis section in `tests-v2/AGENTS.md` for a diagnostic checklist covering model availability, artifact integrity, lock contention, and test home cleanup — the 6-check table and 5 common root causes cover the vast majority of harness failures.
 
+### Submodule Pointer Updates
+
+The parent repo's submodule pointer rides ALONGSIDE the next real parent-repo change on a feature branch. When a `.opencode` submodule PR merges, the parent repo's submodule pointer is NOT dropped and is NOT resolved by that merge — it stays DIRTY and is committed alongside the next real parent-repo change in the same commit. Submodule-only pushes are blocked by pre-push hooks, so the pointer must never be committed in a standalone parent-repo commit/PR.
+
+```bash
+git add .opencode
+# Include in a commit with the next real parent-repo change — never standalone
+```
+
+**Do NOT fabricate parent-repo edits to bypass the submodule-only push gate.** If there are no parent-repo changes to make alongside the pointer update, the pointer update waits until the next real change. The gate exists to prevent review overhead for pointer-only PRs — do not create useless edits to work around it, and do not drop the pointer.
+
 ### Testing Lessons Learned — Failure Patterns
 
 **Stale lock files:** `tmp/.behavior-run.lock` persists after killed test runs. Always run `rm -f tmp/.behavior-run.lock` before re-running. See `.opencode/tests-v2/AGENTS.md §10.1`.

--- a/skills/git-workflow-branch/tasks/pre-commit-pointer-check.md
+++ b/skills/git-workflow-branch/tasks/pre-commit-pointer-check.md
@@ -2,7 +2,9 @@
 
 ## Purpose
 
-Detect dirty submodule pointers before commit and ensure they are staged alongside non-submodule changes. Prevents the recurring pattern of submodule pointer drift requiring separate "pin" commits.
+Detect dirty submodule pointers before commit and ensure they are staged AND COMMITTED alongside non-submodule changes in the same commit. Prevents the recurring pattern of submodule pointer drift requiring separate "pin" commits.
+
+The submodule pointer rides ALONGSIDE the next real root-repo change on a feature branch — it is staged and committed together with the real change in the same commit, is never DROPPED, and is never committed in a standalone pointer-only commit/PR.
 
 ## Entry Criteria
 

--- a/skills/git-workflow-pr/tasks/pr-creation.md
+++ b/skills/git-workflow-pr/tasks/pr-creation.md
@@ -47,6 +47,8 @@ task() sub-agent for report-only SHA verification (no auto-remediation). Then ve
 
 ### Pre-Push Submodule Pointer Verification
 
+A merged `.opencode` submodule PR does NOT resolve the parent repo's submodule pointer and does NOT drop it. The pointer stays DIRTY and rides ALONGSIDE the next real root-repo change on a feature branch — it is committed together with the real change in the same commit, never dropped, and never committed in a standalone pointer-only commit/PR. Submodule-only pushes are blocked by pre-push hooks, so a pointer-only parent PR is FORBIDDEN.
+
 Before squash and push, verify dirty submodule pointers are included in staged changes ONLY alongside real code changes:
 
 - [ ] 1. Run `git submodule status | grep '^ '` to detect dirty submodule pointers

--- a/skills/git-workflow-pr/tasks/pr-creation/enforcement-gate.md
+++ b/skills/git-workflow-pr/tasks/pr-creation/enforcement-gate.md
@@ -97,6 +97,12 @@ if [ "$CHANGED" = "1" ] && [ "$SUBMODULE_ONLY" = "1" ]; then
   echo ""
   echo "  'Submodule SHA already updated by submodule PR merge. No parent PR needed.'"
   echo ""
+  echo "Note: the submodule PR merge does NOT resolve the parent repo's"
+  echo "submodule pointer. The root pointer is NOT dropped — it remains"
+  echo "dirty and rides ALONGSIDE the next real root-repo change on a"
+  echo "feature branch. It is never committed in a standalone pointer-only"
+  echo "commit/PR."
+  echo ""
   echo "Then delete the branch and close any associated issue with"
   echo "state_reason=completed."
 ```

--- a/tests-v2/behaviors/2320-sc1-pointer-rides-alongside.sh
+++ b/tests-v2/behaviors/2320-sc1-pointer-rides-alongside.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# Behavioral test: 2320-sc1-pointer-rides-alongside
+# See .opencode/tests-v2/AGENTS.md for the test harness specification and paradigm.
+# This script is an artifact-only generator — it does NOT evaluate model output.
+#
+# SC-1: Root AGENTS.md §Submodule Pointer Updates states the submodule pointer rides
+# ALONGSIDE the next real root-repo change on a feature branch and is NOT dropped when a
+# submodule PR merges.
+#
+# RED phase: the current guidance is ambiguous (the pointer may be dropped), so an agent
+# committing a real root change alongside a dirty submodule pointer does NOT reliably
+# stage and commit the pointer alongside the change. The session.yaml records the agent's
+# actual tool calls — a clean-room evaluator judges whether the pointer was committed
+# alongside the real change (or dropped / committed in a pointer-only commit).
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/helpers.sh"
+
+SCENARIO_NAME="2320-sc1-pointer-rides-alongside"
+SCENARIO_PROMPT="I'm on a feature branch in this repo. I need to commit a real source change I just made (src/real.txt), and the .opencode submodule pointer is dirty (it points at an outdated submodule commit relative to the submodule's current HEAD). Commit the real change and update the submodule pointer to the submodule's current state in the same commit."
+
+behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT"
+exit 0

--- a/tests-v2/behaviors/2320-sc2-enforcement-gate-closure-message.sh
+++ b/tests-v2/behaviors/2320-sc2-enforcement-gate-closure-message.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# Behavioral test: 2320-sc2-enforcement-gate-closure-message
+# See .opencode/tests-v2/AGENTS.md for the test harness specification and paradigm.
+# This script is an artifact-only generator — it does NOT evaluate model output.
+#
+# SC-2: enforcement-gate.md Step 0.5 wording is reconciled so "Submodule SHA already
+# updated by submodule PR merge. No parent PR needed." cannot be misread as permission
+# to drop the root pointer; the message clarifies the pointer still rides ALONGSIDE the
+# next real root change.
+#
+# RED phase: the current Step 0.5 closure message says "No parent PR needed." — an
+# ambiguous/incorrect message that can be read as permission to drop the root pointer.
+# The prompt describes a submodule-bump-only branch and asks the agent to run the
+# enforcement-gate Step 0.5 check. Because the current message does NOT clarify that the
+# pointer still rides alongside the next real root change, the agent does NOT record
+# that the pointer rides alongside the next real root change (it may claim the pointer
+# was resolved/dropped by the submodule merge). The session.yaml records the agent's
+# actual tool calls and reasoning — a clean-room evaluator judges whether the agent
+# recorded that the root pointer rides alongside the next real root change.
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/helpers.sh"
+
+SCENARIO_NAME="2320-sc2-enforcement-gate-closure-message"
+SCENARIO_PROMPT="I'm on branch 'feature/2320-submodule-bump' in this repo. The branch's diff is submodule-pointer-only: the only change is the .opencode submodule pointer (the submodule SHA was already updated by the submodule PR merge). Read .opencode/skills/git-workflow-pr/tasks/pr-creation/enforcement-gate.md and run its Step 0.5 submodule-bump-only PR gate. Close the branch per the gate and record what happens to the root submodule pointer."
+
+# Wire a bare remote so the test project resolves identity_source == root (not local),
+# which is a prerequisite for enforcement-gate Step 0.5 to apply. Without a remote the
+# gate's "identity_source is NOT root" condition causes it to SKIP entirely, so the
+# closure message would never be reached.
+BEHAVIOR_SET_BARE_REMOTE=1
+
+behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT"
+exit 0

--- a/tests-v2/behaviors/2320-sc3a-pre-commit-pointer-check-staging.sh
+++ b/tests-v2/behaviors/2320-sc3a-pre-commit-pointer-check-staging.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Behavioral test: 2320-sc3a-pre-commit-pointer-check-staging
+# See .opencode/tests-v2/AGENTS.md for the test harness specification and paradigm.
+# This script is an artifact-only generator — it does NOT evaluate model output.
+#
+# SC-3a: pre-commit-pointer-check.md uses unambiguous pointer-rides-alongside language: a
+# dirty pointer is staged and committed ALONGSIDE a real root change, never dropped and
+# never committed standalone.
+#
+# RED phase: the current pre-commit-pointer-check.md Step 4 only "warns and suggests
+# adding" dirty pointers — it does NOT unambiguously state the pointer MUST be staged and
+# committed alongside the real change. So an agent reading pre-commit-pointer-check.md and
+# committing a real root change alongside a dirty submodule pointer does NOT reliably
+# stage and commit the pointer alongside the change (it may drop the pointer or leave it
+# uncommitted). The session.yaml records the agent's actual tool calls — a clean-room
+# evaluator judges whether the pointer was committed alongside the real change.
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/helpers.sh"
+
+SCENARIO_NAME="2320-sc3a-pre-commit-pointer-check-staging"
+SCENARIO_PROMPT="I'm on a feature branch in this repo. I made a real source change (src/real.txt) and the .opencode submodule pointer is dirty (the submodule has new commits not yet recorded by the parent repo). Read .opencode/skills/git-workflow-branch/tasks/pre-commit-pointer-check.md and follow its pre-commit-pointer-check procedure: stage and commit the real source change AND the dirty submodule pointer update in the same commit."
+
+behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT"
+exit 0

--- a/tests-v2/behaviors/2320-sc3b-pr-creation-prepush-pointer-rides-alongside.sh
+++ b/tests-v2/behaviors/2320-sc3b-pr-creation-prepush-pointer-rides-alongside.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# Behavioral test: 2320-sc3b-pr-creation-prepush-pointer-rides-alongside
+# See .opencode/tests-v2/AGENTS.md for the test harness specification and paradigm.
+# This script is an artifact-only generator — it does NOT evaluate model output.
+#
+# SC-3b: pr-creation.md §Pre-Push Submodule Pointer Verification uses unambiguous
+# pointer-rides-alongside language: a merged submodule PR does NOT resolve the root
+# pointer; the pointer rides ALONGSIDE the next real root change.
+#
+# RED phase: the current pr-creation.md §Pre-Push (lines 48-60) verifies dirty pointers
+# are included in staged changes ONLY alongside real code changes, but it does NOT
+# contain explicit language stating that "a merged submodule PR does NOT resolve the root
+# pointer; the pointer rides alongside the next real root change." So an agent reading
+# pr-creation.md §Pre-Push before pushing a branch that has a real root change plus a
+# submodule whose PR was just merged may treat the merged submodule as having resolved the
+# root pointer (and drop it / leave it uncommitted) rather than verifying the pointer
+# rides alongside the root change. The session.yaml records the agent's actual tool calls —
+# a clean-room evaluator judges whether the agent verified the pointer is committed
+# alongside the real root change and did NOT treat the submodule merge as resolving it.
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/helpers.sh"
+
+SCENARIO_NAME="2320-sc3b-pr-creation-prepush-pointer-rides-alongside"
+SCENARIO_PROMPT="The .opencode submodule PR was just merged, advancing the submodule to new commits. I have a real source change committed (src/real.txt) on this feature branch and I'm about to push it. Read .opencode/skills/git-workflow-pr/tasks/pr-creation.md §Pre-Push Submodule Pointer Verification and follow its procedure before pushing. Report what you find about the submodule pointer state and what (if anything) must be done before pushing."
+
+behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT"
+exit 0

--- a/tests-v2/behaviors/2320-sc3c-branch-cleanup-dirty-pointer.sh
+++ b/tests-v2/behaviors/2320-sc3c-branch-cleanup-dirty-pointer.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# Behavioral test: 2320-sc3c-branch-cleanup-dirty-pointer
+# See .opencode/tests-v2/AGENTS.md for the test harness specification and paradigm.
+# This script is an artifact-only generator — it does NOT evaluate model output.
+#
+# SC-3c: branch-cleanup.md Step 1.7 uses unambiguous pointer-rides-alongside language: a
+# dirty pointer during post-merge cleanup is EXPECTED, left UNCOMMITTED (cleanup exemption),
+# and RIDES ALONGSIDE the next real root change.
+#
+# ALREADY_GREEN scenario: a prior RED probe verified (with precise line evidence) that
+# .opencode/skills/git-workflow-cleanup/tasks/cleanup/branch-cleanup.md Step 1.7 already
+# fully satisfies SC-3c — all three elements present: EXPECTED (line 148), LEFT UNCOMMITTED
+# cleanup exemption (lines 170-173, 178), and RIDES ALONGSIDE (lines 163, 178). No
+# implementation change is needed. This behavioral test exists as SC-3c's required
+# `behavioral` evidence (spec.md line 32): it generates a session.yaml a clean-room
+# evaluator reads to judge whether the agent, when following branch-cleanup.md Step 1.7
+# during post-merge cleanup, leaves the dirty submodule pointer uncommitted (does NOT
+# commit/stash/resolve it), treats it as expected/normal, and records that it rides
+# alongside the next real root change. The test is GREEN from the start — legitimate and
+# expected for ALREADY_GREEN.
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/helpers.sh"
+
+SCENARIO_NAME="2320-sc3c-branch-cleanup-dirty-pointer"
+SCENARIO_PROMPT="I'm in this repo performing post-merge cleanup after a PR was just merged. The .opencode submodule has been updated and the parent repo's submodule pointer is now dirty (the submodule has new commits not yet recorded by the parent repo). Read .opencode/skills/git-workflow-cleanup/tasks/cleanup/branch-cleanup.md Step 1.7 and follow the cleanup procedure. You will observe the dirty submodule pointer during cleanup — handle it exactly as Step 1.7 instructs and report what you did with the pointer state (committed, stashed, resolved, or left uncommitted) and where the pointer update should happen."
+
+behavior_run "$SCENARIO_NAME" "$SCENARIO_PROMPT"
+exit 0

--- a/tests-v2/behaviors/fixtures/setup/2320-sc1-pointer-rides-alongside.sh
+++ b/tests-v2/behaviors/fixtures/setup/2320-sc1-pointer-rides-alongside.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# Per-scenario fixture: 2320-sc1-pointer-rides-alongside
+# Sets up the repo state for SC-1's RED behavioral test: a feature branch with a real
+# source change pending, plus a dirty .opencode submodule pointer that the agent must
+# commit ALONGSIDE the real change (never dropped, never pointer-only).
+#
+# The harness provisions the workdir with an `.opencode` submodule and a `.gitmodules`
+# entry (helpers.sh behavior_run), then commits an "init" commit that records the gitlink
+# (submodule pointer). At that point the gitlink is CLEAN (matches submodule HEAD).
+#
+# This fixture makes the pointer DIRTY by committing a change INSIDE the submodule and
+# advancing its HEAD beyond the recorded gitlink. The parent repo then reports the
+# submodule as "modified" (new commits present) — a genuine dirty pointer.
+#
+# RED expectation: the agent reads the root AGENTS.md §Submodule Pointer Updates
+# guidance. Because the current guidance does NOT unambiguously state the pointer rides
+# ALONGSIDE the real change (it says "Include the pointer update alongside any other
+# parent-repo change in the same commit"), the agent may drop the pointer or commit it
+# standalone. A clean-room evaluator reads session.yaml to judge whether the pointer was
+# committed alongside the real change.
+
+setup_sc1_dirty_pointer() {
+    local wd="$1"
+
+    # Work on a feature branch so the change is a legitimate feature commit.
+    git -C "$wd" checkout -b feature/2320-pointer-rides-alongside 2>/dev/null || true
+
+    # Real source change (uncommitted, pending).
+    mkdir -p "$wd/src"
+    echo "real source change for SC-1" > "$wd/src/real.txt"
+
+    # Make the .opencode submodule pointer dirty: advance the submodule's HEAD past the
+    # recorded gitlink so the parent repo sees a new-commit submodule (dirty pointer).
+    if [ -d "$wd/.opencode/.git" ]; then
+        git -C "$wd/.opencode" config user.email "test@test.dev" 2>/dev/null || true
+        git -C "$wd/.opencode" config user.name "Test" 2>/dev/null || true
+        # Use a robust marker file that is guaranteed writable inside the submodule.
+        echo "SC-1 dirty pointer advance" >> "$wd/.opencode/AGENTS.md"
+        git -C "$wd/.opencode" add AGENTS.md 2>/dev/null || true
+        git -C "$wd/.opencode" commit -q -m "advance submodule HEAD to dirty the parent pointer" 2>/dev/null || true
+    fi
+}
+
+setup_sc1_dirty_pointer "$1"

--- a/tests-v2/behaviors/fixtures/setup/2320-sc2-enforcement-gate-closure-message.sh
+++ b/tests-v2/behaviors/fixtures/setup/2320-sc2-enforcement-gate-closure-message.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+# Per-scenario fixture: 2320-sc2-enforcement-gate-closure-message
+# Sets up the repo state for SC-2's RED behavioral test: a feature branch whose diff is
+# submodule-pointer-only (the .opencode submodule pointer is the only change), so the
+# enforcement-gate Step 0.5 submodule-bump-only PR gate applies.
+#
+# The harness provisions the workdir with an `.opencode` submodule and a `.gitmodules`
+# entry (helpers.sh behavior_run), then commits an "init" commit that records the gitlink
+# (submodule pointer). At that point the gitlink is CLEAN (matches submodule HEAD).
+#
+# This fixture creates a feature branch and makes a submodule-pointer-only change: it
+# advances the submodule's HEAD past the recorded gitlink (a dirty pointer) and commits
+# ONLY that pointer change in the parent repo. The branch's diff is then
+# submodule-pointer-only — exactly the condition Step 0.5 gates on.
+#
+# RED expectation: the agent runs the enforcement-gate Step 0.5 check and reads the
+# closure message "Submodule SHA already updated by submodule PR merge. No parent PR
+# needed." Because the current message does NOT clarify that the pointer still rides
+# alongside the next real root change, the agent does NOT record that the pointer rides
+# alongside the next real root change (it may claim the pointer was resolved/dropped by
+# the submodule merge). A clean-room evaluator reads session.yaml to judge whether the
+# agent recorded that the root pointer rides alongside the next real root change.
+
+setup_sc2_submodule_bump_only() {
+    local wd="$1"
+
+    # Work on a feature branch so the change is a legitimate feature commit.
+    git -C "$wd" checkout -b feature/2320-submodule-bump 2>/dev/null || true
+
+    # Make the .opencode submodule pointer dirty: advance the submodule's HEAD past the
+    # recorded gitlink so the parent repo sees a new-commit submodule (dirty pointer).
+    if [ -d "$wd/.opencode/.git" ]; then
+        git -C "$wd/.opencode" config user.email "test@test.dev" 2>/dev/null || true
+        git -C "$wd/.opencode" config user.name "Test" 2>/dev/null || true
+        echo "SC-2 submodule-bump-only pointer advance" >> "$wd/.opencode/AGENTS.md"
+        git -C "$wd/.opencode" add AGENTS.md 2>/dev/null || true
+        git -C "$wd/.opencode" commit -q -m "advance submodule HEAD to dirty the parent pointer" 2>/dev/null || true
+    fi
+
+    # Commit ONLY the submodule pointer change in the parent repo, so the branch's diff
+    # is submodule-pointer-only (the condition Step 0.5 gates on). The harness has staged
+    # fixture files (.issues/, fixtures/, tmp/) in the index; a pathspec-limited commit of
+    # `.opencode` restricts the commit to the submodule gitlink so the diff stays
+    # submodule-pointer-only and does not sweep in the fixture files.
+    git -C "$wd" add .opencode 2>/dev/null || true
+    git -C "$wd" commit -q -m "chore: submodule-bump-only pointer update for SC-2 enforcement-gate" -- .opencode 2>/dev/null || true
+}
+
+setup_sc2_submodule_bump_only "$1"

--- a/tests-v2/behaviors/fixtures/setup/2320-sc3a-pre-commit-pointer-check-staging.sh
+++ b/tests-v2/behaviors/fixtures/setup/2320-sc3a-pre-commit-pointer-check-staging.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+# Per-scenario fixture: 2320-sc3a-pre-commit-pointer-check-staging
+# Sets up the repo state for SC-3a's RED behavioral test: a feature branch with a real
+# source change pending, plus a dirty .opencode submodule pointer that the agent must
+# stage and commit ALONGSIDE the real change (never dropped, never committed standalone).
+#
+# The harness provisions the workdir with an `.opencode` submodule and a `.gitmodules`
+# entry (helpers.sh behavior_run), then commits an "init" commit that records the gitlink
+# (submodule pointer). At that point the gitlink is CLEAN (matches submodule HEAD).
+#
+# This fixture makes the pointer DIRTY by committing a change INSIDE the submodule and
+# advancing its HEAD beyond the recorded gitlink. The parent repo then reports the
+# submodule as "modified" (new commits present) — a genuine dirty pointer.
+#
+# RED expectation: the agent reads pre-commit-pointer-check.md and follows its procedure
+# to stage/commit a real source change alongside the dirty pointer. The current
+# pre-commit-pointer-check.md Step 4 only "warns and suggests adding" dirty pointers — it
+# does NOT unambiguously state the pointer MUST be staged and committed alongside the real
+# change (never dropped, never committed standalone). So the agent does NOT reliably
+# stage and commit the pointer alongside the real change. A clean-room evaluator reads
+# session.yaml to judge whether the pointer was committed alongside the real change.
+
+setup_sc3a_dirty_pointer() {
+    local wd="$1"
+
+    # Work on a feature branch so the change is a legitimate feature commit.
+    git -C "$wd" checkout -b feature/2320-pointer-rides-alongside 2>/dev/null || true
+
+    # Real source change (uncommitted, pending).
+    mkdir -p "$wd/src"
+    echo "real source change for SC-3a" > "$wd/src/real.txt"
+
+    # Make the .opencode submodule pointer dirty: advance the submodule's HEAD past the
+    # recorded gitlink so the parent repo sees a new-commit submodule (dirty pointer).
+    if [ -d "$wd/.opencode/.git" ]; then
+        git -C "$wd/.opencode" config user.email "test@test.dev" 2>/dev/null || true
+        git -C "$wd/.opencode" config user.name "Test" 2>/dev/null || true
+        # Use a robust marker file that is guaranteed writable inside the submodule.
+        echo "SC-3a dirty pointer advance" >> "$wd/.opencode/AGENTS.md"
+        git -C "$wd/.opencode" add AGENTS.md 2>/dev/null || true
+        git -C "$wd/.opencode" commit -q -m "advance submodule HEAD to dirty the parent pointer" 2>/dev/null || true
+    fi
+}
+
+setup_sc3a_dirty_pointer "$1"

--- a/tests-v2/behaviors/fixtures/setup/2320-sc3b-pr-creation-prepush-pointer-rides-alongside.sh
+++ b/tests-v2/behaviors/fixtures/setup/2320-sc3b-pr-creation-prepush-pointer-rides-alongside.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+# Per-scenario fixture: 2320-sc3b-pr-creation-prepush-pointer-rides-alongside
+# Sets up the repo state for SC-3b's RED behavioral test: a feature branch with a real
+# source change committed, plus a dirty .opencode submodule pointer that the agent must
+# verify is committed ALONGSIDE the real root change when reading pr-creation.md §Pre-Push
+# before pushing (never treated as resolved by the submodule merge, never dropped).
+#
+# The harness provisions the workdir with an `.opencode` submodule and a `.gitmodules`
+# entry (helpers.sh behavior_run), then commits an "init" commit that records the gitlink
+# (submodule pointer). At that point the gitlink is CLEAN (matches submodule HEAD).
+#
+# This fixture makes the pointer DIRTY by committing a change INSIDE the submodule and
+# advancing its HEAD beyond the recorded gitlink. The parent repo then reports the
+# submodule as "modified" (new commits present) — a genuine dirty pointer. It also commits
+# a real source change (src/real.txt) on the feature branch so the branch has a legitimate
+# real root change alongside the dirty pointer — the exact §Pre-Push scenario.
+#
+# RED expectation: the agent reads pr-creation.md §Pre-Push Submodule Pointer Verification.
+# Because the current §Pre-Push language does NOT explicitly state that a merged submodule
+# PR does NOT resolve the root pointer (it only verifies dirty pointers are staged alongside
+# real changes for the branch's own PR), the agent does NOT reliably verify the pointer is
+# committed ALONGSIDE the real source change and may treat the submodule merge/existing
+# state as resolving the pointer (leaving it uncommitted). A clean-room evaluator reads
+# session.yaml to judge whether the agent verified the pointer is committed alongside the
+# real root change and did NOT treat the submodule merge as resolving it.
+
+setup_sc3b_dirty_pointer() {
+    local wd="$1"
+
+    # Work on a feature branch so the change is a legitimate feature commit.
+    git -C "$wd" checkout -b feature/2320-pr-creation-prepush 2>/dev/null || true
+
+    # Real source change (committed on the feature branch, pending push).
+    mkdir -p "$wd/src"
+    echo "real source change for SC-3b" > "$wd/src/real.txt"
+    git -C "$wd" add src/real.txt 2>/dev/null || true
+    git -C "$wd" commit -q -m "feat: real source change for SC-3b" 2>/dev/null || true
+
+    # Make the .opencode submodule pointer dirty: advance the submodule's HEAD past the
+    # current gitlink so the parent repo sees a new-commit submodule (dirty pointer).
+    if [ -d "$wd/.opencode/.git" ]; then
+        git -C "$wd/.opencode" config user.email "test@test.dev" 2>/dev/null || true
+        git -C "$wd/.opencode" config user.name "Test" 2>/dev/null || true
+        # Use a robust marker file that is guaranteed writable inside the submodule.
+        echo "SC-3b dirty pointer advance" >> "$wd/.opencode/AGENTS.md"
+        git -C "$wd/.opencode" add AGENTS.md 2>/dev/null || true
+        git -C "$wd/.opencode" commit -q -m "advance submodule HEAD to dirty the parent pointer" 2>/dev/null || true
+    fi
+}
+
+setup_sc3b_dirty_pointer "$1"

--- a/tests-v2/behaviors/fixtures/setup/2320-sc3c-branch-cleanup-dirty-pointer.sh
+++ b/tests-v2/behaviors/fixtures/setup/2320-sc3c-branch-cleanup-dirty-pointer.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# Per-scenario fixture: 2320-sc3c-branch-cleanup-dirty-pointer
+# Sets up the repo state for SC-3c's ALREADY_GREEN behavioral test: a repo whose
+# submodule pointer is dirty during post-merge cleanup, which the agent must leave
+# uncommitted per branch-cleanup.md Step 1.7 (cleanup exemption) and record as riding
+# alongside the next real root change.
+#
+# The harness provisions the workdir with an `.opencode` submodule and a `.gitmodules`
+# entry (helpers.sh behavior_run), then commits an "init" commit that records the gitlink
+# (submodule pointer). At that point the gitlink is CLEAN (matches submodule HEAD).
+#
+# This fixture makes the pointer DIRTY by committing a change INSIDE the submodule and
+# advancing its HEAD beyond the recorded gitlink. The parent repo then reports the
+# submodule as "modified" (new commits present) — a genuine dirty pointer that appears
+# during the post-merge cleanup workflow when Step 1.7 evaluates the parent repo state.
+#
+# The agent is NOT put on a feature branch for this scenario — it is the post-merge
+# cleanup context, which operates on the trunk. The dirty pointer is observed there and,
+# per branch-cleanup.md Step 1.7, MUST be left uncommitted (cleanup exemption) and
+# acknowledged as expected, with the update riding alongside the next real root change.
+#
+# ALREADY_GREEN expectation: branch-cleanup.md Step 1.7 already states the dirty pointer
+# is expected (line 148), left uncommitted (lines 170-173, 178), and rides alongside the
+# next real root change (lines 163, 178). The agent following Step 1.7 leaves the pointer
+# uncommitted and records it rides alongside. A clean-room evaluator reads session.yaml to
+# judge whether the agent left the pointer uncommitted, treated it as expected, and
+# recorded it rides alongside the next real root change.
+
+setup_sc3c_dirty_pointer() {
+    local wd="$1"
+
+    # Make the .opencode submodule pointer dirty: advance the submodule's HEAD past the
+    # current gitlink so the parent repo sees a new-commit submodule (dirty pointer).
+    if [ -d "$wd/.opencode/.git" ]; then
+        git -C "$wd/.opencode" config user.email "test@test.dev" 2>/dev/null || true
+        git -C "$wd/.opencode" config user.name "Test" 2>/dev/null || true
+        # Use a robust marker file that is guaranteed writable inside the submodule.
+        echo "SC-3c dirty pointer advance" >> "$wd/.opencode/AGENTS.md"
+        git -C "$wd/.opencode" add AGENTS.md 2>/dev/null || true
+        git -C "$wd/.opencode" commit -q -m "advance submodule HEAD to dirty the parent pointer" 2>/dev/null || true
+    fi
+}
+
+setup_sc3c_dirty_pointer "$1"


### PR DESCRIPTION
## Summary

Reconciles agent-facing guidance so the submodule pointer lifecycle is stated unambiguously everywhere: a merged submodule PR does **NOT** resolve the parent repo's submodule pointer. The pointer stays dirty and rides **ALONGSIDE** the next real root-repo change on a feature branch — it is never dropped and never committed in a standalone pointer-only commit/PR.

The enforcement-gate message "Submodule SHA already updated by submodule PR merge. No parent PR needed." could be misread as permission to drop the root pointer, contradicting the pointer-rides-alongside mandate. This change reconciles the wording across all guidance locations while preserving the submodule-bump-only PR prohibition and the dirty-pointer-cleanup-exemption.

## Outcome

- **SC-1** — Root `AGENTS.md` §Submodule Pointer Updates now states the pointer rides ALONGSIDE the next real root-repo change and is NOT dropped when a submodule PR merges.
- **SC-2** — `enforcement-gate.md` Step 0.5 closure message clarified: a merged submodule PR does NOT resolve the root pointer; the pointer still rides alongside the next real root change.
- **SC-3a** — `pre-commit-pointer-check.md` uses unambiguous pointer-rides-alongside language: a dirty pointer is staged and committed alongside a real root change, never dropped and never standalone.
- **SC-3b** — `pr-creation.md` §Pre-Push uses unambiguous pointer-rides-alongside language: a merged submodule PR does NOT resolve the root pointer.
- **SC-3c** — `branch-cleanup.md` Step 1.7 already carried the correct pointer-rides-alongside language (dirty pointer expected, left uncommitted, rides alongside the next real root change); verified no change needed.

All changes are agent-facing documentation/guidance text — no code, hooks, or git tooling changes. Each SC is verified behaviorally via `opencode run` under the with-test-home harness (5 behavioral tests + 5 fixtures added).

## Fixes

Closes #2320

Compare: https://github.com/michael-conrad/.opencode/compare/main...feature/2320-pointer-rides-alongside-guidance-alignment

🤖 Co-authored with AI: OpenCode (deepseek-v4-flash)
