### PR TITLE
[SPEC] Skill card pre-flight guard for sub-agent dispatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- **Skill card pre-flight guard for sub-agent dispatch** (#2339) - Added a pre-flight guard to all skill cards (SKILL.md) that detects sub-agent context and returns `BLOCKED` with `ORCHESTRATOR_ONLY_SKILL_CARD` before any orchestrator-only routing metadata (Trigger Dispatch Table, DISPATCH_GATE, Invocation) is consumed. Defined a single canonical guard definition in the skill card requirements documentation, updated the skill card template generator (`init_skill.py`) so new cards are born with the guard, and enforced presence via `skildeck-lint` and `validate_skill_cards.py`. Added behavioral enforcement tests verifying sub-agents halt on skill-card receipt.
+
 - **for_pr scope routes through executing-plans** (#1364) - Eliminated the for_pr gap-fill bypass where the agent jumped straight to PR creation without executing the plan. Added Pre-Flight + Pipeline columns to the Authorization Scope Model table, a mandatory executing-plans routing rule for `for_pr` scope with an existing plan, a new `executing-plans` skill with a plan-reading mandate, and behavioral enforcement tests verifying the agent routes through executing-plans (not direct PR creation).
 
 ### Changed

--- a/guidelines/000-critical-rules.md
+++ b/guidelines/000-critical-rules.md
@@ -187,6 +187,8 @@ Dispatching SKILL.md content (the skill card) to a sub-agent via `task()` is a c
 
 The skill card (SKILL.md) tells the orchestrator WHAT to dispatch. The task card (tasks/<name>.md) tells the sub-agent HOW to execute. Dispatching the skill card to a sub-agent means the sub-agent receives instructions about dispatching — which it cannot do.
 
+**Defensive backstop — the pre-flight guard.** Every SKILL.md carries a pre-flight guard (see the canonical definition in the skill card requirements documentation) that detects sub-agent context and returns `BLOCKED` with reason `ORCHESTRATOR_ONLY_SKILL_CARD` before any routing metadata is consumed. If a skill card is nonetheless dispatched to a sub-agent, the guard halts the sub-agent immediately rather than allowing it to consume orchestrator-level routing metadata it cannot execute. This guard is the defensive backstop for this rule — it is enforced mechanically by `skildeck-lint` and `validate_skill_cards.py`.
+
 | Artifact | File | Consumer | Content | Action |
 |----------|------|----------|---------|--------|
 | Skill Card | SKILL.md | Orchestrator | Routing metadata (Trigger Dispatch Table, Invocation, DISPATCH_GATE) | Load via skill(), read in own context, do NOT dispatch |

--- a/reference/skill-card-description-standards.md
+++ b/reference/skill-card-description-standards.md
@@ -12,6 +12,26 @@ The `description` field in a SKILL.md YAML frontmatter is a **semantic router** 
 
 ---
 
+## Pre-Flight Guard Mandate (Required)
+
+Every SKILL.md MUST carry a pre-flight guard that detects sub-agent context and returns `BLOCKED` with reason `ORCHESTRATOR_ONLY_SKILL_CARD` before any routing metadata is consumed. The guard is positioned as a pre-flight entry check ahead of the Workflows/routing sections. A sub-agent that receives a skill card cannot act on orchestrator-level routing metadata (sub-agents cannot call `task()`), so it must halt immediately rather than attempt to follow orchestrator-level instructions.
+
+The guard is additive — it does not alter frontmatter or the Workflows dispatch contract. The canonical guard definition is defined once in the requirements documentation and applied verbatim to every skill card. Linting (`skildeck-lint`) and validation (`validate_skill_cards.py`) enforce the guard's presence mechanically.
+
+## Canonical Guard Definition (Single Source of Truth)
+
+Every SKILL.md MUST carry the following pre-flight guard section verbatim, positioned as the first section after the YAML frontmatter and Overview, immediately before the Workflows/routing sections. This is the single canonical definition — apply it verbatim, do not invent variants.
+
+```markdown
+## Pre-Flight Guard (Mandatory)
+
+**This skill card is orchestrator-only routing metadata.**
+
+If you are a sub-agent (dispatched via `task()`), you MUST NOT consume the routing metadata below. Sub-agents cannot call `task()` and cannot execute orchestrator-level dispatch instructions. Return `BLOCKED` with reason `ORCHESTRATOR_ONLY_SKILL_CARD` and halt.
+
+If you are the orchestrator (loaded this card via `skill({name: "..."})`), proceed to the Workflows section.
+```
+
 ## 1. The Description Field as a Semantic Router
 
 ### How Semantic Matching Works

--- a/reference/skill-card-schema.md
+++ b/reference/skill-card-schema.md
@@ -97,6 +97,26 @@ description: "Authorization gatekeeper that verifies scope, cascade, and halt bo
 
 ---
 
+## Pre-Flight Guard Mandate (Required)
+
+Every SKILL.md MUST carry a pre-flight guard that detects sub-agent context and returns `BLOCKED` with reason `ORCHESTRATOR_ONLY_SKILL_CARD` before any routing metadata is consumed. The guard is positioned as a pre-flight entry check ahead of the Workflows/routing sections. A sub-agent that receives a skill card cannot act on orchestrator-level routing metadata (sub-agents cannot call `task()`), so it must halt immediately rather than attempt to follow orchestrator-level instructions.
+
+The guard is additive — it does not alter frontmatter or the Workflows dispatch contract. The canonical guard definition is defined once in the requirements documentation and applied verbatim to every skill card. Linting (`skildeck-lint`) and validation (`validate_skill_cards.py`) enforce the guard's presence mechanically.
+
+## Canonical Guard Definition (Single Source of Truth)
+
+Every SKILL.md MUST carry the following pre-flight guard section verbatim, positioned as the first section after the YAML frontmatter and Overview, immediately before the Workflows/routing sections. This is the single canonical definition — apply it verbatim, do not invent variants.
+
+```markdown
+## Pre-Flight Guard (Mandatory)
+
+**This skill card is orchestrator-only routing metadata.**
+
+If you are a sub-agent (dispatched via `task()`), you MUST NOT consume the routing metadata below. Sub-agents cannot call `task()` and cannot execute orchestrator-level dispatch instructions. Return `BLOCKED` with reason `ORCHESTRATOR_ONLY_SKILL_CARD` and halt.
+
+If you are the orchestrator (loaded this card via `skill({name: "..."})`), proceed to the Workflows section.
+```
+
 ## Project Conventions (Advisory)
 
 These conventions are followed by all cards in this repository but are **not enforced by the binary**. They are project-level quality standards.

--- a/skills/approval-gate/SKILL.md
+++ b/skills/approval-gate/SKILL.md
@@ -23,6 +23,14 @@ This skill operates in the main repo directory (direct-branch mode). When `WORKT
 - [ ] 3. Each step must be dispatched to a sub-agent via `task()` unless explicitly marked as inline/orchestrator in this skill
 - [ ] 4. Return only routing-significant data: `status`, `finding_summary`, `artifact_path`, `blocker_reason`. Full evidence goes to disk.
 
+## Pre-Flight Guard (Mandatory)
+
+**This skill card is orchestrator-only routing metadata.**
+
+If you are a sub-agent (dispatched via `task()`), you MUST NOT consume the routing metadata below. Sub-agents cannot call `task()` and cannot execute orchestrator-level dispatch instructions. Return `BLOCKED` with reason `ORCHESTRATOR_ONLY_SKILL_CARD` and halt.
+
+If you are the orchestrator (loaded this card via `skill({name: "..."})`), proceed to the Workflows section.
+
 ## Trigger Dispatch Table
 
 | User says / Context | Task | Dispatch | Context passed |

--- a/skills/audit/SKILL.md
+++ b/skills/audit/SKILL.md
@@ -60,6 +60,14 @@ When any audit produces a FAIL verdict, the following remediation procedure MUST
 4. **Escalate** — If the FAIL cannot be remediated (e.g., the deliverable's core design is structurally unsound, or required analytical artifacts cannot be generated without developer input), escalate to the developer with: the specific SC(s) that failed, the root cause, what the developer must do to resolve, and the recommended action.
 5. **Never proceed past FAIL** — A deliverable with any unremediated FAIL must NOT advance to the next pipeline stage. The audit verdict is the gate, not a suggestion.
 
+## Pre-Flight Guard (Mandatory)
+
+**This skill card is orchestrator-only routing metadata.**
+
+If you are a sub-agent (dispatched via `task()`), you MUST NOT consume the routing metadata below. Sub-agents cannot call `task()` and cannot execute orchestrator-level dispatch instructions. Return `BLOCKED` with reason `ORCHESTRATOR_ONLY_SKILL_CARD` and halt.
+
+If you are the orchestrator (loaded this card via `skill({name: "..."})`), proceed to the Workflows section.
+
 ## Workflows
 
 **The orchestrator does NOT read task cards.** Each step below is dispatched to a clean-room sub-agent via `task()`. The sub-agent independently discovers and reads the task card file. The orchestrator receives only the result contract — it never loads task card content.
@@ -140,5 +148,3 @@ ALL failures are agent-owned. Remediation is the default action. Escalation is o
 8. **No "pre-existing failure" rationalization** — test infrastructure is part of the ship condition. An agent MUST NOT use "pre-existing failure", "already broken before my change", "baseline failure", or any equivalent rationalization to justify proceeding past a test failure, verification mismatch, or pipeline gate FAIL. The agent owns the pipeline state at entry; any failure present at entry must be remediated before proceeding.
 
 All failures are agent-owned. Remediation is the default action. Escalation is only permitted after verified remediation failure — never as a first response, never as a shortcut.
-
-

--- a/skills/brainstorming/SKILL.md
+++ b/skills/brainstorming/SKILL.md
@@ -25,6 +25,14 @@ This skill operates in the main repo directory (direct-branch mode). When `WORKT
 - [ ] 4. Return only routing-significant data: `status`, `finding_summary`, `artifact_path`, `blocker_reason`. Full evidence goes to disk.
 - [ ] 5. **Preliminary analytical artifact production required before spec-creation handoff.** Artifact requirements are conditional: blast-radius always required; concern-map required for multi-concern specs; code-path-inventory required when spec touches existing code; cross-cutting-matrix required for multi-concern specs; interface-compatibility required when spec modifies public APIs; state-analysis required when spec modifies stateful components; testability-assessment required when spec has behavioral SCs.
 
+## Pre-Flight Guard (Mandatory)
+
+**This skill card is orchestrator-only routing metadata.**
+
+If you are a sub-agent (dispatched via `task()`), you MUST NOT consume the routing metadata below. Sub-agents cannot call `task()` and cannot execute orchestrator-level dispatch instructions. Return `BLOCKED` with reason `ORCHESTRATOR_ONLY_SKILL_CARD` and halt.
+
+If you are the orchestrator (loaded this card via `skill({name: "..."})`), proceed to the Workflows section.
+
 ## Trigger Dispatch Table
 
 | User says / Context | Task | Dispatch | Context passed |
@@ -146,5 +154,3 @@ When brainstorming specs, if a proposed change affects runtime behavior, its SCs
 ## Cross-References
 
 Skills: `spec-creation`, `writing-plans`. Guidelines: `015-pre-spec-inspection.md`.
-
-

--- a/skills/changelog-generator/SKILL.md
+++ b/skills/changelog-generator/SKILL.md
@@ -26,6 +26,14 @@ This skill operates in the main repo directory (direct-branch mode). When `WORKT
 - [ ] 3. Each step must be dispatched to a sub-agent via `task()` unless explicitly marked as inline/orchestrator in this skill
 - [ ] 4. Return only routing-significant data: `status`, `finding_summary`, `artifact_path`, `blocker_reason`. Full evidence goes to disk.
 
+## Pre-Flight Guard (Mandatory)
+
+**This skill card is orchestrator-only routing metadata.**
+
+If you are a sub-agent (dispatched via `task()`), you MUST NOT consume the routing metadata below. Sub-agents cannot call `task()` and cannot execute orchestrator-level dispatch instructions. Return `BLOCKED` with reason `ORCHESTRATOR_ONLY_SKILL_CARD` and halt.
+
+If you are the orchestrator (loaded this card via `skill({name: "..."})`), proceed to the Workflows section.
+
 ## Trigger Dispatch Table
 
 | User says / Context | Task | Dispatch | Context passed |
@@ -107,5 +115,3 @@ After loading this skill and reading the Trigger Dispatch Table, the orchestrato
 - NOT write a custom prompt with preloaded context
 - NOT add orchestrator reasoning, file paths, step sequences, or expected outcomes
 - If the canonical dispatch produces an empty result: re-task clean-room with the same canonical string (max 2 retries)
-
-

--- a/skills/completeness-gate/SKILL.md
+++ b/skills/completeness-gate/SKILL.md
@@ -18,6 +18,14 @@ Completeness check that runs after a RED/GREEN sub-agent returns and before the 
 - [ ] 3. Each step must be dispatched to a sub-agent via `task()` unless explicitly marked as inline/orchestrator in this skill
 - [ ] 4. Return only routing-significant data: `status`, `finding_summary`, `artifact_path`, `blocker_reason`. Full evidence goes to disk.
 
+## Pre-Flight Guard (Mandatory)
+
+**This skill card is orchestrator-only routing metadata.**
+
+If you are a sub-agent (dispatched via `task()`), you MUST NOT consume the routing metadata below. Sub-agents cannot call `task()` and cannot execute orchestrator-level dispatch instructions. Return `BLOCKED` with reason `ORCHESTRATOR_ONLY_SKILL_CARD` and halt.
+
+If you are the orchestrator (loaded this card via `skill({name: "..."})`), proceed to the Workflows section.
+
 ## Trigger Dispatch Table
 
 | User says / Context | Task | Dispatch | Context passed |

--- a/skills/completion-core/SKILL.md
+++ b/skills/completion-core/SKILL.md
@@ -23,6 +23,14 @@ This skill operates in the main repo directory (direct-branch mode). When `WORKT
 - [ ] 3. Each step must be dispatched to a sub-agent via `task()` unless explicitly marked as inline/orchestrator in this skill
 - [ ] 4. Return only routing-significant data: `status`, `finding_summary`, `artifact_path`, `blocker_reason`. Full evidence goes to disk.
 
+## Pre-Flight Guard (Mandatory)
+
+**This skill card is orchestrator-only routing metadata.**
+
+If you are a sub-agent (dispatched via `task()`), you MUST NOT consume the routing metadata below. Sub-agents cannot call `task()` and cannot execute orchestrator-level dispatch instructions. Return `BLOCKED` with reason `ORCHESTRATOR_ONLY_SKILL_CARD` and halt.
+
+If you are the orchestrator (loaded this card via `skill({name: "..."})`), proceed to the Workflows section.
+
 ## Workflows
 
 ### Complete a skill task workflow
@@ -155,5 +163,3 @@ After loading this skill and reading the Workflows section, the orchestrator MUS
 - If the canonical dispatch produces an empty result: re-task clean-room with the same canonical string (max 2 retries)
 ### [critical-rules-016] Skipping Completion Guarantee on Workflow Halt
 Call `--task completion` on current skill before halting. Amateurs abandon workflows mid-stream. Professionals close out every skill before halting.
-
-

--- a/skills/conflict-resolution/SKILL.md
+++ b/skills/conflict-resolution/SKILL.md
@@ -22,6 +22,14 @@ This skill operates in the main repo directory (direct-branch mode). When `WORKT
 - [ ] 3. Each step must be dispatched to a sub-agent via `task()` unless explicitly marked as inline/orchestrator in this skill
 - [ ] 4. Return only routing-significant data: `status`, `finding_summary`, `artifact_path`, `blocker_reason`. Full evidence goes to disk.
 
+## Pre-Flight Guard (Mandatory)
+
+**This skill card is orchestrator-only routing metadata.**
+
+If you are a sub-agent (dispatched via `task()`), you MUST NOT consume the routing metadata below. Sub-agents cannot call `task()` and cannot execute orchestrator-level dispatch instructions. Return `BLOCKED` with reason `ORCHESTRATOR_ONLY_SKILL_CARD` and halt.
+
+If you are the orchestrator (loaded this card via `skill({name: "..."})`), proceed to the Workflows section.
+
 ## Trigger Dispatch Table
 
 | User says / Context | Task | Dispatch | Context passed |
@@ -119,5 +127,3 @@ After loading this skill and reading the Trigger Dispatch Table, the orchestrato
 
 ### [critical-rules-042] Blind Conflict Resolution
 Resolving conflicts blindly produces broken merges. Professional engineers classify conflicts by intent before resolving — amateurs merge first and find the corruption later. Three tiers: Trivial → auto, Textual → note, Intent → HALT. Read [conflict-resolution skill](skills/conflict-resolution/SKILL.md).
-
-

--- a/skills/correspondence/SKILL.md
+++ b/skills/correspondence/SKILL.md
@@ -27,6 +27,14 @@ This skill operates in the main repo directory (direct-branch mode). When `WORKT
 - [ ] 3. Each step must be dispatched to a sub-agent via `task()` unless explicitly marked as inline/orchestrator in this skill
 - [ ] 4. Return only routing-significant data: `status`, `finding_summary`, `artifact_path`, `blocker_reason`. Full evidence goes to disk.
 
+## Pre-Flight Guard (Mandatory)
+
+**This skill card is orchestrator-only routing metadata.**
+
+If you are a sub-agent (dispatched via `task()`), you MUST NOT consume the routing metadata below. Sub-agents cannot call `task()` and cannot execute orchestrator-level dispatch instructions. Return `BLOCKED` with reason `ORCHESTRATOR_ONLY_SKILL_CARD` and halt.
+
+If you are the orchestrator (loaded this card via `skill({name: "..."})`), proceed to the Workflows section.
+
 ## Trigger Dispatch Table
 
 | User says / Context | Task | Dispatch | Context passed |
@@ -120,5 +128,3 @@ Skills: `verification-enforcement`. Guidelines: `000-critical-rules.md` (audienc
 
 ### [critical-rules-009] Audience Separation — leaking internal artifacts to stakeholders
 Leaking internal audit findings and raw status into stakeholder communications damages trust. Drafting tools and delivery channels are separate concerns — professional communicators maintain audience separation. Read [correspondence skill](skills/correspondence/SKILL.md) → "Audience Separation Principle".
-
-

--- a/skills/engineering-approach/SKILL.md
+++ b/skills/engineering-approach/SKILL.md
@@ -27,6 +27,14 @@ This skill operates in the main repo directory (direct-branch mode). When `WORKT
 - [ ] 3. Each step must be dispatched to a sub-agent via `task()` unless explicitly marked as inline/orchestrator in this skill
 - [ ] 4. Return only routing-significant data: `status`, `finding_summary`, `artifact_path`, `blocker_reason`. Full evidence goes to disk.
 
+## Pre-Flight Guard (Mandatory)
+
+**This skill card is orchestrator-only routing metadata.**
+
+If you are a sub-agent (dispatched via `task()`), you MUST NOT consume the routing metadata below. Sub-agents cannot call `task()` and cannot execute orchestrator-level dispatch instructions. Return `BLOCKED` with reason `ORCHESTRATOR_ONLY_SKILL_CARD` and halt.
+
+If you are the orchestrator (loaded this card via `skill({name: "..."})`), proceed to the Workflows section.
+
 ## Trigger Dispatch Table
 
 | User says / Context | Task | Dispatch | Context passed |
@@ -120,5 +128,3 @@ Guidelines: `000-critical-rules.md`, `010-approval-gate.md`.
 
 ### [critical-rules-042] Engineering Mindset Required
 Understand → Design → Verify → Communicate. Amateurs jump from understanding to implementation. Professional engineers verify before building. Read [engineering-approach skill](skills/engineering-approach/SKILL.md).
-
-

--- a/skills/executing-plans/SKILL.md
+++ b/skills/executing-plans/SKILL.md
@@ -26,6 +26,14 @@ Enables the orchestrator to execute an approved implementation plan by first rea
 - [ ] 4. Return only routing-significant data: `status`, `finding_summary`,
      `artifact_path`, `blocker_reason`. Full evidence goes to disk.
 
+## Pre-Flight Guard (Mandatory)
+
+**This skill card is orchestrator-only routing metadata.**
+
+If you are a sub-agent (dispatched via `task()`), you MUST NOT consume the routing metadata below. Sub-agents cannot call `task()` and cannot execute orchestrator-level dispatch instructions. Return `BLOCKED` with reason `ORCHESTRATOR_ONLY_SKILL_CARD` and halt.
+
+If you are the orchestrator (loaded this card via `skill({name: "..."})`), proceed to the Workflows section.
+
 ## Workflows
 
 ### Read the plan

--- a/skills/finishing-a-development-branch/SKILL.md
+++ b/skills/finishing-a-development-branch/SKILL.md
@@ -31,6 +31,14 @@ This skill operates in the main repo directory (direct-branch mode). When `WORKT
 - [ ] 3. Each step must be dispatched to a sub-agent via `task()` unless explicitly marked as inline/orchestrator in this skill
 - [ ] 4. Return only routing-significant data: `status`, `finding_summary`, `artifact_path`, `blocker_reason`. Full evidence goes to disk.
 
+## Pre-Flight Guard (Mandatory)
+
+**This skill card is orchestrator-only routing metadata.**
+
+If you are a sub-agent (dispatched via `task()`), you MUST NOT consume the routing metadata below. Sub-agents cannot call `task()` and cannot execute orchestrator-level dispatch instructions. Return `BLOCKED` with reason `ORCHESTRATOR_ONLY_SKILL_CARD` and halt.
+
+If you are the orchestrator (loaded this card via `skill({name: "..."})`), proceed to the Workflows section.
+
 ## Trigger Dispatch Table
 
 | User says / Context | Task | Dispatch | Context passed |
@@ -121,5 +129,3 @@ Skills: `git-workflow`, `verification-before-completion`. Guidelines: `000-criti
 
 ### [critical-rules-024] Uncommitted/Unpushed Changes After Implementation
 Read [finishing-a-development-branch --task checklist](skills/finishing-a-development-branch/SKILL.md).
-
-

--- a/skills/gb-cli/SKILL.md
+++ b/skills/gb-cli/SKILL.md
@@ -19,6 +19,14 @@ GitBucket CLI (gb) operations for authentication, issue and PR workflows, labels
 - [ ] 3. Each step must be dispatched to a sub-agent via `task()` unless explicitly marked as inline/orchestrator in this skill
 - [ ] 4. Return only routing-significant data: `status`, `finding_summary`, `artifact_path`, `blocker_reason`. Full evidence goes to disk.
 
+## Pre-Flight Guard (Mandatory)
+
+**This skill card is orchestrator-only routing metadata.**
+
+If you are a sub-agent (dispatched via `task()`), you MUST NOT consume the routing metadata below. Sub-agents cannot call `task()` and cannot execute orchestrator-level dispatch instructions. Return `BLOCKED` with reason `ORCHESTRATOR_ONLY_SKILL_CARD` and halt.
+
+If you are the orchestrator (loaded this card via `skill({name: "..."})`), proceed to the Workflows section.
+
 ## Workflows
 
 ### Authenticate with GitBucket CLI

--- a/skills/gh-cli/SKILL.md
+++ b/skills/gh-cli/SKILL.md
@@ -18,6 +18,14 @@ GitHub CLI (gh) operations for repository management, issue/PR workflows, releas
 - [ ] 3. Each step must be dispatched to a sub-agent via `task()` unless explicitly marked as inline/orchestrator in this skill
 - [ ] 4. Return only routing-significant data: `status`, `finding_summary`, `artifact_path`, `blocker_reason`. Full evidence goes to disk.
 
+## Pre-Flight Guard (Mandatory)
+
+**This skill card is orchestrator-only routing metadata.**
+
+If you are a sub-agent (dispatched via `task()`), you MUST NOT consume the routing metadata below. Sub-agents cannot call `task()` and cannot execute orchestrator-level dispatch instructions. Return `BLOCKED` with reason `ORCHESTRATOR_ONLY_SKILL_CARD` and halt.
+
+If you are the orchestrator (loaded this card via `skill({name: "..."})`), proceed to the Workflows section.
+
 ## Workflows
 
 ### Authenticate with GitHub CLI

--- a/skills/git-workflow-branch/SKILL.md
+++ b/skills/git-workflow-branch/SKILL.md
@@ -18,6 +18,14 @@ Branch management sub-skill of git-workflow. Handles feature branch creation, su
 - [ ] 3. Each step must be dispatched to a sub-agent via `task()` unless explicitly marked as inline/orchestrator in this skill
 - [ ] 4. Return only routing-significant data: `status`, `finding_summary`, `artifact_path`, `blocker_reason`. Full evidence goes to disk.
 
+## Pre-Flight Guard (Mandatory)
+
+**This skill card is orchestrator-only routing metadata.**
+
+If you are a sub-agent (dispatched via `task()`), you MUST NOT consume the routing metadata below. Sub-agents cannot call `task()` and cannot execute orchestrator-level dispatch instructions. Return `BLOCKED` with reason `ORCHESTRATOR_ONLY_SKILL_CARD` and halt.
+
+If you are the orchestrator (loaded this card via `skill({name: "..."})`), proceed to the Workflows section.
+
 ## Workflows
 
 ### Set up a feature branch

--- a/skills/git-workflow-cleanup/SKILL.md
+++ b/skills/git-workflow-cleanup/SKILL.md
@@ -18,6 +18,14 @@ Cleanup management sub-skill of git-workflow. Handles post-merge cleanup, PR sta
 - [ ] 3. Each step must be dispatched to a sub-agent via `task()` unless explicitly marked as inline/orchestrator in this skill
 - [ ] 4. Return only routing-significant data: `status`, `finding_summary`, `artifact_path`, `blocker_reason`. Full evidence goes to disk.
 
+## Pre-Flight Guard (Mandatory)
+
+**This skill card is orchestrator-only routing metadata.**
+
+If you are a sub-agent (dispatched via `task()`), you MUST NOT consume the routing metadata below. Sub-agents cannot call `task()` and cannot execute orchestrator-level dispatch instructions. Return `BLOCKED` with reason `ORCHESTRATOR_ONLY_SKILL_CARD` and halt.
+
+If you are the orchestrator (loaded this card via `skill({name: "..."})`), proceed to the Workflows section.
+
 ## Workflows
 
 ### Clean up after a PR merge

--- a/skills/git-workflow-commit/SKILL.md
+++ b/skills/git-workflow-commit/SKILL.md
@@ -18,6 +18,14 @@ Commit management sub-skill of git-workflow. Handles implementation commits, com
 - [ ] 3. Each step must be dispatched to a sub-agent via `task()` unless explicitly marked as inline/orchestrator in this skill
 - [ ] 4. Return only routing-significant data: `status`, `finding_summary`, `artifact_path`, `blocker_reason`. Full evidence goes to disk.
 
+## Pre-Flight Guard (Mandatory)
+
+**This skill card is orchestrator-only routing metadata.**
+
+If you are a sub-agent (dispatched via `task()`), you MUST NOT consume the routing metadata below. Sub-agents cannot call `task()` and cannot execute orchestrator-level dispatch instructions. Return `BLOCKED` with reason `ORCHESTRATOR_ONLY_SKILL_CARD` and halt.
+
+If you are the orchestrator (loaded this card via `skill({name: "..."})`), proceed to the Workflows section.
+
 ## Workflows
 
 ### Implement changes and commit

--- a/skills/git-workflow-conflict/SKILL.md
+++ b/skills/git-workflow-conflict/SKILL.md
@@ -18,6 +18,14 @@ Conflict resolution sub-skill of git-workflow. Handles rebase-pending conflict r
 - [ ] 3. Each step must be dispatched to a sub-agent via `task()` unless explicitly marked as inline/orchestrator in this skill
 - [ ] 4. Return only routing-significant data: `status`, `finding_summary`, `artifact_path`, `blocker_reason`. Full evidence goes to disk.
 
+## Pre-Flight Guard (Mandatory)
+
+**This skill card is orchestrator-only routing metadata.**
+
+If you are a sub-agent (dispatched via `task()`), you MUST NOT consume the routing metadata below. Sub-agents cannot call `task()` and cannot execute orchestrator-level dispatch instructions. Return `BLOCKED` with reason `ORCHESTRATOR_ONLY_SKILL_CARD` and halt.
+
+If you are the orchestrator (loaded this card via `skill({name: "..."})`), proceed to the Workflows section.
+
 ## Workflows
 
 ### Resolve a rebase, merge, or cherry-pick conflict

--- a/skills/git-workflow-pr/SKILL.md
+++ b/skills/git-workflow-pr/SKILL.md
@@ -18,6 +18,14 @@ Pull request management sub-skill of git-workflow. Handles PR creation, review p
 - [ ] 3. Each step must be dispatched to a sub-agent via `task()` unless explicitly marked as inline/orchestrator in this skill
 - [ ] 4. Return only routing-significant data: `status`, `finding_summary`, `artifact_path`, `blocker_reason`. Full evidence goes to disk.
 
+## Pre-Flight Guard (Mandatory)
+
+**This skill card is orchestrator-only routing metadata.**
+
+If you are a sub-agent (dispatched via `task()`), you MUST NOT consume the routing metadata below. Sub-agents cannot call `task()` and cannot execute orchestrator-level dispatch instructions. Return `BLOCKED` with reason `ORCHESTRATOR_ONLY_SKILL_CARD` and halt.
+
+If you are the orchestrator (loaded this card via `skill({name: "..."})`), proceed to the Workflows section.
+
 ## Workflows
 
 ### Create a PR

--- a/skills/git-workflow/SKILL.md
+++ b/skills/git-workflow/SKILL.md
@@ -19,6 +19,14 @@ This is a **dispatcher skill** that routes to 5 sub-skills. All original trigger
 - [ ] 3. Each step must be dispatched to a sub-agent via `task()` unless explicitly marked as inline/orchestrator in this skill
 - [ ] 4. Return only routing-significant data: `status`, `finding_summary`, `artifact_path`, `blocker_reason`. Full evidence goes to disk.
 
+## Pre-Flight Guard (Mandatory)
+
+**This skill card is orchestrator-only routing metadata.**
+
+If you are a sub-agent (dispatched via `task()`), you MUST NOT consume the routing metadata below. Sub-agents cannot call `task()` and cannot execute orchestrator-level dispatch instructions. Return `BLOCKED` with reason `ORCHESTRATOR_ONLY_SKILL_CARD` and halt.
+
+If you are the orchestrator (loaded this card via `skill({name: "..."})`), proceed to the Workflows section.
+
 ## Workflows
 
 ### Set up a feature branch

--- a/skills/issue-operations-comments/SKILL.md
+++ b/skills/issue-operations-comments/SKILL.md
@@ -11,6 +11,14 @@ provenance: AI-generated
 
 Comment gating and posting for issues/PRs. Enforces the substantive comment gate — only meaningful updates are posted as issue comments. Non-substantive progress updates (status updates, phase complete, implemented X) MUST NOT be posted to GitHub Issues.
 
+## Pre-Flight Guard (Mandatory)
+
+**This skill card is orchestrator-only routing metadata.**
+
+If you are a sub-agent (dispatched via `task()`), you MUST NOT consume the routing metadata below. Sub-agents cannot call `task()` and cannot execute orchestrator-level dispatch instructions. Return `BLOCKED` with reason `ORCHESTRATOR_ONLY_SKILL_CARD` and halt.
+
+If you are the orchestrator (loaded this card via `skill({name: "..."})`), proceed to the Workflows section.
+
 ## Trigger Dispatch Table
 
 | User says / Context | Task | Dispatch | Context passed |

--- a/skills/issue-operations-core/SKILL.md
+++ b/skills/issue-operations-core/SKILL.md
@@ -11,6 +11,14 @@ provenance: AI-generated
 
 Core CRUD operations for issue management. Routes all operations to the appropriate platform sub-skill (github-mcp, gitbucket-api, local). Handles creation, reading, updating, closing, listing, searching, body editing, merge verification, single-task checks, artifact pushing, and pre/post-creation validation.
 
+## Pre-Flight Guard (Mandatory)
+
+**This skill card is orchestrator-only routing metadata.**
+
+If you are a sub-agent (dispatched via `task()`), you MUST NOT consume the routing metadata below. Sub-agents cannot call `task()` and cannot execute orchestrator-level dispatch instructions. Return `BLOCKED` with reason `ORCHESTRATOR_ONLY_SKILL_CARD` and halt.
+
+If you are the orchestrator (loaded this card via `skill({name: "..."})`), proceed to the Workflows section.
+
 ## Trigger Dispatch Table
 
 | User says / Context | Task | Dispatch | Context passed |

--- a/skills/issue-operations-sub-issues/SKILL.md
+++ b/skills/issue-operations-sub-issues/SKILL.md
@@ -11,6 +11,14 @@ provenance: AI-generated
 
 Sub-issue management for parent-child issue relationships. Handles linking sub-issues to parent plan issues and reading sub-issue structures for authorization cascade and closure order verification.
 
+## Pre-Flight Guard (Mandatory)
+
+**This skill card is orchestrator-only routing metadata.**
+
+If you are a sub-agent (dispatched via `task()`), you MUST NOT consume the routing metadata below. Sub-agents cannot call `task()` and cannot execute orchestrator-level dispatch instructions. Return `BLOCKED` with reason `ORCHESTRATOR_ONLY_SKILL_CARD` and halt.
+
+If you are the orchestrator (loaded this card via `skill({name: "..."})`), proceed to the Workflows section.
+
 ## Trigger Dispatch Table
 
 | User says / Context | Task | Dispatch | Context passed |
@@ -69,5 +77,3 @@ Phases require sub-issue linkage. Read [issue-operations skill](skills/issue-ope
 
 ### [critical-rules-018] Sub-issue Linkage Verification — phase count mismatch
 Read [approval-gate --task verify-authorization](skills/approval-gate/SKILL.md) Step 5.
-
-

--- a/skills/issue-operations-sync/SKILL.md
+++ b/skills/issue-operations-sync/SKILL.md
@@ -11,6 +11,14 @@ provenance: AI-generated
 
 Issue synchronization between remote platforms and local `.issues/` tracking. Handles reconciling remote issues against local state, mirroring remote issue bodies to local spec files, and retroactively importing pre-existing remote issues.
 
+## Pre-Flight Guard (Mandatory)
+
+**This skill card is orchestrator-only routing metadata.**
+
+If you are a sub-agent (dispatched via `task()`), you MUST NOT consume the routing metadata below. Sub-agents cannot call `task()` and cannot execute orchestrator-level dispatch instructions. Return `BLOCKED` with reason `ORCHESTRATOR_ONLY_SKILL_CARD` and halt.
+
+If you are the orchestrator (loaded this card via `skill({name: "..."})`), proceed to the Workflows section.
+
 ## Trigger Dispatch Table
 
 | User says / Context | Task | Dispatch | Context passed |

--- a/skills/issue-operations/SKILL.md
+++ b/skills/issue-operations/SKILL.md
@@ -22,6 +22,14 @@ This skill operates in the main repo directory (direct-branch mode). When `WORKT
 - [ ] 3. Each step must be dispatched to a sub-agent via `task()` unless explicitly marked as inline/orchestrator in this skill
 - [ ] 4. Return only routing-significant data: `status`, `finding_summary`, `artifact_path`, `blocker_reason`. Full evidence goes to disk.
 
+## Pre-Flight Guard (Mandatory)
+
+**This skill card is orchestrator-only routing metadata.**
+
+If you are a sub-agent (dispatched via `task()`), you MUST NOT consume the routing metadata below. Sub-agents cannot call `task()` and cannot execute orchestrator-level dispatch instructions. Return `BLOCKED` with reason `ORCHESTRATOR_ONLY_SKILL_CARD` and halt.
+
+If you are the orchestrator (loaded this card via `skill({name: "..."})`), proceed to the Workflows section.
+
 ## Trigger Dispatch Table
 
 | User says / Context | Task | Dispatch | Context passed |
@@ -213,5 +221,3 @@ The `issue-operations` dispatcher resolves platform selection automatically base
 
 ### [critical-rules-011] Bug Reports Without Fix Spec
 Reporting a bug without a fix spec means you are asking the developer to guess what happened. Professional engineers always create a fix spec with every bug report — amateurs file half-baked tickets and expect someone else to figure them out.
-
-

--- a/skills/issue-operations/platforms/gitbucket-api/SKILL.md
+++ b/skills/issue-operations/platforms/gitbucket-api/SKILL.md
@@ -70,6 +70,14 @@ See `gitbucket-api/tasks/tool-detection.md` for tool detection and version check
 | Create repo | ✅ | `gb repo create <name> [-g group]` |
 | API passthrough | ✅ | `gb api <endpoint> [-X method] [--input ...]` |
 
+## Pre-Flight Guard (Mandatory)
+
+**This skill card is orchestrator-only routing metadata.**
+
+If you are a sub-agent (dispatched via `task()`), you MUST NOT consume the routing metadata below. Sub-agents cannot call `task()` and cannot execute orchestrator-level dispatch instructions. Return `BLOCKED` with reason `ORCHESTRATOR_ONLY_SKILL_CARD` and halt.
+
+If you are the orchestrator (loaded this card via `skill({name: "..."})`), proceed to the Workflows section.
+
 ## Tasks
 
 | Task | Purpose |

--- a/skills/issue-operations/platforms/github-mcp/SKILL.md
+++ b/skills/issue-operations/platforms/github-mcp/SKILL.md
@@ -96,6 +96,14 @@ See `github-mcp/tasks/spec-mirror.md` for the full spec mirror sync procedure, f
 - Router: `../SKILL.md` (issue-operations)
 - Related platform: `../gitbucket-api/SKILL.md`
 
+## Pre-Flight Guard (Mandatory)
+
+**This skill card is orchestrator-only routing metadata.**
+
+If you are a sub-agent (dispatched via `task()`), you MUST NOT consume the routing metadata below. Sub-agents cannot call `task()` and cannot execute orchestrator-level dispatch instructions. Return `BLOCKED` with reason `ORCHESTRATOR_ONLY_SKILL_CARD` and halt.
+
+If you are the orchestrator (loaded this card via `skill({name: "..."})`), proceed to the Workflows section.
+
 ## Sub-Agent Tasks
 
 ### Task Routing

--- a/skills/issue-operations/platforms/local/SKILL.md
+++ b/skills/issue-operations/platforms/local/SKILL.md
@@ -194,6 +194,14 @@ When `github.platform` is NOT `local` (remote available), local issues can be pr
 
 `.issues/` (root repo) or `{project_root}/{path}/.issues/` (submodule/sub-repo) files are non-behavioral metadata. Exempt from worktree requirement per `060-tool-usage.md` §Worktree Exemption, but NOT exempt from branching requirement (no direct commits to `$DEFAULT_BRANCH`/`main`).
 
+## Pre-Flight Guard (Mandatory)
+
+**This skill card is orchestrator-only routing metadata.**
+
+If you are a sub-agent (dispatched via `task()`), you MUST NOT consume the routing metadata below. Sub-agents cannot call `task()` and cannot execute orchestrator-level dispatch instructions. Return `BLOCKED` with reason `ORCHESTRATOR_ONLY_SKILL_CARD` and halt.
+
+If you are the orchestrator (loaded this card via `skill({name: "..."})`), proceed to the Workflows section.
+
 ## Sub-Agent Tasks
 
 ### Task Routing
@@ -284,4 +292,3 @@ After loading this skill and reading the Trigger Dispatch Table, the orchestrato
 | Worktree exemption | `060-tool-usage.md` §Worktree Exemption                                   |
 | Critical rules     | `000-critical-rules.md` §Creating .opencode/.opencode/ Nested Directories |
 | Card-020           | `.issues/979/cards/card-020-local-skill-capability-contract.md`           |
-

--- a/skills/issue-review/SKILL.md
+++ b/skills/issue-review/SKILL.md
@@ -22,6 +22,14 @@ This skill operates in the main repo directory (direct-branch mode). When `WORKT
 - [ ] 3. Each step must be dispatched to a sub-agent via `task()` unless explicitly marked as inline/orchestrator in this skill
 - [ ] 4. Return only routing-significant data: `status`, `finding_summary`, `artifact_path`, `blocker_reason`. Full evidence goes to disk.
 
+## Pre-Flight Guard (Mandatory)
+
+**This skill card is orchestrator-only routing metadata.**
+
+If you are a sub-agent (dispatched via `task()`), you MUST NOT consume the routing metadata below. Sub-agents cannot call `task()` and cannot execute orchestrator-level dispatch instructions. Return `BLOCKED` with reason `ORCHESTRATOR_ONLY_SKILL_CARD` and halt.
+
+If you are the orchestrator (loaded this card via `skill({name: "..."})`), proceed to the Workflows section.
+
 ## Trigger Dispatch Table
 
 | User says / Context | Task | Dispatch | Context passed |
@@ -126,5 +134,3 @@ After loading this skill and reading the Trigger Dispatch Table, the orchestrato
 ## Cross-References
 
 Skills: `audit --task spec-audit`, `brainstorming`, `spec-creation`, `issue-operations`, `approval-gate`. Guidelines: `000-critical-rules.md`, `067-context-completeness.md`.
-
-

--- a/skills/mcp-tool-usage/SKILL.md
+++ b/skills/mcp-tool-usage/SKILL.md
@@ -26,6 +26,14 @@ This skill operates in the main repo directory (direct-branch mode). When `WORKT
 - [ ] 3. Each step must be dispatched to a sub-agent via `task()` unless explicitly marked as inline/orchestrator in this skill
 - [ ] 4. Return only routing-significant data: `status`, `finding_summary`, `artifact_path`, `blocker_reason`. Full evidence goes to disk.
 
+## Pre-Flight Guard (Mandatory)
+
+**This skill card is orchestrator-only routing metadata.**
+
+If you are a sub-agent (dispatched via `task()`), you MUST NOT consume the routing metadata below. Sub-agents cannot call `task()` and cannot execute orchestrator-level dispatch instructions. Return `BLOCKED` with reason `ORCHESTRATOR_ONLY_SKILL_CARD` and halt.
+
+If you are the orchestrator (loaded this card via `skill({name: "..."})`), proceed to the Workflows section.
+
 ## Trigger Dispatch Table
 
 | User says / Context | Task | Dispatch | Context passed |

--- a/skills/multimodal-dispatch/SKILL.md
+++ b/skills/multimodal-dispatch/SKILL.md
@@ -22,6 +22,14 @@ This skill operates in the main repo directory (direct-branch mode). When `WORKT
 - [ ] 3. Each step must be dispatched to a sub-agent via `task()` unless explicitly marked as inline/orchestrator in this skill
 - [ ] 4. Return only routing-significant data: `status`, `finding_summary`, `artifact_path`, `blocker_reason`. Full evidence goes to disk.
 
+## Pre-Flight Guard (Mandatory)
+
+**This skill card is orchestrator-only routing metadata.**
+
+If you are a sub-agent (dispatched via `task()`), you MUST NOT consume the routing metadata below. Sub-agents cannot call `task()` and cannot execute orchestrator-level dispatch instructions. Return `BLOCKED` with reason `ORCHESTRATOR_ONLY_SKILL_CARD` and halt.
+
+If you are the orchestrator (loaded this card via `skill({name: "..."})`), proceed to the Workflows section.
+
 ## Trigger Dispatch Table
 
 | User says / Context | Task | Dispatch | Context passed |
@@ -107,5 +115,3 @@ After loading this skill and reading the Trigger Dispatch Table, the orchestrato
 - NOT write a custom prompt with preloaded context
 - NOT add orchestrator reasoning, file paths, step sequences, or expected outcomes
 - If the canonical dispatch produces an empty result: re-task clean-room with the same canonical string (max 2 retries)
-
-

--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -18,6 +18,14 @@ Provides AI planning capabilities wrapping `unified-planning` with workflow inte
 - [ ] 3. Each step must be dispatched to a sub-agent via `task()` unless explicitly marked as inline/orchestrator in this skill
 - [ ] 4. Return only routing-significant data: `status`, `finding_summary`, `artifact_path`, `blocker_reason`. Full evidence goes to disk.
 
+## Pre-Flight Guard (Mandatory)
+
+**This skill card is orchestrator-only routing metadata.**
+
+If you are a sub-agent (dispatched via `task()`), you MUST NOT consume the routing metadata below. Sub-agents cannot call `task()` and cannot execute orchestrator-level dispatch instructions. Return `BLOCKED` with reason `ORCHESTRATOR_ONLY_SKILL_CARD` and halt.
+
+If you are the orchestrator (loaded this card via `skill({name: "..."})`), proceed to the Workflows section.
+
 ## Trigger Dispatch Table
 
 | User says / Context | Task | Dispatch | Context passed |

--- a/skills/playwright-cli/SKILL.md
+++ b/skills/playwright-cli/SKILL.md
@@ -41,6 +41,14 @@ The global `--raw` option strips page status, generated code, and snapshot secti
 
 Read [open parameters](skills/playwright-cli/tasks/commands-reference.md).
 
+## Pre-Flight Guard (Mandatory)
+
+**This skill card is orchestrator-only routing metadata.**
+
+If you are a sub-agent (dispatched via `task()`), you MUST NOT consume the routing metadata below. Sub-agents cannot call `task()` and cannot execute orchestrator-level dispatch instructions. Return `BLOCKED` with reason `ORCHESTRATOR_ONLY_SKILL_CARD` and halt.
+
+If you are the orchestrator (loaded this card via `skill({name: "..."})`), proceed to the Workflows section.
+
 ## Workflows
 
 ### Browse the web

--- a/skills/pre-analysis/SKILL.md
+++ b/skills/pre-analysis/SKILL.md
@@ -18,6 +18,14 @@ Universal pipeline gate that prevents orchestrators from preloading sub-agents w
 - [ ] 3. Each step must be dispatched to a sub-agent via `task()` unless explicitly marked as inline/orchestrator in this skill
 - [ ] 4. Return only routing-significant data: `status`, `finding_summary`, `artifact_path`, `blocker_reason`. Full evidence goes to disk.
 
+## Pre-Flight Guard (Mandatory)
+
+**This skill card is orchestrator-only routing metadata.**
+
+If you are a sub-agent (dispatched via `task()`), you MUST NOT consume the routing metadata below. Sub-agents cannot call `task()` and cannot execute orchestrator-level dispatch instructions. Return `BLOCKED` with reason `ORCHESTRATOR_ONLY_SKILL_CARD` and halt.
+
+If you are the orchestrator (loaded this card via `skill({name: "..."})`), proceed to the Workflows section.
+
 ## Trigger Dispatch Table
 
 | User says / Context | Task | Dispatch | Context passed |
@@ -120,5 +128,3 @@ After loading this skill and reading the Trigger Dispatch Table, the orchestrato
 ## Worktree Mode
 
 When `worktree.path` is set, all file operations and git commands MUST use it as the base directory.
-
-

--- a/skills/programming-principles/SKILL.md
+++ b/skills/programming-principles/SKILL.md
@@ -28,6 +28,14 @@ This skill operates in the main repo directory (direct-branch mode). When `WORKT
 - [ ] 3. Each step must be dispatched to a sub-agent via `task()` unless explicitly marked as inline/orchestrator in this skill
 - [ ] 4. Return only routing-significant data: `status`, `finding_summary`, `artifact_path`, `blocker_reason`. Full evidence goes to disk.
 
+## Pre-Flight Guard (Mandatory)
+
+**This skill card is orchestrator-only routing metadata.**
+
+If you are a sub-agent (dispatched via `task()`), you MUST NOT consume the routing metadata below. Sub-agents cannot call `task()` and cannot execute orchestrator-level dispatch instructions. Return `BLOCKED` with reason `ORCHESTRATOR_ONLY_SKILL_CARD` and halt.
+
+If you are the orchestrator (loaded this card via `skill({name: "..."})`), proceed to the Workflows section.
+
 ## Trigger Dispatch Table
 
 | User says / Context | Task | Dispatch | Context passed |
@@ -119,5 +127,3 @@ Professional engineers ship one concern per artifact — commits, PRs, issues, s
 
 ### [critical-rules-042] Scope Creep — never do things outside the spec
 Professional engineers implement exactly what the spec defines — nothing more, nothing less. Amateurs add features the spec never asked for — then wonder why reviewers flag every third line as scope creep.
-
-

--- a/skills/receiving-code-review/SKILL.md
+++ b/skills/receiving-code-review/SKILL.md
@@ -26,6 +26,14 @@ This skill operates in the main repo directory (direct-branch mode). When `WORKT
 - [ ] 3. Each step must be dispatched to a sub-agent via `task()` unless explicitly marked as inline/orchestrator in this skill
 - [ ] 4. Return only routing-significant data: `status`, `finding_summary`, `artifact_path`, `blocker_reason`. Full evidence goes to disk.
 
+## Pre-Flight Guard (Mandatory)
+
+**This skill card is orchestrator-only routing metadata.**
+
+If you are a sub-agent (dispatched via `task()`), you MUST NOT consume the routing metadata below. Sub-agents cannot call `task()` and cannot execute orchestrator-level dispatch instructions. Return `BLOCKED` with reason `ORCHESTRATOR_ONLY_SKILL_CARD` and halt.
+
+If you are the orchestrator (loaded this card via `skill({name: "..."})`), proceed to the Workflows section.
+
 ## Trigger Dispatch Table
 
 | User says / Context | Task | Dispatch | Context passed |
@@ -115,5 +123,3 @@ After loading this skill and reading the Trigger Dispatch Table, the orchestrato
 - NOT write a custom prompt with preloaded context
 - NOT add orchestrator reasoning, file paths, step sequences, or expected outcomes
 - If the canonical dispatch produces an empty result: re-task clean-room with the same canonical string (max 2 retries)
-
-

--- a/skills/release-promoter/SKILL.md
+++ b/skills/release-promoter/SKILL.md
@@ -26,6 +26,14 @@ This skill operates in the main repo directory (direct-branch mode). When `WORKT
 - [ ] 3. Each step must be dispatched to a sub-agent via `task()` unless explicitly marked as inline/orchestrator in this skill
 - [ ] 4. Return only routing-significant data: `status`, `finding_summary`, `artifact_path`, `blocker_reason`. Full evidence goes to disk.
 
+## Pre-Flight Guard (Mandatory)
+
+**This skill card is orchestrator-only routing metadata.**
+
+If you are a sub-agent (dispatched via `task()`), you MUST NOT consume the routing metadata below. Sub-agents cannot call `task()` and cannot execute orchestrator-level dispatch instructions. Return `BLOCKED` with reason `ORCHESTRATOR_ONLY_SKILL_CARD` and halt.
+
+If you are the orchestrator (loaded this card via `skill({name: "..."})`), proceed to the Workflows section.
+
 ## Trigger Dispatch Table
 
 | User says / Context | Task | Dispatch | Context passed |

--- a/skills/requesting-code-review/SKILL.md
+++ b/skills/requesting-code-review/SKILL.md
@@ -26,6 +26,14 @@ This skill operates in the main repo directory (direct-branch mode). When `WORKT
 - [ ] 3. Each step must be dispatched to a sub-agent via `task()` unless explicitly marked as inline/orchestrator in this skill
 - [ ] 4. Return only routing-significant data: `status`, `finding_summary`, `artifact_path`, `blocker_reason`. Full evidence goes to disk.
 
+## Pre-Flight Guard (Mandatory)
+
+**This skill card is orchestrator-only routing metadata.**
+
+If you are a sub-agent (dispatched via `task()`), you MUST NOT consume the routing metadata below. Sub-agents cannot call `task()` and cannot execute orchestrator-level dispatch instructions. Return `BLOCKED` with reason `ORCHESTRATOR_ONLY_SKILL_CARD` and halt.
+
+If you are the orchestrator (loaded this card via `skill({name: "..."})`), proceed to the Workflows section.
+
 ## Trigger Dispatch Table
 
 | User says / Context | Task | Dispatch | Context passed |
@@ -100,5 +108,3 @@ After loading this skill and reading the Trigger Dispatch Table, the orchestrato
 - NOT write a custom prompt with preloaded context
 - NOT add orchestrator reasoning, file paths, step sequences, or expected outcomes
 - If the canonical dispatch produces an empty result: re-task clean-room with the same canonical string (max 2 retries)
-
-

--- a/skills/research/SKILL.md
+++ b/skills/research/SKILL.md
@@ -22,6 +22,14 @@ This skill operates in the main repo directory (direct-branch mode). When `WORKT
 - [ ] 3. Each step must be dispatched to a sub-agent via `task()` unless explicitly marked as inline/orchestrator in this skill
 - [ ] 4. Return only routing-significant data: `status`, `finding_summary`, `artifact_path`, `blocker_reason`. Full evidence goes to disk.
 
+## Pre-Flight Guard (Mandatory)
+
+**This skill card is orchestrator-only routing metadata.**
+
+If you are a sub-agent (dispatched via `task()`), you MUST NOT consume the routing metadata below. Sub-agents cannot call `task()` and cannot execute orchestrator-level dispatch instructions. Return `BLOCKED` with reason `ORCHESTRATOR_ONLY_SKILL_CARD` and halt.
+
+If you are the orchestrator (loaded this card via `skill({name: "..."})`), proceed to the Workflows section.
+
 ## Trigger Dispatch Table
 
 | User says / Context | Task | Dispatch | Context passed |
@@ -104,5 +112,3 @@ After loading this skill and reading the Trigger Dispatch Table, the orchestrato
 - NOT write a custom prompt with preloaded context
 - NOT add orchestrator reasoning, file paths, step sequences, or expected outcomes
 - If the canonical dispatch produces an empty result: re-task clean-room with the same canonical string (max 2 retries)
-
-

--- a/skills/skill-creator/SKILL.md
+++ b/skills/skill-creator/SKILL.md
@@ -28,6 +28,14 @@ This skill operates in the main repo directory (direct-branch mode). When `WORKT
 - [ ] 3. Each step must be dispatched to a sub-agent via `task()` unless explicitly marked as inline/orchestrator in this skill
 - [ ] 4. Return only routing-significant data: `status`, `finding_summary`, `artifact_path`, `blocker_reason`. Full evidence goes to disk.
 
+## Pre-Flight Guard (Mandatory)
+
+**This skill card is orchestrator-only routing metadata.**
+
+If you are a sub-agent (dispatched via `task()`), you MUST NOT consume the routing metadata below. Sub-agents cannot call `task()` and cannot execute orchestrator-level dispatch instructions. Return `BLOCKED` with reason `ORCHESTRATOR_ONLY_SKILL_CARD` and halt.
+
+If you are the orchestrator (loaded this card via `skill({name: "..."})`), proceed to the Workflows section.
+
 ## Trigger Dispatch Table
 
 | User says / Context | Task | Dispatch | Context passed |

--- a/skills/skill-creator/reference/routing-only-template.md
+++ b/skills/skill-creator/reference/routing-only-template.md
@@ -10,6 +10,26 @@ Co-authored with AI: OpenCode (deepseek-v4-flash)
 
 This template defines the canonical structure for a routing-only SKILL.md file. A routing-only SKILL.md contains **no procedure text** — no step definitions, no entry/exit criteria, no code snippets, no "Operating Protocol" sections. The orchestrator receives only routing metadata (workflows with dispatch contracts, cross-references). Procedure content lives exclusively in `tasks/*.md` files that only sub-agents read.
 
+## Pre-Flight Guard Mandate (Required)
+
+Every SKILL.md MUST carry a pre-flight guard that detects sub-agent context and returns `BLOCKED` with reason `ORCHESTRATOR_ONLY_SKILL_CARD` before any routing metadata is consumed. The guard is positioned as a pre-flight entry check ahead of the Workflows/routing sections. A sub-agent that receives a skill card cannot act on orchestrator-level routing metadata (sub-agents cannot call `task()`), so it must halt immediately rather than attempt to follow orchestrator-level instructions.
+
+The guard is additive — it does not alter frontmatter or the Workflows dispatch contract. The canonical guard definition is defined once in the requirements documentation and applied verbatim to every skill card. Linting (`skildeck-lint`) and validation (`validate_skill_cards.py`) enforce the guard's presence mechanically.
+
+## Canonical Guard Definition (Single Source of Truth)
+
+Every SKILL.md MUST carry the following pre-flight guard section verbatim, positioned as the first section after the YAML frontmatter and Overview, immediately before the Workflows/routing sections. This is the single canonical definition — apply it verbatim, do not invent variants.
+
+```markdown
+## Pre-Flight Guard (Mandatory)
+
+**This skill card is orchestrator-only routing metadata.**
+
+If you are a sub-agent (dispatched via `task()`), you MUST NOT consume the routing metadata below. Sub-agents cannot call `task()` and cannot execute orchestrator-level dispatch instructions. Return `BLOCKED` with reason `ORCHESTRATOR_ONLY_SKILL_CARD` and halt.
+
+If you are the orchestrator (loaded this card via `skill({name: "..."})`), proceed to the Workflows section.
+```
+
 ## Template
 
 ```markdown

--- a/skills/skill-creator/reference/skill-card-spec.md
+++ b/skills/skill-creator/reference/skill-card-spec.md
@@ -6,6 +6,26 @@
 
 Co-authored with AI: OpenCode (ollama-cloud/deepseek-v4-flash)
 
+## Pre-Flight Guard Mandate (Required)
+
+Every SKILL.md MUST carry a pre-flight guard that detects sub-agent context and returns `BLOCKED` with reason `ORCHESTRATOR_ONLY_SKILL_CARD` before any routing metadata is consumed. The guard is positioned as a pre-flight entry check ahead of the Workflows/routing sections. A sub-agent that receives a skill card cannot act on orchestrator-level routing metadata (sub-agents cannot call `task()`), so it must halt immediately rather than attempt to follow orchestrator-level instructions.
+
+The guard is additive — it does not alter frontmatter or the Workflows dispatch contract. The canonical guard definition is defined once in the requirements documentation and applied verbatim to every skill card. Linting (`skildeck-lint`) and validation (`validate_skill_cards.py`) enforce the guard's presence mechanically.
+
+## Canonical Guard Definition (Single Source of Truth)
+
+Every SKILL.md MUST carry the following pre-flight guard section verbatim, positioned as the first section after the YAML frontmatter and Overview, immediately before the Workflows/routing sections. This is the single canonical definition — apply it verbatim, do not invent variants.
+
+```markdown
+## Pre-Flight Guard (Mandatory)
+
+**This skill card is orchestrator-only routing metadata.**
+
+If you are a sub-agent (dispatched via `task()`), you MUST NOT consume the routing metadata below. Sub-agents cannot call `task()` and cannot execute orchestrator-level dispatch instructions. Return `BLOCKED` with reason `ORCHESTRATOR_ONLY_SKILL_CARD` and halt.
+
+If you are the orchestrator (loaded this card via `skill({name: "..."})`), proceed to the Workflows section.
+```
+
 ## Mandatory Task Discipline Admonishment
 
 ### SKILL.md Version (5 items)

--- a/skills/skill-creator/scripts/init_skill.py
+++ b/skills/skill-creator/scripts/init_skill.py
@@ -48,15 +48,23 @@ provenance: AI-generated
 - [ ] 4. Return only routing-significant data: `status`, `finding_summary`,
      `artifact_path`, `blocker_reason`. Full evidence goes to disk.
 
+## Pre-Flight Guard (Mandatory)
+
+**This skill card is orchestrator-only routing metadata.**
+
+If you are a sub-agent (dispatched via `task()`), you MUST NOT consume the routing metadata below. Sub-agents cannot call `task()` and cannot execute orchestrator-level dispatch instructions. Return `BLOCKED` with reason `ORCHESTRATOR_ONLY_SKILL_CARD` and halt.
+
+If you are the orchestrator (loaded this card via `skill({{name: "..."}})`), proceed to the Workflows section.
+
 ## Trigger Dispatch Table
 
 - [ ] **"[TODO: trigger phrase]"** → `[TODO: task-name]` (dispatch-type)
-  - Context: `{field1, field2}`
+  - Context: `{{field1, field2}}`
   - Task file: `{skill_name}/tasks/[TODO: task-name].md`
 
 ## Invocation
 
-`skill({name: "{skill_name}"})` — call the skill, then call via task():
+`skill({{name: "{skill_name}"}})` — call the skill, then call via task():
 
 - [ ] **`[TODO: task-name]`** → `task(..., prompt: "execute [TODO: task-name] task from {skill_name}")`
 

--- a/skills/skill-creator/scripts/validate_skill_cards.py
+++ b/skills/skill-creator/scripts/validate_skill_cards.py
@@ -18,6 +18,7 @@ Validates SKILL.md files per spec #2076:
   REQ-3: Worktree Mode section requirement for skills with bash/git/file ops
   REQ-4: Mandatory Task Discipline admonishment presence (5-item checklist)
   REQ-6: Workflows section presence and structure (replaces old DISPATCH_GATE)
+  REQ-7: Pre-flight guard presence (ORCHESTRATOR_ONLY_SKILL_CARD marker)
 
 Usage:
     uv run .opencode/skills/skill-creator/scripts/validate_skill_cards.py           # validate
@@ -438,6 +439,22 @@ def validate_condensation(name: str, body: str, file_path: str) -> list[Violatio
             )
     return violations
 
+GUARD_MARKER = "ORCHESTRATOR_ONLY_SKILL_CARD"
+
+def validate_req_skill_preflight_guard(name: str, body: str, file_path: str) -> list[Violation]:
+    violations: list[Violation] = []
+    if GUARD_MARKER not in body:
+        violations.append(
+            Violation(
+                "REQ",
+                name,
+                "skill-preflight-guard-missing",
+                f"Missing pre-flight guard (marker {GUARD_MARKER})",
+                file_path=file_path,
+            )
+        )
+    return violations
+
 ADMONISHMENT_HEADING_RE = re.compile(r"^##\s+Mandatory\s+Task\s+Discipline", re.MULTILINE)
 WORKFLOWS_HEADING_RE = re.compile(
     r"^##\s+Workflows", re.MULTILINE
@@ -539,6 +556,7 @@ def validate_card(card_path: Path, root: Path) -> list[Violation]:
     violations.extend(validate_req5(name, body, rel_path))
     violations.extend(validate_req6(name, body, rel_path))
     violations.extend(validate_condensation(name, body, rel_path))
+    violations.extend(validate_req_skill_preflight_guard(name, body, rel_path))
     return violations
 
 def violation_to_dict(v: Violation) -> dict:

--- a/skills/solve/SKILL.md
+++ b/skills/solve/SKILL.md
@@ -18,6 +18,14 @@ The `solve` tool is a Z3 constraint solver for workflow correctness. It operates
 - [ ] 3. Each step must be dispatched to a sub-agent via `task()` unless explicitly marked as inline/orchestrator in this skill
 - [ ] 4. Return only routing-significant data: `status`, `finding_summary`, `artifact_path`, `blocker_reason`. Full evidence goes to disk.
 
+## Pre-Flight Guard (Mandatory)
+
+**This skill card is orchestrator-only routing metadata.**
+
+If you are a sub-agent (dispatched via `task()`), you MUST NOT consume the routing metadata below. Sub-agents cannot call `task()` and cannot execute orchestrator-level dispatch instructions. Return `BLOCKED` with reason `ORCHESTRATOR_ONLY_SKILL_CARD` and halt.
+
+If you are the orchestrator (loaded this card via `skill({name: "..."})`), proceed to the Workflows section.
+
 ## Trigger Dispatch Table
 
 | User says / Context | Task | Dispatch | Context passed |
@@ -109,4 +117,3 @@ When `worktree.path` is set, all file operations MUST use it as the base directo
 <!-- SPDX-FileCopyrightText: 2026 Michael Conrad -->
 <!-- SPDX-License-Identifier: MIT -->
 <!-- Provenance: AI-generated -->
-

--- a/skills/spec-creation/SKILL.md
+++ b/skills/spec-creation/SKILL.md
@@ -20,6 +20,14 @@ The orchestrator dispatches each step as a clean-room `task()` call. The orchest
 analyze → create → validate → (revise → validate)* → done
 ```
 
+## Pre-Flight Guard (Mandatory)
+
+**This skill card is orchestrator-only routing metadata.**
+
+If you are a sub-agent (dispatched via `task()`), you MUST NOT consume the routing metadata below. Sub-agents cannot call `task()` and cannot execute orchestrator-level dispatch instructions. Return `BLOCKED` with reason `ORCHESTRATOR_ONLY_SKILL_CARD` and halt.
+
+If you are the orchestrator (loaded this card via `skill({name: "..."})`), proceed to the Workflows section.
+
 ## Workflows
 
 **The orchestrator does NOT read task cards.** Each step below is dispatched to a clean-room sub-agent via `task()`. The sub-agent independently discovers and reads the task card file. The orchestrator receives only the result contract — it never loads task card content.
@@ -155,5 +163,3 @@ When auditing or updating any plan, strictly follow the mandatory code deep dive
 ---
 
 *Co-authored with AI: OpenCode (deepseek-v4-flash)*
-
-

--- a/skills/sre-runbook/SKILL.md
+++ b/skills/sre-runbook/SKILL.md
@@ -22,6 +22,14 @@ This skill operates in the main repo directory (direct-branch mode). When `WORKT
 - [ ] 3. Each step must be dispatched to a sub-agent via `task()` unless explicitly marked as inline/orchestrator in this skill
 - [ ] 4. Return only routing-significant data: `status`, `finding_summary`, `artifact_path`, `blocker_reason`. Full evidence goes to disk.
 
+## Pre-Flight Guard (Mandatory)
+
+**This skill card is orchestrator-only routing metadata.**
+
+If you are a sub-agent (dispatched via `task()`), you MUST NOT consume the routing metadata below. Sub-agents cannot call `task()` and cannot execute orchestrator-level dispatch instructions. Return `BLOCKED` with reason `ORCHESTRATOR_ONLY_SKILL_CARD` and halt.
+
+If you are the orchestrator (loaded this card via `skill({name: "..."})`), proceed to the Workflows section.
+
 ## Trigger Dispatch Table
 
 | User says / Context | Task | Dispatch | Context passed |
@@ -119,5 +127,3 @@ After loading this skill and reading the Trigger Dispatch Table, the orchestrato
 ## Cross-References
 
 Skills: `systematic-debugging`, `verification-before-completion`, `issue-operations`, `spec-auditor`. Guidelines: `010-approval-gate.md`, `000-critical-rules.md`, `065-verification-honesty.md`. Reference data: `reference/directnic-record-types.md`.
-
-

--- a/skills/sync-guidelines/SKILL.md
+++ b/skills/sync-guidelines/SKILL.md
@@ -26,6 +26,14 @@ This skill operates in the main repo directory (direct-branch mode). When `WORKT
 - [ ] 3. Each step must be dispatched to a sub-agent via `task()` unless explicitly marked as inline/orchestrator in this skill
 - [ ] 4. Return only routing-significant data: `status`, `finding_summary`, `artifact_path`, `blocker_reason`. Full evidence goes to disk.
 
+## Pre-Flight Guard (Mandatory)
+
+**This skill card is orchestrator-only routing metadata.**
+
+If you are a sub-agent (dispatched via `task()`), you MUST NOT consume the routing metadata below. Sub-agents cannot call `task()` and cannot execute orchestrator-level dispatch instructions. Return `BLOCKED` with reason `ORCHESTRATOR_ONLY_SKILL_CARD` and halt.
+
+If you are the orchestrator (loaded this card via `skill({name: "..."})`), proceed to the Workflows section.
+
 ## Trigger Dispatch Table
 
 | User says / Context | Task | Dispatch | Context passed |
@@ -109,5 +117,3 @@ After loading this skill and reading the Trigger Dispatch Table, the orchestrato
 - NOT write a custom prompt with preloaded context
 - NOT add orchestrator reasoning, file paths, step sequences, or expected outcomes
 - If the canonical dispatch produces an empty result: re-task clean-room with the same canonical string (max 2 retries)
-
-

--- a/skills/systematic-debugging/SKILL.md
+++ b/skills/systematic-debugging/SKILL.md
@@ -26,6 +26,14 @@ This skill operates in the main repo directory (direct-branch mode). When `WORKT
 - [ ] 3. Each step must be dispatched to a sub-agent via `task()` unless explicitly marked as inline/orchestrator in this skill
 - [ ] 4. Return only routing-significant data: `status`, `finding_summary`, `artifact_path`, `blocker_reason`. Full evidence goes to disk.
 
+## Pre-Flight Guard (Mandatory)
+
+**This skill card is orchestrator-only routing metadata.**
+
+If you are a sub-agent (dispatched via `task()`), you MUST NOT consume the routing metadata below. Sub-agents cannot call `task()` and cannot execute orchestrator-level dispatch instructions. Return `BLOCKED` with reason `ORCHESTRATOR_ONLY_SKILL_CARD` and halt.
+
+If you are the orchestrator (loaded this card via `skill({name: "..."})`), proceed to the Workflows section.
+
 ## Trigger Dispatch Table
 
 | User says / Context | Task | Dispatch | Context passed |
@@ -111,5 +119,3 @@ After loading this skill and reading the Trigger Dispatch Table, the orchestrato
 ## Cross-References
 
 Skills: `issue-review`, `approval-gate`, `verification-before-completion`. Guidelines: `000-critical-rules.md`.
-
-

--- a/skills/test-driven-development/SKILL.md
+++ b/skills/test-driven-development/SKILL.md
@@ -31,6 +31,14 @@ This skill operates in the main repo directory (direct-branch mode). When `WORKT
 - [ ] 3. Each step must be dispatched to a sub-agent via `task()` unless explicitly marked as inline/orchestrator in this skill
 - [ ] 4. Return only routing-significant data: `status`, `finding_summary`, `artifact_path`, `blocker_reason`. Full evidence goes to disk.
 
+## Pre-Flight Guard (Mandatory)
+
+**This skill card is orchestrator-only routing metadata.**
+
+If you are a sub-agent (dispatched via `task()`), you MUST NOT consume the routing metadata below. Sub-agents cannot call `task()` and cannot execute orchestrator-level dispatch instructions. Return `BLOCKED` with reason `ORCHESTRATOR_ONLY_SKILL_CARD` and halt.
+
+If you are the orchestrator (loaded this card via `skill({name: "..."})`), proceed to the Workflows section.
+
 ## Trigger Dispatch Table
 
 | User says / Context | Task | Dispatch | Context passed |
@@ -479,5 +487,3 @@ Behavioral test artifacts (stdout.log, stderr.log, session.yaml) are raw output 
 ## Provenance
 
 Derived from [majiayu000/claude-skill-registry](https://github.com/majiayu000/claude-skill-registry) (MIT).
-
-

--- a/skills/using-git-worktrees/SKILL.md
+++ b/skills/using-git-worktrees/SKILL.md
@@ -22,6 +22,14 @@ This skill operates in the main repo directory (direct-branch mode). When `WORKT
 - [ ] 3. Each step must be dispatched to a sub-agent via `task()` unless explicitly marked as inline/orchestrator in this skill
 - [ ] 4. Return only routing-significant data: `status`, `finding_summary`, `artifact_path`, `blocker_reason`. Full evidence goes to disk.
 
+## Pre-Flight Guard (Mandatory)
+
+**This skill card is orchestrator-only routing metadata.**
+
+If you are a sub-agent (dispatched via `task()`), you MUST NOT consume the routing metadata below. Sub-agents cannot call `task()` and cannot execute orchestrator-level dispatch instructions. Return `BLOCKED` with reason `ORCHESTRATOR_ONLY_SKILL_CARD` and halt.
+
+If you are the orchestrator (loaded this card via `skill({name: "..."})`), proceed to the Workflows section.
+
 ## Trigger Dispatch Table
 
 | User says / Context | Task | Dispatch | Context passed |
@@ -169,5 +177,3 @@ Sub-agents that modify the main repo instead of the worktree are contaminating t
 | Violation Pattern | Consequence |
 |-------------------|-------------|
 | Sub-agents modifying main repo instead of worktree | Every file they write goes to the wrong directory |
-
-

--- a/skills/verification-before-completion/SKILL.md
+++ b/skills/verification-before-completion/SKILL.md
@@ -29,6 +29,14 @@ This skill operates in the main repo directory (direct-branch mode). When `WORKT
 - [ ] 4. Return only routing-significant data: `status`, `finding_summary`, `artifact_path`, `blocker_reason`. Full evidence goes to disk.
 - [ ] 5. **Analytical artifact cross-reference required before completion claim.** Each analytical artifact must be verified against actual implementation evidence. Contradictions between analytical artifacts and implementation evidence produce HALT. Unverified artifacts produce HALT with the specific artifact name.
 
+## Pre-Flight Guard (Mandatory)
+
+**This skill card is orchestrator-only routing metadata.**
+
+If you are a sub-agent (dispatched via `task()`), you MUST NOT consume the routing metadata below. Sub-agents cannot call `task()` and cannot execute orchestrator-level dispatch instructions. Return `BLOCKED` with reason `ORCHESTRATOR_ONLY_SKILL_CARD` and halt.
+
+If you are the orchestrator (loaded this card via `skill({name: "..."})`), proceed to the Workflows section.
+
 ## Trigger Dispatch Table
 
 | User says / Context | Task | Dispatch | Context passed |
@@ -165,5 +173,3 @@ Reporting that a file exists as evidence that behavior is correct is what amateu
 
 ### [critical-rules-039] Process Gaps Are Bugs — completed issues not auto-closed
 Read [verify-already-implemented skill](skills/verification-before-completion/SKILL.md) → Auto-Close Procedure.
-
-

--- a/skills/verification-enforcement/SKILL.md
+++ b/skills/verification-enforcement/SKILL.md
@@ -24,6 +24,14 @@ This skill operates in the main repo directory (direct-branch mode). When `WORKT
 - [ ] 3. Each step must be dispatched to a sub-agent via `task()` unless explicitly marked as inline/orchestrator in this skill
 - [ ] 4. Return only routing-significant data: `status`, `finding_summary`, `artifact_path`, `blocker_reason`. Full evidence goes to disk.
 
+## Pre-Flight Guard (Mandatory)
+
+**This skill card is orchestrator-only routing metadata.**
+
+If you are a sub-agent (dispatched via `task()`), you MUST NOT consume the routing metadata below. Sub-agents cannot call `task()` and cannot execute orchestrator-level dispatch instructions. Return `BLOCKED` with reason `ORCHESTRATOR_ONLY_SKILL_CARD` and halt.
+
+If you are the orchestrator (loaded this card via `skill({name: "..."})`), proceed to the Workflows section.
+
 ## Trigger Dispatch Table
 
 | User says / Context | Task | Dispatch | Context passed |
@@ -116,5 +124,3 @@ After loading this skill and reading the Trigger Dispatch Table, the orchestrato
 ## Cross-References
 
 Guidelines: `065-verification-honesty.md`, `000-critical-rules.md`. Skills: `spec-creation`, `writing-plans`, `sre-runbook`, `skill-creator`, `correspondence`, `audit --task guideline-audit`.
-
-

--- a/skills/verification/SKILL.md
+++ b/skills/verification/SKILL.md
@@ -22,6 +22,14 @@ This skill operates in the main repo directory (direct-branch mode). When `WORKT
 - [ ] 3. Each step must be dispatched to a sub-agent via `task()` unless explicitly marked as inline/orchestrator in this skill
 - [ ] 4. Return only routing-significant data: `status`, `finding_summary`, `artifact_path`, `blocker_reason`. Full evidence goes to disk.
 
+## Pre-Flight Guard (Mandatory)
+
+**This skill card is orchestrator-only routing metadata.**
+
+If you are a sub-agent (dispatched via `task()`), you MUST NOT consume the routing metadata below. Sub-agents cannot call `task()` and cannot execute orchestrator-level dispatch instructions. Return `BLOCKED` with reason `ORCHESTRATOR_ONLY_SKILL_CARD` and halt.
+
+If you are the orchestrator (loaded this card via `skill({name: "..."})`), proceed to the Workflows section.
+
 ## Trigger Dispatch Table
 
 | User says / Context | Task | Dispatch | Context passed |
@@ -104,5 +112,3 @@ After loading this skill and reading the Trigger Dispatch Table, the orchestrato
 - NOT write a custom prompt with preloaded context
 - NOT add orchestrator reasoning, file paths, step sequences, or expected outcomes
 - If the canonical dispatch produces an empty result: re-task clean-room with the same canonical string (max 2 retries)
-
-

--- a/skills/version-manager/SKILL.md
+++ b/skills/version-manager/SKILL.md
@@ -26,6 +26,14 @@ This skill operates in the main repo directory (direct-branch mode). When `WORKT
 - [ ] 3. Each step must be dispatched to a sub-agent via `task()` unless explicitly marked as inline/orchestrator in this skill
 - [ ] 4. Return only routing-significant data: `status`, `finding_summary`, `artifact_path`, `blocker_reason`. Full evidence goes to disk.
 
+## Pre-Flight Guard (Mandatory)
+
+**This skill card is orchestrator-only routing metadata.**
+
+If you are a sub-agent (dispatched via `task()`), you MUST NOT consume the routing metadata below. Sub-agents cannot call `task()` and cannot execute orchestrator-level dispatch instructions. Return `BLOCKED` with reason `ORCHESTRATOR_ONLY_SKILL_CARD` and halt.
+
+If you are the orchestrator (loaded this card via `skill({name: "..."})`), proceed to the Workflows section.
+
 ## Trigger Dispatch Table
 
 | User says / Context | Task | Dispatch | Context passed |

--- a/skills/writing-plans/SKILL.md
+++ b/skills/writing-plans/SKILL.md
@@ -12,6 +12,14 @@ provenance: AI-generated
 
 Generate and validate implementation plans from approved specs. Flat architecture — no sub-skills, 7 task files. The orchestrator sequences a clean-room pipeline: HANDOFF (authorization verification) → ANALYZE (entry gates) → RESEARCH (scope discovery, structure, Z3 solving) → CREATE (plan writing) → VALIDATE (structural validation, holistic check) → (revise loop) → COMPLETION (lifecycle event). Each sub-agent receives only its scoped context — no preloaded reasoning, no orchestrator conclusions.
 
+## Pre-Flight Guard (Mandatory)
+
+**This skill card is orchestrator-only routing metadata.**
+
+If you are a sub-agent (dispatched via `task()`), you MUST NOT consume the routing metadata below. Sub-agents cannot call `task()` and cannot execute orchestrator-level dispatch instructions. Return `BLOCKED` with reason `ORCHESTRATOR_ONLY_SKILL_CARD` and halt.
+
+If you are the orchestrator (loaded this card via `skill({name: "..."})`), proceed to the Workflows section.
+
 ## Workflows
 
 ### Create a plan from an approved spec

--- a/tests-v2/test-2339-sc1-preflight-guard-applied.sh
+++ b/tests-v2/test-2339-sc1-preflight-guard-applied.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: 2026 michael-conrad
+# SPDX-License-Identifier: MIT
+# Provenance: AI-generated
+#
+# Content-verification test: .opencode#2339 SC-1 — every SKILL.md under
+# .opencode/skills/ (including platforms/*/SKILL.md) contains the pre-flight
+# guard that detects sub-agent context and returns BLOCKED +
+# ORCHESTRATOR_ONLY_SKILL_CARD before any routing metadata is consumed.
+#
+# Maps to SC-1 from issue #2339:
+#   Every SKILL.md under .opencode/skills/ (including platforms/*/SKILL.md)
+#   contains a pre-flight guard that detects sub-agent context and returns
+#   BLOCKED + ORCHESTRATOR_ONLY_SKILL_CARD before any routing metadata is
+#   consumed.
+#
+# Evidence type: string — grep all 51 SKILL.md files for the guard marker
+# (ORCHESTRATOR_ONLY_SKILL_CARD) and assert the guard is present in each.
+#
+# RED state: none of the 51 SKILL.md files currently contain the guard marker.
+# The assertions below assert the guard IS present in each; they FAIL now (RED)
+# and PASS after the GREEN phase applies the canonical guard to all 51.
+#
+# Usage: bash .opencode/tests-v2/test-2339-sc1-preflight-guard-applied.sh
+# Exit: 0 if all checks pass (GREEN), 1 if any check fails (expected RED).
+
+# Co-authored with AI: OpenCode (deepseek-v4-flash)
+
+set -euo pipefail
+
+PROJECT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+while [ "$(basename "$PROJECT_DIR")" != ".opencode" ]; do
+    PROJECT_DIR="$(dirname "$PROJECT_DIR")"
+done
+
+SKILL_DIR="$PROJECT_DIR/skills"
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+check_pass() {
+    local label="$1"
+    echo "  PASS: $label"
+    PASS_COUNT=$((PASS_COUNT + 1))
+}
+
+check_fail() {
+    local label="$1"
+    local detail="$2"
+    echo "  FAIL: $label -- $detail" >&2
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+}
+
+echo ""
+echo "=== SC-1: pre-flight guard applied to all skill cards (#2339) ==="
+echo ""
+
+CARDS=()
+while IFS= read -r card; do
+    CARDS+=("$card")
+done < <(find "$SKILL_DIR" -name 'SKILL.md' -type f | sort)
+
+if [ "${#CARDS[@]}" -eq 0 ]; then
+    check_fail "SC-1: skill cards discovered" "no SKILL.md files found under $SKILL_DIR"
+else
+    check_pass "SC-1: ${#CARDS[@]} SKILL.md files discovered under $SKILL_DIR"
+fi
+
+for card in "${CARDS[@]}"; do
+    name="${card#"$PROJECT_DIR"/}"
+    if grep -q 'ORCHESTRATOR_ONLY_SKILL_CARD' "$card"; then
+        check_pass "SC-1: $name contains the pre-flight guard"
+    else
+        check_fail "SC-1: $name contains the pre-flight guard" \
+            "guard marker (ORCHESTRATOR_ONLY_SKILL_CARD) absent in $name (RED phase expected)"
+    fi
+done
+
+echo ""
+echo "=== Results ==="
+echo "PASSED: $PASS_COUNT"
+echo "FAILED: $FAIL_COUNT"
+echo ""
+
+if [ "$FAIL_COUNT" -gt 0 ]; then
+    echo "RED phase expected: SC-1 (#2339) pre-flight guard not yet applied to all skill cards."
+    echo ""
+    exit 1
+fi
+exit 0

--- a/tests-v2/test-2339-sc2-skildeck-lint-guard.sh
+++ b/tests-v2/test-2339-sc2-skildeck-lint-guard.sh
@@ -1,0 +1,168 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: 2026 michael-conrad
+# SPDX-License-Identifier: MIT
+# Provenance: AI-generated
+#
+# Behavioral enforcement test: .opencode#2339 SC-2 — skildeck-lint guard
+# enforcement. The skill card linting tool (skildeck-lint) SHALL flag a
+# SKILL.md that lacks the pre-flight guard and SHALL NOT flag a card with
+# the guard (idempotent — no double-guard finding).
+#
+# Maps to SC-2 from issue #2339:
+#   The skill card linting tool (skildeck-lint) flags a SKILL.md that lacks
+#   the pre-flight guard.
+#
+# Evidence type: behavioral — run skildeck-lint against a card with and
+#   without the guard and inspect its output; assert a finding when the
+#   guard is missing and no finding when present.
+#
+# RED: On the current linter there is no lint_skill_preflight_guard rule, so
+#   running skildeck-lint against an unguarded fixture SKILL.md produces no
+#   guard finding. The assertion "unguarded card produces a finding" FAILs
+#   (exit 1) — a genuine RED, not a FALSE (it executes the linter, the system
+#   under test, and observes the absence of the expected finding).
+#
+# GREEN: add lint_skill_preflight_guard to skildeck-lint, at which point the
+#   unguarded fixture produces a finding and the guarded fixture produces
+#   none. Both assertions PASS (exit 0).
+#
+# Usage: bash .opencode/tests-v2/test-2339-sc2-skildeck-lint-guard.sh
+# Exit:  0 if skildeck-lint flags the unguarded card and passes the guarded
+#         card (GREEN), 1 otherwise (RED).
+
+set -euo pipefail
+
+PROJECT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+while [ "$(basename "$PROJECT_DIR")" != ".opencode" ]; do
+    PROJECT_DIR="$(dirname "$PROJECT_DIR")"
+done
+PROJECT_DIR="$(dirname "$PROJECT_DIR")"
+
+SKILDECK="$PROJECT_DIR/.opencode/tools/skildeck"
+FIXTURE_BASE="$PROJECT_DIR/.opencode/tmp/2339-sc2-fixture"
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+check_pass() {
+    local label="$1"
+    echo "  PASS: $label"
+    PASS_COUNT=$((PASS_COUNT + 1))
+}
+
+check_fail() {
+    local label="$1"
+    local detail="$2"
+    echo "  FAIL: $label -- $detail" >&2
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+}
+
+# --- Set up the fixture skills --------------------------------------------
+# Each scenario uses its own scan dir so the unguarded card cannot
+# contaminate the guarded-card run (the guard rule scans all skill dirs).
+rm -rf "$FIXTURE_BASE"
+mkdir -p "$FIXTURE_BASE/unguarded/skills/2339-unguarded"
+mkdir -p "$FIXTURE_BASE/guarded/skills/2339-guarded"
+
+cat > "$FIXTURE_BASE/unguarded/skills/2339-unguarded/SKILL.md" <<'UNGUARDEDEOF'
+---
+name: 2339-unguarded
+description: "Fixture skill for SC-2 skildeck-lint guard enforcement testing. Intentionally lacks the pre-flight guard. Not a real skill."
+license: MIT
+compatibility: opencode
+---
+
+# Skill: 2339-unguarded
+
+## Trigger Dispatch Table
+
+| User says / Context | Task | Dispatch | Context passed |
+|---------------------|------|----------|----------------|
+| "run task" | `run` | `sub-task` | {issue_number} |
+UNGUARDEDEOF
+
+cat > "$FIXTURE_BASE/guarded/skills/2339-guarded/SKILL.md" <<'GUARDEDEOF'
+---
+name: 2339-guarded
+description: "Fixture skill for SC-2 skildeck-lint guard enforcement testing. Carries the canonical pre-flight guard. Not a real skill."
+license: MIT
+compatibility: opencode
+---
+
+# Skill: 2339-guarded
+
+## Pre-Flight Guard (Mandatory)
+
+**This skill card is orchestrator-only routing metadata.**
+
+If you are a sub-agent (dispatched via `task()`), you MUST NOT consume the routing metadata below. Sub-agents cannot call `task()` and cannot execute orchestrator-level dispatch instructions. Return `BLOCKED` with reason `ORCHESTRATOR_ONLY_SKILL_CARD` and halt.
+
+If you are the orchestrator (loaded this card via `skill({name: "..."})`), proceed to the Workflows section.
+
+## Trigger Dispatch Table
+
+| User says / Context | Task | Dispatch | Context passed |
+|---------------------|------|----------|----------------|
+| "run task" | `run` | `sub-task` | {issue_number} |
+GUARDEDEOF
+
+echo ""
+echo "=== SC-2: skildeck-lint pre-flight guard enforcement (#2339) ==="
+echo ""
+
+# --- Unguarded card must produce a guard finding -------------------------
+UNGUARDED_OUTPUT=$("$SKILDECK" lint --dir "$FIXTURE_BASE/unguarded/skills" --skill 2339-unguarded --json 2>/dev/null || true)
+if [ -z "$UNGUARDED_OUTPUT" ]; then
+    check_fail "SC-2: unguarded card flagged" "skildeck-lint produced no JSON output"
+else
+    UNGUARDED_COUNT=$(echo "$UNGUARDED_OUTPUT" | python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+count = sum(1 for f in data if f.get('rule_id') == 'skill-preflight-guard-missing')
+print(count)
+" 2>/dev/null || echo "0")
+    if [ "$UNGUARDED_COUNT" -gt 0 ]; then
+        check_pass "SC-2: unguarded card flagged (skill-preflight-guard-missing, $UNGUARDED_COUNT finding)"
+    else
+        check_fail "SC-2: unguarded card flagged" "no skill-preflight-guard-missing finding for 2339-unguarded (RED phase expected)"
+    fi
+fi
+
+# --- Guarded card must produce no guard finding ---------------------------
+GUARDED_OUTPUT=$("$SKILDECK" lint --dir "$FIXTURE_BASE/guarded/skills" --skill 2339-guarded --json 2>/dev/null || true)
+if [ -z "$GUARDED_OUTPUT" ]; then
+    check_fail "SC-2: guarded card passed" "skildeck-lint produced no JSON output"
+else
+    GUARDED_COUNT=$(echo "$GUARDED_OUTPUT" | python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+count = sum(1 for f in data if f.get('rule_id') == 'skill-preflight-guard-missing')
+print(count)
+" 2>/dev/null || echo "0")
+    if [ "$GUARDED_COUNT" -eq 0 ]; then
+        check_pass "SC-2: guarded card not flagged (no skill-preflight-guard-missing finding)"
+    else
+        check_fail "SC-2: guarded card not flagged" "$GUARDED_COUNT skill-preflight-guard-missing finding(s) for guarded card"
+    fi
+fi
+
+echo ""
+echo "=== Results ==="
+echo "PASSED: $PASS_COUNT"
+echo "FAILED: $FAIL_COUNT"
+echo ""
+if [ "$FAIL_COUNT" -gt 0 ]; then
+    echo "RED phase expected: SC-2 (#2339) skildeck-lint does not yet enforce the pre-flight guard."
+    echo ""
+    echo "--- current linter findings on unguarded fixture ---"
+    echo "$UNGUARDED_OUTPUT" | python3 -c "
+import sys, json
+for f in json.load(sys.stdin):
+    print(f\"  [{f.get('rule_id','')}] {f.get('source')}: {f.get('message')}\")
+" 2>/dev/null || true
+    echo ""
+    exit 1
+fi
+echo "SC-2 is GREEN — skildeck-lint flags the unguarded card and passes the guarded card."
+echo ""
+exit 0

--- a/tests-v2/test-2339-sc3-validate-skill-cards-guard.sh
+++ b/tests-v2/test-2339-sc3-validate-skill-cards-guard.sh
@@ -1,0 +1,188 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: 2026 michael-conrad
+# SPDX-License-Identifier: MIT
+# Provenance: AI-generated
+#
+# Behavioral enforcement test: .opencode#2339 SC-3 — validate_skill_cards.py
+# guard enforcement. The skill card validator (validate_skill_cards.py) SHALL
+# flag a SKILL.md that lacks the pre-flight guard and SHALL NOT flag a card
+# with the guard (idempotent — no double-guard finding).
+#
+# Maps to SC-3 from issue #2339:
+#   The skill card validation tool (validate_skill_cards.py) flags a SKILL.md
+#   that lacks the pre-flight guard.
+#
+# Evidence type: behavioral — run validate_skill_cards.py against a card with
+#   and without the guard and inspect its output; assert a finding when the
+#   guard is missing and no finding when present.
+#
+# RED: On the current validator there is no pre-flight-guard rule, so running
+#   validate_skill_cards.py against an unguarded fixture SKILL.md produces no
+#   guard finding. The assertion "unguarded card produces a finding" FAILs
+#   (exit 1) — a genuine RED, not a FALSE (it executes the validator, the
+#   system under test, and observes the absence of the expected finding).
+#
+# GREEN: add a pre-flight-guard REQ rule to validate_skill_cards.py, at which
+#   point the unguarded fixture produces a finding and the guarded fixture
+#   produces none. Both assertions PASS (exit 0).
+#
+# Usage: bash .opencode/tests-v2/test-2339-sc3-validate-skill-cards-guard.sh
+# Exit:  0 if validate_skill_cards.py flags the unguarded card and passes the
+#         guarded card (GREEN), 1 otherwise (RED).
+
+# Co-authored with AI: OpenCode (deepseek-v4-flash)
+
+set -euo pipefail
+
+PROJECT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+while [ "$(basename "$PROJECT_DIR")" != ".opencode" ]; do
+    PROJECT_DIR="$(dirname "$PROJECT_DIR")"
+done
+PROJECT_DIR="$(dirname "$PROJECT_DIR")"
+
+VALIDATOR="$PROJECT_DIR/.opencode/skills/skill-creator/scripts/validate_skill_cards.py"
+# The validator is a PEP 723 uv script (not marked executable), so invoke via
+# `uv run --script` regardless of how the test itself is launched.
+UV_RUN_CMD=(uv run --script "$VALIDATOR")
+FIXTURE_BASE="$PROJECT_DIR/.opencode/tmp/2339-sc3-fixture"
+
+RULE_ID="skill-preflight-guard-missing"
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+check_pass() {
+    local label="$1"
+    echo "  PASS: $label"
+    PASS_COUNT=$((PASS_COUNT + 1))
+}
+
+check_fail() {
+    local label="$1"
+    local detail="$2"
+    echo "  FAIL: $label -- $detail" >&2
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+}
+
+# --- Set up the fixture skills --------------------------------------------
+# Each scenario uses its own fixture project root so the unguarded card
+# cannot contaminate the guarded-card run (the validator scans every card
+# under its CWD's .opencode/skills/ tree).
+rm -rf "$FIXTURE_BASE"
+mkdir -p "$FIXTURE_BASE/unguarded/.opencode/skills/2339-unguarded"
+mkdir -p "$FIXTURE_BASE/guarded/.opencode/skills/2339-guarded"
+
+cat > "$FIXTURE_BASE/unguarded/.opencode/skills/2339-unguarded/SKILL.md" <<'UNGUARDEDEOF'
+---
+name: 2339-unguarded
+description: "Fixture skill for SC-3 validate_skill_cards.py guard enforcement testing. Intentionally lacks the pre-flight guard. Not a real skill."
+license: MIT
+compatibility: opencode
+---
+
+# Skill: 2339-unguarded
+
+## Trigger Dispatch Table
+
+| User says / Context | Task | Dispatch | Context passed |
+|---------------------|------|----------|----------------|
+| "run task" | `run` | `sub-task` | {issue_number} |
+UNGUARDEDEOF
+
+cat > "$FIXTURE_BASE/guarded/.opencode/skills/2339-guarded/SKILL.md" <<'GUARDEDEOF'
+---
+name: 2339-guarded
+description: "Fixture skill for SC-3 validate_skill_cards.py guard enforcement testing. Carries the canonical pre-flight guard. Not a real skill."
+license: MIT
+compatibility: opencode
+---
+
+# Skill: 2339-guarded
+
+## Pre-Flight Guard (Mandatory)
+
+**This skill card is orchestrator-only routing metadata.**
+
+If you are a sub-agent (dispatched via `task()`), you MUST NOT consume the routing metadata below. Sub-agents cannot call `task()` and cannot execute orchestrator-level dispatch instructions. Return `BLOCKED` with reason `ORCHESTRATOR_ONLY_SKILL_CARD` and halt.
+
+If you are the orchestrator (loaded this card via `skill({name: "..."})`), proceed to the Workflows section.
+
+## Trigger Dispatch Table
+
+| User says / Context | Task | Dispatch | Context passed |
+|---------------------|------|----------|----------------|
+| "run task" | `run` | `sub-task` | {issue_number} |
+GUARDEDEOF
+
+echo ""
+echo "=== SC-3: validate_skill_cards.py pre-flight guard enforcement (#2339) ==="
+echo ""
+
+count_guard_findings() {
+    # $1 = JSON output from validate_skill_cards.py --json
+    echo "$1" | python3 -c "
+import sys, json
+try:
+    data = json.load(sys.stdin)
+except Exception:
+    print(0)
+    sys.exit(0)
+count = sum(1 for f in data if f.get('rule_id') == '$RULE_ID')
+print(count)
+"
+}
+
+# --- Unguarded card must produce a guard finding -------------------------
+UNGUARDED_OUTPUT=$(
+    cd "$FIXTURE_BASE/unguarded" && "${UV_RUN_CMD[@]}" --json 2>/dev/null || true
+)
+if [ -z "$UNGUARDED_OUTPUT" ]; then
+    check_fail "SC-3: unguarded card flagged" "validate_skill_cards.py produced no JSON output"
+else
+    UNGUARDED_COUNT=$(count_guard_findings "$UNGUARDED_OUTPUT")
+    if [ "$UNGUARDED_COUNT" -gt 0 ]; then
+        check_pass "SC-3: unguarded card flagged (skill-preflight-guard-missing, $UNGUARDED_COUNT finding)"
+    else
+        check_fail "SC-3: unguarded card flagged" "no $RULE_ID finding for 2339-unguarded (RED phase expected)"
+    fi
+fi
+
+# --- Guarded card must produce no guard finding ---------------------------
+GUARDED_OUTPUT=$(
+    cd "$FIXTURE_BASE/guarded" && "${UV_RUN_CMD[@]}" --json 2>/dev/null || true
+)
+if [ -z "$GUARDED_OUTPUT" ]; then
+    check_fail "SC-3: guarded card passed" "validate_skill_cards.py produced no JSON output"
+else
+    GUARDED_COUNT=$(count_guard_findings "$GUARDED_OUTPUT")
+    if [ "$GUARDED_COUNT" -eq 0 ]; then
+        check_pass "SC-3: guarded card not flagged (no $RULE_ID finding)"
+    else
+        check_fail "SC-3: guarded card not flagged" "$GUARDED_COUNT $RULE_ID finding(s) for guarded card"
+    fi
+fi
+
+echo ""
+echo "=== Results ==="
+echo "PASSED: $PASS_COUNT"
+echo "FAILED: $FAIL_COUNT"
+echo ""
+if [ "$FAIL_COUNT" -gt 0 ]; then
+    echo "RED phase expected: SC-3 (#2339) validate_skill_cards.py does not yet enforce the pre-flight guard."
+    echo ""
+    echo "--- current validator findings on unguarded fixture ---"
+    echo "$UNGUARDED_OUTPUT" | python3 -c "
+import sys, json
+try:
+    data = json.load(sys.stdin)
+except Exception:
+    sys.exit(0)
+for f in data:
+    print(f\"  [{f.get('rule_id','')}] {f.get('file_path')}: {f.get('message')}\")
+" 2>/dev/null || true
+    echo ""
+    exit 1
+fi
+echo "SC-3 is GREEN — validate_skill_cards.py flags the unguarded card and passes the guarded card."
+echo ""
+exit 0

--- a/tests-v2/test-2339-sc4-guard-mandate.sh
+++ b/tests-v2/test-2339-sc4-guard-mandate.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: 2026 michael-conrad
+# SPDX-License-Identifier: MIT
+# Provenance: AI-generated
+#
+# Content-verification test: .opencode#2339 SC-4 — the four skill card
+# requirements documentation documents mandate the pre-flight guard.
+#
+# Maps to SC-4 from issue #2339:
+#   The skill card requirements documentation (skill-card-schema.md,
+#   skill-card-description-standards.md, skill-card-spec.md,
+#   routing-only-template.md) mandates the pre-flight guard.
+#
+# Evidence type: string — grep the four reference documents for the guard
+# mandate marker (ORCHESTRATOR_ONLY_SKILL_CARD / pre-flight guard).
+#
+# RED state: none of the four documents currently contain the guard mandate
+# marker. The assertions below assert the mandate IS present; they FAIL now
+# (RED) and PASS after the GREEN phase adds the guard mandate to all four.
+#
+# Usage: bash .opencode/tests-v2/test-2339-sc4-guard-mandate.sh
+# Exit: 0 if all checks pass (GREEN), 1 if any check fails (expected RED).
+
+# Co-authored with AI: OpenCode (deepseek-v4-flash)
+
+set -euo pipefail
+
+PROJECT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+while [ "$(basename "$PROJECT_DIR")" != ".opencode" ]; do
+    PROJECT_DIR="$(dirname "$PROJECT_DIR")"
+done
+
+DOCS=(
+    "$PROJECT_DIR/reference/skill-card-schema.md"
+    "$PROJECT_DIR/reference/skill-card-description-standards.md"
+    "$PROJECT_DIR/skills/skill-creator/reference/skill-card-spec.md"
+    "$PROJECT_DIR/skills/skill-creator/reference/routing-only-template.md"
+)
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+check_pass() {
+    local label="$1"
+    echo "  PASS: $label"
+    PASS_COUNT=$((PASS_COUNT + 1))
+}
+
+check_fail() {
+    local label="$1"
+    local detail="$2"
+    echo "  FAIL: $label -- $detail" >&2
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+}
+
+echo ""
+echo "=== SC-4: guard mandate present in four reference docs (#2339) ==="
+echo ""
+
+for doc in "${DOCS[@]}"; do
+    name="$(basename "$doc")"
+    if [ -f "$doc" ]; then
+        if grep -qE 'ORCHESTRATOR_ONLY_SKILL_CARD|pre-flight guard|preflight guard' "$doc"; then
+            check_pass "SC-4: $name contains the guard mandate"
+        else
+            check_fail "SC-4: $name contains the guard mandate" \
+                "guard mandate marker absent in $name (RED phase expected)"
+        fi
+    else
+        check_fail "SC-4: $name exists" "missing $doc"
+    fi
+done
+
+echo ""
+echo "=== Results ==="
+echo "PASSED: $PASS_COUNT"
+echo "FAILED: $FAIL_COUNT"
+echo ""
+
+if [ "$FAIL_COUNT" -gt 0 ]; then
+    echo "RED phase expected: SC-4 (#2339) guard mandate not yet added to the four reference docs."
+    echo ""
+    exit 1
+fi
+exit 0

--- a/tests-v2/test-2339-sc5-canonical-guard-definition.sh
+++ b/tests-v2/test-2339-sc5-canonical-guard-definition.sh
@@ -1,0 +1,125 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: 2026 michael-conrad
+# SPDX-License-Identifier: MIT
+# Provenance: AI-generated
+#
+# Content-verification test: .opencode#2339 SC-5 — the four skill card
+# requirements documentation documents define a single canonical guard
+# definition that is consistent across all four.
+#
+# Maps to SC-5 from issue #2339:
+#   The skill card requirements documentation (skill-card-schema.md,
+#   skill-card-description-standards.md, skill-card-spec.md,
+#   routing-only-template.md) defines a single canonical guard definition
+#   consistent across all reference documents.
+#
+# Evidence type: string — grep the four reference documents for the canonical
+# guard definition marker (## Canonical Guard Definition) and assert it is
+# present in all four with an identical guard block (single source of truth).
+#
+# RED state: none of the four documents contained the canonical guard
+# definition section. The assertions below assert it IS present in all four
+# and that the guard block is byte-identical; they FAIL now (RED) and PASS
+# after the GREEN phase adds the canonical definition to all four.
+#
+# Usage: bash .opencode/tests-v2/test-2339-sc5-canonical-guard-definition.sh
+# Exit: 0 if all checks pass (GREEN), 1 if any check fails (expected RED).
+
+# Co-authored with AI: OpenCode (deepseek-v4-flash)
+
+set -euo pipefail
+
+PROJECT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+while [ "$(basename "$PROJECT_DIR")" != ".opencode" ]; do
+    PROJECT_DIR="$(dirname "$PROJECT_DIR")"
+done
+
+DOCS=(
+    "$PROJECT_DIR/reference/skill-card-schema.md"
+    "$PROJECT_DIR/reference/skill-card-description-standards.md"
+    "$PROJECT_DIR/skills/skill-creator/reference/skill-card-spec.md"
+    "$PROJECT_DIR/skills/skill-creator/reference/routing-only-template.md"
+)
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+check_pass() {
+    local label="$1"
+    echo "  PASS: $label"
+    PASS_COUNT=$((PASS_COUNT + 1))
+}
+
+check_fail() {
+    local label="$1"
+    local detail="$2"
+    echo "  FAIL: $label -- $detail" >&2
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+}
+
+echo ""
+echo "=== SC-5: canonical guard definition present and consistent in four reference docs (#2339) ==="
+echo ""
+
+# Extract the canonical guard definition block: from the "## Canonical Guard
+# Definition" heading through the first closing fenced code block.
+extract_canonical_block() {
+    local doc="$1"
+    awk '/^## Canonical Guard Definition/{flag=1} flag{print} flag && /^```$/{exit}' "$doc"
+}
+
+BLOCKS=()
+for doc in "${DOCS[@]}"; do
+    name="$(basename "$doc")"
+    if [ ! -f "$doc" ]; then
+        check_fail "SC-5: $name exists" "missing $doc"
+        continue
+    fi
+
+    if grep -q '^## Canonical Guard Definition' "$doc"; then
+        check_pass "SC-5: $name contains the canonical guard definition section"
+    else
+        check_fail "SC-5: $name contains the canonical guard definition section" \
+            "canonical guard definition heading absent in $name (RED phase expected)"
+    fi
+
+    block="$(extract_canonical_block "$doc")"
+    if [ -z "$block" ]; then
+        check_fail "SC-5: $name canonical guard block non-empty" \
+            "canonical guard definition block empty/missing in $name"
+    fi
+    BLOCKS+=("$block")
+done
+
+# Assert a single consistent canonical definition across all four documents:
+# every extracted block must be byte-identical.
+if [ "$FAIL_COUNT" -eq 0 ]; then
+    first="${BLOCKS[0]}"
+    consistent=1
+    for block in "${BLOCKS[@]}"; do
+        if [ "$block" != "$first" ]; then
+            consistent=0
+            break
+        fi
+    done
+
+    if [ "$consistent" -eq 1 ]; then
+        check_pass "SC-5: canonical guard definition is identical across all four documents"
+    else
+        check_fail "SC-5: canonical guard definition is identical across all four documents" \
+            "canonical guard definition blocks differ across documents (inconsistent)"
+    fi
+fi
+
+echo ""
+echo "=== Results ==="
+echo "PASSED: $PASS_COUNT"
+echo "FAILED: $FAIL_COUNT"
+echo ""
+
+if [ "$FAIL_COUNT" -gt 0 ]; then
+    echo "RED phase expected: SC-5 (#2339) canonical guard definition not yet added/consistent in the four reference docs."
+    echo ""
+    exit 1
+fi
+exit 0

--- a/tests-v2/test-2339-sc6-template-generator-guard.sh
+++ b/tests-v2/test-2339-sc6-template-generator-guard.sh
@@ -1,0 +1,136 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: 2026 michael-conrad
+# SPDX-License-Identifier: MIT
+# Provenance: AI-generated
+#
+# Content-verification test: .opencode#2339 SC-6 — the skill card template
+# generator (init_skill.py) includes the pre-flight guard in the generated
+# SKILL_TEMPLATE so new cards are born with the guard.
+#
+# Maps to SC-6 from issue #2339:
+#   The skill card template generator (init_skill.py) includes the pre-flight
+#   guard in the generated SKILL_TEMPLATE so new cards are born with the guard.
+#
+# Evidence type: behavioral — run the template generator on init_skill.py and
+# inspect its output; generate a card from the template and assert the guard is
+# present.
+#
+# RED state: the SKILL_TEMPLATE in init_skill.py does not currently contain the
+# pre-flight guard. The assertions below assert the generated card DOES contain
+# the guard marker (ORCHESTRATOR_ONLY_SKILL_CARD); they FAIL now (RED) and PASS
+# after the GREEN phase adds the guard section to the SKILL_TEMPLATE.
+#
+# Usage: bash .opencode/tests-v2/test-2339-sc6-template-generator-guard.sh
+# Exit: 0 if all checks pass (GREEN), 1 if any check fails (expected RED).
+
+# Co-authored with AI: OpenCode (deepseek-v4-flash)
+
+set -euo pipefail
+
+PROJECT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+while [ "$(basename "$PROJECT_DIR")" != ".opencode" ]; do
+    PROJECT_DIR="$(dirname "$PROJECT_DIR")"
+done
+
+INIT_SKILL="$PROJECT_DIR/skills/skill-creator/scripts/init_skill.py"
+GUARD_MARKER="ORCHESTRATOR_ONLY_SKILL_CARD"
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+check_pass() {
+    local label="$1"
+    echo "  PASS: $label"
+    PASS_COUNT=$((PASS_COUNT + 1))
+}
+
+check_fail() {
+    local label="$1"
+    local detail="$2"
+    echo "  FAIL: $label -- $detail" >&2
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+}
+
+echo ""
+echo "=== SC-6: template generator emits pre-flight guard (#2339) ==="
+echo ""
+
+if [ ! -f "$INIT_SKILL" ]; then
+    check_fail "SC-6: init_skill.py exists" "missing $INIT_SKILL"
+    echo ""
+    echo "FAILED: $FAIL_COUNT"
+    exit 1
+fi
+
+# Generate a throwaway skill in a temp dir under the project so the template
+# string can be inspected. Use a unique skill name to avoid collisions.
+TMP_DIR="$(mktemp -d "$PROJECT_DIR/tmp/test-2339-sc6-XXXXXX")"
+TEST_SKILL="sc6-guard-test"
+
+if command -v uv &>/dev/null; then
+    UV_RUN=(uv run)
+else
+    UV_RUN=()
+fi
+
+if "${UV_RUN[@]}" python "$INIT_SKILL" "$TEST_SKILL" --path "$TMP_DIR" >/dev/null 2>&1; then
+    check_pass "SC-6: template generator runs successfully"
+else
+    check_fail "SC-6: template generator runs successfully" \
+        "init_skill.py failed to generate a skill (RED phase expected if template broken)"
+fi
+
+GENERATED_CARD="$TMP_DIR/$TEST_SKILL/SKILL.md"
+
+if [ -f "$GENERATED_CARD" ]; then
+    check_pass "SC-6: generated SKILL.md exists"
+else
+    check_fail "SC-6: generated SKILL.md exists" "generated card not found at $GENERATED_CARD"
+fi
+
+if grep -q "$GUARD_MARKER" "$GENERATED_CARD"; then
+    check_pass "SC-6: generated SKILL.md contains the guard marker ($GUARD_MARKER)"
+else
+    check_fail "SC-6: generated SKILL.md contains the guard marker ($GUARD_MARKER)" \
+        "guard marker absent in generated card (RED phase expected)"
+fi
+
+# Guard must appear BEFORE any routing metadata (Trigger Dispatch Table) in the
+# generated card, matching the pre-flight positioning.
+if grep -q "## Pre-Flight Guard (Mandatory)" "$GENERATED_CARD"; then
+    guard_line="$(grep -n '^## Pre-Flight Guard (Mandatory)' "$GENERATED_CARD" | head -1 | cut -d: -f1)"
+    tdt_line="$(grep -n '^## Trigger Dispatch Table' "$GENERATED_CARD" | head -1 | cut -d: -f1)"
+    if [ -n "$guard_line" ] && [ -n "$tdt_line" ] && [ "$guard_line" -lt "$tdt_line" ]; then
+        check_pass "SC-6: guard positioned before routing metadata in generated card"
+    else
+        check_fail "SC-6: guard positioned before routing metadata in generated card" \
+            "guard (line $guard_line) is not before Trigger Dispatch Table (line $tdt_line)"
+    fi
+else
+    check_fail "SC-6: generated SKILL.md contains Pre-Flight Guard heading" \
+        "Pre-Flight Guard heading absent in generated card (RED phase expected)"
+fi
+
+# Also assert the template string directly contains the guard marker.
+if grep -q "$GUARD_MARKER" "$INIT_SKILL"; then
+    check_pass "SC-6: SKILL_TEMPLATE in init_skill.py contains the guard marker"
+else
+    check_fail "SC-6: SKILL_TEMPLATE in init_skill.py contains the guard marker" \
+        "guard marker absent in init_skill.py (RED phase expected)"
+fi
+
+# Clean up the throwaway skill.
+rm -rf "$TMP_DIR"
+
+echo ""
+echo "=== Results ==="
+echo "PASSED: $PASS_COUNT"
+echo "FAILED: $FAIL_COUNT"
+echo ""
+
+if [ "$FAIL_COUNT" -gt 0 ]; then
+    echo "RED phase expected: SC-6 (#2339) template generator does not yet emit the guard."
+    echo ""
+    exit 1
+fi
+exit 0

--- a/tests-v2/test-2339-sc7-critical-rule-guard.sh
+++ b/tests-v2/test-2339-sc7-critical-rule-guard.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: 2026 michael-conrad
+# SPDX-License-Identifier: MIT
+# Provenance: AI-generated
+#
+# Content-verification test: .opencode#2339 SC-7 — the critical-rules-XXX
+# rule (dispatching SKILL.md to sub-agents) references the pre-flight guard
+# as the defensive backstop.
+#
+# Maps to SC-7 from issue #2339:
+#   The critical-rules-XXX rule (dispatching SKILL.md to sub-agents)
+#   references the pre-flight guard as the defensive backstop.
+#
+# Evidence type: string — read the critical-rules-XXX section in
+# 000-critical-rules.md and assert the guard reference is present.
+#
+# RED state: the critical-rules-XXX section does not currently reference the
+# pre-flight guard. The assertions below assert the guard reference IS present;
+# they FAIL now (RED) and PASS after the GREEN phase adds the reference.
+#
+# Usage: bash .opencode/tests-v2/test-2339-sc7-critical-rule-guard.sh
+# Exit: 0 if all checks pass (GREEN), 1 if any check fails (expected RED).
+
+# Co-authored with AI: OpenCode (deepseek-v4-flash)
+
+set -euo pipefail
+
+PROJECT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+while [ "$(basename "$PROJECT_DIR")" != ".opencode" ]; do
+    PROJECT_DIR="$(dirname "$PROJECT_DIR")"
+done
+
+CRITICAL_RULES="$PROJECT_DIR/guidelines/000-critical-rules.md"
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+check_pass() {
+    local label="$1"
+    echo "  PASS: $label"
+    PASS_COUNT=$((PASS_COUNT + 1))
+}
+
+check_fail() {
+    local label="$1"
+    local detail="$2"
+    echo "  FAIL: $label -- $detail" >&2
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+}
+
+echo ""
+echo "=== SC-7: critical rule references the pre-flight guard backstop (#2339) ==="
+echo ""
+
+if [ ! -f "$CRITICAL_RULES" ]; then
+    check_fail "SC-7: $CRITICAL_RULES exists" "missing $CRITICAL_RULES"
+else
+    check_pass "SC-7: $CRITICAL_RULES exists"
+fi
+
+# The critical-rules-XXX section (dispatching SKILL.md to sub-agents) must
+# reference the pre-flight guard as the defensive backstop. Assert the guard
+# marker (ORCHESTRATOR_ONLY_SKILL_CARD) appears within the section that
+# discusses dispatching SKILL.md to sub-agents.
+if [ -f "$CRITICAL_RULES" ]; then
+    if grep -q 'Dispatching SKILL.md to sub-agents' "$CRITICAL_RULES"; then
+        check_pass "SC-7: critical-rules-XXX section (dispatching SKILL.md to sub-agents) present"
+    else
+        check_fail "SC-7: critical-rules-XXX section (dispatching SKILL.md to sub-agents) present" \
+            "section heading absent in $CRITICAL_RULES"
+    fi
+
+    if grep -q 'ORCHESTRATOR_ONLY_SKILL_CARD' "$CRITICAL_RULES"; then
+        check_pass "SC-7: critical rule references the pre-flight guard (ORCHESTRATOR_ONLY_SKILL_CARD)"
+    else
+        check_fail "SC-7: critical rule references the pre-flight guard (ORCHESTRATOR_ONLY_SKILL_CARD)" \
+            "guard marker absent in $CRITICAL_RULES (RED phase expected)"
+    fi
+fi
+
+echo ""
+echo "=== Results ==="
+echo "PASSED: $PASS_COUNT"
+echo "FAILED: $FAIL_COUNT"
+echo ""
+
+if [ "$FAIL_COUNT" -gt 0 ]; then
+    echo "RED phase expected: SC-7 (#2339) critical rule does not yet reference the pre-flight guard backstop."
+    echo ""
+    exit 1
+fi
+exit 0

--- a/tools/impl/skildeck/skildeck-lint
+++ b/tools/impl/skildeck/skildeck-lint
@@ -293,6 +293,43 @@ def lint_progressive_disclosure(base_dir: Path) -> list[LintFinding]:
 
     return findings
 
+
+GUARD_MARKER = "ORCHESTRATOR_ONLY_SKILL_CARD"
+
+
+def lint_skill_preflight_guard(base_dir: Path) -> list[LintFinding]:
+    """Flag SKILL.md cards lacking the canonical pre-flight guard.
+
+    SC-2 (.opencode#2339): every SKILL.md under skills/ (including
+    platforms/*/SKILL.md) MUST carry the pre-flight guard that returns
+    BLOCKED + ORCHESTRATOR_ONLY_SKILL_CARD before routing metadata is
+    consumed. The guard is additive; a card with the guard produces no
+    finding (idempotent — no double-guard finding).
+    """
+    findings: list[LintFinding] = []
+
+    skills_dir = base_dir / "skills"
+    if not skills_dir.exists():
+        return findings
+
+    for skill_dir in sorted(skills_dir.iterdir()):
+        if not skill_dir.is_dir():
+            continue
+        skmd = skill_dir / "SKILL.md"
+        if not skmd.exists():
+            continue
+        rel = str(skmd.relative_to(base_dir))
+        text = skmd.read_text()
+        if GUARD_MARKER not in text:
+            findings.append(LintFinding(
+                severity="error", category="skill-preflight-guard",
+                source=rel, rule_id="skill-preflight-guard-missing",
+                message=f"SKILL.md missing pre-flight guard (marker {GUARD_MARKER})"
+            ))
+
+    return findings
+
+
 def lint_all(
     scan_dir: Path,
     skill_filter: str = "",
@@ -1249,6 +1286,7 @@ def main() -> None:
     base_dir = scan_dir.parent if scan_dir.name == "skills" else scan_dir
     findings.extend(lint_progressive_disclosure(base_dir))
     findings.extend(lint_skill_frontmatter(base_dir))
+    findings.extend(lint_skill_preflight_guard(base_dir))
     findings.extend(lint_skill_deck_completeness(base_dir))
     findings.extend(lint_skill_workflows_prompts(base_dir))
     findings.extend(lint_skill_card_format_rules(base_dir))


### PR DESCRIPTION
## Summary

Prevents sub-agents from consuming orchestrator-only routing metadata by adding a pre-flight guard to every skill card that halts with `BLOCKED` + `ORCHESTRATOR_ONLY_SKILL_CARD` before any routing metadata is consumed.

## Outcome

Sub-agents that receive a skill card will halt immediately instead of silently consuming Trigger Dispatch Tables, DISPATCH_GATE protocols, and Invocation sections they cannot execute — eliminating the category error of dispatching orchestrator-level routing metadata to sub-agents.

## Verification Attestation

All success criteria verified PASS — exact-match against live evidence. The DiMo 4-role audit chain (Investigator → Validator → Evaluator → Arbiter) returned consensus PASS on every criterion. No caveats. No qualifications. Every PASS is a binary exact match. The Arbiter accepted all Evaluator verdicts as final — no synthesis corrections were needed or applied. This deliverable is ready for merge.

## Detail: VbC Table

| ID | Criterion | Test | Result |
|----|-----------|------|--------|
| SC-1 | Every SKILL.md under `.opencode/skills/` (including `platforms/*/SKILL.md`) contains a pre-flight guard detecting sub-agent context and returning `BLOCKED` + `ORCHESTRATOR_ONLY_SKILL_CARD` before any routing metadata is consumed. | string: `bash tests-v2/test-2339-sc1-preflight-guard-applied.sh` (52 PASS / 0 FAIL) + `skildeck verify-acceptance` | PASS |
| SC-2 | `skildeck-lint` flags a SKILL.md lacking the pre-flight guard. | behavioral: `bash tests-v2/test-2339-sc2-skildeck-lint-guard.sh` (2 PASS / 0 FAIL) | PASS |
| SC-3 | `validate_skill_cards.py` flags a SKILL.md lacking the pre-flight guard. | behavioral: `bash tests-v2/test-2339-sc3-validate-skill-cards-guard.sh` (2 PASS / 0 FAIL) | PASS |
| SC-4 | The four reference docs mandate the pre-flight guard. | string: `bash tests-v2/test-2339-sc4-guard-mandate.sh` (4 PASS / 0 FAIL) | PASS |
| SC-5 | A single canonical guard definition consistent across all four reference docs. | string: `bash tests-v2/test-2339-sc5-canonical-guard-definition.sh` (5 PASS / 0 FAIL) | PASS |
| SC-6 | Template generator (`init_skill.py`) includes the pre-flight guard so new cards are born with the guard. | behavioral: `bash tests-v2/test-2339-sc6-template-generator-guard.sh` (5 PASS / 0 FAIL) | PASS |
| SC-7 | critical-rules-XXX rule references the pre-flight guard as defensive backstop. | string: `bash tests-v2/test-2339-sc7-critical-rule-guard.sh` (3 PASS / 0 FAIL) | PASS |

## Detail: DiMo Chain Attestation

| Criterion | Evidence Type | Investigator | Validator | Evaluator | Arbiter |
|-----------|---------------|-------------|-----------|-----------|---------|
| SC-1 | string | evidence.yaml | reasoning.yaml | PASS | PASS |
| SC-2 | behavioral | evidence.yaml | reasoning.yaml | PASS | PASS |
| SC-3 | behavioral | evidence.yaml | reasoning.yaml | PASS | PASS |
| SC-4 | string | evidence.yaml | reasoning.yaml | PASS | PASS |
| SC-5 | string | evidence.yaml | reasoning.yaml | PASS | PASS |
| SC-6 | behavioral | evidence.yaml | reasoning.yaml | PASS | PASS |
| SC-7 | string | evidence.yaml | reasoning.yaml | PASS | PASS |

## Detail: Spec-Card-Mapped Commits

| Commit | Issue | Spec Card | Description |
|--------|-------|-----------|-------------|
| 4eff82ec | #2339 | SC-1..SC-7 | Add pre-flight guard to all skill cards, enforce via skildeck-lint and validate_skill_cards.py, emit via template generator, define canonical guard, reference in critical rules |

## Closing Keywords

```
Implements #2339
```

🤖 Co-authored with AI: OpenCode (deepseek-v4-flash)